### PR TITLE
Sanitize path-based gemspecs to remove fine requirements

### DIFF
--- a/spec/dependabot/file_updaters/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_updaters/ruby/bundler_spec.rb
@@ -279,6 +279,7 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
 
       context "when another gem in the Gemfile has a path source" do
         let(:gemfile_body) { fixture("ruby", "gemfiles", "path_source") }
+        let(:lockfile_body) { fixture("ruby", "lockfiles", "path_source.lock") }
 
         context "that we've downloaded" do
           let(:gemspec_body) { fixture("ruby", "gemspecs", "example") }
@@ -312,6 +313,18 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
 
           it "updates the gem just fine" do
             expect(file.content).to include "business (1.5.0)"
+          end
+
+          context "that requires other files" do
+            let(:gemspec_body) { fixture("ruby", "gemspecs", "with_require") }
+
+            it "updates the gem just fine" do
+              expect(file.content).to include "business (1.5.0)"
+            end
+
+            it "doesn't change the version of the path dependency" do
+              expect(file.content).to include "example (0.9.3)"
+            end
           end
         end
       end

--- a/spec/dependabot/update_checkers/ruby/bundler_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler_spec.rb
@@ -205,6 +205,12 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
             to_not(change { ::Bundler.root })
         end
 
+        context "that requires other files" do
+          let(:gemspec_body) { fixture("ruby", "gemspecs", "with_require") }
+
+          it { is_expected.to eq(Gem::Version.new("1.8.0")) }
+        end
+
         context "that is the gem we're checking" do
           let(:dependency) do
             Dependabot::Dependency.new(

--- a/spec/fixtures/ruby/gemspecs/with_require
+++ b/spec/fixtures/ruby/gemspecs/with_require
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'example/version'
+
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = Example::VERSION
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency "bundler", ">= 1.12.0"
+  spec.add_dependency "excon", "~> 0.55"
+  spec.add_dependency "gemnasium-parser", "~> 0.1"
+  spec.add_dependency "gems", "~> 1.0"
+  spec.add_dependency "octokit", "~> 4.6"
+  spec.add_dependency "gitlab", "~> 4.1"
+
+  spec.add_development_dependency "webmock", "~> 2.3.1"
+  spec.add_development_dependency "rspec", "~> 3.5.0"
+  spec.add_development_dependency "rspec-its", "~> 1.2.0"
+  spec.add_development_dependency "rubocop", "~> 0.48.0"
+  spec.add_development_dependency "rake"
+end


### PR DESCRIPTION
A little hacky, but this will considerably improve our support for path-based Ruby dependencies.