### PR TITLE
Manually set Bundler root

### DIFF
--- a/lib/dependabot/file_updaters/ruby/bundler.rb
+++ b/lib/dependabot/file_updaters/ruby/bundler.rb
@@ -131,10 +131,11 @@ module Dependabot
 
         def build_updated_lockfile
           lockfile_body =
-            SharedHelpers.in_a_temporary_directory do
+            SharedHelpers.in_a_temporary_directory do |tmp_dir|
               write_temporary_dependency_files
 
               SharedHelpers.in_a_forked_process do
+                ::Bundler.instance_variable_set(:@root, tmp_dir)
                 # Remove installed gems from the default Rubygems index
                 ::Gem::Specification.all = []
 

--- a/lib/dependabot/shared_helpers.rb
+++ b/lib/dependabot/shared_helpers.rb
@@ -26,7 +26,8 @@ module Dependabot
     def self.in_a_temporary_directory
       Dir.mkdir(BUMP_TMP_DIR_PATH) unless Dir.exist?(BUMP_TMP_DIR_PATH)
       Dir.mktmpdir(BUMP_TMP_FILE_PREFIX, BUMP_TMP_DIR_PATH) do |dir|
-        Dir.chdir(dir) { yield }
+        path = Pathname.new(dir).expand_path
+        Dir.chdir(path) { yield(path) }
       end
     end
 

--- a/spec/dependabot/file_updaters/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_updaters/ruby/bundler_spec.rb
@@ -378,6 +378,14 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
             expect(file.content).to include "business (1.5.0)"
           end
 
+          it "does not change the original path" do
+            expect(file.content).to include "remote: plugins/example"
+            expect(file.content).
+              not_to include Dependabot::SharedHelpers::BUMP_TMP_FILE_PREFIX
+            expect(file.content).
+              not_to include Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH
+          end
+
           context "that requires other files" do
             let(:gemspec_body) { fixture("ruby", "gemspecs", "with_require") }
 

--- a/spec/dependabot/shared_helpers_spec.rb
+++ b/spec/dependabot/shared_helpers_spec.rb
@@ -3,6 +3,22 @@ require "spec_helper"
 require "dependabot/shared_helpers"
 
 RSpec.describe Dependabot::SharedHelpers do
+  describe ".in_a_temporary_directory" do
+    subject(:in_a_temporary_directory) do
+      Dependabot::SharedHelpers.in_a_temporary_directory { output_dir.call }
+    end
+
+    let(:output_dir) { -> { Dir.pwd } }
+    it "runs inside the temporary directory created" do
+      expect(in_a_temporary_directory).to match(%r{tmp\/dependabot_+.})
+    end
+
+    it "yields the path to the temporary directory created" do
+      expect { |b| described_class.in_a_temporary_directory(&b) }.
+        to yield_with_args(Pathname)
+    end
+  end
+
   describe ".in_a_forked_process" do
     subject(:run_sub_process) do
       Dependabot::SharedHelpers.in_a_forked_process { task.call }


### PR DESCRIPTION
When the Bundler root is not set to the working directory, it attempts to
add the fully expanded path to the `Gemfile` for gems that are path based.
This resulted in an erroneous path being added to the updated `Gemfile.lock`
due to the temporary working directory not being on the original
repository.

That means that if my gem had a path of:
```YAML
PATH
  remote: path/to/my_library
```

it would output:

```YAML
PATH
  remote: tmp/dependabot_20170907-3-5asdast/path/to/my_library
```