### PR TITLE
Use python3.6 rather than python

### DIFF
--- a/lib/dependabot/file_parsers/python/pip.rb
+++ b/lib/dependabot/file_parsers/python/pip.rb
@@ -31,7 +31,7 @@ module Dependabot
             write_temporary_dependency_files
 
             SharedHelpers.run_helper_subprocess(
-              command: "python #{python_helper_path}",
+              command: "python3 #{python_helper_path}",
               function: "parse",
               args: [Dir.pwd]
             )

--- a/lib/dependabot/file_parsers/python/pip.rb
+++ b/lib/dependabot/file_parsers/python/pip.rb
@@ -31,7 +31,7 @@ module Dependabot
             write_temporary_dependency_files
 
             SharedHelpers.run_helper_subprocess(
-              command: "python3 #{python_helper_path}",
+              command: "python3.6 #{python_helper_path}",
               function: "parse",
               args: [Dir.pwd]
             )


### PR DESCRIPTION
It's more specific, and dependabot-core doesn't work with python2.