### PR TITLE
Raise helpful message for Ruby private sources without auth details

### DIFF
--- a/lib/dependabot/errors.rb
+++ b/lib/dependabot/errors.rb
@@ -55,4 +55,15 @@ module Dependabot
       super(msg)
     end
   end
+
+  class PrivateSourceNotReachable < DependabotError
+    attr_reader :source
+
+    def initialize(source)
+      @source = source
+      msg = "The following source could not be reached as it requires "\
+            "authentication (and any provided details were invalid): #{source}"
+      super(msg)
+    end
+  end
 end

--- a/lib/dependabot/update_checkers/ruby/bundler.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler.rb
@@ -155,6 +155,10 @@ module Dependabot
             map { |details| Gem::Version.new(details.fetch(:number)) }
 
           versions.reject(&:prerelease?).sort.last
+        rescue ::Bundler::Fetcher::AuthenticationRequiredError => error
+          regex = /bundle config (?<repo>.*) username:password/
+          source = error.message.match(regex)[:repo]
+          raise Dependabot::PrivateSourceNotReachable, source
         end
 
         def gemfile

--- a/spec/dependabot/update_checkers/ruby/bundler_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler_spec.rb
@@ -377,6 +377,20 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
       end
 
       it { is_expected.to eq(Gem::Version.new("1.9.0")) }
+
+      context "that we don't have authentication details for" do
+        before do
+          stub_request(:get, gemfury_business_url).to_return(status: 401)
+        end
+
+        it "blows up with a useful error" do
+          expect { checker.latest_version }.
+            to raise_error do |error|
+              expect(error).to be_a(Dependabot::PrivateSourceNotReachable)
+              expect(error.source).to eq("repo.fury.io")
+            end
+        end
+      end
     end
 
     context "given an unreadable Gemfile" do


### PR DESCRIPTION
That. If a private source tells us we aren't authenticated, there's not much we can do except serve the error back to the user.

Example Gemfile this came from is:

```
source 'https://gems.graphql.pro/' do
  gem 'graphql-pro'
end
```