### PR TITLE
[WIP] Add dependency#source attribute, and use for getting correct metadata

### DIFF
--- a/lib/dependabot/dependency.rb
+++ b/lib/dependabot/dependency.rb
@@ -45,9 +45,9 @@ module Dependabot
         raise ArgumentError, "requirements must be an array of hashes"
       end
 
-      required_keys = %i(requirement file groups)
+      required_keys = %i(requirement file groups source)
       unless requirement_fields.flatten.
-             all? { |r| (required_keys - r.keys).empty? }
+             all? { |r| required_keys.sort == r.keys.sort }
         raise ArgumentError, "each requirement must have the following "\
                              "required keys: #{required_keys.join(', ')}."
       end

--- a/lib/dependabot/dependency.rb
+++ b/lib/dependabot/dependency.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 module Dependabot
   class Dependency
-    attr_reader :name, :version, :source, :requirements, :package_manager,
+    attr_reader :name, :version, :requirements, :package_manager,
                 :previous_version, :previous_requirements
 
     def initialize(name:, requirements:, package_manager:, version: nil,
-                   previous_version: nil, previous_requirements: nil,
-                   source: nil)
+                   previous_version: nil, previous_requirements: nil)
       @name = name
       @version = version
-      @source = source
       @requirements = requirements.map { |req| symbolize_keys(req) }
       @previous_version = previous_version
       @previous_requirements =
@@ -23,7 +21,6 @@ module Dependabot
       {
         "name" => name,
         "version" => version,
-        "source" => source,
         "requirements" => requirements,
         "previous_version" => previous_version,
         "previous_requirements" => previous_requirements,
@@ -50,7 +47,7 @@ module Dependabot
 
       required_keys = %i(requirement file groups)
       unless requirement_fields.flatten.
-             all? { |r| (r.keys - required_keys).empty? }
+             all? { |r| (required_keys - r.keys).empty? }
         raise ArgumentError, "each requirement must have the following "\
                              "required keys: #{required_keys.join(', ')}."
       end

--- a/lib/dependabot/dependency.rb
+++ b/lib/dependabot/dependency.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 module Dependabot
   class Dependency
-    attr_reader :name, :version, :requirements, :package_manager,
+    attr_reader :name, :version, :source, :requirements, :package_manager,
                 :previous_version, :previous_requirements
 
     def initialize(name:, requirements:, package_manager:, version: nil,
-                   previous_version: nil, previous_requirements: nil)
+                   previous_version: nil, previous_requirements: nil,
+                   source: nil)
       @name = name
       @version = version
+      @source = source
       @requirements = requirements.map { |req| symbolize_keys(req) }
       @previous_version = previous_version
       @previous_requirements =
@@ -21,6 +23,7 @@ module Dependabot
       {
         "name" => name,
         "version" => version,
+        "source" => source,
         "requirements" => requirements,
         "previous_version" => previous_version,
         "previous_requirements" => previous_requirements,

--- a/lib/dependabot/file_parsers/git/submodules.rb
+++ b/lib/dependabot/file_parsers/git/submodules.rb
@@ -30,6 +30,7 @@ module Dependabot
                 requirements: [{
                   requirement: { url: url, branch: branch },
                   file: ".gitmodules",
+                  source: "git",
                   groups: []
                 }]
               )

--- a/lib/dependabot/file_parsers/git/submodules.rb
+++ b/lib/dependabot/file_parsers/git/submodules.rb
@@ -30,7 +30,7 @@ module Dependabot
                 requirements: [{
                   requirement: { url: url, branch: branch },
                   file: ".gitmodules",
-                  source: "git",
+                  source: nil,
                   groups: []
                 }]
               )

--- a/lib/dependabot/file_parsers/java_script/yarn.rb
+++ b/lib/dependabot/file_parsers/java_script/yarn.rb
@@ -21,6 +21,7 @@ module Dependabot
               requirements: [{
                 requirement: parsed_package_json.dig(dep_group, dep["name"]),
                 file: "package.json",
+                source: nil,
                 groups: [dep_group]
               }]
             )

--- a/lib/dependabot/file_parsers/php/composer.rb
+++ b/lib/dependabot/file_parsers/php/composer.rb
@@ -32,6 +32,7 @@ module Dependabot
               requirements: [{
                 requirement: req,
                 file: "composer.json",
+                source: nil,
                 groups: ["runtime"]
               }],
               package_manager: "composer"
@@ -57,6 +58,7 @@ module Dependabot
               requirements: [{
                 requirement: req,
                 file: "composer.json",
+                source: nil,
                 groups: ["development"]
               }],
               package_manager: "composer"

--- a/lib/dependabot/file_parsers/python/pip.rb
+++ b/lib/dependabot/file_parsers/python/pip.rb
@@ -16,6 +16,7 @@ module Dependabot
               requirements: [{
                 requirement: dep["requirement"],
                 file: "requirements.txt",
+                source: nil,
                 groups: []
               }],
               package_manager: "pip"

--- a/lib/dependabot/file_parsers/ruby/bundler.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler.rb
@@ -28,7 +28,6 @@ module Dependabot
                 Dependency.new(
                   name: existing_dependency.name,
                   version: existing_dependency.version || dep.version,
-                  source: existing_dependency.source,
                   requirements:
                     existing_dependency.requirements + dep.requirements,
                   package_manager: "bundler"
@@ -49,10 +48,10 @@ module Dependabot
             Dependency.new(
               name: dependency.name,
               version: dependency_version(dependency.name)&.to_s,
-              source: source_for(dependency),
               requirements: [{
                 requirement: dependency.requirement.to_s,
                 groups: dependency.groups,
+                source: source_for(dependency),
                 file: "Gemfile"
               }],
               package_manager: "bundler"
@@ -69,7 +68,6 @@ module Dependabot
             Dependency.new(
               name: dependency.name,
               version: dependency_version(dependency.name)&.to_s,
-              source: source_for(dependency),
               requirements: [{
                 requirement: dependency.requirement.to_s,
                 groups: dependency.runtime? ? ["runtime"] : ["development"],

--- a/lib/dependabot/file_parsers/ruby/bundler.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler.rb
@@ -71,6 +71,7 @@ module Dependabot
               requirements: [{
                 requirement: dependency.requirement.to_s,
                 groups: dependency.runtime? ? ["runtime"] : ["development"],
+                source: nil,
                 file: gemspec.name
               }],
               package_manager: "bundler"
@@ -179,9 +180,8 @@ module Dependabot
             raise "Unexpected Ruby source: #{source}"
           end
 
-          return { type: "default" } if dependency.source.nil?
-
-          { type: source.class.name.split("::").last.downcase }
+          return nil if dependency.source.nil?
+          source.class.name.split("::").last.downcase
         end
 
         def dependency_version(dependency_name)

--- a/lib/dependabot/metadata_finders/ruby/bundler.rb
+++ b/lib/dependabot/metadata_finders/ruby/bundler.rb
@@ -40,6 +40,14 @@ module Dependabot
         def rubygems_listing
           return @rubygems_listing unless @rubygems_listing.nil?
 
+          # Unless we're using the default source (i.e., no source was
+          # specified), return early. In future we should check for metadata
+          # at the custom source's URL, but we'll need to store that at parse
+          # time to do so.
+          unless dependency.requirements.all? { |r| r.fetch(:source).nil? }
+            return @rubygems_listing = {}
+          end
+
           @rubygems_listing = Gems.info(dependency.name)
         rescue JSON::ParserError
           # Replace with Gems::NotFound error if/when

--- a/spec/dependabot/dependency_spec.rb
+++ b/spec/dependabot/dependency_spec.rb
@@ -10,7 +10,12 @@ RSpec.describe Dependabot::Dependency do
       {
         name: "dep",
         requirements: [
-          { "file" => "a.rb", "requirement" => ">= 0", "groups" => [] }
+          {
+            "file" => "a.rb",
+            "requirement" => ">= 0",
+            "groups" => [],
+            source: nil
+          }
         ],
         package_manager: "bundler"
       }
@@ -18,7 +23,7 @@ RSpec.describe Dependabot::Dependency do
 
     it "converts string keys to symbols" do
       expect(dependency.requirements).
-        to eq([{ file: "a.rb", requirement: ">= 0", groups: [] }])
+        to eq([{ file: "a.rb", requirement: ">= 0", groups: [], source: nil }])
     end
   end
 end

--- a/spec/dependabot/file_parsers/git/submodules_spec.rb
+++ b/spec/dependabot/file_parsers/git/submodules_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Dependabot::FileParsers::Git::Submodules do
                 branch: "gh-pages"
               },
               file: ".gitmodules",
-              source: "git",
+              source: nil,
               groups: []
             }
           ]
@@ -68,7 +68,7 @@ RSpec.describe Dependabot::FileParsers::Git::Submodules do
                 branch: "master"
               },
               file: ".gitmodules",
-              source: "git",
+              source: nil,
               groups: []
             }
           ]

--- a/spec/dependabot/file_parsers/git/submodules_spec.rb
+++ b/spec/dependabot/file_parsers/git/submodules_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Dependabot::FileParsers::Git::Submodules do
                 branch: "gh-pages"
               },
               file: ".gitmodules",
+              source: "git",
               groups: []
             }
           ]
@@ -67,6 +68,7 @@ RSpec.describe Dependabot::FileParsers::Git::Submodules do
                 branch: "master"
               },
               file: ".gitmodules",
+              source: "git",
               groups: []
             }
           ]

--- a/spec/dependabot/file_parsers/java_script/yarn_spec.rb
+++ b/spec/dependabot/file_parsers/java_script/yarn_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe Dependabot::FileParsers::JavaScript::Yarn do
               {
                 requirement: "^0.0.1",
                 file: "package.json",
-                groups: ["dependencies"]
+                groups: ["dependencies"],
+                source: nil
               }
             ]
           )
@@ -69,7 +70,8 @@ RSpec.describe Dependabot::FileParsers::JavaScript::Yarn do
               {
                 requirement: "^1.0.0",
                 file: "package.json",
-                groups: ["devDependencies"]
+                groups: ["devDependencies"],
+                source: nil
               }
             ]
           )
@@ -96,7 +98,8 @@ RSpec.describe Dependabot::FileParsers::JavaScript::Yarn do
               {
                 requirement: "^1.0.0",
                 file: "package.json",
-                groups: ["optionalDependencies"]
+                groups: ["optionalDependencies"],
+                source: nil
               }
             ]
           )

--- a/spec/dependabot/file_parsers/php/composer_spec.rb
+++ b/spec/dependabot/file_parsers/php/composer_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe Dependabot::FileParsers::Php::Composer do
               {
                 requirement: "1.0.*",
                 file: "composer.json",
-                groups: ["runtime"]
+                groups: ["runtime"],
+                source: nil
               }
             ]
           )
@@ -75,7 +76,8 @@ RSpec.describe Dependabot::FileParsers::Php::Composer do
               {
                 requirement: "1.0.1",
                 file: "composer.json",
-                groups: ["development"]
+                groups: ["development"],
+                source: nil
               }
             ]
           )

--- a/spec/dependabot/file_parsers/python/pip_spec.rb
+++ b/spec/dependabot/file_parsers/python/pip_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
               {
                 requirement: "==2.6.1",
                 file: "requirements.txt",
-                groups: []
+                groups: [],
+                source: nil
               }
             ]
           )
@@ -63,7 +64,8 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
               {
                 requirement: "==2.6.1",
                 file: "requirements.txt",
-                groups: []
+                groups: [],
+                source: nil
               }
             ]
           )
@@ -88,7 +90,8 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
               {
                 requirement: "==2.6.1",
                 file: "requirements.txt",
-                groups: []
+                groups: [],
+                source: nil
               }
             ]
           )
@@ -157,7 +160,8 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
               {
                 requirement: "==2.1.4",
                 file: "requirements.txt",
-                groups: []
+                groups: [],
+                source: nil
               }
             ]
           )

--- a/spec/dependabot/file_parsers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/bundler_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           [{
             requirement: "~> 1.4.0",
             file: "Gemfile",
-            source: { type: "default" },
+            source: nil,
             groups: [:default]
           }]
         end
@@ -60,7 +60,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           [{
             requirement: ">= 0",
             file: "Gemfile",
-            source: { type: "default" },
+            source: nil,
             groups: [:default]
           }]
         end
@@ -86,7 +86,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           [{
             requirement: "< 1.5.0, > 1.0.0",
             file: "Gemfile",
-            source: { type: "default" },
+            source: nil,
             groups: [:default]
           }]
         end
@@ -111,7 +111,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           [{
             requirement: "~> 1.4.0",
             file: "Gemfile",
-            source: { type: "default" },
+            source: nil,
             groups: %i(development test)
           }]
         end
@@ -166,7 +166,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           [{
             requirement: ">= 0",
             file: "Gemfile",
-            source: { type: "rubygems" },
+            source: "rubygems",
             groups: [:default]
           }]
         end
@@ -222,6 +222,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
             [{
               requirement: "~> 4.1",
               file: "example.gemspec",
+              source: nil,
               groups: ["runtime"]
             }]
           end
@@ -238,6 +239,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
             [{
               requirement: "~> 2.3.1",
               file: "example.gemspec",
+              source: nil,
               groups: ["development"]
             }]
           end
@@ -293,12 +295,13 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
               {
                 requirement: "~> 1.0",
                 file: "example.gemspec",
+                source: nil,
                 groups: ["runtime"]
               },
               {
                 requirement: "~> 1.4.0",
                 file: "Gemfile",
-                source: { type: "git" },
+                source: "git",
                 groups: [:default]
               }
             ]
@@ -333,6 +336,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           [{
             requirement: ">= 0",
             file: "example.gemspec",
+            source: nil,
             groups: ["development"]
           }]
         end
@@ -361,7 +365,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           [{
             requirement: "~> 1.4.0",
             file: "Gemfile",
-            source: { type: "default" },
+            source: nil,
             groups: [:default]
           }]
         end

--- a/spec/dependabot/file_parsers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/bundler_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           [{
             requirement: "~> 1.4.0",
             file: "Gemfile",
+            source: { type: "default" },
             groups: [:default]
           }]
         end
@@ -42,7 +43,6 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
         its(:name) { is_expected.to eq("business") }
         its(:requirements) { is_expected.to eq(expected_requirements) }
         its(:version) { is_expected.to eq("1.4.0") }
-        its(:source) { is_expected.to eq(type: "default") }
       end
     end
 
@@ -60,6 +60,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           [{
             requirement: ">= 0",
             file: "Gemfile",
+            source: { type: "default" },
             groups: [:default]
           }]
         end
@@ -68,7 +69,6 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
         its(:name) { is_expected.to eq("business") }
         its(:version) { is_expected.to eq("1.4.0") }
         its(:requirements) { is_expected.to eq(expected_requirements) }
-        its(:source) { is_expected.to eq(type: "default") }
       end
     end
 
@@ -86,6 +86,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           [{
             requirement: "< 1.5.0, > 1.0.0",
             file: "Gemfile",
+            source: { type: "default" },
             groups: [:default]
           }]
         end
@@ -110,6 +111,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           [{
             requirement: "~> 1.4.0",
             file: "Gemfile",
+            source: { type: "default" },
             groups: %i(development test)
           }]
         end
@@ -118,7 +120,6 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
         its(:name) { is_expected.to eq("business") }
         its(:version) { is_expected.to eq("1.4.0") }
         its(:requirements) { is_expected.to eq(expected_requirements) }
-        its(:source) { is_expected.to eq(type: "default") }
       end
     end
 
@@ -161,9 +162,18 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
       describe "the private dependency" do
         subject { dependencies.last }
 
+        let(:expected_requirements) do
+          [{
+            requirement: ">= 0",
+            file: "Gemfile",
+            source: { type: "rubygems" },
+            groups: [:default]
+          }]
+        end
+
         it { is_expected.to be_a(Dependabot::Dependency) }
         its(:name) { is_expected.to eq("business") }
-        its(:source) { is_expected.to eq(type: "rubygems") }
+        its(:requirements) { is_expected.to eq(expected_requirements) }
       end
     end
 
@@ -220,7 +230,6 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           its(:name) { is_expected.to eq("gitlab") }
           its(:version) { is_expected.to eq("4.2.0") }
           its(:requirements) { is_expected.to eq(expected_requirements) }
-          its(:source) { is_expected.to eq(type: "default") }
         end
 
         describe "a development gemspec dependency" do
@@ -237,7 +246,6 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           its(:name) { is_expected.to eq("webmock") }
           its(:version) { is_expected.to eq("2.3.2") }
           its(:requirements) { is_expected.to eq(expected_requirements) }
-          its(:source) { is_expected.to eq(type: "default") }
         end
 
         context "that needs to be sanitized" do
@@ -290,6 +298,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
               {
                 requirement: "~> 1.4.0",
                 file: "Gemfile",
+                source: { type: "git" },
                 groups: [:default]
               }
             ]
@@ -301,7 +310,6 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           its(:requirements) do
             is_expected.to match_array(expected_requirements)
           end
-          its(:source) { is_expected.to eq(type: "git") }
         end
       end
     end
@@ -333,7 +341,6 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
         its(:name) { is_expected.to eq("rake") }
         its(:version) { is_expected.to be_nil }
         its(:requirements) { is_expected.to eq(expected_requirements) }
-        its(:source) { is_expected.to eq(type: "default") }
       end
 
       context "that needs to be sanitized" do
@@ -354,6 +361,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           [{
             requirement: "~> 1.4.0",
             file: "Gemfile",
+            source: { type: "default" },
             groups: [:default]
           }]
         end
@@ -362,7 +370,6 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
         its(:name) { is_expected.to eq("business") }
         its(:version) { is_expected.to be_nil }
         its(:requirements) { is_expected.to eq(expected_requirements) }
-        its(:source) { is_expected.to eq(type: "default") }
       end
 
       context "with a dependency for an alternative platform" do

--- a/spec/dependabot/file_parsers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/bundler_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
         its(:name) { is_expected.to eq("business") }
         its(:requirements) { is_expected.to eq(expected_requirements) }
         its(:version) { is_expected.to eq("1.4.0") }
+        its(:source) { is_expected.to eq(type: "default") }
       end
     end
 
@@ -67,6 +68,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
         its(:name) { is_expected.to eq("business") }
         its(:version) { is_expected.to eq("1.4.0") }
         its(:requirements) { is_expected.to eq(expected_requirements) }
+        its(:source) { is_expected.to eq(type: "default") }
       end
     end
 
@@ -116,6 +118,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
         its(:name) { is_expected.to eq("business") }
         its(:version) { is_expected.to eq("1.4.0") }
         its(:requirements) { is_expected.to eq(expected_requirements) }
+        its(:source) { is_expected.to eq(type: "default") }
       end
     end
 
@@ -145,6 +148,23 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
       end
 
       its(:length) { is_expected.to eq(4) }
+    end
+
+    context "with a gem from a private gem source" do
+      let(:lockfile_content) do
+        fixture("ruby", "lockfiles", "specified_source.lock")
+      end
+      let(:gemfile_content) { fixture("ruby", "gemfiles", "specified_source") }
+
+      its(:length) { is_expected.to eq(2) }
+
+      describe "the private dependency" do
+        subject { dependencies.last }
+
+        it { is_expected.to be_a(Dependabot::Dependency) }
+        its(:name) { is_expected.to eq("business") }
+        its(:source) { is_expected.to eq(type: "rubygems") }
+      end
     end
 
     context "when the Gemfile can't be evaluated" do
@@ -200,6 +220,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           its(:name) { is_expected.to eq("gitlab") }
           its(:version) { is_expected.to eq("4.2.0") }
           its(:requirements) { is_expected.to eq(expected_requirements) }
+          its(:source) { is_expected.to eq(type: "default") }
         end
 
         describe "a development gemspec dependency" do
@@ -216,6 +237,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           its(:name) { is_expected.to eq("webmock") }
           its(:version) { is_expected.to eq("2.3.2") }
           its(:requirements) { is_expected.to eq(expected_requirements) }
+          its(:source) { is_expected.to eq(type: "default") }
         end
 
         context "that needs to be sanitized" do
@@ -234,7 +256,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
       end
     end
 
-    context "with a gemspec and gemfile (no lockfile)" do
+    context "with a gemspec and Gemfile (no lockfile)" do
       let(:files) { [gemspec, gemfile] }
 
       let(:gemspec) do
@@ -249,9 +271,12 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
       its(:length) { is_expected.to eq(13) }
 
       context "when a dependency appears in both" do
+        let(:gemfile_content) do
+          fixture("ruby", "gemfiles", "imports_gemspec_git_override")
+        end
         let(:gemspec_content) { fixture("ruby", "gemspecs", "small_example") }
 
-        its(:length) { is_expected.to eq(2) }
+        its(:length) { is_expected.to eq(1) }
 
         describe "the first dependency" do
           subject { dependencies.first }
@@ -276,6 +301,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
           its(:requirements) do
             is_expected.to match_array(expected_requirements)
           end
+          its(:source) { is_expected.to eq(type: "git") }
         end
       end
     end
@@ -307,6 +333,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
         its(:name) { is_expected.to eq("rake") }
         its(:version) { is_expected.to be_nil }
         its(:requirements) { is_expected.to eq(expected_requirements) }
+        its(:source) { is_expected.to eq(type: "default") }
       end
 
       context "that needs to be sanitized" do
@@ -335,6 +362,7 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
         its(:name) { is_expected.to eq("business") }
         its(:version) { is_expected.to be_nil }
         its(:requirements) { is_expected.to eq(expected_requirements) }
+        its(:source) { is_expected.to eq(type: "default") }
       end
 
       context "with a dependency for an alternative platform" do

--- a/spec/dependabot/file_updaters/base_spec.rb
+++ b/spec/dependabot/file_updaters/base_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Dependabot::FileUpdaters::Base do
       version: "1.5.0",
       package_manager: "bundler",
       requirements: [
-        { file: "Gemfile", requirement: "~> 1.4.0", groups: [] }
+        { file: "Gemfile", requirement: "~> 1.4.0", groups: [], source: nil }
       ]
     )
   end

--- a/spec/dependabot/file_updaters/git/submodules_spec.rb
+++ b/spec/dependabot/file_updaters/git/submodules_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Dependabot::FileUpdaters::Git::Submodules do
             url: "https://github.com/example/manifesto.git",
             branch: "master"
           },
+          source: nil,
           groups: []
         }
       ],
@@ -51,6 +52,7 @@ RSpec.describe Dependabot::FileUpdaters::Git::Submodules do
             url: "https://github.com/example/manifesto.git",
             branch: "master"
           },
+          source: nil,
           groups: []
         }
       ],

--- a/spec/dependabot/file_updaters/java_script/yarn_spec.rb
+++ b/spec/dependabot/file_updaters/java_script/yarn_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
       version: "0.0.2",
       package_manager: "yarn",
       requirements: [
-        { file: "package.json", requirement: "^0.0.1", groups: [] }
+        { file: "package.json", requirement: "^0.0.1", groups: [], source: nil }
       ]
     )
   end
@@ -74,7 +74,12 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
             version: "0.2.1",
             package_manager: "yarn",
             requirements: [
-              { file: "package.json", requirement: "^0.0.1", groups: [] }
+              {
+                file: "package.json",
+                requirement: "^0.0.1",
+                groups: [],
+                source: nil
+              }
             ]
           )
         end
@@ -105,7 +110,12 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
             version: "1.3.1",
             package_manager: "yarn",
             requirements: [
-              { file: "package.json", requirement: "^1.2.1", groups: [] }
+              {
+                file: "package.json",
+                requirement: "^1.2.1",
+                groups: [],
+                source: nil
+              }
             ]
           )
         end
@@ -147,7 +157,12 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
             version: "1.3.1",
             package_manager: "yarn",
             requirements: [
-              { file: "package.json", requirement: "^1.2.1", groups: [] }
+              {
+                file: "package.json",
+                requirement: "^1.2.1",
+                groups: [],
+                source: nil
+              }
             ]
           )
         end

--- a/spec/dependabot/file_updaters/php/composer_spec.rb
+++ b/spec/dependabot/file_updaters/php/composer_spec.rb
@@ -37,7 +37,12 @@ RSpec.describe Dependabot::FileUpdaters::Php::Composer do
       name: "monolog/monolog",
       version: "1.22.1",
       requirements: [
-        { file: "composer.json", requirement: "1.22.*", groups: [] }
+        {
+          file: "composer.json",
+          requirement: "1.22.*",
+          groups: [],
+          source: nil
+        }
       ],
       package_manager: "composer"
     )

--- a/spec/dependabot/file_updaters/python/pip_spec.rb
+++ b/spec/dependabot/file_updaters/python/pip_spec.rb
@@ -30,7 +30,12 @@ RSpec.describe Dependabot::FileUpdaters::Python::Pip do
       name: "psycopg2",
       version: "2.8.1",
       requirements: [
-        { file: "requirements.txt", requirement: "==2.8.1", groups: [] }
+        {
+          file: "requirements.txt",
+          requirement: "==2.8.1",
+          groups: [],
+          source: nil
+        }
       ],
       package_manager: "pip"
     )

--- a/spec/dependabot/file_updaters/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_updaters/ruby/bundler_spec.rb
@@ -60,10 +60,10 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
     )
   end
   let(:requirements) do
-    [{ file: "Gemfile", requirement: "~> 1.5.0", groups: [] }]
+    [{ file: "Gemfile", requirement: "~> 1.5.0", groups: [], source: nil }]
   end
   let(:previous_requirements) do
-    [{ file: "Gemfile", requirement: "~> 1.4.0", groups: [] }]
+    [{ file: "Gemfile", requirement: "~> 1.4.0", groups: [], source: nil }]
   end
   let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
 
@@ -92,10 +92,10 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
           fixture("ruby", "gemfiles", "version_not_specified")
         end
         let(:requirements) do
-          [{ file: "Gemfile", requirement: ">= 0", groups: [] }]
+          [{ file: "Gemfile", requirement: ">= 0", groups: [], source: nil }]
         end
         let(:previous_requirements) do
-          [{ file: "Gemfile", requirement: ">= 0", groups: [] }]
+          [{ file: "Gemfile", requirement: ">= 0", groups: [], source: nil }]
         end
         it { is_expected.to be_nil }
       end
@@ -103,10 +103,24 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
       context "when the full version is specified" do
         let(:gemfile_body) { fixture("ruby", "gemfiles", "version_specified") }
         let(:requirements) do
-          [{ file: "Gemfile", requirement: "~> 1.5.0", groups: [] }]
+          [
+            {
+              file: "Gemfile",
+              requirement: "~> 1.5.0",
+              groups: [],
+              source: nil
+            }
+          ]
         end
         let(:previous_requirements) do
-          [{ file: "Gemfile", requirement: "~> 1.4.0", groups: [] }]
+          [
+            {
+              file: "Gemfile",
+              requirement: "~> 1.4.0",
+              groups: [],
+              source: nil
+            }
+          ]
         end
         its(:content) { is_expected.to include "\"business\", \"~> 1.5.0\"" }
         its(:content) { is_expected.to include "\"statesman\", \"~> 1.2.0\"" }
@@ -117,10 +131,24 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
           fixture("ruby", "gemfiles", "prerelease_specified")
         end
         let(:requirements) do
-          [{ file: "Gemfile", requirement: "~> 1.5.0", groups: [] }]
+          [
+            {
+              file: "Gemfile",
+              requirement: "~> 1.5.0",
+              groups: [],
+              source: nil
+            }
+          ]
         end
         let(:previous_requirements) do
-          [{ file: "Gemfile", requirement: "~> 1.4.0.rc1", groups: [] }]
+          [
+            {
+              file: "Gemfile",
+              requirement: "~> 1.4.0.rc1",
+              groups: [],
+              source: nil
+            }
+          ]
         end
         its(:content) { is_expected.to include "\"business\", \"~> 1.5.0\"" }
       end
@@ -130,10 +158,10 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
           fixture("ruby", "gemfiles", "minor_version_specified")
         end
         let(:requirements) do
-          [{ file: "Gemfile", requirement: "~> 1.5", groups: [] }]
+          [{ file: "Gemfile", requirement: "~> 1.5", groups: [], source: nil }]
         end
         let(:previous_requirements) do
-          [{ file: "Gemfile", requirement: "~> 1.4", groups: [] }]
+          [{ file: "Gemfile", requirement: "~> 1.4", groups: [], source: nil }]
         end
         its(:content) { is_expected.to include "\"business\", \"~> 1.5\"" }
         its(:content) { is_expected.to include "\"statesman\", \"~> 1.2\"" }
@@ -149,10 +177,20 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
             name: "i18n",
             version: "0.5.0",
             requirements: [
-              { file: "Gemfile", requirement: "~> 0.5.0", groups: [] }
+              {
+                file: "Gemfile",
+                requirement: "~> 0.5.0",
+                groups: [],
+                source: nil
+              }
             ],
             previous_requirements: [
-              { file: "Gemfile", requirement: "~> 0.4.0", groups: [] }
+              {
+                file: "Gemfile",
+                requirement: "~> 0.4.0",
+                groups: [],
+                source: nil
+              }
             ],
             package_manager: "bundler"
           )
@@ -179,10 +217,24 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
           fixture("ruby", "gemfiles", "version_between_bounds")
         end
         let(:requirements) do
-          [{ file: "Gemfile", requirement: "> 1.0.0, < 1.6.0", groups: [] }]
+          [
+            {
+              file: "Gemfile",
+              requirement: "> 1.0.0, < 1.6.0",
+              groups: [],
+              source: nil
+            }
+          ]
         end
         let(:previous_requirements) do
-          [{ file: "Gemfile", requirement: "> 1.0.0, < 1.5.0", groups: [] }]
+          [
+            {
+              file: "Gemfile",
+              requirement: "> 1.0.0, < 1.5.0",
+              groups: [],
+              source: nil
+            }
+          ]
         end
         its(:content) do
           is_expected.to include "\"business\", \"> 1.0.0\", \"< 1.6.0\""
@@ -246,10 +298,20 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
               version: "1.4.6",
               previous_version: "1.4.0",
               requirements: [
-                { file: "Gemfile", requirement: "~> 1.5.0", groups: [] }
+                {
+                  file: "Gemfile",
+                  requirement: "~> 1.5.0",
+                  groups: [],
+                  source: nil
+                }
               ],
               previous_requirements: [
-                { file: "Gemfile", requirement: "~> 1.4.0", groups: [] }
+                {
+                  file: "Gemfile",
+                  requirement: "~> 1.4.0",
+                  groups: [],
+                  source: nil
+                }
               ],
               package_manager: "bundler"
             )
@@ -422,10 +484,20 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
               version: "2.0.0",
               previous_version: "1.4.0",
               requirements: [
-                { file: "Gemfile", requirement: "~> 2.0", groups: [] }
+                {
+                  file: "Gemfile",
+                  requirement: "~> 2.0",
+                  groups: [],
+                  source: nil
+                }
               ],
               previous_requirements: [
-                { file: "Gemfile", requirement: "~> 1.2.0", groups: [] }
+                {
+                  file: "Gemfile",
+                  requirement: "~> 1.2.0",
+                  groups: [],
+                  source: nil
+                }
               ],
               package_manager: "bundler"
             )
@@ -447,24 +519,28 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
                 {
                   file: "example.gemspec",
                   requirement: requirement,
-                  groups: []
+                  groups: [],
+                  source: nil
                 },
                 {
                   file: "Gemfile",
                   requirement: requirement,
-                  groups: []
+                  groups: [],
+                  source: nil
                 }
               ],
               previous_requirements: [
                 {
                   file: "example.gemspec",
                   requirement: "~> 1.0",
-                  groups: []
+                  groups: [],
+                  source: nil
                 },
                 {
                   file: "Gemfile",
                   requirement: "~> 1.4.0",
-                  groups: []
+                  groups: [],
+                  source: nil
                 }
               ],
               package_manager: "bundler"
@@ -500,11 +576,17 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
                   {
                     file: "example.gemspec",
                     requirement: ">= 1.0, < 3.0",
-                    groups: []
+                    groups: [],
+                    source: nil
                   }
                 ],
                 previous_requirements: [
-                  { file: "example.gemspec", requirement: "~> 1.0", groups: [] }
+                  {
+                    file: "example.gemspec",
+                    requirement: "~> 1.0",
+                    groups: [],
+                    source: nil
+                  }
                 ],
                 package_manager: "bundler"
               )
@@ -545,11 +627,17 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
             {
               file: "example.gemspec",
               requirement: ">= 4.6, < 6.0",
-              groups: []
+              groups: [],
+              source: nil
             }
           ],
           previous_requirements: [
-            { file: "example.gemspec", requirement: "~> 4.6", groups: [] }
+            {
+              file: "example.gemspec",
+              requirement: "~> 4.6",
+              groups: [],
+              source: nil
+            }
           ],
           package_manager: "bundler"
         )
@@ -571,10 +659,20 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
               name: dependency_name,
               version: "5.1.0",
               requirements: [
-                { file: "example.gemspec", requirement: "~> 4.6", groups: [] }
+                {
+                  file: "example.gemspec",
+                  requirement: "~> 4.6",
+                  groups: [],
+                  source: nil
+                }
               ],
               previous_requirements: [
-                { file: "example.gemspec", requirement: "~> 4.6", groups: [] }
+                {
+                  file: "example.gemspec",
+                  requirement: "~> 4.6",
+                  groups: [],
+                  source: nil
+                }
               ],
               package_manager: "bundler"
             )
@@ -649,10 +747,24 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
         )
       end
       let(:requirements) do
-        [{ file: "example.gemspec", requirement: ">= 4.6, < 6.0", groups: [] }]
+        [
+          {
+            file: "example.gemspec",
+            requirement: ">= 4.6, < 6.0",
+            groups: [],
+            source: nil
+          }
+        ]
       end
       let(:previous_requirements) do
-        [{ file: "example.gemspec", requirement: "~> 4.6", groups: [] }]
+        [
+          {
+            file: "example.gemspec",
+            requirement: "~> 4.6",
+            groups: [],
+            source: nil
+          }
+        ]
       end
       let(:dependency_name) { "octokit" }
 
@@ -670,19 +782,31 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
             {
               file: "example.gemspec",
               requirement: ">= 1.0, < 6.0",
-              groups: []
+              groups: [],
+              source: nil
             },
             {
               file: "Gemfile",
               requirement: "~> 5.1.0",
-              groups: []
+              groups: [],
+              source: nil
             }
           ]
         end
         let(:previous_requirements) do
           [
-            { file: "example.gemspec", requirement: "~> 1.0", groups: [] },
-            { file: "Gemfile", requirement: "~> 1.4.0", groups: [] }
+            {
+              file: "example.gemspec",
+              requirement: "~> 1.0",
+              groups: [],
+              source: nil
+            },
+            {
+              file: "Gemfile",
+              requirement: "~> 1.4.0",
+              groups: [],
+              source: nil
+            }
           ]
         end
 
@@ -736,10 +860,20 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
             version: "1.5.0",
             previous_version: "1.4.0",
             requirements: [
-              { file: "Gemfile", requirement: "~> 1.5.0", groups: [] }
+              {
+                file: "Gemfile",
+                requirement: "~> 1.5.0",
+                groups: [],
+                source: nil
+              }
             ],
             previous_requirements: [
-              { file: "Gemfile", requirement: "~> 1.4.0", groups: [] }
+              {
+                file: "Gemfile",
+                requirement: "~> 1.4.0",
+                groups: [],
+                source: nil
+              }
             ],
             package_manager: "bundler"
           )
@@ -759,10 +893,20 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
           Dependabot::Dependency.new(
             name: "octokit",
             requirements: [
-              { file: "some.gemspec", requirement: ">= 4.6, < 6.0", groups: [] }
+              {
+                file: "some.gemspec",
+                requirement: ">= 4.6, < 6.0",
+                groups: [],
+                source: nil
+              }
             ],
             previous_requirements: [
-              { file: "some.gemspec", requirement: "~> 4.6", groups: [] }
+              {
+                file: "some.gemspec",
+                requirement: "~> 4.6",
+                groups: [],
+                source: nil
+              }
             ],
             package_manager: "bundler"
           )

--- a/spec/dependabot/metadata_finders/base_spec.rb
+++ b/spec/dependabot/metadata_finders/base_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe Dependabot::MetadataFinders::Base do
     Dependabot::Dependency.new(
       name: dependency_name,
       version: dependency_version,
-      requirements: [{ file: "Gemfile", requirement: ">= 0", groups: [] }],
+      requirements: [
+        { file: "Gemfile", requirement: ">= 0", groups: [], source: nil }
+      ],
       previous_version: dependency_previous_version,
       package_manager: "bundler"
     )

--- a/spec/dependabot/metadata_finders/git/submodules_spec.rb
+++ b/spec/dependabot/metadata_finders/git/submodules_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Dependabot::MetadataFinders::Git::Submodules do
         {
           file: ".gitmodules",
           requirement: { url: url, branch: "master" },
-          groups: []
+          groups: [],
+          source: nil
         }
       ],
       package_manager: "submodules"

--- a/spec/dependabot/metadata_finders/java_script/yarn_spec.rb
+++ b/spec/dependabot/metadata_finders/java_script/yarn_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe Dependabot::MetadataFinders::JavaScript::Yarn do
     Dependabot::Dependency.new(
       name: dependency_name,
       version: "1.0",
-      requirements: [{ file: "package.json", requirement: "^1.0", groups: [] }],
+      requirements: [
+        { file: "package.json", requirement: "^1.0", groups: [], source: nil }
+      ],
       package_manager: "yarn"
     )
   end

--- a/spec/dependabot/metadata_finders/php/composer_spec.rb
+++ b/spec/dependabot/metadata_finders/php/composer_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe Dependabot::MetadataFinders::Php::Composer do
     Dependabot::Dependency.new(
       name: dependency_name,
       version: "1.0",
-      requirements: [{ file: "composer.json", requirement: "1.*", groups: [] }],
+      requirements: [
+        { file: "composer.json", requirement: "1.*", groups: [], source: nil }
+      ],
       package_manager: "composer"
     )
   end

--- a/spec/dependabot/metadata_finders/python/pip_spec.rb
+++ b/spec/dependabot/metadata_finders/python/pip_spec.rb
@@ -13,7 +13,12 @@ RSpec.describe Dependabot::MetadataFinders::Python::Pip do
       name: dependency_name,
       version: "1.0",
       requirements: [
-        { file: "requirements.txt", requirement: "=1.0", groups: [] }
+        {
+          file: "requirements.txt",
+          requirement: "=1.0",
+          groups: [],
+          source: nil
+        }
       ],
       package_manager: "pip"
     )

--- a/spec/dependabot/metadata_finders/ruby/bundler_spec.rb
+++ b/spec/dependabot/metadata_finders/ruby/bundler_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe Dependabot::MetadataFinders::Ruby::Bundler do
     Dependabot::Dependency.new(
       name: dependency_name,
       version: "1.0",
-      requirements: [{ file: "Gemfile", requirement: ">= 0", groups: [] }],
+      requirements: [
+        { file: "Gemfile", requirement: ">= 0", groups: [], source: nil }
+      ],
       package_manager: "bundler"
     )
   end
@@ -24,77 +26,99 @@ RSpec.describe Dependabot::MetadataFinders::Ruby::Bundler do
 
   describe "#source_url" do
     subject(:source_url) { finder.source_url }
-    let(:rubygems_url) { "https://rubygems.org/api/v1/gems/business.json" }
-    let(:rubygems_response_code) { 200 }
 
-    before do
-      stub_request(:get, rubygems_url).
-        to_return(status: rubygems_response_code, body: rubygems_response)
-    end
-
-    context "when there is a github link in the rubygems response" do
-      let(:rubygems_response) { fixture("ruby", "rubygems_response.json") }
-
-      it { is_expected.to eq("https://github.com/gocardless/business") }
-
-      it "caches the call to rubygems" do
-        2.times { source_url }
-        expect(WebMock).to have_requested(:get, rubygems_url).once
+    context "for a non-default source" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "1.0",
+          requirements: [
+            {
+              file: "Gemfile",
+              requirement: ">= 0",
+              groups: [],
+              source: "rubygems"
+            }
+          ],
+          package_manager: "bundler"
+        )
       end
 
-      context "that contains a .git suffix" do
-        let(:rubygems_response) do
-          fixture("ruby", "rubygems_response_period_github.json")
+      it { is_expected.to eq(nil) }
+    end
+
+    context "for a default source" do
+      let(:rubygems_url) { "https://rubygems.org/api/v1/gems/business.json" }
+      let(:rubygems_response_code) { 200 }
+      before do
+        stub_request(:get, rubygems_url).
+          to_return(status: rubygems_response_code, body: rubygems_response)
+      end
+
+      context "when there is a github link in the rubygems response" do
+        let(:rubygems_response) { fixture("ruby", "rubygems_response.json") }
+
+        it { is_expected.to eq("https://github.com/gocardless/business") }
+
+        it "caches the call to rubygems" do
+          2.times { source_url }
+          expect(WebMock).to have_requested(:get, rubygems_url).once
         end
 
-        it { is_expected.to eq("https://github.com/gocardless/business.rb") }
-      end
-    end
+        context "that contains a .git suffix" do
+          let(:rubygems_response) do
+            fixture("ruby", "rubygems_response_period_github.json")
+          end
 
-    context "when there is a bitbucket link in the rubygems response" do
-      let(:rubygems_response) do
-        fixture("ruby", "rubygems_response_bitbucket.json")
-      end
-
-      it { is_expected.to eq("https://bitbucket.org/gocardless/business") }
-
-      it "caches the call to rubygems" do
-        2.times { source_url }
-        expect(WebMock).to have_requested(:get, rubygems_url).once
-      end
-    end
-
-    context "when there is a gitlab link in the rubygems response" do
-      let(:rubygems_response) do
-        fixture("ruby", "rubygems_response_gitlab.json")
+          it { is_expected.to eq("https://github.com/gocardless/business.rb") }
+        end
       end
 
-      it { is_expected.to eq("https://gitlab.com/zachdaniel/result-monad") }
+      context "when there is a bitbucket link in the rubygems response" do
+        let(:rubygems_response) do
+          fixture("ruby", "rubygems_response_bitbucket.json")
+        end
 
-      it "caches the call to rubygems" do
-        2.times { source_url }
-        expect(WebMock).to have_requested(:get, rubygems_url).once
+        it { is_expected.to eq("https://bitbucket.org/gocardless/business") }
+
+        it "caches the call to rubygems" do
+          2.times { source_url }
+          expect(WebMock).to have_requested(:get, rubygems_url).once
+        end
       end
-    end
 
-    context "when there isn't a source link in the rubygems response" do
-      let(:rubygems_response) do
-        fixture("ruby", "rubygems_response_no_source.json")
+      context "when there is a gitlab link in the rubygems response" do
+        let(:rubygems_response) do
+          fixture("ruby", "rubygems_response_gitlab.json")
+        end
+
+        it { is_expected.to eq("https://gitlab.com/zachdaniel/result-monad") }
+
+        it "caches the call to rubygems" do
+          2.times { source_url }
+          expect(WebMock).to have_requested(:get, rubygems_url).once
+        end
       end
 
-      it { is_expected.to be_nil }
+      context "when there isn't a source link in the rubygems response" do
+        let(:rubygems_response) do
+          fixture("ruby", "rubygems_response_no_source.json")
+        end
 
-      it "caches the call to rubygems" do
-        2.times { source_url }
-        expect(WebMock).to have_requested(:get, rubygems_url).once
+        it { is_expected.to be_nil }
+
+        it "caches the call to rubygems" do
+          2.times { source_url }
+          expect(WebMock).to have_requested(:get, rubygems_url).once
+        end
       end
-    end
 
-    context "when the gem isn't on Rubygems" do
-      let(:rubygems_response_code) { 404 }
-      let(:rubygems_response) { "This rubygem could not be found." }
+      context "when the gem isn't on Rubygems" do
+        let(:rubygems_response_code) { 404 }
+        let(:rubygems_response) { "This rubygem could not be found." }
 
-      it { is_expected.to be_nil }
+        it { is_expected.to be_nil }
+      end
     end
   end
 

--- a/spec/dependabot/pull_request_creator_spec.rb
+++ b/spec/dependabot/pull_request_creator_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe Dependabot::PullRequestCreator do
       version: "1.5.0",
       previous_version: "1.4.0",
       package_manager: "bundler",
-      requirements: [{ file: "Gemfile", requirement: "~> 1.4.0", groups: [] }]
+      requirements: [
+        { file: "Gemfile", requirement: "~> 1.4.0", groups: [], source: nil }
+      ]
     )
   end
   let(:repo) { "gocardless/bump" }
@@ -108,7 +110,12 @@ RSpec.describe Dependabot::PullRequestCreator do
           version: "1.5.0",
           package_manager: "bundler",
           requirements: [
-            { file: "Gemfile", requirement: "~> 1.4.0", groups: [] }
+            {
+              file: "Gemfile",
+              requirement: "~> 1.4.0",
+              groups: [],
+              source: nil
+            }
           ]
         )
       end
@@ -284,10 +291,20 @@ RSpec.describe Dependabot::PullRequestCreator do
           version: "1.5.0",
           package_manager: "bundler",
           requirements: [
-            { file: "some.gemspec", requirement: ">= 1.0, < 3.0", groups: [] }
+            {
+              file: "some.gemspec",
+              requirement: ">= 1.0, < 3.0",
+              groups: [],
+              source: nil
+            }
           ],
           previous_requirements: [
-            { file: "some.gemspec", requirement: "~> 1.4.0", groups: [] }
+            {
+              file: "some.gemspec",
+              requirement: "~> 1.4.0",
+              groups: [],
+              source: nil
+            }
           ]
         )
       end
@@ -300,7 +317,12 @@ RSpec.describe Dependabot::PullRequestCreator do
             version: "1.5.0",
             package_manager: "bundler",
             requirements: [
-              { file: "some.gemspec", requirement: ">= 1.0, < 3.0", groups: [] }
+              {
+                file: "some.gemspec",
+                requirement: ">= 1.0, < 3.0",
+                groups: [],
+                source: nil
+              }
             ]
           )
         end
@@ -363,10 +385,20 @@ RSpec.describe Dependabot::PullRequestCreator do
           version: "1.5.0",
           package_manager: "bundler",
           requirements: [
-            { file: "Gemfile", requirement: "~> 1.5.0", groups: [] }
+            {
+              file: "Gemfile",
+              requirement: "~> 1.5.0",
+              groups: [],
+              source: nil
+            }
           ],
           previous_requirements: [
-            { file: "Gemfile", requirement: "~> 1.4.0", groups: [] }
+            {
+              file: "Gemfile",
+              requirement: "~> 1.4.0",
+              groups: [],
+              source: nil
+            }
           ]
         )
       end
@@ -379,7 +411,12 @@ RSpec.describe Dependabot::PullRequestCreator do
             version: "1.5.0",
             package_manager: "bundler",
             requirements: [
-              { file: "Gemfile", requirement: "~> 1.5.0", groups: [] }
+              {
+                file: "Gemfile",
+                requirement: "~> 1.5.0",
+                groups: [],
+                source: nil
+              }
             ]
           )
         end

--- a/spec/dependabot/update_checkers/base_spec.rb
+++ b/spec/dependabot/update_checkers/base_spec.rb
@@ -15,13 +15,22 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
     Dependabot::Dependency.new(
       name: "business",
       version: "1.5.0",
-      requirements: [{ file: "Gemfile", requirement: ">= 0", groups: [] }],
+      requirements: [
+        { file: "Gemfile", requirement: ">= 0", groups: [], source: nil }
+      ],
       package_manager: "bundler"
     )
   end
   let(:latest_version) { Gem::Version.new("1.0.0") }
   let(:updated_requirements) do
-    [{ file: "Gemfile", requirement: updated_requirement, groups: [] }]
+    [
+      {
+        file: "Gemfile",
+        requirement: updated_requirement,
+        groups: [],
+        source: nil
+      }
+    ]
   end
   let(:updated_requirement) { ">= 1.0.0" }
   let(:latest_resolvable_version) { latest_version }
@@ -77,7 +86,7 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
         )
       end
       let(:requirements) do
-        [{ file: "Gemfile", requirement: "~> 1", groups: [] }]
+        [{ file: "Gemfile", requirement: "~> 1", groups: [], source: nil }]
       end
 
       context "that already permits the latest version" do
@@ -87,14 +96,28 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
 
       context "that doesn't yet permit the latest version" do
         let(:updated_requirements) do
-          [{ file: "Gemfile", requirement: ">= 1, < 3", groups: [] }]
+          [
+            {
+              file: "Gemfile",
+              requirement: ">= 1, < 3",
+              groups: [],
+              source: nil
+            }
+          ]
         end
         it { is_expected.to be_truthy }
       end
 
       context "that we don't know how to fix" do
         let(:updated_requirements) do
-          [{ file: "Gemfile", requirement: :unfixable, groups: [] }]
+          [
+            {
+              file: "Gemfile",
+              requirement: :unfixable,
+              groups: [],
+              source: nil
+            }
+          ]
         end
         it { is_expected.to be_falsey }
       end

--- a/spec/dependabot/update_checkers/git/submodules_spec.rb
+++ b/spec/dependabot/update_checkers/git/submodules_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Dependabot::UpdateCheckers::Git::Submodules do
         {
           file: ".gitmodules",
           requirement: { url: url, branch: branch },
-          groups: []
+          groups: [],
+          source: nil
         }
       ],
       package_manager: "submodules"

--- a/spec/dependabot/update_checkers/java_script/yarn_spec.rb
+++ b/spec/dependabot/update_checkers/java_script/yarn_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe Dependabot::UpdateCheckers::JavaScript::Yarn do
     Dependabot::Dependency.new(
       name: "etag",
       version: "1.0.0",
-      requirements: [{ file: "yarn.lock", requirement: "^1.0.0", groups: [] }],
+      requirements: [
+        { file: "yarn.lock", requirement: "^1.0.0", groups: [], source: nil }
+      ],
       package_manager: "yarn"
     )
   end
@@ -43,7 +45,12 @@ RSpec.describe Dependabot::UpdateCheckers::JavaScript::Yarn do
           name: "etag",
           version: "1.7.0",
           requirements: [
-            { file: "yarn.lock", requirement: "^1.0.0", groups: [] }
+            {
+              file: "yarn.lock",
+              requirement: "^1.0.0",
+              groups: [],
+              source: nil
+            }
           ],
           package_manager: "yarn"
         )
@@ -65,7 +72,12 @@ RSpec.describe Dependabot::UpdateCheckers::JavaScript::Yarn do
           name: "@blep/blep",
           version: "1.0.0",
           requirements: [
-            { file: "yarn.lock", requirement: "^1.0.0", groups: [] }
+            {
+              file: "yarn.lock",
+              requirement: "^1.0.0",
+              groups: [],
+              source: nil
+            }
           ],
           package_manager: "yarn"
         )
@@ -128,7 +140,12 @@ RSpec.describe Dependabot::UpdateCheckers::JavaScript::Yarn do
         name: "etag",
         version: "1.0.0",
         requirements: [
-          { file: "yarn.lock", requirement: original_requirement, groups: [] }
+          {
+            file: "yarn.lock",
+            requirement: original_requirement,
+            groups: [],
+            source: nil
+          }
         ],
         package_manager: "yarn"
       )

--- a/spec/dependabot/update_checkers/php/composer_spec.rb
+++ b/spec/dependabot/update_checkers/php/composer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer do
       name: "monolog/monolog",
       version: "1.0.1",
       requirements: [
-        { file: "composer.json", requirement: "1.0.*", groups: [] }
+        { file: "composer.json", requirement: "1.0.*", groups: [], source: nil }
       ],
       package_manager: "composer"
     )
@@ -81,7 +81,12 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer do
           name: "doctrine/dbal",
           version: "2.1.5",
           requirements: [
-            { file: "composer.json", requirement: "1.0.*", groups: [] }
+            {
+              file: "composer.json",
+              requirement: "1.0.*",
+              groups: [],
+              source: nil
+            }
           ],
           package_manager: "composer"
         )
@@ -116,7 +121,12 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer do
             name: "symfony/polyfill-mbstring",
             version: "1.0.1",
             requirements: [
-              { file: "composer.json", requirement: "1.0.*", groups: [] }
+              {
+                file: "composer.json",
+                requirement: "1.0.*",
+                groups: [],
+                source: nil
+              }
             ],
             package_manager: "composer"
           )
@@ -139,7 +149,12 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer do
           name: "wpackagist-plugin/acf-to-rest-api",
           version: "2.2.1",
           requirements: [
-            { file: "composer.json", requirement: "*", groups: ["runtime"] }
+            {
+              file: "composer.json",
+              requirement: "*",
+              groups: ["runtime"],
+              source: nil
+            }
           ],
           package_manager: "composer"
         )
@@ -164,7 +179,8 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer do
             {
               file: "composer.json",
               requirement: "^5.2.0",
-              groups: ["runtime"]
+              groups: ["runtime"],
+              source: nil
             }
           ],
           package_manager: "composer"
@@ -183,7 +199,12 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer do
         name: "monolog/monolog",
         version: "1.0.1",
         requirements: [
-          { file: "composer.json", requirement: old_requirement, groups: [] }
+          {
+            file: "composer.json",
+            requirement: old_requirement,
+            groups: [],
+            source: nil
+          }
         ],
         package_manager: "composer"
       )

--- a/spec/dependabot/update_checkers/python/pip_spec.rb
+++ b/spec/dependabot/update_checkers/python/pip_spec.rb
@@ -27,7 +27,12 @@ RSpec.describe Dependabot::UpdateCheckers::Python::Pip do
       name: "luigi",
       version: "2.0.0",
       requirements: [
-        { file: "requirements.txt", requirement: "==2.0.0", groups: [] }
+        {
+          file: "requirements.txt",
+          requirement: "==2.0.0",
+          groups: [],
+          source: nil
+        }
       ],
       package_manager: "pip"
     )
@@ -46,7 +51,12 @@ RSpec.describe Dependabot::UpdateCheckers::Python::Pip do
           name: "luigi",
           version: "2.6.0",
           requirements: [
-            { file: "requirements.txt", requirement: "==2.6.0", groups: [] }
+            {
+              file: "requirements.txt",
+              requirement: "==2.6.0",
+              groups: [],
+              source: nil
+            }
           ],
           package_manager: "pip"
         )
@@ -92,7 +102,8 @@ RSpec.describe Dependabot::UpdateCheckers::Python::Pip do
               {
                 file: "requirements.txt",
                 requirement: "==2.6.0.alpha",
-                groups: []
+                groups: [],
+                source: nil
               }
             ],
             package_manager: "pip"

--- a/spec/dependabot/update_checkers/ruby/bundler_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
     )
   end
   let(:requirements) do
-    [{ file: "Gemfile", requirement: ">= 0", groups: [] }]
+    [{ file: "Gemfile", requirement: ">= 0", groups: [], source: nil }]
   end
 
   let(:gemfile) do
@@ -287,7 +287,7 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
         end
 
         let(:requirements) do
-          [{ file: "Gemfile", requirement: "~> 4.6", groups: [] }]
+          [{ file: "Gemfile", requirement: "~> 4.6", groups: [], source: nil }]
         end
 
         before do
@@ -778,12 +778,14 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
           {
             file: "Gemfile",
             requirement: "~> 1.4.0",
-            groups: [:default]
+            groups: [:default],
+            source: nil
           },
           {
             file: "example.gemspec",
             requirement: "~> 1.0",
-            groups: [:default]
+            groups: [:default],
+            source: nil
           }
         ]
       end
@@ -823,12 +825,14 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
           {
             file: "Gemfile",
             requirement: "~> 1.4.0",
-            groups: [:default]
+            groups: [:default],
+            source: nil
           },
           {
             file: "example.gemspec",
             requirement: "~> 1.0",
-            groups: [:default]
+            groups: [:default],
+            source: nil
           }
         ]
       end
@@ -864,12 +868,14 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
           {
             file: "Gemfile",
             requirement: "~> 1.4.0",
-            groups: [:default]
+            groups: [:default],
+            source: nil
           },
           {
             file: "example.gemspec",
             requirement: "~> 1.0",
-            groups: [:default]
+            groups: [:default],
+            source: nil
           }
         ]
       end
@@ -904,7 +910,8 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
           {
             file: "Gemfile",
             requirement: "~> 1.4.0",
-            groups: [:default]
+            groups: [:default],
+            source: nil
           }
         ]
       end
@@ -938,7 +945,8 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
           {
             file: "example.gemspec",
             requirement: "~> 0.9",
-            groups: ["runtime"]
+            groups: ["runtime"],
+            source: nil
           }
         ]
       end

--- a/spec/fixtures/ruby/gemfiles/imports_gemspec_git_override
+++ b/spec/fixtures/ruby/gemfiles/imports_gemspec_git_override
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec
+
+gem "business", "~> 1.4.0", git: "https://github.com/gocardless/business"


### PR DESCRIPTION
Currently, if a Ruby gem exists in the default Rubygems source, but is taken from a private one, the Ruby metadata finder will return details of the public version.

That's particularly annoying for `sidekiq-pro`, which has a (benevolent) squatter on its Rubygems listing, but it's a more general bug.

This PR will fix the issue by extracting the source at dependency-file parsing time, and checking it when looking up metadata.