### PR TITLE
Cascading python requirements

### DIFF
--- a/lib/dependabot/file_parsers/python/pip.rb
+++ b/lib/dependabot/file_parsers/python/pip.rb
@@ -36,9 +36,7 @@ module Dependabot
         end
 
         def write_temporary_dependency_files
-          File.write("requirements.txt", requirements.content)
-
-          setup_files.each do |file|
+          dependency_files.each do |file|
             path = file.name
             FileUtils.mkdir_p(Pathname.new(path).dirname)
             File.write(path, file.content)
@@ -52,15 +50,6 @@ module Dependabot
 
         def required_files
           Dependabot::FileFetchers::Python::Pip.required_files
-        end
-
-        def requirements
-          @requirements ||= get_original_file("requirements.txt")
-        end
-
-        def setup_files
-          @setup_files ||=
-            dependency_files.select { |f| f.name.end_with?("setup.py") }
         end
       end
     end

--- a/lib/dependabot/file_updaters/python/pip.rb
+++ b/lib/dependabot/file_updaters/python/pip.rb
@@ -22,7 +22,10 @@ module Dependabot
         end
 
         def requirements
-          @requirements ||= get_original_file("requirements.txt")
+          @requirements ||= dependency_files.find do |file|
+            next if file.name.end_with?("setup.py")
+            file.content.match?(/^#{Regexp.escape(dependency.name)}==/)
+          end
         end
 
         def updated_requirements_content

--- a/spec/dependabot/file_fetchers/python/pip_spec.rb
+++ b/spec/dependabot/file_fetchers/python/pip_spec.rb
@@ -5,6 +5,72 @@ require_relative "../shared_examples_for_file_fetchers"
 RSpec.describe Dependabot::FileFetchers::Python::Pip do
   it_behaves_like "a dependency file fetcher"
 
+  context "with a cascading requirement" do
+    let(:github_client) { Octokit::Client.new(access_token: "token") }
+    let(:file_fetcher_instance) do
+      described_class.new(repo: "gocardless/bump", github_client: github_client)
+    end
+
+    let(:url) { "https://api.github.com/repos/gocardless/bump/contents/" }
+
+    before do
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+      stub_request(:get, url + "requirements.txt?ref=sha").
+        to_return(
+          status: 200,
+          body: fixture("github", "requirements_with_cascade.json"),
+          headers: { "content-type" => "application/json" }
+        )
+    end
+
+    context "that is fetchable" do
+      before do
+        stub_request(:get, url + "more_requirements.txt?ref=sha").
+          to_return(
+            status: 200,
+            body: fixture("github", "requirements_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+      end
+
+      it "fetches the additional requirements" do
+        expect(file_fetcher_instance.files.count).to eq(2)
+        expect(file_fetcher_instance.files.map(&:name)).
+          to include("more_requirements.txt")
+      end
+
+      context "and is circular" do
+        before do
+          stub_request(:get, url + "more_requirements.txt?ref=sha").
+            to_return(
+              status: 200,
+              body: fixture("github", "requirements_with_cascade.json"),
+              headers: { "content-type" => "application/json" }
+            )
+        end
+
+        it "only fetches the additional requirements once" do
+          expect(file_fetcher_instance.files.count).to eq(2)
+          expect(file_fetcher_instance.files.map(&:name)).
+            to include("more_requirements.txt")
+        end
+      end
+    end
+
+    context "that has an unfetchable path" do
+      before do
+        stub_request(:get, url + "more_requirements.txt?ref=sha").
+          to_return(status: 404)
+      end
+
+      it "raises a DependencyFileNotFound error with details" do
+        expect { file_fetcher_instance.files }.
+          to raise_error(Dependabot::DependencyFileNotFound)
+      end
+    end
+  end
+
   context "with a path-based dependency" do
     let(:github_client) { Octokit::Client.new(access_token: "token") }
     let(:file_fetcher_instance) do
@@ -38,6 +104,29 @@ RSpec.describe Dependabot::FileFetchers::Python::Pip do
         expect(file_fetcher_instance.files.count).to eq(2)
         expect(file_fetcher_instance.files.map(&:name)).
           to include("setup.py")
+      end
+
+      context "but is in a child requirement file" do
+        before do
+          stub_request(:get, url + "requirements.txt?ref=sha").
+            to_return(
+              status: 200,
+              body: fixture("github", "requirements_with_cascade.json"),
+              headers: { "content-type" => "application/json" }
+            )
+          stub_request(:get, url + "more_requirements.txt?ref=sha").
+            to_return(
+              status: 200,
+              body: fixture("github", "requirements_with_self_reference.json"),
+              headers: { "content-type" => "application/json" }
+            )
+        end
+
+        it "fetches the setup.py" do
+          expect(file_fetcher_instance.files.count).to eq(3)
+          expect(file_fetcher_instance.files.map(&:name)).
+            to include("setup.py")
+        end
       end
     end
 

--- a/spec/dependabot/file_parsers/python/pip_spec.rb
+++ b/spec/dependabot/file_parsers/python/pip_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
       end
 
       # TODO: For now we ignore dependencies with multiple requirements, because
-      # they'd cause trouble at the dependency update step.
+      # they would cause trouble at the dependency update step.
       its(:length) { is_expected.to eq(1) }
     end
 
@@ -119,6 +119,24 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
         its(:name) { is_expected.to eq("requests") }
         its(:version) { is_expected.to eq(Gem::Version.new("2.1.4")) }
       end
+    end
+
+    context "with child requirement files" do
+      let(:files) { [requirements, child_requirements] }
+      let(:requirements) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: fixture("python", "requirements", "cascading.txt")
+        )
+      end
+      let(:child_requirements) do
+        Dependabot::DependencyFile.new(
+          name: "more_requirements.txt",
+          content: fixture("python", "requirements", "version_specified.txt")
+        )
+      end
+
+      its(:length) { is_expected.to eq(3) }
     end
   end
 end

--- a/spec/dependabot/file_updaters/python/pip_spec.rb
+++ b/spec/dependabot/file_updaters/python/pip_spec.rb
@@ -79,6 +79,36 @@ RSpec.describe Dependabot::FileUpdaters::Python::Pip do
         its(:content) { is_expected.to include "psycopg2==2.8.1\n" }
         its(:content) { is_expected.to include "# This is just a comment" }
       end
+
+      context "when the dependency is in a child requirement file" do
+        subject(:updated_requirements_file) do
+          updated_files.find { |f| f.name == "more_requirements.txt" }
+        end
+
+        let(:updater) do
+          described_class.new(
+            dependency_files: [requirements, more_requirements],
+            dependency: dependency,
+            github_access_token: "token"
+          )
+        end
+
+        let(:requirements_body) do
+          fixture("python", "requirements", "cascading.txt")
+        end
+
+        let(:more_requirements) do
+          Dependabot::DependencyFile.new(
+            content: fixture("python", "requirements", "version_specified.txt"),
+            name: "more_requirements.txt"
+          )
+        end
+
+        it "updates and returns the right file" do
+          expect(updated_files.count).to eq(1)
+          expect(updated_files.first.content).to include("psycopg2==2.8.1\n")
+        end
+      end
     end
   end
 

--- a/spec/fixtures/github/requirements_with_cascade.json
+++ b/spec/fixtures/github/requirements_with_cascade.json
@@ -1,0 +1,18 @@
+{
+  "name": "requirements.txt",
+  "path": "requirements.txt",
+  "sha": "8d9a77a86256c11409622fd16d799d9718f1ff62",
+  "size": 29,
+  "url": "https://api.github.com/repos/gocardless/bump/contents/requirements.txt?ref=master",
+  "html_url": "https://github.com/gocardless/bump/blob/master/requirements.txt",
+  "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/8d9a77a86256c11409622fd16d799d9718f1ff62",
+  "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/requirements.txt?token=ABMwe8vXxd4DBCEsxz3jMusk5sr_fFsoks5WJWE-wA%3D%3D",
+  "type": "file",
+  "content": "cmVxdWVzdHM9PTIuNC4xCi1yIC4vbW9yZV9yZXF1aXJlbWVudHMudHh0Cg==\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/gocardless/bump/contents/requirements.txt?ref=master",
+    "git": "https://api.github.com/repos/gocardless/bump/git/blobs/8d9a77a86256c11409622fd16d799d9718f1ff62",
+    "html": "https://github.com/gocardless/bump/blob/master/requirements.txt"
+  }
+}

--- a/spec/fixtures/python/requirements/cascading.txt
+++ b/spec/fixtures/python/requirements/cascading.txt
@@ -1,0 +1,2 @@
+requests==2.4.1
+-r ./more_requirements.txt


### PR DESCRIPTION
Support for cascading requirement files in Python. See [heroku's advice](https://devcenter.heroku.com/articles/python-pip#cascading-requirements-files) on them, for example.

With this added, I'm happy to move Python to beta (from alpha).