### PR TITLE
Handle Ruby Gemfile requirements with multiple components

### DIFF
--- a/lib/dependabot/file_parsers/ruby/bundler.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler.rb
@@ -35,10 +35,6 @@ module Dependabot
         def gemfile_dependencies
           return [] unless gemfile
           parsed_gemfile.map do |dependency|
-            # Ignore dependencies with multiple requirements, since they would
-            # cause trouble at the gem update step. TODO: fix!
-            next if dependency.requirement.requirements.count > 1
-
             Dependency.new(
               name: dependency.name,
               version: dependency_version(dependency.name)&.to_s,

--- a/lib/dependabot/update_checkers/ruby/bundler/requirements_updater.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler/requirements_updater.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "gemnasium/parser"
 require "dependabot/update_checkers/base"
 
 module Dependabot
@@ -39,18 +38,30 @@ module Dependabot
 
           private
 
+          # rubocop:disable Metrics/CyclomaticComplexity
+          # rubocop:disable Metrics/PerceivedComplexity
           def updated_gemfile_requirement(req)
             return req unless latest_resolvable_version
             return req if existing_version && no_change_in_version?
             return req if !existing_version && new_version_satisfies?(req)
 
-            new_req = req[:requirement].gsub(/<=?/, "~>")
-            new_req.sub!(Gemnasium::Parser::Patterns::VERSION) do |old_version|
-              at_same_precision(latest_resolvable_version, old_version)
-            end
+            requirements =
+              req[:requirement].split(",").map { |r| Gem::Requirement.new(r) }
+
+            new_req =
+              if requirements.any?(&:exact?)
+                "= #{latest_resolvable_version}"
+              elsif requirements.any? { |r| r.to_s.start_with?("~>") }
+                tw_req = requirements.find { |r| r.to_s.start_with?("~>") }
+                update_twiddle_version(tw_req, latest_resolvable_version).to_s
+              else
+                update_gemfile_range(requirements).map(&:to_s).join(", ")
+              end
 
             req.merge(requirement: new_req)
           end
+          # rubocop:enable Metrics/CyclomaticComplexity
+          # rubocop:enable Metrics/PerceivedComplexity
 
           def no_change_in_version?
             latest_resolvable_version <= existing_version
@@ -59,6 +70,25 @@ module Dependabot
           def new_version_satisfies?(req)
             original_req = Gem::Requirement.new(req[:requirement].split(","))
             original_req.satisfied_by?(latest_resolvable_version)
+          end
+
+          def update_gemfile_range(requirements)
+            updated_requirements =
+              requirements.flat_map do |r|
+                next r if r.satisfied_by?(latest_resolvable_version)
+
+                case op = r.requirements.first.first
+                when "<", "<="
+                  [update_greatest_version(r, latest_resolvable_version)]
+                when "!="
+                  []
+                else
+                  raise "Unexpected operation for unsatisfied Gemfile "\
+                        "requirement: #{op}"
+                end
+              end
+
+            binding_requirements(updated_requirements)
           end
 
           def at_same_precision(new_version, old_version)
@@ -124,8 +154,8 @@ module Dependabot
 
             case op
             when "=", nil then [Gem::Requirement.new(">= #{version}")]
-            when "<", "<=" then [updated_greatest_version(r)]
-            when "~>" then updated_twidle_requirements(r)
+            when "<", "<=" then [update_greatest_version(r, latest_version)]
+            when "~>" then convert_twidle_to_range(r, latest_version)
             when "!=" then []
             when ">", ">=" then raise UnfixableRequirement
             else raise "Unexpected operation for requirement: #{op}"
@@ -133,16 +163,15 @@ module Dependabot
           end
 
           def fixed_development_requirements(r)
-            op, version = r.requirements.first
+            op = r.requirements.first.first
 
             case op
             when "=", nil
               [Gem::Requirement.new("#{op} #{latest_resolvable_version}")]
             when "<", "<="
-              [updated_greatest_version(r)]
+              [update_greatest_version(r, latest_version)]
             when "~>"
-              updated_v = at_same_precision(latest_resolvable_version, version)
-              [Gem::Requirement.new("~> #{updated_v}")]
+              [update_twiddle_version(r, latest_resolvable_version)]
             when "!="
               []
             when ">", ">="
@@ -153,13 +182,13 @@ module Dependabot
           end
 
           # rubocop:disable Metrics/AbcSize
-          def updated_twidle_requirements(requirement)
+          def convert_twidle_to_range(requirement, version_to_be_permitted)
             version = requirement.requirements.first.last
             version = version.release if version.prerelease?
 
             index_to_update = version.segments.count - 2
 
-            ub_segments = latest_version.segments
+            ub_segments = version_to_be_permitted.segments
             ub_segments << 0 while ub_segments.count <= index_to_update
             ub_segments = ub_segments[0..index_to_update]
             ub_segments[index_to_update] += 1
@@ -179,9 +208,20 @@ module Dependabot
           end
           # rubocop:enable Metrics/AbcSize
 
-          # Updates the version in a "<" or "<=" constraint to allow the latest
+          # Updates the version in a "~>" constraint to allow the given version
+          def update_twiddle_version(requirement, version_to_be_permitted)
+            old_version = requirement.requirements.first.last
+            updated_v = at_same_precision(version_to_be_permitted, old_version)
+            Gem::Requirement.new("~> #{updated_v}")
+          end
+
+          # Updates the version in a "<" or "<=" constraint to allow the given
           # version
-          def updated_greatest_version(requirement)
+          def update_greatest_version(requirement, version_to_be_permitted)
+            if version_to_be_permitted.is_a?(String)
+              version_to_be_permitted =
+                Gem::Version.new(version_to_be_permitted)
+            end
             op, version = requirement.requirements.first
             version = version.release if version.prerelease?
 
@@ -190,9 +230,9 @@ module Dependabot
 
             new_segments = version.segments.map.with_index do |_, index|
               if index < index_to_update
-                latest_version.segments[index]
+                version_to_be_permitted.segments[index]
               elsif index == index_to_update
-                latest_version.segments[index] + 1
+                version_to_be_permitted.segments[index] + 1
               else 0
               end
             end

--- a/lib/dependabot/update_checkers/ruby/bundler/requirements_updater.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler/requirements_updater.rb
@@ -42,7 +42,7 @@ module Dependabot
           def updated_gemfile_requirement(req)
             return req unless latest_resolvable_version
             return req if existing_version && no_change_in_version?
-            return req if no_lockfile? && new_version_satisfies?(req)
+            return req if !existing_version && new_version_satisfies?(req)
 
             new_req = req[:requirement].gsub(/<=?/, "~>")
             new_req.sub!(Gemnasium::Parser::Patterns::VERSION) do |old_version|
@@ -50,10 +50,6 @@ module Dependabot
             end
 
             req.merge(requirement: new_req)
-          end
-
-          def no_lockfile?
-            existing_version.nil?
           end
 
           def no_change_in_version?

--- a/spec/dependabot/file_parsers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/bundler_spec.rb
@@ -76,7 +76,20 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
       end
       let(:lockfile_content) { fixture("ruby", "lockfiles", "Gemfile.lock") }
 
-      its(:length) { is_expected.to eq(1) }
+      its(:length) { is_expected.to eq(2) }
+
+      describe "the first dependency" do
+        subject { dependencies.first }
+        let(:expected_requirements) do
+          [{
+            requirement: "< 2.0.0, > 1.0.0",
+            file: "Gemfile",
+            groups: [:default]
+          }]
+        end
+
+        its(:requirements) { is_expected.to eq(expected_requirements) }
+      end
     end
 
     context "with development dependencies" do

--- a/spec/dependabot/file_parsers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/bundler_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
         subject { dependencies.first }
         let(:expected_requirements) do
           [{
-            requirement: "< 2.0.0, > 1.0.0",
+            requirement: "< 1.5.0, > 1.0.0",
             file: "Gemfile",
             groups: [:default]
           }]

--- a/spec/fixtures/ruby/gemfiles/version_between_bounds
+++ b/spec/fixtures/ruby/gemfiles/version_between_bounds
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "business", "> 1.0.0", "< 2.0.0"
+gem "business", "> 1.0.0", "< 1.5.0"
 gem "statesman", "~> 1.2.0"


### PR DESCRIPTION
Previously, Dependabot was ignoring Ruby dependencies whose requirement had multiple components (e.g., `gem "business", "~> 1.0", ">= 1.0.3"`).

This PR updates the Ruby parsing, update checking and file-updating code to fix that. 🎉 