### PR TITLE
Better requirements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Style/DotPosition:
   EnforcedStyle: trailing
 
 Metrics/ClassLength:
-  Max: 350
+  Max: 250
 
 Metrics/LineLength:
   Max: 80

--- a/lib/dependabot/dependency.rb
+++ b/lib/dependabot/dependency.rb
@@ -21,18 +21,20 @@ module Dependabot
         raise ArgumentError, "blank strings must not be provided as versions"
       end
 
-      unless requirements.is_a?(Array) &&
-             requirements.all? { |r| r.is_a?(Hash) }
+      requirement_fields = [requirements, previous_requirements].compact
+      unless requirement_fields.all? { |r| r.is_a?(Array) } &&
+             requirement_fields.flatten.all? { |r| r.is_a?(Hash) }
         raise ArgumentError, "requirements must be an array of hashes"
       end
 
       required_keys = %i(requirement file groups)
-      unless requirements.all? { |r| (r.keys - required_keys).empty? }
+      unless requirement_fields.flatten.
+             all? { |r| (r.keys - required_keys).empty? }
         raise ArgumentError, "each requirement must have the following "\
                              "required keys: #{required_keys.join(', ')}."
       end
 
-      return unless [requirements, previous_requirements].any? { |r| r == "" }
+      return if requirement_fields.flatten.none? { |r| r[:requirement] == "" }
       raise ArgumentError, "blank strings must not be provided as requirements"
     end
 

--- a/lib/dependabot/dependency.rb
+++ b/lib/dependabot/dependency.rb
@@ -8,13 +8,27 @@ module Dependabot
                    previous_version: nil, previous_requirements: nil)
       @name = name
       @version = version
-      @requirements = requirements
+      @requirements = requirements.map { |req| symbolize_keys(req) }
       @previous_version = previous_version
-      @previous_requirements = previous_requirements
+      @previous_requirements =
+        previous_requirements&.map { |req| symbolize_keys(req) }
       @package_manager = package_manager
 
       check_values
     end
+
+    def to_h
+      {
+        "name" => name,
+        "version" => version,
+        "requirements" => requirements,
+        "previous_version" => previous_version,
+        "previous_requirements" => previous_requirements,
+        "package_manager" => package_manager
+      }
+    end
+
+    private
 
     def check_values
       if [version, previous_version].any? { |v| v == "" }
@@ -38,15 +52,8 @@ module Dependabot
       raise ArgumentError, "blank strings must not be provided as requirements"
     end
 
-    def to_h
-      {
-        "name" => name,
-        "version" => version,
-        "requirements" => requirements,
-        "previous_version" => previous_version,
-        "previous_requirements" => previous_requirements,
-        "package_manager" => package_manager
-      }
+    def symbolize_keys(hash)
+      Hash[hash.map { |k, v| [k.to_sym, v] }]
     end
   end
 end

--- a/lib/dependabot/dependency.rb
+++ b/lib/dependabot/dependency.rb
@@ -1,32 +1,38 @@
 # frozen_string_literal: true
 module Dependabot
   class Dependency
-    attr_reader :name, :version, :requirement, :package_manager, :groups,
-                :previous_version, :previous_requirement
+    attr_reader :name, :version, :requirements, :package_manager,
+                :previous_version, :previous_requirements
 
-    def initialize(name:, requirement:, package_manager:, groups:, version: nil,
-                   previous_version: nil, previous_requirement: nil)
+    def initialize(name:, requirements:, package_manager:, version: nil,
+                   previous_version: nil, previous_requirements: nil)
       @name = name
       @version = version
-      @requirement = requirement
+      @requirements = requirements
       @previous_version = previous_version
-      @previous_requirement = previous_requirement
+      @previous_requirements = previous_requirements
       @package_manager = package_manager
-      @groups = groups
 
       check_values
     end
 
     def check_values
-      unless groups.instance_of?(Array)
-        raise ArgumentError, "groups must be and array"
-      end
-
       if [version, previous_version].any? { |v| v == "" }
         raise ArgumentError, "blank strings must not be provided as versions"
       end
 
-      return unless [requirement, previous_requirement].any? { |r| r == "" }
+      unless requirements.is_a?(Array) &&
+             requirements.all? { |r| r.is_a?(Hash) }
+        raise ArgumentError, "requirements must be an array of hashes"
+      end
+
+      required_keys = %i(requirement file groups)
+      unless requirements.all? { |r| (r.keys - required_keys).empty? }
+        raise ArgumentError, "each requirement must have the following "\
+                             "required keys: #{required_keys.join(', ')}."
+      end
+
+      return unless [requirements, previous_requirements].any? { |r| r == "" }
       raise ArgumentError, "blank strings must not be provided as requirements"
     end
 
@@ -34,11 +40,10 @@ module Dependabot
       {
         "name" => name,
         "version" => version,
-        "requirement" => requirement,
+        "requirements" => requirements,
         "previous_version" => previous_version,
-        "previous_requirement" => previous_requirement,
-        "package_manager" => package_manager,
-        "groups" => groups
+        "previous_requirements" => previous_requirements,
+        "package_manager" => package_manager
       }
     end
   end

--- a/lib/dependabot/file_parsers/java_script/yarn.rb
+++ b/lib/dependabot/file_parsers/java_script/yarn.rb
@@ -18,7 +18,7 @@ module Dependabot
               package_manager: "yarn",
               requirements: [{
                 requirement: parsed_package_json.dig(dep_group, dep["name"]),
-                file: "yarn.lock",
+                file: "package.json",
                 groups: [dep_group]
               }]
             )

--- a/lib/dependabot/file_parsers/java_script/yarn.rb
+++ b/lib/dependabot/file_parsers/java_script/yarn.rb
@@ -16,8 +16,11 @@ module Dependabot
               name: dep["name"],
               version: dep["version"],
               package_manager: "yarn",
-              requirement: parsed_package_json.dig(dep_group, dep["name"]),
-              groups: [dep_group]
+              requirements: [{
+                requirement: parsed_package_json.dig(dep_group, dep["name"]),
+                file: "yarn.lock",
+                groups: [dep_group]
+              }]
             )
           end
         end

--- a/lib/dependabot/file_parsers/php/composer.rb
+++ b/lib/dependabot/file_parsers/php/composer.rb
@@ -30,9 +30,12 @@ module Dependabot
             Dependency.new(
               name: name,
               version: dependency_version(name),
-              requirement: requirement,
-              package_manager: "composer",
-              groups: []
+              requirements: [{
+                requirement: requirement,
+                file: "composer.json",
+                groups: []
+              }],
+              package_manager: "composer"
             )
           end.compact
         end

--- a/lib/dependabot/file_parsers/python/pip.rb
+++ b/lib/dependabot/file_parsers/python/pip.rb
@@ -13,9 +13,12 @@ module Dependabot
             Dependency.new(
               name: dep["name"],
               version: dep["version"],
-              requirement: dep["requirement"],
-              package_manager: "pip",
-              groups: []
+              requirements: [{
+                requirement: dep["requirement"],
+                file: "requirements.txt",
+                groups: []
+              }],
+              package_manager: "pip"
             )
           end
         end

--- a/lib/dependabot/file_updaters/ruby/bundler.rb
+++ b/lib/dependabot/file_updaters/ruby/bundler.rb
@@ -235,7 +235,8 @@ module Dependabot
           quote_character = original_requirement.include?("'") ? "'" : '"'
 
           formatted_new_requirement =
-            dependency.requirement.split(",").
+            dependency.requirements.find { |r| r[:file].end_with?(".gemspec") }.
+            fetch(:requirement).split(",").
             map { |r| %(#{quote_character}#{r.strip}#{quote_character}) }.
             join(", ")
 

--- a/lib/dependabot/update_checkers/base.rb
+++ b/lib/dependabot/update_checkers/base.rb
@@ -17,7 +17,7 @@ module Dependabot
           version_needs_update?
         else
           # If the dependency has no version it means we're updating a library.
-          requirement_needs_update?
+          requirements_need_update?
         end
       end
 
@@ -27,11 +27,10 @@ module Dependabot
         Dependency.new(
           name: dependency.name,
           version: latest_resolvable_version.to_s,
-          requirement: updated_requirement,
+          requirements: updated_requirements,
           previous_version: dependency.version,
-          previous_requirement: dependency.requirement,
-          package_manager: dependency.package_manager,
-          groups: dependency.groups
+          previous_requirements: dependency.requirements,
+          package_manager: dependency.package_manager
         )
       end
 
@@ -43,7 +42,7 @@ module Dependabot
         raise NotImplementedError
       end
 
-      def updated_requirement
+      def updated_requirements
         raise NotImplementedError
       end
 
@@ -62,14 +61,9 @@ module Dependabot
         latest_resolvable_version > Gem::Version.new(dependency.version)
       end
 
-      def requirement_needs_update?
-        original_requirement =
-          Gem::Requirement.new(*dependency.requirement.split(","))
-
-        return false if latest_version.nil?
-        return false if original_requirement.satisfied_by?(latest_version)
-
-        !updated_requirement.nil?
+      def requirements_need_update?
+        (updated_requirements - dependency.requirements).any? &&
+          updated_requirements.none? { |r| r[:requirement] == :unfixable }
       end
     end
   end

--- a/lib/dependabot/update_checkers/java_script/yarn.rb
+++ b/lib/dependabot/update_checkers/java_script/yarn.rb
@@ -17,18 +17,26 @@ module Dependabot
           latest_version
         end
 
-        def updated_requirement
-          return unless latest_resolvable_version
+        def updated_requirements
+          return dependency.requirements unless latest_resolvable_version
 
           version_regex = /[0-9]+(?:\.[A-Za-z0-9\-_]+)*/
-          dependency.requirement.sub(version_regex) do |old_version|
-            old_parts = old_version.split(".")
-            parts =
-              latest_resolvable_version.to_s.split(".").first(old_parts.count)
-            parts.map.with_index do |part, i|
-              old_parts[i].match?(/^x\b/) ? "x" : part
-            end.join(".")
-          end
+
+          updated_requirement =
+            dependency.requirements.first[:requirement].
+            sub(version_regex) do |old_version|
+              old_parts = old_version.split(".")
+              parts =
+                latest_resolvable_version.to_s.split(".").first(old_parts.count)
+              parts.map.with_index do |part, i|
+                old_parts[i].match?(/^x\b/) ? "x" : part
+              end.join(".")
+            end
+
+          [
+            dependency.requirements.first.
+              merge(requirement: updated_requirement)
+          ]
         end
 
         private

--- a/lib/dependabot/update_checkers/php/composer.rb
+++ b/lib/dependabot/update_checkers/php/composer.rb
@@ -18,14 +18,24 @@ module Dependabot
           @latest_resolvable_version ||= fetch_latest_resolvable_version
         end
 
-        def updated_requirement
-          return unless latest_resolvable_version
+        def updated_requirements
+          return dependency.requirements unless latest_resolvable_version
 
           version_regex = /[0-9]+(?:\.[a-zA-Z0-9]+)*/
-          dependency.requirement.sub(version_regex) do |old_version|
-            precision = old_version.split(".").count
-            latest_resolvable_version.to_s.split(".").first(precision).join(".")
-          end
+          updated_requirement =
+            dependency.requirements.first[:requirement].
+            sub(version_regex) do |old_version|
+              precision = old_version.split(".").count
+              latest_resolvable_version.to_s.
+                split(".").
+                first(precision).
+                join(".")
+            end
+
+          [
+            dependency.requirements.first.
+              merge(requirement: updated_requirement)
+          ]
         end
 
         private

--- a/lib/dependabot/update_checkers/python/pip.rb
+++ b/lib/dependabot/update_checkers/python/pip.rb
@@ -19,9 +19,11 @@ module Dependabot
           latest_version
         end
 
-        def updated_requirement
-          return unless latest_resolvable_version
-          dependency.requirement.
+        def updated_requirements
+          return dependency.requirements unless latest_resolvable_version
+
+          updated_requirement =
+            dependency.requirements.first[:requirement].
             sub(PythonRequirementLineParser::VERSION) do |ver|
               precision = ver.split(".").count
               latest_resolvable_version.to_s.
@@ -29,6 +31,11 @@ module Dependabot
                 first(precision).
                 join(".")
             end
+
+          [
+            dependency.requirements.first.
+              merge(requirement: updated_requirement)
+          ]
         end
 
         private

--- a/lib/dependabot/update_checkers/ruby/bundler.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler.rb
@@ -7,6 +7,7 @@ require "gems"
 require "gemnasium/parser"
 require "dependabot/file_updaters/ruby/bundler"
 require "dependabot/update_checkers/base"
+require "dependabot/update_checkers/ruby/bundler/requirements_updater"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
 
@@ -25,13 +26,12 @@ module Dependabot
         end
 
         def updated_requirements
-          dependency.requirements.map do |req|
-            case req[:file]
-            when "Gemfile" then updated_gemfile_requirement(req)
-            when /\.gemspec/ then updated_gemspec_requirement(req)
-            else raise "Unexpected file name: #{req[:file]}"
-            end
-          end
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            existing_version: dependency.version,
+            latest_version: latest_version&.to_s,
+            latest_resolvable_version: latest_resolvable_version&.to_s
+          ).updated_requirements
         end
 
         private
@@ -283,155 +283,6 @@ module Dependabot
             original_gem_declaration_string,
             updated_gem_declaration_string
           )
-        end
-
-        def updated_gemfile_requirement(req)
-          return req unless latest_resolvable_version
-
-          original_req = Gem::Requirement.new(req[:requirement].split(","))
-
-          if original_req.satisfied_by?(latest_resolvable_version) &&
-             dependency.version &&
-             latest_resolvable_version <= Gem::Version.new(dependency.version)
-            return req
-          end
-
-          new_req = req[:requirement].gsub(/<=?/, "~>")
-          new_req.sub!(Gemnasium::Parser::Patterns::VERSION) do |old_version|
-            version_at_same_precision(latest_resolvable_version, old_version)
-          end
-
-          req.dup.merge(requirement: new_req)
-        end
-
-        def version_at_same_precision(new_version, old_version)
-          precision = old_version.to_s.split(".").count
-          new_version.to_s.split(".").first(precision).join(".")
-        end
-
-        def updated_gemspec_requirement(req)
-          return req unless latest_version
-
-          requirements =
-            req[:requirement].split(",").map { |r| Gem::Requirement.new(r) }
-
-          if requirements.all? { |r| r.satisfied_by?(latest_version) }
-            return req
-          end
-
-          updated_requirements =
-            requirements.flat_map do |r|
-              next r if r.satisfied_by?(latest_version)
-              if req[:groups] == ["development"]
-                fixed_development_requirements(r)
-              else
-                fixed_requirements(r)
-              end
-            end
-
-          updated_requirements = binding_requirements(updated_requirements)
-          req.merge(requirement: updated_requirements.map(&:to_s).join(", "))
-        rescue UnfixableRequirement
-          req.merge(requirement: :unfixable)
-        end
-
-        def binding_requirements(requirements)
-          grouped_by_operator =
-            requirements.uniq.group_by { |r| r.requirements.first.first }
-
-          binding_reqs = grouped_by_operator.flat_map do |operator, reqs|
-            case operator
-            when "<", "<="
-              reqs.sort_by { |r| r.requirements.first.last }.first
-            when ">", ">="
-              reqs.sort_by { |r| r.requirements.first.last }.last
-            else requirements
-            end
-          end
-
-          binding_reqs.sort_by { |r| r.requirements.first.last }
-        end
-
-        def fixed_requirements(r)
-          op, version = r.requirements.first
-
-          if version.segments.any? { |s| !s.instance_of?(Integer) }
-            # Ignore constraints with non-integer values for now.
-            # TODO: Handle pre-release constraints properly.
-            raise UnfixableRequirement
-          end
-
-          case op
-          when "=", nil then [Gem::Requirement.new(">= #{version}")]
-          when "<", "<=" then [updated_greatest_version(r)]
-          when "~>" then updated_twidle_requirements(r)
-          when "!=", ">", ">=" then raise UnfixableRequirement
-          else raise "Unexpected operation for requirement: #{op}"
-          end
-        end
-
-        def fixed_development_requirements(r)
-          op, version = r.requirements.first
-
-          if version.segments.any? { |s| !s.instance_of?(Integer) }
-            # Ignore constraints with non-integer values for now.
-            # TODO: Handle pre-release constraints properly.
-            raise UnfixableRequirement
-          end
-
-          case op
-          when "=", nil then [Gem::Requirement.new("#{op} #{latest_version}")]
-          when "<", "<=" then [updated_greatest_version(r)]
-          when "~>" then
-            updated_version = version_at_same_precision(latest_version, version)
-            [Gem::Requirement.new("~> #{updated_version}")]
-          when "!=", ">", ">=" then raise UnfixableRequirement
-          else raise "Unexpected operation for requirement: #{op}"
-          end
-        end
-
-        def updated_twidle_requirements(requirement)
-          version = requirement.requirements.first.last
-
-          index_to_update = version.segments.count - 2
-
-          ub_segments = latest_version.segments
-          ub_segments << 0 while ub_segments.count <= index_to_update
-          ub_segments = ub_segments[0..index_to_update]
-          ub_segments[index_to_update] += 1
-
-          lb_segments = version.segments
-          lb_segments.pop while lb_segments.last.zero?
-
-          # Ensure versions have the same length as each other (cosmetic)
-          length = [lb_segments.count, ub_segments.count].max
-          lb_segments.fill(0, lb_segments.count...length)
-          ub_segments.fill(0, ub_segments.count...length)
-
-          [
-            Gem::Requirement.new(">= #{lb_segments.join('.')}"),
-            Gem::Requirement.new("< #{ub_segments.join('.')}")
-          ]
-        end
-
-        # Updates the version in a "<" or "<=" constraint to allow the latest
-        # version
-        def updated_greatest_version(requirement)
-          op, version = requirement.requirements.first
-
-          index_to_update =
-            version.segments.map.with_index { |seg, i| seg.zero? ? 0 : i }.max
-
-          new_segments = version.segments.map.with_index do |_, index|
-            if index < index_to_update
-              latest_version.segments[index]
-            elsif index == index_to_update
-              latest_version.segments[index] + 1
-            else 0
-            end
-          end
-
-          Gem::Requirement.new("#{op} #{new_segments.join('.')}")
         end
       end
     end

--- a/lib/dependabot/update_checkers/ruby/bundler/requirements_updater.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler/requirements_updater.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+require "gemnasium/parser"
+require "dependabot/update_checkers/base"
+
+module Dependabot
+  module UpdateCheckers
+    module Ruby
+      class Bundler < Dependabot::UpdateCheckers::Base
+        class RequirementsUpdater
+          class UnfixableRequirement < StandardError; end
+
+          attr_reader :requirements, :existing_version,
+                      :latest_version, :latest_resolvable_version
+
+          def initialize(requirements:, existing_version:,
+                         latest_version:, latest_resolvable_version:)
+            @requirements = requirements
+
+            if existing_version
+              @existing_version = Gem::Version.new(existing_version)
+            end
+
+            @latest_version = Gem::Version.new(latest_version) if latest_version
+
+            return unless latest_resolvable_version
+            @latest_resolvable_version =
+              Gem::Version.new(latest_resolvable_version)
+          end
+
+          def updated_requirements
+            requirements.map do |req|
+              case req[:file]
+              when "Gemfile" then updated_gemfile_requirement(req)
+              when /\.gemspec/ then updated_gemspec_requirement(req)
+              else raise "Unexpected file name: #{req[:file]}"
+              end
+            end
+          end
+
+          private
+
+          def updated_gemfile_requirement(req)
+            return req unless latest_resolvable_version
+
+            original_req = Gem::Requirement.new(req[:requirement].split(","))
+
+            if original_req.satisfied_by?(latest_resolvable_version) &&
+               (existing_version.nil? ||
+               latest_resolvable_version <= existing_version)
+              return req
+            end
+
+            new_req = req[:requirement].gsub(/<=?/, "~>")
+            new_req.sub!(Gemnasium::Parser::Patterns::VERSION) do |old_version|
+              at_same_precision(latest_resolvable_version, old_version)
+            end
+
+            req.dup.merge(requirement: new_req)
+          end
+
+          def at_same_precision(new_version, old_version)
+            precision = old_version.to_s.split(".").count
+            new_version.to_s.split(".").first(precision).join(".")
+          end
+
+          def updated_gemspec_requirement(req)
+            return req unless latest_version
+
+            requirements =
+              req[:requirement].split(",").map { |r| Gem::Requirement.new(r) }
+
+            if requirements.all? { |r| r.satisfied_by?(latest_version) }
+              return req
+            end
+
+            updated_requirements =
+              requirements.flat_map do |r|
+                next r if r.satisfied_by?(latest_version)
+                if req[:groups] == ["development"]
+                  fixed_development_requirements(r)
+                else
+                  fixed_requirements(r)
+                end
+              end
+
+            updated_requirements = binding_requirements(updated_requirements)
+            req.merge(requirement: updated_requirements.map(&:to_s).join(", "))
+          rescue UnfixableRequirement
+            req.merge(requirement: :unfixable)
+          end
+
+          def binding_requirements(requirements)
+            grouped_by_operator =
+              requirements.uniq.group_by { |r| r.requirements.first.first }
+
+            binding_reqs = grouped_by_operator.flat_map do |operator, reqs|
+              case operator
+              when "<", "<="
+                reqs.sort_by { |r| r.requirements.first.last }.first
+              when ">", ">="
+                reqs.sort_by { |r| r.requirements.first.last }.last
+              else requirements
+              end
+            end
+
+            binding_reqs.sort_by { |r| r.requirements.first.last }
+          end
+
+          def fixed_requirements(r)
+            op, version = r.requirements.first
+
+            if version.segments.any? { |s| !s.instance_of?(Integer) }
+              # Ignore constraints with non-integer values for now.
+              # TODO: Handle pre-release constraints properly.
+              raise UnfixableRequirement
+            end
+
+            case op
+            when "=", nil then [Gem::Requirement.new(">= #{version}")]
+            when "<", "<=" then [updated_greatest_version(r)]
+            when "~>" then updated_twidle_requirements(r)
+            when "!=", ">", ">=" then raise UnfixableRequirement
+            else raise "Unexpected operation for requirement: #{op}"
+            end
+          end
+
+          def fixed_development_requirements(r)
+            op, version = r.requirements.first
+
+            if version.segments.any? { |s| !s.instance_of?(Integer) }
+              # Ignore constraints with non-integer values for now.
+              # TODO: Handle pre-release constraints properly.
+              raise UnfixableRequirement
+            end
+
+            case op
+            when "=", nil then [Gem::Requirement.new("#{op} #{latest_version}")]
+            when "<", "<=" then [updated_greatest_version(r)]
+            when "~>" then
+              updated_version = at_same_precision(latest_version, version)
+              [Gem::Requirement.new("~> #{updated_version}")]
+            when "!=", ">", ">=" then raise UnfixableRequirement
+            else raise "Unexpected operation for requirement: #{op}"
+            end
+          end
+
+          def updated_twidle_requirements(requirement)
+            version = requirement.requirements.first.last
+
+            index_to_update = version.segments.count - 2
+
+            ub_segments = latest_version.segments
+            ub_segments << 0 while ub_segments.count <= index_to_update
+            ub_segments = ub_segments[0..index_to_update]
+            ub_segments[index_to_update] += 1
+
+            lb_segments = version.segments
+            lb_segments.pop while lb_segments.last.zero?
+
+            # Ensure versions have the same length as each other (cosmetic)
+            length = [lb_segments.count, ub_segments.count].max
+            lb_segments.fill(0, lb_segments.count...length)
+            ub_segments.fill(0, ub_segments.count...length)
+
+            [
+              Gem::Requirement.new(">= #{lb_segments.join('.')}"),
+              Gem::Requirement.new("< #{ub_segments.join('.')}")
+            ]
+          end
+
+          # Updates the version in a "<" or "<=" constraint to allow the latest
+          # version
+          def updated_greatest_version(requirement)
+            op, version = requirement.requirements.first
+
+            index_to_update =
+              version.segments.map.with_index { |seg, i| seg.zero? ? 0 : i }.max
+
+            new_segments = version.segments.map.with_index do |_, index|
+              if index < index_to_update
+                latest_version.segments[index]
+              elsif index == index_to_update
+                latest_version.segments[index] + 1
+              else 0
+              end
+            end
+
+            Gem::Requirement.new("#{op} #{new_segments.join('.')}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dependabot/dependency_spec.rb
+++ b/spec/dependabot/dependency_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "dependabot/dependency"
+
+RSpec.describe Dependabot::Dependency do
+  describe ".new" do
+    subject(:dependency) { described_class.new(args) }
+
+    let(:args) do
+      {
+        name: "dep",
+        requirements: [
+          { "file" => "a.rb", "requirement" => ">= 0", "groups" => [] }
+        ],
+        package_manager: "bundler"
+      }
+    end
+
+    it "converts string keys to symbols" do
+      expect(dependency.requirements).
+        to eq([{ file: "a.rb", requirement: ">= 0", groups: [] }])
+    end
+  end
+end

--- a/spec/dependabot/file_parsers/java_script/yarn_spec.rb
+++ b/spec/dependabot/file_parsers/java_script/yarn_spec.rb
@@ -35,8 +35,17 @@ RSpec.describe Dependabot::FileParsers::JavaScript::Yarn do
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("fetch-factory") }
         its(:version) { is_expected.to eq("0.0.1") }
-        its(:requirement) { is_expected.to eq("^0.0.1") }
-        its(:groups) { ["dependencies"] }
+        its(:requirements) do
+          is_expected.to eq(
+            [
+              {
+                requirement: "^0.0.1",
+                file: "yarn.lock",
+                groups: ["dependencies"]
+              }
+            ]
+          )
+        end
       end
     end
 
@@ -54,8 +63,17 @@ RSpec.describe Dependabot::FileParsers::JavaScript::Yarn do
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("etag") }
         its(:version) { is_expected.to eq("1.8.0") }
-        its(:requirement) { is_expected.to eq("^1.0.0") }
-        its(:groups) { ["devDependencies"] }
+        its(:requirements) do
+          is_expected.to eq(
+            [
+              {
+                requirement: "^1.0.0",
+                file: "yarn.lock",
+                groups: ["devDependencies"]
+              }
+            ]
+          )
+        end
       end
     end
   end

--- a/spec/dependabot/file_parsers/java_script/yarn_spec.rb
+++ b/spec/dependabot/file_parsers/java_script/yarn_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Dependabot::FileParsers::JavaScript::Yarn do
             [
               {
                 requirement: "^0.0.1",
-                file: "yarn.lock",
+                file: "package.json",
                 groups: ["dependencies"]
               }
             ]
@@ -68,7 +68,7 @@ RSpec.describe Dependabot::FileParsers::JavaScript::Yarn do
             [
               {
                 requirement: "^1.0.0",
-                file: "yarn.lock",
+                file: "package.json",
                 groups: ["devDependencies"]
               }
             ]

--- a/spec/dependabot/file_parsers/php/composer_spec.rb
+++ b/spec/dependabot/file_parsers/php/composer_spec.rb
@@ -40,7 +40,10 @@ RSpec.describe Dependabot::FileParsers::Php::Composer do
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("monolog/monolog") }
         its(:version) { is_expected.to eq("1.0.2") }
-        its(:requirement) { is_expected.to eq("1.0.*") }
+        its(:requirements) do
+          is_expected.
+            to eq([{ requirement: "1.0.*", file: "composer.json", groups: [] }])
+        end
       end
     end
 

--- a/spec/dependabot/file_parsers/python/pip_spec.rb
+++ b/spec/dependabot/file_parsers/python/pip_spec.rb
@@ -32,7 +32,15 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("psycopg2")
           expect(dependency.version).to eq("2.6.1")
-          expect(dependency.requirement).to eq("==2.6.1")
+          expect(dependency.requirements).to eq(
+            [
+              {
+                requirement: "==2.6.1",
+                file: "requirements.txt",
+                groups: []
+              }
+            ]
+          )
         end
       end
     end
@@ -50,7 +58,15 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("psycopg2")
           expect(dependency.version).to eq("2.6.1")
-          expect(dependency.requirement).to eq("==2.6.1")
+          expect(dependency.requirements).to eq(
+            [
+              {
+                requirement: "==2.6.1",
+                file: "requirements.txt",
+                groups: []
+              }
+            ]
+          )
         end
       end
     end
@@ -67,7 +83,15 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("psycopg2")
           expect(dependency.version).to eq("2.6.1")
-          expect(dependency.requirement).to eq("==2.6.1")
+          expect(dependency.requirements).to eq(
+            [
+              {
+                requirement: "==2.6.1",
+                file: "requirements.txt",
+                groups: []
+              }
+            ]
+          )
         end
       end
     end
@@ -128,7 +152,15 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("requests")
           expect(dependency.version).to eq("2.1.4")
-          expect(dependency.requirement).to eq("==2.1.4")
+          expect(dependency.requirements).to eq(
+            [
+              {
+                requirement: "==2.1.4",
+                file: "requirements.txt",
+                groups: []
+              }
+            ]
+          )
         end
       end
     end

--- a/spec/dependabot/file_parsers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/bundler_spec.rb
@@ -30,12 +30,18 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
 
       describe "the first dependency" do
         subject { dependencies.first }
+        let(:expected_requirements) do
+          [{
+            requirement: "~> 1.4.0",
+            file: "Gemfile",
+            groups: [:default]
+          }]
+        end
 
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("business") }
-        its(:requirement) { is_expected.to eq("~> 1.4.0") }
+        its(:requirements) { is_expected.to eq(expected_requirements) }
         its(:version) { is_expected.to eq("1.4.0") }
-        its(:groups) { is_expected.to eq(%i(default)) }
       end
     end
 
@@ -49,12 +55,18 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
 
       describe "the first dependency" do
         subject { dependencies.first }
+        let(:expected_requirements) do
+          [{
+            requirement: ">= 0",
+            file: "Gemfile",
+            groups: [:default]
+          }]
+        end
 
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("business") }
         its(:version) { is_expected.to eq("1.4.0") }
-        its(:requirement) { is_expected.to eq(">= 0") }
-        its(:groups) { is_expected.to eq(%i(default)) }
+        its(:requirements) { is_expected.to eq(expected_requirements) }
       end
     end
 
@@ -79,12 +91,18 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
 
       describe "the last dependency" do
         subject { dependencies.last }
+        let(:expected_requirements) do
+          [{
+            requirement: "~> 1.4.0",
+            file: "Gemfile",
+            groups: %i(development test)
+          }]
+        end
 
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("business") }
         its(:version) { is_expected.to eq("1.4.0") }
-        its(:requirement) { is_expected.to eq("~> 1.4.0") }
-        its(:groups) { is_expected.to eq(%i(development test)) }
+        its(:requirements) { is_expected.to eq(expected_requirements) }
       end
     end
 
@@ -142,12 +160,18 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
 
         describe "the last dependency" do
           subject { dependencies.last }
+          let(:expected_requirements) do
+            [{
+              requirement: "~> 4.1",
+              file: "example.gemspec",
+              groups: ["runtime"]
+            }]
+          end
 
           it { is_expected.to be_a(Dependabot::Dependency) }
           its(:name) { is_expected.to eq("gitlab") }
           its(:version) { is_expected.to eq("4.2.0") }
-          its(:requirement) { is_expected.to eq("~> 4.1") }
-          its(:groups) { is_expected.to eq(["runtime"]) }
+          its(:requirements) { is_expected.to eq(expected_requirements) }
         end
 
         context "that needs to be sanitized" do
@@ -179,6 +203,37 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
       let(:gemfile_content) { fixture("ruby", "gemfiles", "imports_gemspec") }
 
       its(:length) { is_expected.to eq(13) }
+
+      context "when a dependency appears in both" do
+        let(:gemspec_content) { fixture("ruby", "gemspecs", "small_example") }
+
+        its(:length) { is_expected.to eq(2) }
+
+        describe "the first dependency" do
+          subject { dependencies.first }
+          let(:expected_requirements) do
+            [
+              {
+                requirement: "~> 1.0",
+                file: "example.gemspec",
+                groups: ["runtime"]
+              },
+              {
+                requirement: "~> 1.4.0",
+                file: "Gemfile",
+                groups: [:default]
+              }
+            ]
+          end
+
+          it { is_expected.to be_a(Dependabot::Dependency) }
+          its(:name) { is_expected.to eq("business") }
+          its(:version) { is_expected.to be_nil }
+          its(:requirements) do
+            is_expected.to match_array(expected_requirements)
+          end
+        end
+      end
     end
 
     context "with only a gemspec" do
@@ -196,12 +251,18 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
 
       describe "the last dependency" do
         subject { dependencies.last }
+        let(:expected_requirements) do
+          [{
+            requirement: ">= 0",
+            file: "example.gemspec",
+            groups: ["development"]
+          }]
+        end
 
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("rake") }
         its(:version) { is_expected.to be_nil }
-        its(:requirement) { is_expected.to eq(">= 0") }
-        its(:groups) { is_expected.to eq(["development"]) }
+        its(:requirements) { is_expected.to eq(expected_requirements) }
       end
 
       context "that needs to be sanitized" do
@@ -218,12 +279,18 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
 
       describe "the first dependency" do
         subject { dependencies.first }
+        let(:expected_requirements) do
+          [{
+            requirement: "~> 1.4.0",
+            file: "Gemfile",
+            groups: [:default]
+          }]
+        end
 
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("business") }
         its(:version) { is_expected.to be_nil }
-        its(:requirement) { is_expected.to eq("~> 1.4.0") }
-        its(:groups) { is_expected.to eq([:default]) }
+        its(:requirements) { is_expected.to eq(expected_requirements) }
       end
     end
   end

--- a/spec/dependabot/file_updaters/base_spec.rb
+++ b/spec/dependabot/file_updaters/base_spec.rb
@@ -34,8 +34,9 @@ RSpec.describe Dependabot::FileUpdaters::Base do
       name: "business",
       version: "1.5.0",
       package_manager: "bundler",
-      requirement: "~> 1.4.0",
-      groups: []
+      requirements: [
+        { file: "Gemfile", requirement: "~> 1.4.0", groups: [] }
+      ]
     )
   end
   let(:github_access_token) { "token" }

--- a/spec/dependabot/file_updaters/java_script/yarn_spec.rb
+++ b/spec/dependabot/file_updaters/java_script/yarn_spec.rb
@@ -35,8 +35,9 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
       name: "fetch-factory",
       version: "0.0.2",
       package_manager: "yarn",
-      requirement: "^0.0.1",
-      groups: []
+      requirements: [
+        { file: "package.json", requirement: "^0.0.1", groups: [] }
+      ]
     )
   end
   let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
@@ -70,9 +71,10 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
           Dependabot::Dependency.new(
             name: "fetch-factory",
             version: "0.2.1",
-            requirement: "^0.0.1",
             package_manager: "yarn",
-            groups: []
+            requirements: [
+              { file: "package.json", requirement: "^0.0.1", groups: [] }
+            ]
           )
         end
         let(:package_json_body) do

--- a/spec/dependabot/file_updaters/php/composer_spec.rb
+++ b/spec/dependabot/file_updaters/php/composer_spec.rb
@@ -36,9 +36,10 @@ RSpec.describe Dependabot::FileUpdaters::Php::Composer do
     Dependabot::Dependency.new(
       name: "monolog/monolog",
       version: "1.22.1",
-      requirement: "1.22.*",
-      package_manager: "composer",
-      groups: []
+      requirements: [
+        { file: "composer.json", requirement: "1.22.*", groups: [] }
+      ],
+      package_manager: "composer"
     )
   end
   let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }

--- a/spec/dependabot/file_updaters/python/pip_spec.rb
+++ b/spec/dependabot/file_updaters/python/pip_spec.rb
@@ -29,9 +29,10 @@ RSpec.describe Dependabot::FileUpdaters::Python::Pip do
     Dependabot::Dependency.new(
       name: "psycopg2",
       version: "2.8.1",
-      requirement: "==2.8.1",
-      package_manager: "pip",
-      groups: []
+      requirements: [
+        { file: "requirements.txt", requirement: "==2.8.1", groups: [] }
+      ],
+      package_manager: "pip"
     )
   end
   let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }

--- a/spec/dependabot/file_updaters/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_updaters/ruby/bundler_spec.rb
@@ -53,9 +53,8 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
     Dependabot::Dependency.new(
       name: "business",
       version: "1.5.0",
-      requirement: "~> 1.5.0",
-      package_manager: "bundler",
-      groups: []
+      requirements: [{ file: "Gemfile", requirement: "~> 1.5.0", groups: [] }],
+      package_manager: "bundler"
     )
   end
   let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
@@ -117,9 +116,10 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
           Dependabot::Dependency.new(
             name: "i18n",
             version: "0.5.0",
-            requirement: "~> 0.5.0",
-            package_manager: "bundler",
-            groups: []
+            requirements: [
+              { file: "Gemfile", requirement: "~> 0.5.0", groups: [] }
+            ],
+            package_manager: "bundler"
           )
         end
         before do
@@ -204,9 +204,10 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
             Dependabot::Dependency.new(
               name: "public_suffix",
               version: "1.4.6",
-              requirement: "~> 1.4.0",
-              package_manager: "bundler",
-              groups: []
+              requirements: [
+                { file: "Gemfile", requirement: "~> 1.5.0", groups: [] }
+              ],
+              package_manager: "bundler"
             )
           end
 
@@ -367,9 +368,10 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
             Dependabot::Dependency.new(
               name: "statesman",
               version: "2.0.0",
-              requirement: ">= 1.0, < 3.0",
-              package_manager: "bundler",
-              groups: []
+              requirements: [
+                { file: "Gemfile", requirement: ">= 1.0, < 3.0", groups: [] }
+              ],
+              package_manager: "bundler"
             )
           end
 
@@ -384,9 +386,19 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
             Dependabot::Dependency.new(
               name: "business",
               version: "1.8.0",
-              requirement: requirement,
-              package_manager: "bundler",
-              groups: []
+              requirements: [
+                {
+                  file: "example.gemspec",
+                  requirement: requirement,
+                  groups: []
+                },
+                {
+                  file: "Gemfile",
+                  requirement: requirement,
+                  groups: []
+                }
+              ],
+              package_manager: "bundler"
             )
           end
           let(:requirement) { ">= 1.0, < 3.0" }
@@ -414,9 +426,14 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
               Dependabot::Dependency.new(
                 name: "json",
                 version: "2.0.3",
-                requirement: ">= 1.0, < 3.0",
-                package_manager: "bundler",
-                groups: []
+                requirements: [
+                  {
+                    file: "example.gemspec",
+                    requirement: ">= 1.0, < 3.0",
+                    groups: []
+                  }
+                ],
+                package_manager: "bundler"
               )
             end
 
@@ -451,9 +468,14 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
         Dependabot::Dependency.new(
           name: dependency_name,
           version: "5.1.0",
-          requirement: ">= 4.6, < 6.0",
-          package_manager: "bundler",
-          groups: []
+          requirements: [
+            {
+              file: "example.gemspec",
+              requirement: ">= 4.6, < 6.0",
+              groups: []
+            }
+          ],
+          package_manager: "bundler"
         )
       end
       let(:dependency_name) { "octokit" }
@@ -533,9 +555,14 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
         Dependabot::Dependency.new(
           name: dependency_name,
           version: "5.1.0",
-          requirement: ">= 4.6, < 6.0",
-          package_manager: "bundler",
-          groups: []
+          requirements: [
+            {
+              file: "example.gemspec",
+              requirement: ">= 4.6, < 6.0",
+              groups: []
+            }
+          ],
+          package_manager: "bundler"
         )
       end
       let(:dependency_name) { "octokit" }

--- a/spec/dependabot/metadata_finders/base_spec.rb
+++ b/spec/dependabot/metadata_finders/base_spec.rb
@@ -13,10 +13,9 @@ RSpec.describe Dependabot::MetadataFinders::Base do
     Dependabot::Dependency.new(
       name: dependency_name,
       version: dependency_version,
-      requirement: ">= 0",
+      requirements: [{ file: "Gemfile", requirement: ">= 0", groups: [] }],
       previous_version: dependency_previous_version,
-      package_manager: "bundler",
-      groups: []
+      package_manager: "bundler"
     )
   end
   let(:dependency_name) { "business" }

--- a/spec/dependabot/metadata_finders/java_script/yarn_spec.rb
+++ b/spec/dependabot/metadata_finders/java_script/yarn_spec.rb
@@ -12,9 +12,8 @@ RSpec.describe Dependabot::MetadataFinders::JavaScript::Yarn do
     Dependabot::Dependency.new(
       name: dependency_name,
       version: "1.0",
-      requirement: "^1.0",
-      package_manager: "yarn",
-      groups: []
+      requirements: [{ file: "package.json", requirement: "^1.0", groups: [] }],
+      package_manager: "yarn"
     )
   end
   subject(:finder) do

--- a/spec/dependabot/metadata_finders/php/composer_spec.rb
+++ b/spec/dependabot/metadata_finders/php/composer_spec.rb
@@ -12,9 +12,8 @@ RSpec.describe Dependabot::MetadataFinders::Php::Composer do
     Dependabot::Dependency.new(
       name: dependency_name,
       version: "1.0",
-      requirement: "1.*",
-      package_manager: "composer",
-      groups: []
+      requirements: [{ file: "composer.json", requirement: "1.*", groups: [] }],
+      package_manager: "composer"
     )
   end
   subject(:finder) do

--- a/spec/dependabot/metadata_finders/python/pip_spec.rb
+++ b/spec/dependabot/metadata_finders/python/pip_spec.rb
@@ -12,9 +12,10 @@ RSpec.describe Dependabot::MetadataFinders::Python::Pip do
     Dependabot::Dependency.new(
       name: dependency_name,
       version: "1.0",
-      requirement: "==1.0",
-      package_manager: "pip",
-      groups: []
+      requirements: [
+        { file: "requirements.txt", requirement: "=1.0", groups: [] }
+      ],
+      package_manager: "pip"
     )
   end
   subject(:finder) do

--- a/spec/dependabot/metadata_finders/ruby/bundler_spec.rb
+++ b/spec/dependabot/metadata_finders/ruby/bundler_spec.rb
@@ -12,9 +12,8 @@ RSpec.describe Dependabot::MetadataFinders::Ruby::Bundler do
     Dependabot::Dependency.new(
       name: dependency_name,
       version: "1.0",
-      requirement: ">= 0",
-      package_manager: "bundler",
-      groups: []
+      requirements: [{ file: "Gemfile", requirement: ">= 0", groups: [] }],
+      package_manager: "bundler"
     )
   end
   subject(:finder) do

--- a/spec/dependabot/pull_request_creator_spec.rb
+++ b/spec/dependabot/pull_request_creator_spec.rb
@@ -15,12 +15,13 @@ RSpec.describe Dependabot::PullRequestCreator do
   end
 
   let(:dependency) do
-    Dependabot::Dependency.new(name: "business",
-                               version: "1.5.0",
-                               previous_version: "1.4.0",
-                               package_manager: "bundler",
-                               requirement: "~> 1.4.0",
-                               groups: [])
+    Dependabot::Dependency.new(
+      name: "business",
+      version: "1.5.0",
+      previous_version: "1.4.0",
+      package_manager: "bundler",
+      requirements: [{ file: "Gemfile", requirement: "~> 1.4.0", groups: [] }]
+    )
   end
   let(:repo) { "gocardless/bump" }
   let(:files) { [gemfile, gemfile_lock] }
@@ -94,11 +95,14 @@ RSpec.describe Dependabot::PullRequestCreator do
   describe "#create" do
     context "without a previous version" do
       let(:dependency) do
-        Dependabot::Dependency.new(name: "business",
-                                   version: "1.5.0",
-                                   package_manager: "bundler",
-                                   requirement: "~> 1.4.0",
-                                   groups: [])
+        Dependabot::Dependency.new(
+          name: "business",
+          version: "1.5.0",
+          package_manager: "bundler",
+          requirements: [
+            { file: "Gemfile", requirement: "~> 1.4.0", groups: [] }
+          ]
+        )
       end
 
       it "errors out on initialization" do
@@ -192,22 +196,30 @@ RSpec.describe Dependabot::PullRequestCreator do
         )
       end
       let(:dependency) do
-        Dependabot::Dependency.new(name: "business",
-                                   version: "1.5.0",
-                                   requirement: ">= 1.0, < 3.0",
-                                   previous_requirement: "~> 1.4.0",
-                                   package_manager: "bundler",
-                                   groups: [])
+        Dependabot::Dependency.new(
+          name: "business",
+          version: "1.5.0",
+          package_manager: "bundler",
+          requirements: [
+            { file: "some.gemspec", requirement: ">= 1.0, < 3.0", groups: [] }
+          ],
+          previous_requirements: [
+            { file: "some.gemspec", requirement: "~> 1.4.0", groups: [] }
+          ]
+        )
       end
       let(:branch_name) { "dependabot/bundler/business-gte-1.0-and-lt-3.0" }
 
       context "without a previous requirement" do
         let(:dependency) do
-          Dependabot::Dependency.new(name: "business",
-                                     version: "1.5.0",
-                                     requirement: ">= 1.0, < 3.0",
-                                     package_manager: "bundler",
-                                     groups: [])
+          Dependabot::Dependency.new(
+            name: "business",
+            version: "1.5.0",
+            package_manager: "bundler",
+            requirements: [
+              { file: "some.gemspec", requirement: ">= 1.0, < 3.0", groups: [] }
+            ]
+          )
         end
 
         it "errors out on initialization" do
@@ -263,22 +275,30 @@ RSpec.describe Dependabot::PullRequestCreator do
     context "for a Gemfile only" do
       let(:files) { [gemfile] }
       let(:dependency) do
-        Dependabot::Dependency.new(name: "business",
-                                   version: "1.5.0",
-                                   requirement: "~> 1.5.0",
-                                   previous_requirement: "~> 1.4.0",
-                                   package_manager: "bundler",
-                                   groups: [])
+        Dependabot::Dependency.new(
+          name: "business",
+          version: "1.5.0",
+          package_manager: "bundler",
+          requirements: [
+            { file: "Gemfile", requirement: "~> 1.5.0", groups: [] }
+          ],
+          previous_requirements: [
+            { file: "Gemfile", requirement: "~> 1.4.0", groups: [] }
+          ]
+        )
       end
       let(:branch_name) { "dependabot/bundler/business-tw-1.5.0" }
 
       context "without a previous requirement" do
         let(:dependency) do
-          Dependabot::Dependency.new(name: "business",
-                                     version: "1.5.0",
-                                     requirement: ">= 1.0, < 3.0",
-                                     package_manager: "bundler",
-                                     groups: [])
+          Dependabot::Dependency.new(
+            name: "business",
+            version: "1.5.0",
+            package_manager: "bundler",
+            requirements: [
+              { file: "Gemfile", requirement: "~> 1.5.0", groups: [] }
+            ]
+          )
         end
 
         it "errors out on initialization" do

--- a/spec/dependabot/update_checkers/java_script/yarn_spec.rb
+++ b/spec/dependabot/update_checkers/java_script/yarn_spec.rb
@@ -25,9 +25,8 @@ RSpec.describe Dependabot::UpdateCheckers::JavaScript::Yarn do
     Dependabot::Dependency.new(
       name: "etag",
       version: "1.0.0",
-      requirement: "^1.0.0",
-      package_manager: "yarn",
-      groups: []
+      requirements: [{ file: "yarn.lock", requirement: "^1.0.0", groups: [] }],
+      package_manager: "yarn"
     )
   end
 
@@ -43,9 +42,10 @@ RSpec.describe Dependabot::UpdateCheckers::JavaScript::Yarn do
         Dependabot::Dependency.new(
           name: "etag",
           version: "1.7.0",
-          requirement: "^1.0.0",
-          package_manager: "yarn",
-          groups: []
+          requirements: [
+            { file: "yarn.lock", requirement: "^1.0.0", groups: [] }
+          ],
+          package_manager: "yarn"
         )
       end
 
@@ -64,9 +64,10 @@ RSpec.describe Dependabot::UpdateCheckers::JavaScript::Yarn do
         Dependabot::Dependency.new(
           name: "@blep/blep",
           version: "1.0.0",
-          requirement: "^1.0.0",
-          package_manager: "yarn",
-          groups: []
+          requirements: [
+            { file: "yarn.lock", requirement: "^1.0.0", groups: [] }
+          ],
+          package_manager: "yarn"
         )
       end
       it { is_expected.to be_truthy }
@@ -119,16 +120,17 @@ RSpec.describe Dependabot::UpdateCheckers::JavaScript::Yarn do
     end
   end
 
-  describe "#updated_requirement" do
-    subject { checker.updated_requirement }
+  describe "#updated_requirements" do
+    subject { checker.updated_requirements.first }
 
     let(:dependency) do
       Dependabot::Dependency.new(
         name: "etag",
         version: "1.0.0",
-        requirement: original_requirement,
-        package_manager: "yarn",
-        groups: []
+        requirements: [
+          { file: "yarn.lock", requirement: original_requirement, groups: [] }
+        ],
+        package_manager: "yarn"
       )
     end
 
@@ -143,7 +145,7 @@ RSpec.describe Dependabot::UpdateCheckers::JavaScript::Yarn do
 
     context "when there is no resolvable version" do
       let(:latest_resolvable_version) { nil }
-      it { is_expected.to be_nil }
+      its([:requirement]) { is_expected.to eq(original_requirement) }
     end
 
     context "when there is a resolvable version" do
@@ -151,37 +153,37 @@ RSpec.describe Dependabot::UpdateCheckers::JavaScript::Yarn do
 
       context "and a full version was previously specified" do
         let(:original_requirement) { "1.2.3" }
-        it { is_expected.to eq("1.5.0") }
+        its([:requirement]) { is_expected.to eq("1.5.0") }
       end
 
       context "and a partial version was previously specified" do
         let(:original_requirement) { "0.1" }
-        it { is_expected.to eq("1.5") }
+        its([:requirement]) { is_expected.to eq("1.5") }
       end
 
       context "and the new version has fewer digits than the old one§" do
         let(:original_requirement) { "1.1.0.1" }
-        it { is_expected.to eq("1.5.0") }
+        its([:requirement]) { is_expected.to eq("1.5.0") }
       end
 
       context "and a caret was previously specified" do
         let(:original_requirement) { "^1.2.3" }
-        it { is_expected.to eq("^1.5.0") }
+        its([:requirement]) { is_expected.to eq("^1.5.0") }
       end
 
       context "and a pre-release was previously specified" do
         let(:original_requirement) { "^1.2.3-rc1" }
-        it { is_expected.to eq("^1.5.0") }
+        its([:requirement]) { is_expected.to eq("^1.5.0") }
       end
 
       context "and an x.x was previously specified" do
         let(:original_requirement) { "^0.x.x-rc1" }
-        it { is_expected.to eq("^1.x.x") }
+        its([:requirement]) { is_expected.to eq("^1.x.x") }
       end
 
       context "and an x.x was previously specified with four places" do
         let(:original_requirement) { "^0.x.x.rc1" }
-        it { is_expected.to eq("^1.x.x") }
+        its([:requirement]) { is_expected.to eq("^1.x.x") }
       end
     end
   end

--- a/spec/dependabot/update_checkers/python/pip_spec.rb
+++ b/spec/dependabot/update_checkers/python/pip_spec.rb
@@ -26,9 +26,10 @@ RSpec.describe Dependabot::UpdateCheckers::Python::Pip do
     Dependabot::Dependency.new(
       name: "luigi",
       version: "2.0.0",
-      requirement: "==2.0.0",
-      package_manager: "pip",
-      groups: []
+      requirements: [
+        { file: "requirements.txt", requirement: "==2.0.0", groups: [] }
+      ],
+      package_manager: "pip"
     )
   end
 
@@ -44,9 +45,10 @@ RSpec.describe Dependabot::UpdateCheckers::Python::Pip do
         Dependabot::Dependency.new(
           name: "luigi",
           version: "2.6.0",
-          requirement: "==2.6.0",
-          package_manager: "pip",
-          groups: []
+          requirements: [
+            { file: "requirements.txt", requirement: "==2.6.0", groups: [] }
+          ],
+          package_manager: "pip"
         )
       end
       it { is_expected.to be_falsey }
@@ -82,8 +84,8 @@ RSpec.describe Dependabot::UpdateCheckers::Python::Pip do
     it { is_expected.to eq(Gem::Version.new("2.6.0")) }
   end
 
-  describe "#updated_requirement" do
-    subject { checker.updated_requirement }
-    it { is_expected.to eq("==2.6.0") }
+  describe "#updated_requirements" do
+    subject { checker.updated_requirements.first }
+    its([:requirement]) { is_expected.to eq("==2.6.0") }
   end
 end

--- a/spec/dependabot/update_checkers/ruby/bundler/requirements_updater_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler/requirements_updater_spec.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "dependabot/update_checkers/ruby/bundler/requirements_updater"
+
+RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler::RequirementsUpdater do
+  let(:updater) do
+    described_class.new(
+      requirements: requirements,
+      existing_version: existing_version,
+      latest_version: latest_version,
+      latest_resolvable_version: latest_resolvable_version
+    )
+  end
+
+  let(:requirements) { [gemfile_requirement, gemspec_requirement].compact }
+  let(:gemfile_requirement) do
+    {
+      file: "Gemfile",
+      requirement: gemfile_requirement_string,
+      groups: gemfile_groups
+    }
+  end
+  let(:gemspec_requirement) do
+    {
+      file: "some.gemspec",
+      requirement: gemspec_requirement_string,
+      groups: gemspec_groups
+    }
+  end
+  let(:gemfile_requirement_string) { "~> 1.4.0" }
+  let(:gemfile_groups) { [] }
+  let(:gemspec_requirement_string) { "~> 1.4.0" }
+  let(:gemspec_groups) { [] }
+
+  let(:existing_version) { "1.4.0" }
+  let(:latest_version) { "1.8.0" }
+  let(:latest_resolvable_version) { "1.5.0" }
+
+  describe "#updated_requirements" do
+    subject(:updated_requirements) { updater.updated_requirements }
+
+    context "for a Gemfile dependency" do
+      subject { updated_requirements.find { |r| r[:file] == "Gemfile" } }
+
+      context "when there is no resolvable version" do
+        let(:latest_resolvable_version) { nil }
+        it { is_expected.to eq(gemfile_requirement) }
+      end
+
+      context "when there is a resolvable version" do
+        let(:latest_resolvable_version) { "1.5.0" }
+
+        context "and a full version was previously specified" do
+          let(:gemfile_requirement_string) { "~> 1.4.0" }
+          its([:requirement]) { is_expected.to eq("~> 1.5.0") }
+        end
+
+        context "and a pre-release was previously specified" do
+          let(:gemfile_requirement_string) { "~> 1.5.0.beta" }
+          its([:requirement]) { is_expected.to eq("~> 1.5.0") }
+        end
+
+        context "and a minor version was previously specified" do
+          let(:gemfile_requirement_string) { "~> 1.4" }
+          its([:requirement]) { is_expected.to eq("~> 1.5") }
+        end
+
+        context "and a greater than or equal to matcher was used" do
+          let(:gemfile_requirement_string) { ">= 1.4.0" }
+          its([:requirement]) { is_expected.to eq(">= 1.5.0") }
+        end
+
+        context "and a less than matcher was used" do
+          let(:gemfile_requirement_string) { "< 1.4.0" }
+          its([:requirement]) { is_expected.to eq("~> 1.5.0") }
+        end
+
+        context "when there is no `existing_version`" do
+          # In this case we don't have a Gemfile.lock for this repo, so want
+          # slightly different updating behaviour.
+          let(:existing_version) { nil }
+
+          context "and the new version satisfies the old requirements" do
+            let(:gemfile_requirement_string) { "~> 1.4" }
+            it { is_expected.to eq(gemfile_requirement) }
+          end
+
+          context "and the new version does not satisfy the old requirements" do
+            let(:gemfile_requirement_string) { "~> 1.4.0" }
+            its([:requirement]) { is_expected.to eq("~> 1.5.0") }
+          end
+        end
+      end
+    end
+
+    context "for a gemspec dependency" do
+      subject { updated_requirements.find { |r| r[:file].end_with?("emspec") } }
+
+      context "when there is no latest version" do
+        let(:latest_version) { nil }
+        it { is_expected.to eq(gemspec_requirement) }
+      end
+
+      context "when there is a latest version" do
+        let(:latest_version) { "1.5.0" }
+
+        context "when an = specifier was used" do
+          let(:gemspec_requirement_string) { "= 1.4.0" }
+          its([:requirement]) { is_expected.to eq(">= 1.4.0") }
+        end
+
+        context "when no specifier was used" do
+          let(:gemspec_requirement_string) { "1.4.0" }
+          its([:requirement]) { is_expected.to eq(">= 1.4.0") }
+        end
+
+        context "when a < specifier was used" do
+          let(:gemspec_requirement_string) { "< 1.4.0" }
+          its([:requirement]) { is_expected.to eq("< 1.6.0") }
+        end
+
+        context "when a <= specifier was used" do
+          let(:gemspec_requirement_string) { "<= 1.4.0" }
+          its([:requirement]) { is_expected.to eq("<= 1.6.0") }
+        end
+
+        context "when a ~> specifier was used" do
+          let(:gemspec_requirement_string) { "~> 1.4.0" }
+          its([:requirement]) { is_expected.to eq(">= 1.4, < 1.6") }
+
+          context "with two zeros" do
+            let(:gemspec_requirement_string) { "~> 1.0.0" }
+            its([:requirement]) { is_expected.to eq(">= 1.0, < 1.6") }
+          end
+
+          context "with no zeros" do
+            let(:gemspec_requirement_string) { "~> 1.0.1" }
+            its([:requirement]) { is_expected.to eq(">= 1.0.1, < 1.6.0") }
+          end
+
+          context "with minor precision" do
+            let(:gemspec_requirement_string) { "~> 0.1" }
+            its([:requirement]) { is_expected.to eq(">= 0.1, < 2.0") }
+          end
+        end
+
+        context "when there are multiple requirements" do
+          let(:gemspec_requirement_string) { "> 1.0.0, <= 1.4.0" }
+          its([:requirement]) { is_expected.to eq("> 1.0.0, <= 1.6.0") }
+
+          context "that could cause duplication" do
+            let(:gemspec_requirement_string) { "~> 0.5, >= 0.5.2" }
+            its([:requirement]) { is_expected.to eq(">= 0.5.2, < 2.0") }
+          end
+        end
+
+        context "when a beta version was used in the old requirement" do
+          let(:gemspec_requirement_string) { "< 1.4.0.beta" }
+          its([:requirement]) { is_expected.to eq(:unfixable) }
+        end
+
+        context "when a != specifier was used" do
+          let(:gemspec_requirement_string) { "!= 1.5.0" }
+          its([:requirement]) { is_expected.to eq(:unfixable) }
+        end
+
+        context "when a >= specifier was used" do
+          let(:gemspec_requirement_string) { ">= 1.6.0" }
+          its([:requirement]) { is_expected.to eq(:unfixable) }
+        end
+
+        context "when a > specifier was used" do
+          let(:gemspec_requirement_string) { "> 1.6.0" }
+          its([:requirement]) { is_expected.to eq(:unfixable) }
+        end
+
+        context "for a development dependency" do
+          let(:requirements) do
+            [
+              {
+                file: "some.gemspec",
+                requirement: gemspec_requirement_string,
+                groups: ["development"]
+              }
+            ]
+          end
+
+          context "when an = specifier was used" do
+            let(:gemspec_requirement_string) { "= 1.4.0" }
+            its([:requirement]) { is_expected.to eq("= 1.5.0") }
+          end
+
+          context "when no specifier was used" do
+            let(:gemspec_requirement_string) { "1.4.0" }
+            its([:requirement]) { is_expected.to eq("= 1.5.0") }
+          end
+
+          context "when a < specifier was used" do
+            let(:gemspec_requirement_string) { "< 1.4.0" }
+            its([:requirement]) { is_expected.to eq("< 1.6.0") }
+          end
+
+          context "when a <= specifier was used" do
+            let(:gemspec_requirement_string) { "<= 1.4.0" }
+            its([:requirement]) { is_expected.to eq("<= 1.6.0") }
+          end
+
+          context "when a ~> specifier was used" do
+            let(:gemspec_requirement_string) { "~> 1.4.0" }
+            its([:requirement]) { is_expected.to eq("~> 1.5.0") }
+
+            context "with minor precision" do
+              let(:gemspec_requirement_string) { "~> 0.1" }
+              its([:requirement]) { is_expected.to eq("~> 1.5") }
+            end
+          end
+
+          context "when there are multiple requirements" do
+            let(:gemspec_requirement_string) { "> 1.0.0, <= 1.4.0" }
+            its([:requirement]) { is_expected.to eq("> 1.0.0, <= 1.6.0") }
+          end
+
+          context "when a beta version was used in the old requirement" do
+            let(:gemspec_requirement_string) { "< 1.4.0.beta" }
+            its([:requirement]) { is_expected.to eq(:unfixable) }
+          end
+
+          context "when a != specifier was used" do
+            let(:gemspec_requirement_string) { "!= 1.5.0" }
+            its([:requirement]) { is_expected.to eq(:unfixable) }
+          end
+
+          context "when a >= specifier was used" do
+            let(:gemspec_requirement_string) { ">= 1.6.0" }
+            its([:requirement]) { is_expected.to eq(:unfixable) }
+          end
+
+          context "when a > specifier was used" do
+            let(:gemspec_requirement_string) { "> 1.6.0" }
+            its([:requirement]) { is_expected.to eq(:unfixable) }
+          end
+        end
+      end
+    end
+
+    context "with both a Gemfile and a gemspec" do
+      let(:gemfile_requirement_string) { "~> 1.4.0" }
+      let(:gemfile_groups) { [] }
+      let(:gemspec_requirement_string) { ">= 1.0, < 1.5" }
+      let(:gemspec_groups) { [] }
+
+      it "updates both files" do
+        expect(updated_requirements).to match_array(
+          [
+            { file: "Gemfile", requirement: "~> 1.5.0", groups: [] },
+            { file: "some.gemspec", requirement: ">= 1.0, < 1.9", groups: [] }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/dependabot/update_checkers/ruby/bundler_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler_spec.rb
@@ -24,10 +24,12 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
     Dependabot::Dependency.new(
       name: "business",
       version: "1.3",
-      requirement: ">= 0",
-      package_manager: "bundler",
-      groups: []
+      requirements: requirements,
+      package_manager: "bundler"
     )
+  end
+  let(:requirements) do
+    [{ file: "Gemfile", requirement: ">= 0", groups: [] }]
   end
 
   let(:gemfile) do
@@ -110,9 +112,8 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
           Dependabot::Dependency.new(
             name: "sidekiq-pro",
             version: "1.3",
-            requirement: ">= 0",
-            package_manager: "bundler",
-            groups: []
+            requirements: requirements,
+            package_manager: "bundler"
           )
         end
         let(:registry_url) { "https://gems.contribsys.com/" }
@@ -161,9 +162,8 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
           Dependabot::Dependency.new(
             name: "prius",
             version: "0.9",
-            requirement: ">= 0",
-            package_manager: "bundler",
-            groups: []
+            requirements: requirements,
+            package_manager: "bundler"
           )
         end
 
@@ -215,9 +215,8 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
             Dependabot::Dependency.new(
               name: "example",
               version: "0.9.3",
-              requirement: ">= 0",
-              package_manager: "bundler",
-              groups: []
+              requirements: requirements,
+              package_manager: "bundler"
             )
           end
 
@@ -274,10 +273,13 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
         let(:dependency) do
           Dependabot::Dependency.new(
             name: "octokit",
-            requirement: "~> 4.6",
-            package_manager: "bundler",
-            groups: []
+            requirements: requirements,
+            package_manager: "bundler"
           )
+        end
+
+        let(:requirements) do
+          [{ file: "Gemfile", requirement: "~> 4.6", groups: [] }]
         end
 
         before do
@@ -345,9 +347,8 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
           Dependabot::Dependency.new(
             name: "ibandit",
             version: "0.1.0",
-            requirement: ">= 0",
-            package_manager: "bundler",
-            groups: []
+            requirements: requirements,
+            package_manager: "bundler"
           )
         end
 
@@ -377,9 +378,8 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
           Dependabot::Dependency.new(
             name: "public_suffix",
             version: "1.0.1",
-            requirement: ">= 0",
-            package_manager: "bundler",
-            groups: []
+            requirements: requirements,
+            package_manager: "bundler"
           )
         end
 
@@ -491,9 +491,8 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
             Dependabot::Dependency.new(
               name: "example",
               version: "0.9.3",
-              requirement: ">= 0",
-              package_manager: "bundler",
-              groups: []
+              requirements: requirements,
+              package_manager: "bundler"
             )
           end
 
@@ -518,9 +517,8 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
           Dependabot::Dependency.new(
             name: "statesman",
             version: "1.2",
-            requirement: ">= 0",
-            package_manager: "ruby",
-            groups: []
+            requirements: requirements,
+            package_manager: "ruby"
           )
         end
 
@@ -549,9 +547,8 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
           Dependabot::Dependency.new(
             name: "prius",
             version: "0.9",
-            requirement: ">= 0",
-            package_manager: "bundler",
-            groups: []
+            requirements: requirements,
+            package_manager: "bundler"
           )
         end
 
@@ -709,17 +706,20 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
     end
   end
 
-  describe "#updated_requirement" do
-    subject { checker.updated_requirement }
+  describe "#updated_requirements" do
+    subject(:updated_requirements) { checker.updated_requirements }
 
     let(:dependency) do
       Dependabot::Dependency.new(
         name: "business",
         version: "1.3",
-        requirement: original_requirement,
-        package_manager: "bundler",
-        groups: []
+        requirements: requirements,
+        package_manager: "bundler"
       )
+    end
+
+    let(:requirements) do
+      [{ file: "Gemfile", requirement: original_requirement, groups: [] }]
     end
 
     let(:original_requirement) { ">= 0" }
@@ -729,18 +729,16 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
       allow(checker).
         to receive(:latest_resolvable_version).
         and_return(latest_resolvable_version)
-      allow(checker).
-        to receive(:gemfile_requirement).
-        and_return(Gem::Requirement.new(original_requirement.split(",")))
     end
 
     context "when there is no resolvable version" do
       let(:latest_resolvable_version) { nil }
-      it { is_expected.to be_nil }
+      it { is_expected.to eq(requirements) }
     end
 
     context "when there is a resolvable version" do
       let(:latest_resolvable_version) { Gem::Version.new("1.5.0") }
+      subject { updated_requirements.first[:requirement] }
 
       context "and a full version was previously specified" do
         let(:original_requirement) { "~> 1.4.0" }
@@ -782,10 +780,16 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "business",
-          requirement: old_requirement,
-          package_manager: "bundler",
-          groups: []
+          requirements: requirements,
+          package_manager: "bundler"
         )
+      end
+
+      let(:requirements) do
+        [
+          { file: "Gemfile", requirement: old_requirement, groups: [] },
+          { file: "example.gemspec", requirement: old_requirement, groups: [] }
+        ]
       end
 
       let(:old_requirement) { "~> 0.9" }
@@ -794,12 +798,24 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
       before do
         allow(checker).to receive(:latest_version).and_return(latest_version)
         allow(checker).
-          to receive(:gemspec_requirement).
-          and_return(Gem::Requirement.new(old_requirement.split(",")))
+          to receive(:latest_resolvable_version).and_return(latest_version)
       end
 
-      it "picks the gemspec to update the requirement in" do
-        expect(checker.updated_requirement).to eq(">= 0.9, < 2.0")
+      it "updates both files" do
+        expect(checker.updated_requirements).to match_array(
+          [
+            {
+              file: "Gemfile",
+              requirement: "~> 1.5",
+              groups: []
+            },
+            {
+              file: "example.gemspec",
+              requirement: ">= 0.9, < 2.0",
+              groups: []
+            }
+          ]
+        )
       end
 
       context "with a dependency that only appears in the gemspec" do
@@ -807,16 +823,26 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
         let(:dependency) do
           Dependabot::Dependency.new(
             name: "octokit",
-            requirement: old_requirement,
-            package_manager: "bundler",
-            groups: []
+            requirements: requirements,
+            package_manager: "bundler"
           )
         end
         let(:latest_version) { Gem::Version.new("5.0.0") }
         let(:old_requirement) { "~> 4.6" }
+        let(:requirements) do
+          [{ file: "example.gemspec", requirement: "~> 4.6", groups: [] }]
+        end
 
         it "successfully updates the requirement" do
-          expect(checker.updated_requirement).to eq(">= 4.6, < 6.0")
+          expect(checker.updated_requirements).to eq(
+            [
+              {
+                file: "example.gemspec",
+                requirement: ">= 4.6, < 6.0",
+                groups: []
+              }
+            ]
+          )
         end
       end
     end
@@ -828,15 +854,18 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "business",
-          requirement: original_requirement,
-          package_manager: "bundler",
-          groups: []
+          requirements: requirements,
+          package_manager: "bundler"
         )
+      end
+
+      let(:requirements) do
+        [{ file: "Gemfile", requirement: original_requirement, groups: [] }]
       end
 
       context "when there is no resolvable version" do
         let(:latest_resolvable_version) { nil }
-        it { is_expected.to be_nil }
+        it { is_expected.to eq(requirements) }
       end
 
       context "when there is a resolvable version" do
@@ -844,7 +873,18 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
 
         context "and a full version was previously specified" do
           let(:original_requirement) { "~> 1.4.0" }
-          it { is_expected.to eq("~> 1.5.0") }
+
+          it "successfully updates the requirement" do
+            expect(checker.updated_requirements).to eq(
+              [
+                {
+                  file: "Gemfile",
+                  requirement: "~> 1.5.0",
+                  groups: []
+                }
+              ]
+            )
+          end
         end
       end
     end
@@ -862,20 +902,21 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "business",
-          requirement: old_requirement,
-          package_manager: "bundler",
-          groups: []
+          requirements: requirements,
+          package_manager: "bundler"
         )
       end
       let(:old_requirement) { "~> 0.9" }
       let(:latest_version) { Gem::Version.new("1.5.0") }
+      let(:requirements) do
+        [{ file: "example.gemspec", requirement: old_requirement, groups: [] }]
+      end
 
       before do
         allow(checker).to receive(:latest_version).and_return(latest_version)
-        allow(checker).
-          to receive(:gemspec_requirement).
-          and_return(Gem::Requirement.new(old_requirement.split(",")))
       end
+
+      subject { updated_requirements.first[:requirement] }
 
       context "when an = specifier was used" do
         let(:old_requirement) { "= 1.4.0" }
@@ -929,32 +970,33 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
 
       context "when a beta version was used in the old requirement" do
         let(:old_requirement) { "< 1.4.0.beta" }
-        it { is_expected.to be_nil }
+        it { is_expected.to eq(:unfixable) }
       end
 
       context "when a != specifier was used" do
         let(:old_requirement) { "!= 1.5.0" }
-        it { is_expected.to be_nil }
+        it { is_expected.to eq(:unfixable) }
       end
 
       context "when a >= specifier was used" do
         let(:old_requirement) { ">= 1.6.0" }
-        it { is_expected.to be_nil }
+        it { is_expected.to eq(:unfixable) }
       end
 
       context "when a > specifier was used" do
         let(:old_requirement) { "> 1.6.0" }
-        it { is_expected.to be_nil }
+        it { is_expected.to eq(:unfixable) }
       end
 
       context "for a development dependency" do
-        let(:dependency) do
-          Dependabot::Dependency.new(
-            name: "business",
-            requirement: old_requirement,
-            package_manager: "bundler",
-            groups: ["development"]
-          )
+        let(:requirements) do
+          [
+            {
+              file: "example.gemspec",
+              requirement: old_requirement,
+              groups: ["development"]
+            }
+          ]
         end
 
         context "when an = specifier was used" do
@@ -994,22 +1036,22 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
 
         context "when a beta version was used in the old requirement" do
           let(:old_requirement) { "< 1.4.0.beta" }
-          it { is_expected.to be_nil }
+          it { is_expected.to eq(:unfixable) }
         end
 
         context "when a != specifier was used" do
           let(:old_requirement) { "!= 1.5.0" }
-          it { is_expected.to be_nil }
+          it { is_expected.to eq(:unfixable) }
         end
 
         context "when a >= specifier was used" do
           let(:old_requirement) { ">= 1.6.0" }
-          it { is_expected.to be_nil }
+          it { is_expected.to eq(:unfixable) }
         end
 
         context "when a > specifier was used" do
           let(:old_requirement) { "> 1.6.0" }
-          it { is_expected.to be_nil }
+          it { is_expected.to eq(:unfixable) }
         end
       end
     end

--- a/spec/dependabot/update_checkers/ruby/bundler_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler_spec.rb
@@ -709,74 +709,117 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
   describe "#updated_requirements" do
     subject(:updated_requirements) { checker.updated_requirements }
 
-    let(:dependency) do
-      Dependabot::Dependency.new(
-        name: "business",
-        version: "1.3",
-        requirements: requirements,
-        package_manager: "bundler"
+    let(:gemspec) do
+      Dependabot::DependencyFile.new(
+        content: gemspec_body,
+        name: "example.gemspec"
       )
     end
-
-    let(:requirements) do
-      [{ file: "Gemfile", requirement: original_requirement, groups: [] }]
-    end
-
-    let(:original_requirement) { ">= 0" }
-    let(:latest_resolvable_version) { nil }
-
+    let(:gemspec_body) { fixture("ruby", "gemspecs", "small_example") }
     before do
-      allow(checker).
-        to receive(:latest_resolvable_version).
-        and_return(latest_resolvable_version)
+      stub_request(:get, "https://rubygems.org/api/v1/gems/business.json").
+        to_return(status: 200, body: fixture("ruby", "rubygems_response.json"))
+    end
+    before do
+      stub_request(:get, "https://index.rubygems.org/versions").
+        to_return(status: 200, body: fixture("ruby", "rubygems-index"))
+
+      stub_request(:get, "https://index.rubygems.org/info/business").
+        to_return(
+          status: 200,
+          body: fixture("ruby", "rubygems-info-business")
+        )
     end
 
-    context "when there is no resolvable version" do
-      let(:latest_resolvable_version) { nil }
-      it { is_expected.to eq(requirements) }
-    end
-
-    context "when there is a resolvable version" do
-      let(:latest_resolvable_version) { Gem::Version.new("1.5.0") }
-      subject { updated_requirements.first[:requirement] }
-
-      context "and a full version was previously specified" do
-        let(:original_requirement) { "~> 1.4.0" }
-        it { is_expected.to eq("~> 1.5.0") }
-      end
-
-      context "and a pre-release was previously specified" do
-        let(:original_requirement) { "~> 1.5.0.beta" }
-        it { is_expected.to eq("~> 1.5.0") }
-      end
-
-      context "and a minor version was previously specified" do
-        let(:original_requirement) { "~> 1.4" }
-        it { is_expected.to eq("~> 1.5") }
-      end
-
-      context "and a greater than or equal to matcher was used" do
-        let(:original_requirement) { ">= 1.4.0" }
-        it { is_expected.to eq(">= 1.5.0") }
-      end
-
-      context "and a less than matcher was used" do
-        let(:original_requirement) { "< 1.4.0" }
-        it { is_expected.to eq("~> 1.5.0") }
-      end
-    end
-
-    context "with a gemspec and a gemfile" do
-      let(:dependency_files) { [gemspec, gemfile] }
-      let(:gemspec) do
-        Dependabot::DependencyFile.new(
-          content: gemspec_body,
-          name: "example.gemspec"
+    context "with a Gemfile and a Gemfile.lock" do
+      let(:dependency_files) { [gemfile, lockfile] }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "business",
+          version: "1.4.0",
+          requirements: requirements,
+          package_manager: "bundler"
         )
       end
-      let(:gemfile_body) { fixture("ruby", "gemfiles", "Gemfile") }
-      let(:gemspec_body) { fixture("ruby", "gemspecs", "small_example") }
 
+      let(:requirements) do
+        [
+          {
+            file: "Gemfile",
+            requirement: "~> 1.4.0",
+            groups: [:default]
+          },
+          {
+            file: "example.gemspec",
+            requirement: "~> 1.0",
+            groups: [:default]
+          }
+        ]
+      end
+
+      it "delegates to Bundler::RequirementsUpdater with the right params" do
+        expect(Dependabot::UpdateCheckers::Ruby::Bundler::RequirementsUpdater).
+          to receive(:new).with(
+            requirements: requirements,
+            existing_version: "1.4.0",
+            latest_version: "1.5.0",
+            latest_resolvable_version: "1.8.0"
+          ).and_call_original
+
+        expect(updated_requirements.count).to eq(2)
+        expect(updated_requirements.first[:requirement]).to eq("~> 1.8.0")
+        expect(updated_requirements.last[:requirement]).to eq("~> 1.0")
+      end
+    end
+
+    context "with a Gemfile, a Gemfile.lock and a gemspec" do
+      let(:dependency_files) { [gemfile, gemspec, lockfile] }
+      let(:gemfile_body) { fixture("ruby", "gemfiles", "imports_gemspec") }
+      let(:lockfile_body) do
+        fixture("ruby", "lockfiles", "imports_gemspec.lock")
+      end
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "business",
+          version: "1.4.0",
+          requirements: requirements,
+          package_manager: "bundler"
+        )
+      end
+
+      let(:requirements) do
+        [
+          {
+            file: "Gemfile",
+            requirement: "~> 1.4.0",
+            groups: [:default]
+          },
+          {
+            file: "example.gemspec",
+            requirement: "~> 1.0",
+            groups: [:default]
+          }
+        ]
+      end
+
+      it "delegates to Bundler::RequirementsUpdater with the right params" do
+        expect(Dependabot::UpdateCheckers::Ruby::Bundler::RequirementsUpdater).
+          to receive(:new).with(
+            requirements: requirements,
+            existing_version: "1.4.0",
+            latest_version: "1.5.0",
+            latest_resolvable_version: "1.8.0"
+          ).and_call_original
+
+        expect(updated_requirements.count).to eq(2)
+        expect(updated_requirements.first[:requirement]).to eq("~> 1.8.0")
+        expect(updated_requirements.last[:requirement]).to eq("~> 1.0")
+      end
+    end
+
+    context "with a Gemfile and a gemspec" do
+      let(:dependency_files) { [gemfile, gemspec] }
+      let(:gemfile_body) { fixture("ruby", "gemfiles", "imports_gemspec") }
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "business",
@@ -787,70 +830,36 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
 
       let(:requirements) do
         [
-          { file: "Gemfile", requirement: old_requirement, groups: [] },
-          { file: "example.gemspec", requirement: old_requirement, groups: [] }
+          {
+            file: "Gemfile",
+            requirement: "~> 1.4.0",
+            groups: [:default]
+          },
+          {
+            file: "example.gemspec",
+            requirement: "~> 1.0",
+            groups: [:default]
+          }
         ]
       end
 
-      let(:old_requirement) { "~> 0.9" }
-      let(:latest_version) { Gem::Version.new("1.5.0") }
-
-      before do
-        allow(checker).to receive(:latest_version).and_return(latest_version)
-        allow(checker).
-          to receive(:latest_resolvable_version).and_return(latest_version)
-      end
-
-      it "updates both files" do
-        expect(checker.updated_requirements).to match_array(
-          [
-            {
-              file: "Gemfile",
-              requirement: "~> 1.5",
-              groups: []
-            },
-            {
-              file: "example.gemspec",
-              requirement: ">= 0.9, < 2.0",
-              groups: []
-            }
-          ]
-        )
-      end
-
-      context "with a dependency that only appears in the gemspec" do
-        let(:gemspec_body) { fixture("ruby", "gemspecs", "example") }
-        let(:dependency) do
-          Dependabot::Dependency.new(
-            name: "octokit",
+      it "delegates to Bundler::RequirementsUpdater with the right params" do
+        expect(Dependabot::UpdateCheckers::Ruby::Bundler::RequirementsUpdater).
+          to receive(:new).with(
             requirements: requirements,
-            package_manager: "bundler"
-          )
-        end
-        let(:latest_version) { Gem::Version.new("5.0.0") }
-        let(:old_requirement) { "~> 4.6" }
-        let(:requirements) do
-          [{ file: "example.gemspec", requirement: "~> 4.6", groups: [] }]
-        end
+            existing_version: nil,
+            latest_version: "1.5.0",
+            latest_resolvable_version: "1.8.0"
+          ).and_call_original
 
-        it "successfully updates the requirement" do
-          expect(checker.updated_requirements).to eq(
-            [
-              {
-                file: "example.gemspec",
-                requirement: ">= 4.6, < 6.0",
-                groups: []
-              }
-            ]
-          )
-        end
+        expect(updated_requirements.count).to eq(2)
+        expect(updated_requirements.first[:requirement]).to eq("~> 1.8.0")
+        expect(updated_requirements.last[:requirement]).to eq("~> 1.0")
       end
     end
 
-    context "with only a Gemfile" do
+    context "with a Gemfile only" do
       let(:dependency_files) { [gemfile] }
-      let(:gemfile_body) { fixture("ruby", "gemfiles", "Gemfile") }
-
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "business",
@@ -860,45 +869,31 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
       end
 
       let(:requirements) do
-        [{ file: "Gemfile", requirement: original_requirement, groups: [] }]
+        [
+          {
+            file: "Gemfile",
+            requirement: "~> 1.4.0",
+            groups: [:default]
+          }
+        ]
       end
 
-      context "when there is no resolvable version" do
-        let(:latest_resolvable_version) { nil }
-        it { is_expected.to eq(requirements) }
-      end
+      it "delegates to Bundler::RequirementsUpdater with the right params" do
+        expect(Dependabot::UpdateCheckers::Ruby::Bundler::RequirementsUpdater).
+          to receive(:new).with(
+            requirements: requirements,
+            existing_version: nil,
+            latest_version: "1.5.0",
+            latest_resolvable_version: "1.8.0"
+          ).and_call_original
 
-      context "when there is a resolvable version" do
-        let(:latest_resolvable_version) { Gem::Version.new("1.5.0") }
-
-        context "and a full version was previously specified" do
-          let(:original_requirement) { "~> 1.4.0" }
-
-          it "successfully updates the requirement" do
-            expect(checker.updated_requirements).to eq(
-              [
-                {
-                  file: "Gemfile",
-                  requirement: "~> 1.5.0",
-                  groups: []
-                }
-              ]
-            )
-          end
-        end
+        expect(updated_requirements.count).to eq(1)
+        expect(updated_requirements.first[:requirement]).to eq("~> 1.8.0")
       end
     end
 
-    context "with only a gemspec" do
+    context "with a gemspec only" do
       let(:dependency_files) { [gemspec] }
-      let(:gemspec) do
-        Dependabot::DependencyFile.new(
-          content: gemspec_body,
-          name: "example.gemspec"
-        )
-      end
-      let(:gemspec_body) { fixture("ruby", "gemspecs", "small_example") }
-
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "business",
@@ -906,153 +901,28 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
           package_manager: "bundler"
         )
       end
-      let(:old_requirement) { "~> 0.9" }
-      let(:latest_version) { Gem::Version.new("1.5.0") }
+
       let(:requirements) do
-        [{ file: "example.gemspec", requirement: old_requirement, groups: [] }]
+        [
+          {
+            file: "example.gemspec",
+            requirement: "~> 0.9",
+            groups: ["runtime"]
+          }
+        ]
       end
 
-      before do
-        allow(checker).to receive(:latest_version).and_return(latest_version)
-      end
+      it "delegates to Bundler::RequirementsUpdater with the right params" do
+        expect(Dependabot::UpdateCheckers::Ruby::Bundler::RequirementsUpdater).
+          to receive(:new).with(
+            requirements: requirements,
+            existing_version: nil,
+            latest_version: "1.5.0",
+            latest_resolvable_version: "1.5.0"
+          ).and_call_original
 
-      subject { updated_requirements.first[:requirement] }
-
-      context "when an = specifier was used" do
-        let(:old_requirement) { "= 1.4.0" }
-        it { is_expected.to eq(">= 1.4.0") }
-      end
-
-      context "when no specifier was used" do
-        let(:old_requirement) { "1.4.0" }
-        it { is_expected.to eq(">= 1.4.0") }
-      end
-
-      context "when a < specifier was used" do
-        let(:old_requirement) { "< 1.4.0" }
-        it { is_expected.to eq("< 1.6.0") }
-      end
-
-      context "when a <= specifier was used" do
-        let(:old_requirement) { "<= 1.4.0" }
-        it { is_expected.to eq("<= 1.6.0") }
-      end
-
-      context "when a ~> specifier was used" do
-        let(:old_requirement) { "~> 1.4.0" }
-        it { is_expected.to eq(">= 1.4, < 1.6") }
-
-        context "with two zeros" do
-          let(:old_requirement) { "~> 1.0.0" }
-          it { is_expected.to eq(">= 1.0, < 1.6") }
-        end
-
-        context "with no zeros" do
-          let(:old_requirement) { "~> 1.0.1" }
-          it { is_expected.to eq(">= 1.0.1, < 1.6.0") }
-        end
-
-        context "with minor precision" do
-          let(:old_requirement) { "~> 0.1" }
-          it { is_expected.to eq(">= 0.1, < 2.0") }
-        end
-      end
-
-      context "when there are multiple requirements" do
-        let(:old_requirement) { "> 1.0.0, <= 1.4.0" }
-        it { is_expected.to eq("> 1.0.0, <= 1.6.0") }
-
-        context "that could cause duplication" do
-          let(:old_requirement) { "~> 0.5, >= 0.5.2" }
-          it { is_expected.to eq(">= 0.5.2, < 2.0") }
-        end
-      end
-
-      context "when a beta version was used in the old requirement" do
-        let(:old_requirement) { "< 1.4.0.beta" }
-        it { is_expected.to eq(:unfixable) }
-      end
-
-      context "when a != specifier was used" do
-        let(:old_requirement) { "!= 1.5.0" }
-        it { is_expected.to eq(:unfixable) }
-      end
-
-      context "when a >= specifier was used" do
-        let(:old_requirement) { ">= 1.6.0" }
-        it { is_expected.to eq(:unfixable) }
-      end
-
-      context "when a > specifier was used" do
-        let(:old_requirement) { "> 1.6.0" }
-        it { is_expected.to eq(:unfixable) }
-      end
-
-      context "for a development dependency" do
-        let(:requirements) do
-          [
-            {
-              file: "example.gemspec",
-              requirement: old_requirement,
-              groups: ["development"]
-            }
-          ]
-        end
-
-        context "when an = specifier was used" do
-          let(:old_requirement) { "= 1.4.0" }
-          it { is_expected.to eq("= 1.5.0") }
-        end
-
-        context "when no specifier was used" do
-          let(:old_requirement) { "1.4.0" }
-          it { is_expected.to eq("= 1.5.0") }
-        end
-
-        context "when a < specifier was used" do
-          let(:old_requirement) { "< 1.4.0" }
-          it { is_expected.to eq("< 1.6.0") }
-        end
-
-        context "when a <= specifier was used" do
-          let(:old_requirement) { "<= 1.4.0" }
-          it { is_expected.to eq("<= 1.6.0") }
-        end
-
-        context "when a ~> specifier was used" do
-          let(:old_requirement) { "~> 1.4.0" }
-          it { is_expected.to eq("~> 1.5.0") }
-
-          context "with minor precision" do
-            let(:old_requirement) { "~> 0.1" }
-            it { is_expected.to eq("~> 1.5") }
-          end
-        end
-
-        context "when there are multiple requirements" do
-          let(:old_requirement) { "> 1.0.0, <= 1.4.0" }
-          it { is_expected.to eq("> 1.0.0, <= 1.6.0") }
-        end
-
-        context "when a beta version was used in the old requirement" do
-          let(:old_requirement) { "< 1.4.0.beta" }
-          it { is_expected.to eq(:unfixable) }
-        end
-
-        context "when a != specifier was used" do
-          let(:old_requirement) { "!= 1.5.0" }
-          it { is_expected.to eq(:unfixable) }
-        end
-
-        context "when a >= specifier was used" do
-          let(:old_requirement) { ">= 1.6.0" }
-          it { is_expected.to eq(:unfixable) }
-        end
-
-        context "when a > specifier was used" do
-          let(:old_requirement) { "> 1.6.0" }
-          it { is_expected.to eq(:unfixable) }
-        end
+        expect(updated_requirements.count).to eq(1)
+        expect(updated_requirements.first[:requirement]).to eq(">= 0.9, < 2.0")
       end
     end
   end

--- a/spec/dependabot/update_checkers/shared_examples_for_update_checkers.rb
+++ b/spec/dependabot/update_checkers/shared_examples_for_update_checkers.rb
@@ -9,9 +9,9 @@ RSpec.shared_examples "an update checker" do
 
     its(:superclass) { is_expected.to eq(base_class) }
 
-    it "implements updated_requirement" do
+    it "implements updated_requirements" do
       expect(described_class.public_instance_methods(false)).
-        to include(:updated_requirement)
+        to include(:updated_requirements)
     end
 
     it "implements latest_version" do


### PR DESCRIPTION
Overhauls how requirements are stored on dependencies. Allows a dependency to have multiple requirements, coming from different files (e.g., a `Gemfile` and a `gemspec`). Should allow us to support Gemfile-only repos.