### PR TITLE
[WIP] Add Gemspec support

### DIFF
--- a/lib/bundler_metadata_dependencies_patch.rb
+++ b/lib/bundler_metadata_dependencies_patch.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Bundler
   class Resolver
-    class SpecGroup < Array
+    class SpecGroup
       private
 
       # Bundler uses StubSpecification specs for dependencies that are currently

--- a/lib/bundler_metadata_dependencies_patch.rb
+++ b/lib/bundler_metadata_dependencies_patch.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Bundler
   class Resolver
-    class SpecGroup
+    class SpecGroup < Array
       private
 
       # Bundler uses StubSpecification specs for dependencies that are currently

--- a/lib/dependabot/dependency.rb
+++ b/lib/dependabot/dependency.rb
@@ -9,9 +9,10 @@ module Dependabot
       if version.nil? && requirement.nil?
         raise ArgumentError, "Either a version or requirement must be provided"
       end
+
       @name = name
-      @version = Gem::Version.new(version) unless requirement
-      @requirement = Gem::Requirement.new(requirement) unless version
+      @version = Gem::Version.new(version) if version
+      @requirement = cleaned_requirement(requirement) if requirement
       @previous_version = previous_version
       @package_manager = package_manager
     end
@@ -24,6 +25,14 @@ module Dependabot
         "previous_version" => previous_version,
         "package_manager" => package_manager
       }
+    end
+
+    private
+
+    def cleaned_requirement(requirement)
+      return unless requirement
+      return requirement if requirement.is_a?(Gem::Requirement)
+      Gem::Requirement.new(requirement)
     end
   end
 end

--- a/lib/dependabot/dependency.rb
+++ b/lib/dependabot/dependency.rb
@@ -3,7 +3,7 @@ module Dependabot
   class Dependency
     attr_reader :name, :version, :previous_version, :package_manager
 
-    def initialize(name:, package_manager:, previous_version: nil, version: nil)
+    def initialize(name:, version:, package_manager:, previous_version: nil)
       @name = name
       @version = version
       @previous_version = previous_version

--- a/lib/dependabot/dependency.rb
+++ b/lib/dependabot/dependency.rb
@@ -1,18 +1,11 @@
 # frozen_string_literal: true
 module Dependabot
   class Dependency
-    attr_reader :name, :version, :requirement, :previous_version,
-                :package_manager
+    attr_reader :name, :version, :previous_version, :package_manager
 
-    def initialize(name:, package_manager:, previous_version: nil, version: nil,
-                   requirement: nil)
-      if version.nil? && requirement.nil?
-        raise ArgumentError, "Either a version or requirement must be provided"
-      end
-
+    def initialize(name:, package_manager:, previous_version: nil, version: nil)
       @name = name
       @version = version
-      @requirement = cleaned_requirement(requirement) if requirement
       @previous_version = previous_version
       @package_manager = package_manager
     end
@@ -20,19 +13,10 @@ module Dependabot
     def to_h
       {
         "name" => name,
-        "version" => version.to_s,
-        "requirement" => requirement.to_s,
+        "version" => version,
         "previous_version" => previous_version,
         "package_manager" => package_manager
       }
-    end
-
-    private
-
-    def cleaned_requirement(requirement)
-      return unless requirement
-      return requirement if requirement.is_a?(Gem::Requirement)
-      Gem::Requirement.new(requirement)
     end
   end
 end

--- a/lib/dependabot/dependency.rb
+++ b/lib/dependabot/dependency.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 module Dependabot
   class Dependency
-    attr_reader :name, :version, :previous_version, :package_manager
+    attr_reader :name, :version, :requirement, :previous_version,
+                :package_manager
 
-    def initialize(name:, version:, package_manager:, previous_version: nil)
+    def initialize(name:, package_manager:, previous_version: nil, version: nil,
+                   requirement: nil)
+      if version.nil? && requirement.nil?
+        raise ArgumentError, "Either a version or requirement must be provided"
+      end
       @name = name
-      @version = Gem::Version.new(version)
+      @version = Gem::Version.new(version) unless requirement
+      @requirement = Gem::Requirement.new(requirement) unless version
       @previous_version = previous_version
       @package_manager = package_manager
     end
@@ -14,6 +20,7 @@ module Dependabot
       {
         "name" => name,
         "version" => version.to_s,
+        "requirement" => requirement.to_s,
         "previous_version" => previous_version,
         "package_manager" => package_manager
       }

--- a/lib/dependabot/dependency.rb
+++ b/lib/dependabot/dependency.rb
@@ -11,7 +11,7 @@ module Dependabot
       end
 
       @name = name
-      @version = Gem::Version.new(version) if version
+      @version = version
       @requirement = cleaned_requirement(requirement) if requirement
       @previous_version = previous_version
       @package_manager = package_manager

--- a/lib/dependabot/file_fetchers.rb
+++ b/lib/dependabot/file_fetchers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "dependabot/file_fetchers/ruby/bundler"
+require "dependabot/file_fetchers/ruby/gemspec"
 require "dependabot/file_fetchers/python/pip"
 require "dependabot/file_fetchers/java_script/yarn"
 require "dependabot/file_fetchers/php/composer"
@@ -9,6 +10,7 @@ module Dependabot
     def self.for_package_manager(package_manager)
       case package_manager
       when "bundler" then FileFetchers::Ruby::Bundler
+      when "gemspec" then FileFetchers::Ruby::Gemspec
       when "yarn" then FileFetchers::JavaScript::Yarn
       when "pip" then FileFetchers::Python::Pip
       when "composer" then FileFetchers::Php::Composer

--- a/lib/dependabot/file_fetchers/ruby/gemspec.rb
+++ b/lib/dependabot/file_fetchers/ruby/gemspec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "dependabot/file_fetchers/base"
+require "dependabot/errors"
 
 module Dependabot
   module FileFetchers

--- a/lib/dependabot/file_fetchers/ruby/gemspec.rb
+++ b/lib/dependabot/file_fetchers/ruby/gemspec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require "dependabot/file_fetchers/base"
+
+module Dependabot
+  module FileFetchers
+    module Ruby
+      class Gemspec < Dependabot::FileFetchers::Base
+        def self.required_files
+          []
+        end
+
+        private
+
+        def extra_files
+          [gemspec]
+        end
+
+        def gemspec
+          gemspec = github_client.contents(
+            repo,
+            path: Pathname.new(directory).cleanpath.to_path,
+            ref: commit
+          ).find { |file| file.name.end_with?(".gemspec") }
+
+          raise Dependabot::DependencyFileNotFound, "*.gemspec" unless gemspec
+
+          fetch_file_from_github(gemspec.name)
+        end
+      end
+    end
+  end
+end

--- a/lib/dependabot/file_parsers.rb
+++ b/lib/dependabot/file_parsers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "dependabot/file_parsers/ruby/bundler"
+require "dependabot/file_parsers/ruby/gemspec"
 require "dependabot/file_parsers/python/pip"
 require "dependabot/file_parsers/java_script/yarn"
 require "dependabot/file_parsers/php/composer"
@@ -9,6 +10,7 @@ module Dependabot
     def self.for_package_manager(package_manager)
       case package_manager
       when "bundler" then FileParsers::Ruby::Bundler
+      when "gemspec" then FileParsers::Ruby::Gemspec
       when "yarn" then FileParsers::JavaScript::Yarn
       when "pip" then FileParsers::Python::Pip
       when "composer" then FileParsers::Php::Composer

--- a/lib/dependabot/file_parsers/ruby/bundler.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler.rb
@@ -29,8 +29,6 @@ module Dependabot
 
         private
 
-        attr_reader :gemfile, :lockfile
-
         def required_files
           Dependabot::FileFetchers::Ruby::Bundler.required_files
         end

--- a/lib/dependabot/file_parsers/ruby/gemspec.rb
+++ b/lib/dependabot/file_parsers/ruby/gemspec.rb
@@ -13,7 +13,7 @@ module Dependabot
           parsed_gemspec.dependencies.map do |dependency|
             Dependency.new(
               name: dependency.name,
-              requirement: dependency.requirement,
+              version: dependency.requirement.to_s,
               package_manager: "gemspec"
             )
           end

--- a/lib/dependabot/file_parsers/ruby/gemspec.rb
+++ b/lib/dependabot/file_parsers/ruby/gemspec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require "dependabot/dependency"
+require "dependabot/file_parsers/base"
+require "dependabot/file_fetchers/ruby/gemspec"
+require "dependabot/shared_helpers"
+
+module Dependabot
+  module FileParsers
+    module Ruby
+      class Gemspec < Dependabot::FileParsers::Base
+        def parse
+          parsed_gemspec.dependencies.map do |dependency|
+            Dependency.new(
+              name: dependency.name,
+              requirement: dependency.requirement,
+              package_manager: "gemspec"
+            )
+          end
+        end
+
+        private
+
+        def required_files
+          Dependabot::FileFetchers::Ruby::Gemspec.required_files
+        end
+
+        def gemspec
+          dependency_files.find { |f| f.name.end_with?(".gemspec") }
+        end
+
+        def sanitized_gemspec
+          gemspec_content = gemspec.content.gsub(/^\s?require.*$/, "")
+          gemspec_content.gsub(/[^_]?version\s*=.*VERSION.*$/) do |old_version|
+            # No need to set the version correctly, and we have no way of
+            # doing so anyway...
+            old_version.sub(/=.*VERSION.*/, "= '0.0.1'")
+          end
+        end
+
+        def parsed_gemspec
+          @parsed_gemspec ||=
+            SharedHelpers.in_a_temporary_directory do
+              File.write(gemspec.name, sanitized_gemspec)
+
+              SharedHelpers.in_a_forked_process do
+                ::Bundler.instance_variable_set(:@root, Pathname.new(Dir.pwd))
+                ::Bundler.load_gemspec_uncached(gemspec.name)
+              end
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/dependabot/file_updaters.rb
+++ b/lib/dependabot/file_updaters.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "dependabot/file_updaters/ruby/bundler"
+require "dependabot/file_updaters/ruby/gemspec"
 require "dependabot/file_updaters/python/pip"
 require "dependabot/file_updaters/java_script/yarn"
 require "dependabot/file_updaters/php/composer"
@@ -9,6 +10,7 @@ module Dependabot
     def self.for_package_manager(package_manager)
       case package_manager
       when "bundler" then FileUpdaters::Ruby::Bundler
+      when "gemspec" then FileUpdaters::Ruby::Gemspec
       when "yarn" then FileUpdaters::JavaScript::Yarn
       when "pip" then FileUpdaters::Python::Pip
       when "composer" then FileUpdaters::Php::Composer

--- a/lib/dependabot/file_updaters/python/pip.rb
+++ b/lib/dependabot/file_updaters/python/pip.rb
@@ -51,7 +51,7 @@ module Dependabot
             sub(LineParser::REQUIREMENT) do |req|
               req.sub(LineParser::VERSION) do |ver|
                 precision = ver.split(".").count
-                dependency.version.segments.first(precision).join(".")
+                dependency.version.split(".").first(precision).join(".")
               end
             end
         end

--- a/lib/dependabot/file_updaters/ruby/bundler.rb
+++ b/lib/dependabot/file_updaters/ruby/bundler.rb
@@ -60,7 +60,7 @@ module Dependabot
               new_req = old_req.dup.gsub(/<=?/, "~>")
               new_req.sub(Gemnasium::Parser::Patterns::VERSION) do |old_version|
                 precision = old_version.split(".").count
-                dependency.version.segments.first(precision).join(".")
+                dependency.version.split(".").first(precision).join(".")
               end
             end
         end

--- a/lib/dependabot/file_updaters/ruby/gemspec.rb
+++ b/lib/dependabot/file_updaters/ruby/gemspec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+require "dependabot/file_updaters/base"
+require "dependabot/file_fetchers/ruby/gemspec"
+
+module Dependabot
+  module FileUpdaters
+    module Ruby
+      class Gemspec < Dependabot::FileUpdaters::Base
+        DEPENDENCY_DECLARATION_REGEX =
+          /^\s*\w*\.add(?:_development)?_dependency
+            (\s*|\()['"](?<name>.*?)['"],
+            \s*(?<requirements>['"].*['"])\)?/x
+
+        def updated_dependency_files
+          [
+            updated_file(
+              file: gemspec,
+              content: updated_gemspec_content
+            )
+          ]
+        end
+
+        private
+
+        def required_files
+          Dependabot::FileFetchers::Ruby::Gemspec.required_files
+        end
+
+        def gemspec
+          @gemspec ||= dependency_files.find do |file|
+            file.name.end_with?(".gemspec")
+          end
+        end
+
+        def updated_gemspec_content
+          @updated_gemspec_content ||= gemspec.content.gsub(
+            original_dependency_declaration_string,
+            updated_dependency_declaration_string
+          )
+        end
+
+        def original_dependency_declaration_string
+          @original_dependency_declaration_string ||=
+            begin
+              matches = []
+              gemspec.content.scan(DEPENDENCY_DECLARATION_REGEX) do
+                matches << Regexp.last_match
+              end
+              matches.find { |match| match[:name] == dependency.name }.to_s
+            end
+        end
+
+        def updated_dependency_declaration_string
+          original_requirement = DEPENDENCY_DECLARATION_REGEX.match(
+            original_dependency_declaration_string
+          )[:requirements]
+
+          formatted_new_requirement =
+            dependency.requirement.as_list.map { |r| "\"#{r}\"" }.join(", ")
+
+          original_dependency_declaration_string.
+            sub(original_requirement, formatted_new_requirement)
+        end
+      end
+    end
+  end
+end

--- a/lib/dependabot/file_updaters/ruby/gemspec.rb
+++ b/lib/dependabot/file_updaters/ruby/gemspec.rb
@@ -56,7 +56,7 @@ module Dependabot
           )[:requirements]
 
           formatted_new_requirement =
-            dependency.requirement.as_list.map { |r| "\"#{r}\"" }.join(", ")
+            dependency.version.split(",").map { |r| %("#{r.strip}") }.join(", ")
 
           original_dependency_declaration_string.
             sub(original_requirement, formatted_new_requirement)

--- a/lib/dependabot/metadata_finders.rb
+++ b/lib/dependabot/metadata_finders.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "dependabot/metadata_finders/ruby/bundler"
+require "dependabot/metadata_finders/ruby/gemspec"
 require "dependabot/metadata_finders/python/pip"
 require "dependabot/metadata_finders/java_script/yarn"
 require "dependabot/metadata_finders/php/composer"
@@ -9,6 +10,7 @@ module Dependabot
     def self.for_package_manager(package_manager)
       case package_manager
       when "bundler" then MetadataFinders::Ruby::Bundler
+      when "gemspec" then MetadataFinders::Ruby::Gemspec
       when "yarn" then MetadataFinders::JavaScript::Yarn
       when "pip" then MetadataFinders::Python::Pip
       when "composer" then MetadataFinders::Php::Composer

--- a/lib/dependabot/metadata_finders/base.rb
+++ b/lib/dependabot/metadata_finders/base.rb
@@ -48,6 +48,10 @@ module Dependabot
         look_up_release_url
       end
 
+      def latest_version
+        NotImplementedError
+      end
+
       private
 
       def source

--- a/lib/dependabot/metadata_finders/base.rb
+++ b/lib/dependabot/metadata_finders/base.rb
@@ -99,7 +99,7 @@ module Dependabot
       end
 
       def version_regex(version)
-        /(?:[^0-9\.]|\A)#{Regexp.escape(version.to_s)}\z/
+        /(?:[^0-9\.]|\A)#{Regexp.escape(version)}\z/
       end
 
       def fetch_dependency_file_tree

--- a/lib/dependabot/metadata_finders/ruby/gemspec.rb
+++ b/lib/dependabot/metadata_finders/ruby/gemspec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require "dependabot/metadata_finders/ruby/bundler"
+
+module Dependabot
+  module MetadataFinders
+    module Ruby
+      class Gemspec < Dependabot::MetadataFinders::Ruby::Bundler
+        # Identical to the Bundler metadata finder
+      end
+    end
+  end
+end

--- a/lib/dependabot/metadata_finders/ruby/gemspec.rb
+++ b/lib/dependabot/metadata_finders/ruby/gemspec.rb
@@ -4,8 +4,24 @@ require "dependabot/metadata_finders/ruby/bundler"
 module Dependabot
   module MetadataFinders
     module Ruby
+      # Inherit from MetadataFinder::Ruby::Bundler
       class Gemspec < Dependabot::MetadataFinders::Ruby::Bundler
-        # Identical to the Bundler metadata finder
+        def initialize(dependency:, github_client:)
+          super
+
+          # Update the dependency version to be the latest version. On the
+          # original dependency it will have been a requirement string.
+          @dependency = Dependency.new(
+            name: @dependency.name,
+            package_manager: @dependency.package_manager,
+            previous_version: @dependency.previous_version,
+            version: latest_version
+          )
+        end
+
+        def latest_version
+          Gems.info(dependency.name)["version"]
+        end
       end
     end
   end

--- a/lib/dependabot/update_checkers.rb
+++ b/lib/dependabot/update_checkers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "dependabot/update_checkers/ruby/bundler"
+require "dependabot/update_checkers/ruby/gemspec"
 require "dependabot/update_checkers/python/pip"
 require "dependabot/update_checkers/java_script/yarn"
 require "dependabot/update_checkers/php/composer"
@@ -9,6 +10,7 @@ module Dependabot
     def self.for_package_manager(package_manager)
       case package_manager
       when "bundler" then UpdateCheckers::Ruby::Bundler
+      when "gemspec" then UpdateCheckers::Ruby::Gemspec
       when "yarn" then UpdateCheckers::JavaScript::Yarn
       when "pip" then UpdateCheckers::Python::Pip
       when "composer" then UpdateCheckers::Php::Composer

--- a/lib/dependabot/update_checkers/base.rb
+++ b/lib/dependabot/update_checkers/base.rb
@@ -16,17 +16,20 @@ module Dependabot
         # Look at the very latest version before considering resolvability. If
         # we're already up-to-date with it then we don't need to bother doing
         # resolution (which is generally slow).
-        return false if latest_version && latest_version <= dependency.version
+        if latest_version &&
+           latest_version <= Gem::Version.new(dependency.version)
+          return false
+        end
 
+        # If we're not on the latest version, consider resolvability.
         return false if latest_resolvable_version.nil?
-
-        latest_resolvable_version > dependency.version
+        latest_resolvable_version > Gem::Version.new(dependency.version)
       end
 
       def updated_dependency
         Dependency.new(
           name: dependency.name,
-          version: latest_resolvable_version,
+          version: latest_resolvable_version.to_s,
           previous_version: dependency.version,
           package_manager: dependency.package_manager
         )

--- a/lib/dependabot/update_checkers/ruby/gemspec.rb
+++ b/lib/dependabot/update_checkers/ruby/gemspec.rb
@@ -6,6 +6,8 @@ module Dependabot
   module UpdateCheckers
     module Ruby
       class Gemspec < Dependabot::UpdateCheckers::Base
+        class UnfixableRequirement < StandardError; end
+
         def latest_version
           @latest_version ||= fetch_latest_version
         end
@@ -60,36 +62,58 @@ module Dependabot
           updated_requirement = updated_requirements.shift
           updated_requirement.concat(updated_requirements)
           updated_requirement
-        rescue ArgumentError
-          # TODO! Use something other than ArgumentError here
+        rescue UnfixableRequirement
           nil
         end
 
         def fixed_requirement(r)
           op, version = r.requirements.first
 
+          if version.segments.any? { |s| !s.instance_of?(Integer) }
+            # Ignore constraints with non-integer values for now.
+            # TODO: Handle pre-release constraints properly.
+            raise UnfixableRequirement
+          end
+
           case op
           when "=", nil
             Gem::Requirement.new("#{op} #{latest_version}")
           when "<", "<="
-            Gem::Requirement.new("#{op} #{updated_constraint_version(version)}")
+            Gem::Requirement.new("#{op} #{updated_greatest_version(version)}")
           when "~>"
-            Gem::Requirement.new(
-              ">= #{version}",
-              "< #{updated_constraint_version(version)}"
-            )
+            updated_twidle_requirement(r)
           when "!=", ">", ">="
-            raise ArgumentError
+            raise UnfixableRequirement
           end
         end
 
-        def updated_constraint_version(version)
-          # Ignore constraints with non-integer values for now.
-          # TODO: Handle pre-release constraints properly.
-          if version.segments.any? { |s| !s.instance_of?(Integer) }
-            raise ArgumentError
-          end
+        def updated_twidle_requirement(requirement)
+          version = requirement.requirements.first.last
 
+          index_to_update = version.segments.count - 2
+
+          ub_segments = latest_version.segments
+          ub_segments << 0 while ub_segments.count <= index_to_update
+          ub_segments = ub_segments[0..index_to_update]
+          ub_segments[index_to_update] += 1
+
+          lb_segments = version.segments
+          lb_segments.pop while lb_segments.last.zero?
+
+          # Pretty up versions to have the same length as each other
+          length = [lb_segments.count, ub_segments.count].max
+          lb_segments.fill(0, lb_segments.count...length)
+          ub_segments.fill(0, ub_segments.count...length)
+
+          Gem::Requirement.new(
+            ">= #{Gem::Version.new(lb_segments.join('.'))}",
+            "< #{Gem::Version.new(ub_segments.join('.'))}"
+          )
+        end
+
+        # Updates the version in a "<" or "<=" constraint to allow the latest
+        # version
+        def updated_greatest_version(version)
           index_to_update =
             version.segments.map.with_index { |seg, i| seg.zero? ? 0 : i }.max
 

--- a/lib/dependabot/update_checkers/ruby/gemspec.rb
+++ b/lib/dependabot/update_checkers/ruby/gemspec.rb
@@ -84,6 +84,8 @@ module Dependabot
             updated_twidle_requirement(r)
           when "!=", ">", ">="
             raise UnfixableRequirement
+          else
+            raise "Unexpected operation for requirement: #{op}"
           end
         end
 

--- a/lib/dependabot/update_checkers/ruby/gemspec.rb
+++ b/lib/dependabot/update_checkers/ruby/gemspec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+require "gems"
+require "dependabot/update_checkers/base"
+
+module Dependabot
+  module UpdateCheckers
+    module Ruby
+      class Gemspec < Dependabot::UpdateCheckers::Base
+        def latest_version
+          @latest_version ||= fetch_latest_version
+        end
+
+        def latest_resolvable_version
+          latest_version
+        end
+
+        def needs_update?
+          !dependency.requirement.satisfied_by?(latest_version) &&
+            !updated_requirement.nil?
+        end
+
+        def updated_dependency
+          Dependency.new(
+            name: dependency.name,
+            version: dependency.version,
+            requirement: updated_requirement,
+            previous_version: dependency.version,
+            package_manager: dependency.package_manager
+          )
+        end
+
+        private
+
+        def fetch_latest_version
+          # Note: Rubygems excludes pre-releases from the `Gems.info` response.
+          # We might want to add them back in?
+          latest_info = Gems.info(dependency.name)
+
+          if latest_info["version"].nil?
+            raise "No version in Rubygems info:\n\n #{latest_info}"
+          end
+
+          Gem::Version.new(latest_info["version"])
+        rescue JSON::ParserError
+          # Replace with Gems::NotFound error if/when
+          # https://github.com/rubygems/gems/pull/38 is merged.
+          raise "Dependency not found on Rubygems: #{dependency.name}"
+        end
+
+        def updated_requirement
+          requirements =
+            dependency.requirement.as_list.map { |r| Gem::Requirement.new(r) }
+
+          updated_requirements =
+            requirements.map do |r|
+              next r if r.satisfied_by?(latest_version)
+              fixed_requirement(r)
+            end
+
+          updated_requirement = updated_requirements.shift
+          updated_requirement.concat(updated_requirements)
+          updated_requirement
+        rescue ArgumentError
+          # TODO! Use something other than ArgumentError here
+          nil
+        end
+
+        def fixed_requirement(r)
+          op, version = r.requirements.first
+
+          case op
+          when "=", nil
+            Gem::Requirement.new("#{op} #{latest_version}")
+          when "<", "<="
+            Gem::Requirement.new("#{op} #{updated_constraint_version(version)}")
+          when "~>"
+            Gem::Requirement.new(
+              ">= #{version}",
+              "< #{updated_constraint_version(version)}"
+            )
+          when "!=", ">", ">="
+            raise ArgumentError
+          end
+        end
+
+        def updated_constraint_version(version)
+          # Ignore constraints with non-integer values for now.
+          # TODO: Handle pre-release constraints properly.
+          if version.segments.any? { |s| !s.instance_of?(Integer) }
+            raise ArgumentError
+          end
+
+          index_to_update =
+            version.segments.map.with_index { |seg, i| seg.zero? ? 0 : i }.max
+
+          new_segments = version.segments.map.with_index do |_, index|
+            if index < index_to_update
+              latest_version.segments[index]
+            elsif index == index_to_update
+              latest_version.segments[index] + 1
+            else
+              0
+            end
+          end
+
+          Gem::Version.new(new_segments.join("."))
+        end
+      end
+    end
+  end
+end

--- a/lib/dependabot/update_checkers/ruby/gemspec.rb
+++ b/lib/dependabot/update_checkers/ruby/gemspec.rb
@@ -103,7 +103,7 @@ module Dependabot
           lb_segments = version.segments
           lb_segments.pop while lb_segments.last.zero?
 
-          # Pretty up versions to have the same length as each other
+          # Ensure versions have the same length as each other (cosmetic)
           length = [lb_segments.count, ub_segments.count].max
           lb_segments.fill(0, lb_segments.count...length)
           ub_segments.fill(0, ub_segments.count...length)

--- a/spec/dependabot/file_fetchers/ruby/gemspec_spec.rb
+++ b/spec/dependabot/file_fetchers/ruby/gemspec_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require "dependabot/file_fetchers/ruby/gemspec"
+require_relative "../shared_examples_for_file_fetchers"
+
+RSpec.describe Dependabot::FileFetchers::Ruby::Gemspec do
+  it_behaves_like "a dependency file fetcher"
+
+  context "with a gemspec" do
+    let(:github_client) { Octokit::Client.new(access_token: "token") }
+    let(:file_fetcher_instance) do
+      described_class.new(
+        repo: "gocardless/business",
+        github_client: github_client
+      )
+    end
+
+    let(:url) { "https://api.github.com/repos/gocardless/business/contents/" }
+
+    before do
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+      stub_request(:get, url + "?ref=sha").
+        to_return(
+          status: 200,
+          body: fixture("github", "business_files.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, url + "business.gemspec?ref=sha").
+        to_return(
+          status: 200,
+          body: fixture("github", "business_gemspec.json"),
+          headers: { "content-type" => "application/json" }
+        )
+    end
+
+    it "fetches the gemspec file" do
+      expect(file_fetcher_instance.files.count).to eq(1)
+      expect(file_fetcher_instance.files.map(&:name)).
+        to include("business.gemspec")
+    end
+  end
+
+  context "with no gemspec" do
+    let(:github_client) { Octokit::Client.new(access_token: "token") }
+    let(:file_fetcher_instance) do
+      described_class.new(
+        repo: "gocardless/business",
+        github_client: github_client
+      )
+    end
+
+    let(:url) { "https://api.github.com/repos/gocardless/business/contents/" }
+
+    before do
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+      stub_request(:get, url + "?ref=sha").
+        to_return(
+          status: 200,
+          body: fixture("github", "business_files_no_gemspec.json"),
+          headers: { "content-type" => "application/json" }
+        )
+    end
+
+    it "raises a DependencyFileNotFound error" do
+      expect { file_fetcher_instance.files }.
+        to raise_error(Dependabot::DependencyFileNotFound)
+    end
+  end
+end

--- a/spec/dependabot/file_fetchers/shared_examples_for_file_fetchers.rb
+++ b/spec/dependabot/file_fetchers/shared_examples_for_file_fetchers.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples "a dependency file fetcher" do
 
     its(:superclass) { is_expected.to eq(base_class) }
 
-    its(:required_files) { is_expected.to_not be_empty }
+    its(:required_files) { is_expected.to be_an_instance_of(Array) }
 
     it "doesn't define any additional public instance methods" do
       expect(described_class.public_instance_methods).

--- a/spec/dependabot/file_parsers/java_script/yarn_spec.rb
+++ b/spec/dependabot/file_parsers/java_script/yarn_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Dependabot::FileParsers::JavaScript::Yarn do
 
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("fetch-factory") }
-        its(:version) { is_expected.to eq(Gem::Version.new("0.0.1")) }
+        its(:version) { is_expected.to eq("0.0.1") }
       end
     end
   end

--- a/spec/dependabot/file_parsers/php/composer_spec.rb
+++ b/spec/dependabot/file_parsers/php/composer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Dependabot::FileParsers::Php::Composer do
 
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("monolog/monolog") }
-        its(:version) { is_expected.to eq(Gem::Version.new("1.0.2")) }
+        its(:version) { is_expected.to eq("1.0.2") }
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe Dependabot::FileParsers::Php::Composer do
       let(:lockfile_body) { fixture("php", "lockfiles", "v_prefix") }
 
       it "strips the prefix" do
-        expect(dependencies.first.version).to eq(Gem::Version.new("1.0.2"))
+        expect(dependencies.first.version).to eq("1.0.2")
       end
     end
 

--- a/spec/dependabot/file_parsers/python/pip_spec.rb
+++ b/spec/dependabot/file_parsers/python/pip_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
 
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("psycopg2") }
-        its(:version) { is_expected.to eq(Gem::Version.new("2.6.1")) }
+        its(:version) { is_expected.to eq("2.6.1") }
       end
     end
 
@@ -45,7 +45,7 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
 
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("psycopg2") }
-        its(:version) { is_expected.to eq(Gem::Version.new("2.6.1")) }
+        its(:version) { is_expected.to eq("2.6.1") }
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
 
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("psycopg2") }
-        its(:version) { is_expected.to eq(Gem::Version.new("2.6.1")) }
+        its(:version) { is_expected.to eq("2.6.1") }
       end
     end
 

--- a/spec/dependabot/file_parsers/python/pip_spec.rb
+++ b/spec/dependabot/file_parsers/python/pip_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
 
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("requests") }
-        its(:version) { is_expected.to eq(Gem::Version.new("2.1.4")) }
+        its(:version) { is_expected.to eq("2.1.4") }
       end
     end
 

--- a/spec/dependabot/file_parsers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/bundler_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
 
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("business") }
-        its(:version) { is_expected.to eq(Gem::Version.new("1.4.0")) }
+        its(:version) { is_expected.to eq("1.4.0") }
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
 
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("business") }
-        its(:version) { is_expected.to eq(Gem::Version.new("1.4.0")) }
+        its(:version) { is_expected.to eq("1.4.0") }
       end
     end
 

--- a/spec/dependabot/file_parsers/ruby/gemspec_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/gemspec_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Gemspec do
 
       it { is_expected.to be_a(Dependabot::Dependency) }
       its(:name) { is_expected.to eq("bundler") }
-      its(:requirement) { is_expected.to eq(Gem::Requirement.new(">= 1.12.0")) }
+      its(:version) { is_expected.to eq(">= 1.12.0") }
     end
 
     context "with a gemspec that requires in other files" do

--- a/spec/dependabot/file_parsers/ruby/gemspec_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/gemspec_spec.rb
@@ -35,5 +35,14 @@ RSpec.describe Dependabot::FileParsers::Ruby::Gemspec do
 
       its(:length) { is_expected.to eq(11) }
     end
+
+    context "that can't be evaluated" do
+      let(:gemspec_content) { fixture("ruby", "gemspecs", "unevaluatable") }
+
+      it "raises a Dependabot::DependencyFileNotEvaluatable error" do
+        expect { parser.parse }.
+          to raise_error(Dependabot::DependencyFileNotEvaluatable)
+      end
+    end
   end
 end

--- a/spec/dependabot/file_parsers/ruby/gemspec_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/gemspec_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "dependabot/dependency_file"
+require "dependabot/file_parsers/ruby/gemspec"
+require_relative "../shared_examples_for_file_parsers"
+
+RSpec.describe Dependabot::FileParsers::Ruby::Gemspec do
+  it_behaves_like "a dependency file parser"
+
+  let(:files) { [gemspec] }
+  let(:gemspec) do
+    Dependabot::DependencyFile.new(
+      name: "business.gemspec",
+      content: gemspec_content
+    )
+  end
+  let(:parser) { described_class.new(dependency_files: files) }
+
+  describe "parse" do
+    subject(:dependencies) { parser.parse }
+    let(:gemspec_content) { fixture("ruby", "gemspecs", "example") }
+
+    its(:length) { is_expected.to eq(11) }
+
+    describe "the first dependency" do
+      subject { dependencies.first }
+
+      it { is_expected.to be_a(Dependabot::Dependency) }
+      its(:name) { is_expected.to eq("bundler") }
+      its(:requirement) { is_expected.to eq(Gem::Requirement.new(">= 1.12.0")) }
+    end
+
+    context "with a gemspec that requires in other files" do
+      let(:gemspec_content) { fixture("ruby", "gemspecs", "with_require") }
+
+      its(:length) { is_expected.to eq(11) }
+    end
+  end
+end

--- a/spec/dependabot/file_updaters/ruby/gemspec_spec.rb
+++ b/spec/dependabot/file_updaters/ruby/gemspec_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Gemspec do
   let(:dependency) do
     Dependabot::Dependency.new(
       name: "octokit",
-      version: "5.0.0",
-      requirement: Gem::Requirement.new(">= 4.6", "< 6.0"),
+      version: ">= 4.6, < 6.0",
       package_manager: "gemspec"
     )
   end
@@ -49,7 +48,7 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Gemspec do
       end
 
       its(:content) do
-        is_expected.to include "octokit\", \"< 6.0\", \">= 4.6\"\n"
+        is_expected.to include(%("octokit", ">= 4.6", "< 6.0"\n))
       end
     end
   end

--- a/spec/dependabot/file_updaters/ruby/gemspec_spec.rb
+++ b/spec/dependabot/file_updaters/ruby/gemspec_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/file_updaters/ruby/gemspec"
+require "dependabot/shared_helpers"
+require_relative "../shared_examples_for_file_updaters"
+
+RSpec.describe Dependabot::FileUpdaters::Ruby::Gemspec do
+  it_behaves_like "a dependency file updater"
+
+  let(:updater) do
+    described_class.new(
+      dependency_files: [gemspec],
+      dependency: dependency,
+      github_access_token: "token"
+    )
+  end
+  let(:gemspec) do
+    Dependabot::DependencyFile.new(
+      content: gemspec_body,
+      name: "example.gemspec"
+    )
+  end
+  let(:gemspec_body) do
+    fixture("ruby", "gemspecs", "example")
+  end
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "octokit",
+      version: "5.0.0",
+      requirement: Gem::Requirement.new(">= 4.6", "< 6.0"),
+      package_manager: "gemspec"
+    )
+  end
+
+  describe "#updated_dependency_files" do
+    subject(:updated_files) { updater.updated_dependency_files }
+
+    it "returns DependencyFile objects" do
+      updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+    end
+
+    its(:length) { is_expected.to eq(1) }
+
+    describe "the updated gemspec" do
+      subject(:updated_gemspec) do
+        updated_files.find { |f| f.name == "example.gemspec" }
+      end
+
+      its(:content) do
+        is_expected.to include "octokit\", \"< 6.0\", \">= 4.6\"\n"
+      end
+    end
+  end
+end

--- a/spec/dependabot/update_checkers/base_spec.rb
+++ b/spec/dependabot/update_checkers/base_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
     subject(:updated_dependency) { updater_instance.updated_dependency }
     let(:latest_resolvable_version) { Gem::Version.new("0.9.0") }
 
-    its(:version) { is_expected.to eq(latest_resolvable_version) }
-    its(:previous_version) { is_expected.to eq(Gem::Version.new("1.5.0")) }
+    its(:version) { is_expected.to eq("0.9.0") }
+    its(:previous_version) { is_expected.to eq("1.5.0") }
     its(:package_manager) { is_expected.to eq(dependency.package_manager) }
     its(:name) { is_expected.to eq(dependency.name) }
   end

--- a/spec/dependabot/update_checkers/python/pip_spec.rb
+++ b/spec/dependabot/update_checkers/python/pip_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe Dependabot::UpdateCheckers::Python::Pip do
     subject { checker.updated_dependency }
     it "returns an instance of Dependency" do
       expect(subject.name).to eq("luigi")
-      expect(subject.version).to eq(Gem::Version.new("2.6.0"))
-      expect(subject.previous_version).to eq(Gem::Version.new("2.0.0"))
+      expect(subject.version).to eq("2.6.0")
+      expect(subject.previous_version).to eq("2.0.0")
       expect(subject.package_manager).to eq("pip")
     end
   end

--- a/spec/dependabot/update_checkers/ruby/gemspec_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/gemspec_spec.rb
@@ -124,5 +124,25 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Gemspec do
         is_expected.to eq(Gem::Requirement.new("> 1.0.0", "<= 1.6.0"))
       end
     end
+
+    context "when a beta version was used in the old requirement" do
+      let(:old_requirement) { Gem::Requirement.new("< 1.4.0.beta") }
+      its(:requirement) { is_expected.to be_nil }
+    end
+
+    context "when a != specifier was used" do
+      let(:old_requirement) { Gem::Requirement.new("!= 1.5.0") }
+      its(:requirement) { is_expected.to be_nil }
+    end
+
+    context "when a >= specifier was used" do
+      let(:old_requirement) { Gem::Requirement.new(">= 1.6.0") }
+      its(:requirement) { is_expected.to be_nil }
+    end
+
+    context "when a > specifier was used" do
+      let(:old_requirement) { Gem::Requirement.new("> 1.6.0") }
+      its(:requirement) { is_expected.to be_nil }
+    end
   end
 end

--- a/spec/dependabot/update_checkers/ruby/gemspec_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/gemspec_spec.rb
@@ -18,12 +18,11 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Gemspec do
   let(:dependency) do
     Dependabot::Dependency.new(
       name: "business",
-      version: "1.3.0",
-      requirement: old_requirement,
+      version: old_requirement,
       package_manager: "gemspec"
     )
   end
-  let(:old_requirement) { Gem::Requirement.new(">= 1.0.0") }
+  let(:old_requirement) { ">= 1.0.0" }
 
   before do
     stub_request(:get, "https://rubygems.org/api/v1/gems/business.json").
@@ -57,11 +56,11 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Gemspec do
     it { is_expected.to eq(false) }
 
     context "when the existing requirement blocks the latest version" do
-      let(:old_requirement) { Gem::Requirement.new("<= 1.3.0") }
+      let(:old_requirement) { "<= 1.3.0" }
       it { is_expected.to eq(true) }
 
       context "but we don't know how to fix it" do
-        let(:old_requirement) { Gem::Requirement.new("!= 1.5.0") }
+        let(:old_requirement) { "!= 1.5.0" }
         it { is_expected.to eq(false) }
       end
     end
@@ -71,78 +70,68 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Gemspec do
     subject { checker.updated_dependency }
 
     context "when an = specifier was used" do
-      let(:old_requirement) { Gem::Requirement.new("= 1.4.0") }
-      its(:requirement) { is_expected.to eq(Gem::Requirement.new("= 1.5.0")) }
+      let(:old_requirement) { "= 1.4.0" }
+      its(:version) { is_expected.to eq("= 1.5.0") }
     end
 
     context "when no specifier was used" do
-      let(:old_requirement) { Gem::Requirement.new("1.4.0") }
-      its(:requirement) { is_expected.to eq(Gem::Requirement.new("1.5.0")) }
+      let(:old_requirement) { "1.4.0" }
+      its(:version) { is_expected.to eq("= 1.5.0") }
     end
 
     context "when a < specifier was used" do
-      let(:old_requirement) { Gem::Requirement.new("< 1.4.0") }
-      its(:requirement) { is_expected.to eq(Gem::Requirement.new("< 1.6.0")) }
+      let(:old_requirement) { "< 1.4.0" }
+      its(:version) { is_expected.to eq("< 1.6.0") }
     end
 
     context "when a <= specifier was used" do
-      let(:old_requirement) { Gem::Requirement.new("<= 1.4.0") }
-      its(:requirement) { is_expected.to eq(Gem::Requirement.new("<= 1.6.0")) }
+      let(:old_requirement) { "<= 1.4.0" }
+      its(:version) { is_expected.to eq("<= 1.6.0") }
     end
 
     context "when a ~> specifier was used" do
-      let(:old_requirement) { Gem::Requirement.new("~> 1.4.0") }
-      its(:requirement) do
-        is_expected.to eq(Gem::Requirement.new(">= 1.4", "< 1.6"))
-      end
+      let(:old_requirement) { "~> 1.4.0" }
+      its(:version) { is_expected.to eq(">= 1.4, < 1.6") }
 
       context "with two zeros" do
-        let(:old_requirement) { Gem::Requirement.new("~> 1.0.0") }
-        its(:requirement) do
-          is_expected.to eq(Gem::Requirement.new(">= 1.0", "< 1.6"))
-        end
+        let(:old_requirement) { "~> 1.0.0" }
+        its(:version) { is_expected.to eq(">= 1.0, < 1.6") }
       end
 
       context "with no zeros" do
-        let(:old_requirement) { Gem::Requirement.new("~> 1.0.1") }
-        its(:requirement) do
-          is_expected.to eq(Gem::Requirement.new(">= 1.0.1", "< 1.6.0"))
-        end
+        let(:old_requirement) { "~> 1.0.1" }
+        its(:version) { is_expected.to eq(">= 1.0.1, < 1.6.0") }
       end
 
       context "with minor precision" do
-        let(:old_requirement) { Gem::Requirement.new("~> 0.1") }
-        its(:requirement) do
-          is_expected.to eq(Gem::Requirement.new(">= 0.1", "< 2.0"))
-        end
+        let(:old_requirement) { "~> 0.1" }
+        its(:version) { is_expected.to eq(">= 0.1, < 2.0") }
       end
     end
 
     context "when there are multiple requirements" do
-      let(:old_requirement) { Gem::Requirement.new("> 1.0.0", "<= 1.4.0") }
-      its(:requirement) do
-        is_expected.to eq(Gem::Requirement.new("> 1.0.0", "<= 1.6.0"))
-      end
+      let(:old_requirement) { "> 1.0.0, <= 1.4.0" }
+      its(:version) { is_expected.to eq("> 1.0.0, <= 1.6.0") }
     end
 
     context "when a beta version was used in the old requirement" do
-      let(:old_requirement) { Gem::Requirement.new("< 1.4.0.beta") }
-      its(:requirement) { is_expected.to be_nil }
+      let(:old_requirement) { "< 1.4.0.beta" }
+      its(:version) { is_expected.to be_nil }
     end
 
     context "when a != specifier was used" do
-      let(:old_requirement) { Gem::Requirement.new("!= 1.5.0") }
-      its(:requirement) { is_expected.to be_nil }
+      let(:old_requirement) { "!= 1.5.0" }
+      its(:version) { is_expected.to be_nil }
     end
 
     context "when a >= specifier was used" do
-      let(:old_requirement) { Gem::Requirement.new(">= 1.6.0") }
-      its(:requirement) { is_expected.to be_nil }
+      let(:old_requirement) { ">= 1.6.0" }
+      its(:version) { is_expected.to be_nil }
     end
 
     context "when a > specifier was used" do
-      let(:old_requirement) { Gem::Requirement.new("> 1.6.0") }
-      its(:requirement) { is_expected.to be_nil }
+      let(:old_requirement) { "> 1.6.0" }
+      its(:version) { is_expected.to be_nil }
     end
   end
 end

--- a/spec/dependabot/update_checkers/ruby/gemspec_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/gemspec_spec.rb
@@ -59,6 +59,11 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Gemspec do
     context "when the existing requirement blocks the latest version" do
       let(:old_requirement) { Gem::Requirement.new("<= 1.3.0") }
       it { is_expected.to eq(true) }
+
+      context "but we don't know how to fix it" do
+        let(:old_requirement) { Gem::Requirement.new("!= 1.5.0") }
+        it { is_expected.to eq(false) }
+      end
     end
   end
 
@@ -88,7 +93,28 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Gemspec do
     context "when a ~> specifier was used" do
       let(:old_requirement) { Gem::Requirement.new("~> 1.4.0") }
       its(:requirement) do
-        is_expected.to eq(Gem::Requirement.new(">= 1.4.0", "< 1.6.0"))
+        is_expected.to eq(Gem::Requirement.new(">= 1.4", "< 1.6"))
+      end
+
+      context "with two zeros" do
+        let(:old_requirement) { Gem::Requirement.new("~> 1.0.0") }
+        its(:requirement) do
+          is_expected.to eq(Gem::Requirement.new(">= 1.0", "< 1.6"))
+        end
+      end
+
+      context "with no zeros" do
+        let(:old_requirement) { Gem::Requirement.new("~> 1.0.1") }
+        its(:requirement) do
+          is_expected.to eq(Gem::Requirement.new(">= 1.0.1", "< 1.6.0"))
+        end
+      end
+
+      context "with minor precision" do
+        let(:old_requirement) { Gem::Requirement.new("~> 0.1") }
+        its(:requirement) do
+          is_expected.to eq(Gem::Requirement.new(">= 0.1", "< 2.0"))
+        end
       end
     end
 

--- a/spec/dependabot/update_checkers/ruby/gemspec_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/gemspec_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/update_checkers/ruby/gemspec"
+require_relative "../shared_examples_for_update_checkers"
+
+RSpec.describe Dependabot::UpdateCheckers::Ruby::Gemspec do
+  it_behaves_like "an update checker"
+
+  let(:checker) do
+    described_class.new(
+      dependency: dependency,
+      dependency_files: [],
+      github_access_token: "token"
+    )
+  end
+
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "business",
+      version: "1.3.0",
+      requirement: old_requirement,
+      package_manager: "gemspec"
+    )
+  end
+  let(:old_requirement) { Gem::Requirement.new(">= 1.0.0") }
+
+  before do
+    stub_request(:get, "https://rubygems.org/api/v1/gems/business.json").
+      to_return(status: 200, body: fixture("ruby", "rubygems_response.json"))
+  end
+
+  describe "#latest_version" do
+    subject { checker.latest_version }
+
+    it { is_expected.to eq(Gem::Version.new("1.5.0")) }
+
+    it "only hits Rubygems once" do
+      checker.latest_version
+
+      expect(WebMock).
+        to have_requested(
+          :get,
+          "https://rubygems.org/api/v1/gems/business.json"
+        ).once
+    end
+  end
+
+  describe "#latest_resolvable_version" do
+    subject { checker.latest_version }
+    it { is_expected.to eq(Gem::Version.new("1.5.0")) }
+  end
+
+  describe "needs_update?" do
+    subject { checker.needs_update? }
+
+    it { is_expected.to eq(false) }
+
+    context "when the existing requirement blocks the latest version" do
+      let(:old_requirement) { Gem::Requirement.new("<= 1.3.0") }
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  describe "#updated_dependency" do
+    subject { checker.updated_dependency }
+
+    context "when an = specifier was used" do
+      let(:old_requirement) { Gem::Requirement.new("= 1.4.0") }
+      its(:requirement) { is_expected.to eq(Gem::Requirement.new("= 1.5.0")) }
+    end
+
+    context "when no specifier was used" do
+      let(:old_requirement) { Gem::Requirement.new("1.4.0") }
+      its(:requirement) { is_expected.to eq(Gem::Requirement.new("1.5.0")) }
+    end
+
+    context "when a < specifier was used" do
+      let(:old_requirement) { Gem::Requirement.new("< 1.4.0") }
+      its(:requirement) { is_expected.to eq(Gem::Requirement.new("< 1.6.0")) }
+    end
+
+    context "when a <= specifier was used" do
+      let(:old_requirement) { Gem::Requirement.new("<= 1.4.0") }
+      its(:requirement) { is_expected.to eq(Gem::Requirement.new("<= 1.6.0")) }
+    end
+
+    context "when a ~> specifier was used" do
+      let(:old_requirement) { Gem::Requirement.new("~> 1.4.0") }
+      its(:requirement) do
+        is_expected.to eq(Gem::Requirement.new(">= 1.4.0", "< 1.6.0"))
+      end
+    end
+
+    context "when there are multiple requirements" do
+      let(:old_requirement) { Gem::Requirement.new("> 1.0.0", "<= 1.4.0") }
+      its(:requirement) do
+        is_expected.to eq(Gem::Requirement.new("> 1.0.0", "<= 1.6.0"))
+      end
+    end
+  end
+end

--- a/spec/fixtures/github/business_files_no_gemspec.json
+++ b/spec/fixtures/github/business_files_no_gemspec.json
@@ -1,0 +1,130 @@
+[
+    {
+        "name": ".gitignore",
+        "path": ".gitignore",
+        "sha": "d87d4be66f458acd52878902bbf1391732ad21e1",
+        "size": 154,
+        "url": "https://api.github.com/repos/gocardless/business/contents/.gitignore?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/.gitignore",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/d87d4be66f458acd52878902bbf1391732ad21e1",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/.gitignore",
+        "type": "file",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/.gitignore?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/d87d4be66f458acd52878902bbf1391732ad21e1",
+            "html": "https://github.com/gocardless/business/blob/master/.gitignore"
+        }
+    },
+    {
+        "name": ".travis.yml",
+        "path": ".travis.yml",
+        "sha": "f43cdbe6b5209ece7ba65b452e1a70e64799a069",
+        "size": 104,
+        "url": "https://api.github.com/repos/gocardless/business/contents/.travis.yml?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/.travis.yml",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/f43cdbe6b5209ece7ba65b452e1a70e64799a069",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/.travis.yml",
+        "type": "file",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/.travis.yml?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/f43cdbe6b5209ece7ba65b452e1a70e64799a069",
+            "html": "https://github.com/gocardless/business/blob/master/.travis.yml"
+        }
+    },
+    {
+        "name": "CHANGELOG.md",
+        "path": "CHANGELOG.md",
+        "sha": "07d18f5e02c002bfbca35e51ec4b5ec1faddeb75",
+        "size": 403,
+        "url": "https://api.github.com/repos/gocardless/business/contents/CHANGELOG.md?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/CHANGELOG.md",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/07d18f5e02c002bfbca35e51ec4b5ec1faddeb75",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/CHANGELOG.md",
+        "type": "file",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/CHANGELOG.md?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/07d18f5e02c002bfbca35e51ec4b5ec1faddeb75",
+            "html": "https://github.com/gocardless/business/blob/master/CHANGELOG.md"
+        }
+    },
+    {
+        "name": "Gemfile",
+        "path": "Gemfile",
+        "sha": "a7c2a571018c7994b7e18e6ab67bfee11efa60c5",
+        "size": 93,
+        "url": "https://api.github.com/repos/gocardless/business/contents/Gemfile?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/Gemfile",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/a7c2a571018c7994b7e18e6ab67bfee11efa60c5",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/Gemfile",
+        "type": "file",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/Gemfile?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/a7c2a571018c7994b7e18e6ab67bfee11efa60c5",
+            "html": "https://github.com/gocardless/business/blob/master/Gemfile"
+        }
+    },
+    {
+        "name": "LICENSE",
+        "path": "LICENSE",
+        "sha": "f06f3849f61f2c6b0c0188e900548d3dc458ec5f",
+        "size": 1054,
+        "url": "https://api.github.com/repos/gocardless/business/contents/LICENSE?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/LICENSE",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/f06f3849f61f2c6b0c0188e900548d3dc458ec5f",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/LICENSE",
+        "type": "file",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/LICENSE?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/f06f3849f61f2c6b0c0188e900548d3dc458ec5f",
+            "html": "https://github.com/gocardless/business/blob/master/LICENSE"
+        }
+    },
+    {
+        "name": "README.md",
+        "path": "README.md",
+        "sha": "f3b764a5099ffa9f52a7e1799e85bd8171036cbb",
+        "size": 4187,
+        "url": "https://api.github.com/repos/gocardless/business/contents/README.md?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/README.md",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/f3b764a5099ffa9f52a7e1799e85bd8171036cbb",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/README.md",
+        "type": "file",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/README.md?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/f3b764a5099ffa9f52a7e1799e85bd8171036cbb",
+            "html": "https://github.com/gocardless/business/blob/master/README.md"
+        }
+    },
+    {
+        "name": "lib",
+        "path": "lib",
+        "sha": "9a243198d483ad8407f8ee38d8e5bb1b18564d8f",
+        "size": 0,
+        "url": "https://api.github.com/repos/gocardless/business/contents/lib?ref=master",
+        "html_url": "https://github.com/gocardless/business/tree/master/lib",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/trees/9a243198d483ad8407f8ee38d8e5bb1b18564d8f",
+        "download_url": null,
+        "type": "dir",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/lib?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/trees/9a243198d483ad8407f8ee38d8e5bb1b18564d8f",
+            "html": "https://github.com/gocardless/business/tree/master/lib"
+        }
+    },
+    {
+        "name": "spec",
+        "path": "spec",
+        "sha": "ddaa472673172f2407888ec366282a08b23f681c",
+        "size": 0,
+        "url": "https://api.github.com/repos/gocardless/business/contents/spec?ref=master",
+        "html_url": "https://github.com/gocardless/business/tree/master/spec",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/trees/ddaa472673172f2407888ec366282a08b23f681c",
+        "download_url": null,
+        "type": "dir",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/spec?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/trees/ddaa472673172f2407888ec366282a08b23f681c",
+            "html": "https://github.com/gocardless/business/tree/master/spec"
+        }
+    }
+]

--- a/spec/fixtures/github/business_gemspec.json
+++ b/spec/fixtures/github/business_gemspec.json
@@ -1,0 +1,18 @@
+{
+    "name": "business.gemspec",
+    "path": "business.gemspec",
+    "sha": "dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+    "size": 291,
+    "url": "https://api.github.com/repos/gocardless/bump/contents/business.gemspec?ref=master",
+    "html_url": "https://github.com/gocardless/bump/blob/master/business.gemspec",
+    "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+    "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/business.gemspec?token=ABF4KfGg6a7sE1n1i2rrhUvqAKRhIkPiks5WD8X5wA%3D%3D",
+    "type": "file",
+    "content": "IyBmcm96ZW5fc3RyaW5nX2xpdGVyYWw6IHRydWUKbGliID0gRmlsZS5leHBhbmRfcGF0aCgiLi4vbGliIiwgX19GSUxFX18pCiRMT0FEX1BBVEgudW5zaGlmdChsaWIpIHVubGVzcyAkTE9BRF9QQVRILmluY2x1ZGU/KGxpYikKcmVxdWlyZSAiRW5nbGlzaCIKcmVxdWlyZSAiYnVtcC92ZXJzaW9uIgoKc3VtbWFyeSA9ICJBdXRvbWF0ZWQgZGVwZW5kZW5jeSBtYW5hZ2VtZW50IGZvciBSdWJ5LCBQeXRob24gYW5kIEphdmFzY3JpcHQiCgpHZW06OlNwZWNpZmljYXRpb24ubmV3IGRvIHxzcGVjfAogIHNwZWMubmFtZSAgICAgICAgICA9ICJidW1wLWNvcmUiCiAgc3BlYy52ZXJzaW9uICAgICAgID0gQnVtcDo6VkVSU0lPTgogIHNwZWMuYXV0aG9ycyAgICAgICA9IFsiR29DYXJkbGVzcyJdCiAgc3BlYy5lbWFpbCAgICAgICAgID0gWyJlbmdpbmVlcmluZ0Bnb2NhcmRsZXNzLmNvbSJdCiAgc3BlYy5zdW1tYXJ5ICAgICAgID0gc3VtbWFyeQogIHNwZWMuZGVzY3JpcHRpb24gICA9IHN1bW1hcnkKICBzcGVjLmhvbWVwYWdlICAgICAgPSAiaHR0cHM6Ly9naXRodWIuY29tL2dvY2FyZGxlc3MvYnVtcC1jb3JlIgogIHNwZWMubGljZW5zZXMgICAgICA9IFsiTUlUIl0KCiAgc3BlYy5maWxlcyAgICAgICAgID0gYGdpdCBscy1maWxlc2Auc3BsaXQoJElOUFVUX1JFQ09SRF9TRVBBUkFUT1IpCiAgc3BlYy5leGVjdXRhYmxlcyAgID0gc3BlYy5maWxlcy5ncmVwKCVye15iaW4vfSkgeyB8ZnwgRmlsZS5iYXNlbmFtZShmKSB9CiAgc3BlYy50ZXN0X2ZpbGVzICAgID0gc3BlYy5maWxlcy5ncmVwKCVye14odGVzdHxzcGVjfGZlYXR1cmVzKS99KQogIHNwZWMucmVxdWlyZV9wYXRocyA9IFsibGliIl0KCiAgc3BlYy5hZGRfZGVwZW5kZW5jeSAiYnVuZGxlciIsICI+PSAxLjEyLjAiCiAgc3BlYy5hZGRfZGVwZW5kZW5jeSAiZXhjb24iLCAifj4gMC41NSIKICBzcGVjLmFkZF9kZXBlbmRlbmN5ICJnZW1uYXNpdW0tcGFyc2VyIiwgIn4+IDAuMSIKICBzcGVjLmFkZF9kZXBlbmRlbmN5ICJnZW1zIiwgIn4+IDEuMCIKICBzcGVjLmFkZF9kZXBlbmRlbmN5ICJvY3Rva2l0IiwgIn4+IDQuNiIKCiAgc3BlYy5hZGRfZGV2ZWxvcG1lbnRfZGVwZW5kZW5jeSAid2VibW9jayIsICJ+PiAyLjMuMSIKICBzcGVjLmFkZF9kZXZlbG9wbWVudF9kZXBlbmRlbmN5ICJyc3BlYyIsICJ+PiAzLjUuMCIKICBzcGVjLmFkZF9kZXZlbG9wbWVudF9kZXBlbmRlbmN5ICJyc3BlYy1pdHMiLCAifj4gMS4yLjAiCiAgc3BlYy5hZGRfZGV2ZWxvcG1lbnRfZGVwZW5kZW5jeSAicnVib2NvcCIsICJ+PiAwLjQ4LjAiCiAgc3BlYy5hZGRfZGV2ZWxvcG1lbnRfZGVwZW5kZW5jeSAicmFrZSIKZW5kCg==",
+    "encoding": "base64",
+    "_links": {
+        "self": "https://api.github.com/repos/gocardless/bump/contents/business.gemspec?ref=master",
+        "git": "https://api.github.com/repos/gocardless/bump/git/blobs/dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+        "html": "https://github.com/gocardless/bump/blob/master/business.gemspec"
+    }
+}

--- a/spec/fixtures/ruby/gemspecs/unevaluatable
+++ b/spec/fixtures/ruby/gemspecs/unevaluatable
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = bad_code
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency "bundler", ">= 1.12.0"
+  spec.add_dependency "excon", "~> 0.55"
+  spec.add_dependency "gemnasium-parser", "~> 0.1"
+  spec.add_dependency "gems", "~> 1.0"
+  spec.add_dependency "octokit", "~> 4.6"
+  spec.add_dependency "gitlab", "~> 4.1"
+
+  spec.add_development_dependency "webmock", "~> 2.3.1"
+  spec.add_development_dependency "rspec", "~> 3.5.0"
+  spec.add_development_dependency "rspec-its", "~> 1.2.0"
+  spec.add_development_dependency "rubocop", "~> 0.48.0"
+  spec.add_development_dependency "rake"
+end


### PR DESCRIPTION
Following https://github.com/dependabot/feedback/issues/14, it would be nice to create pull requests for library-maintainers to help keep their `gemspec` up-to-date.

I *think* the best way to do this is to treat it in the same way that we would a package manager. Since libraries generally won't have a `Gemfile.lock` they need to be treated very differently to the existing Ruby flow (which relies on parsing that lockfile in several places).

TODO:
- [x] Better error handling in `UpdateChecker` (don't abuse `ArgumentError`)
- [x] Better error handling in `FileParser` (raise `NotEvaluable` errors if simple cleaning doesn't work)
- [x] More specs for `UpdateChecker` (in particular, for `updated_dependency#updated_requirement`)
- [x] Consider populating `requirement` in other languages. At least add a TODO to clean it up
- [x] Pull request text will need to change
- [ ] Think through alternative to `FileFetcher.required_files`, or at least stop relying on it in `Gemspec` classes
- [ ] Naming...