### PR TITLE
[WIP] Include development dependencies in FileParsers::Php::Composer

### DIFF
--- a/spec/dependabot/file_parsers/php/composer_spec.rb
+++ b/spec/dependabot/file_parsers/php/composer_spec.rb
@@ -41,18 +41,46 @@ RSpec.describe Dependabot::FileParsers::Php::Composer do
         its(:name) { is_expected.to eq("monolog/monolog") }
         its(:version) { is_expected.to eq("1.0.2") }
         its(:requirements) do
-          is_expected.
-            to eq([{ requirement: "1.0.*", file: "composer.json", groups: [] }])
+          is_expected.to eq(
+            [
+              {
+                requirement: "1.0.*",
+                file: "composer.json",
+                groups: ["runtime"]
+              }
+            ]
+          )
         end
       end
     end
 
-    pending "for development dependencies" do
+    context "for development dependencies" do
       let(:composer_json_body) do
         fixture("php", "composer_files", "development_dependencies")
       end
 
-      its(:length) { is_expected.to eq(2) }
+      it "includes development dependencies" do
+        expect(dependencies.length).to eq(2)
+      end
+
+      describe "the first dependency" do
+        subject { dependencies.first }
+
+        it { is_expected.to be_a(Dependabot::Dependency) }
+        its(:name) { is_expected.to eq("monolog/monolog") }
+        its(:version) { is_expected.to eq("1.0.2") }
+        its(:requirements) do
+          is_expected.to eq(
+            [
+              {
+                requirement: "1.0.1",
+                file: "composer.json",
+                groups: ["development"]
+              }
+            ]
+          )
+        end
+      end
     end
 
     context "with the PHP version specified" do

--- a/spec/dependabot/file_updaters/php/composer_spec.rb
+++ b/spec/dependabot/file_updaters/php/composer_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Dependabot::FileUpdaters::Php::Composer do
           fixture("php", "composer_files", "development_dependencies")
         end
 
-        pending { is_expected.to include "\"monolog/monolog\":\"1.22.1\"" }
+        it { is_expected.to include "\"monolog/monolog\":\"1.22.1\"" }
       end
     end
 

--- a/spec/dependabot/file_updaters/php/composer_spec.rb
+++ b/spec/dependabot/file_updaters/php/composer_spec.rb
@@ -88,6 +88,14 @@ RSpec.describe Dependabot::FileUpdaters::Php::Composer do
 
         it { is_expected.to include "\"monolog/monolog\":\"1.22.1\"" }
       end
+
+      context "when the dependency is a development dependency" do
+        let(:composer_body) do
+          fixture("php", "composer_files", "development_dependencies")
+        end
+
+        pending { is_expected.to include "\"monolog/monolog\":\"1.22.1\"" }
+      end
     end
 
     describe "the updated lockfile" do


### PR DESCRIPTION
Previously we were ignoring development dependencies for PHP. Including them needs a change to the parser and to the file updater.