### PR TITLE
Patch Bundler to use HTTPS instead of SSH for git sources hosted on GitHub

### DIFF
--- a/lib/bundler_git_source_patch.rb
+++ b/lib/bundler_git_source_patch.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+module Bundler
+  class Source
+    class Git
+      class GitProxy
+        private
+
+        # Bundler allows ssh authentication when talking to GitHub but there's
+        # no way for Dependabot to do so (it doesn't have any ssh keys).
+        # Instead, we convert all `git@github.com:` URLs to use HTTPS.
+        def configured_uri_for(uri)
+          uri = uri.gsub("git@github.com:", "https://github.com/")
+          if /https?:/ =~ uri
+            remote = URI(uri)
+            config_auth =
+              Bundler.settings[remote.to_s] || Bundler.settings[remote.host]
+            remote.userinfo ||= config_auth
+            remote.to_s
+          else
+            uri
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dependabot/file_updaters/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_updaters/ruby/bundler_spec.rb
@@ -295,6 +295,8 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
 
             expect(new_remote_line).to eq(original_remote_line)
             expect(new_revision_line).to eq(original_revision_line)
+            expect(new_lock.index(new_remote_line)).
+              to eq(old_lock.index(original_remote_line))
           end
         end
       end

--- a/spec/dependabot/update_checkers/ruby/bundler_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler_spec.rb
@@ -577,7 +577,7 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
               to raise_error do |error|
                 expect(error).to be_a(Dependabot::GitDependenciesNotReachable)
                 expect(error.dependency_urls).
-                  to eq(["https://github.com/fundingcircle/prius"])
+                  to eq(["git@github.com:fundingcircle/prius"])
               end
           end
         end

--- a/spec/fixtures/ruby/gemfiles/private_git_source
+++ b/spec/fixtures/ruby/gemfiles/private_git_source
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 
 gem "business", "~> 1.4.0"
 gem "statesman", "~> 1.2.0"
-gem "prius", git: "https://github.com/fundingcircle/prius"
+gem "prius", git: "git@github.com:fundingcircle/prius"

--- a/spec/fixtures/ruby/lockfiles/private_git_source.lock
+++ b/spec/fixtures/ruby/lockfiles/private_git_source.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/fundingcircle/prius
+  remote: git@github.com:fundingcircle/prius
   revision: cff701b3bfb182afc99a85657d7c9f3d6c1ccce2
   specs:
     prius (1.0.0)


### PR DESCRIPTION
Fixes a `Gemfile.lock` reordering bug.

Frustratingly, this is extremely hard to spec - ideally we want to have an actual private repo on GitHub, and a corresponding access token stored in the spec suite, but that just not going to happen.