### PR TITLE
Get SHA-1 hash as version for Ruby git dependencies

### DIFF
--- a/lib/dependabot/file_parsers/ruby/bundler.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler.rb
@@ -200,7 +200,7 @@ module Dependabot
           # appear in the lockfile.
           return unless spec
 
-          # If the source is Git we're better off knowing the sha than the
+          # If the source is Git we're better off knowing the SHA-1 than the
           # version.
           if spec.source.instance_of?(::Bundler::Source::Git)
             return spec.source.revision

--- a/lib/dependabot/pull_request_creator.rb
+++ b/lib/dependabot/pull_request_creator.rb
@@ -239,16 +239,16 @@ module Dependabot
     end
 
     def previous_version
-      if dependency.package_manager == "submodules"
-        dependency.previous_version.first(6)
+      if dependency.previous_version.match?(/^[0-9a-f]{40}$/)
+        dependency.previous_version[0..5]
       else
         dependency.previous_version
       end
     end
 
     def new_version
-      if dependency.package_manager == "submodules"
-        dependency.version.first(6)
+      if dependency.version.match?(/^[0-9a-f]{40}$/)
+        dependency.version[0..5]
       else
         dependency.version
       end

--- a/lib/dependabot/update_checkers/base.rb
+++ b/lib/dependabot/update_checkers/base.rb
@@ -48,6 +48,22 @@ module Dependabot
       private
 
       def version_needs_update?
+        return sha1_version_needs_update? if existing_version_is_sha1?
+        numeric_version_needs_update?
+      end
+
+      def existing_version_is_sha1?
+        # 40 characters in the set [0123456789abcdef]
+        dependency.version.match?(/^[0-9a-f]{40}$/)
+      end
+
+      def sha1_version_needs_update?
+        # All we can do with SHA-1 hashes is check for presence and equality
+        return false if latest_resolvable_version.nil?
+        latest_resolvable_version != dependency.version
+      end
+
+      def numeric_version_needs_update?
         # Check if we're up-to-date with the latest version.
         # Saves doing resolution if so.
         if latest_version &&

--- a/lib/dependabot/update_checkers/git/submodules.rb
+++ b/lib/dependabot/update_checkers/git/submodules.rb
@@ -22,11 +22,6 @@ module Dependabot
           dependency.requirements
         end
 
-        def needs_update?
-          # We're comparing commit SHAs, so just look for difference
-          latest_version != dependency.version
-        end
-
         private
 
         def fetch_latest_version

--- a/spec/dependabot/file_parsers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/bundler_spec.rb
@@ -123,6 +123,31 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
       end
     end
 
+    context "with a git dependency" do
+      let(:gemfile_content) { fixture("ruby", "gemfiles", "git_source") }
+      let(:lockfile_content) { fixture("ruby", "lockfiles", "git_source.lock") }
+
+      its(:length) { is_expected.to eq(5) }
+      describe "the last dependency" do
+        subject { dependencies.last }
+        let(:expected_requirements) do
+          [{
+            requirement: ">= 0",
+            file: "Gemfile",
+            source: "git",
+            groups: [:default]
+          }]
+        end
+
+        it { is_expected.to be_a(Dependabot::Dependency) }
+        its(:name) { is_expected.to eq("uk_phone_numbers") }
+        its(:requirements) { is_expected.to eq(expected_requirements) }
+        its(:version) do
+          is_expected.to eq("1530024bd6a68d36ac18e04836ce110e0d433c36")
+        end
+      end
+    end
+
     context "with a dependency that doesn't appear in the lockfile" do
       let(:gemfile_content) { fixture("ruby", "gemfiles", "platform_windows") }
       let(:lockfile_content) do

--- a/spec/dependabot/update_checkers/git/submodules_spec.rb
+++ b/spec/dependabot/update_checkers/git/submodules_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Dependabot::UpdateCheckers::Git::Submodules do
   let(:dependency) do
     Dependabot::Dependency.new(
       name: "manifesto",
-      version: "sha1",
+      version: "2468a02a6230e59ed1232d95d1ad3ef157195b03",
       requirements: [
         {
           file: ".gitmodules",
@@ -44,7 +44,11 @@ RSpec.describe Dependabot::UpdateCheckers::Git::Submodules do
     end
 
     context "given an up-to-date dependency" do
-      before { allow(checker).to receive(:latest_version).and_return("sha1") }
+      before do
+        allow(checker).
+          to receive(:latest_version).
+          and_return("2468a02a6230e59ed1232d95d1ad3ef157195b03")
+      end
       it { is_expected.to be_falsey }
     end
   end

--- a/spec/dependabot/update_checkers/ruby/bundler_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
         let(:dependency) do
           Dependabot::Dependency.new(
             name: "prius",
-            version: "0.9",
+            version: "cff701b3bfb182afc99a85657d7c9f3d6c1ccce2",
             requirements: requirements,
             package_manager: "bundler"
           )
@@ -562,7 +562,7 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
         let(:dependency) do
           Dependabot::Dependency.new(
             name: "prius",
-            version: "0.9",
+            version: "cff701b3bfb182afc99a85657d7c9f3d6c1ccce2",
             requirements: requirements,
             package_manager: "bundler"
           )


### PR DESCRIPTION
- Get SHA-1 hash as version for Ruby git dependencies
- Update `UpdateCheckers::Base` and `PullRequestCreator` to handle SHA-1 versions (and remove the special-casing we were previously using for Git submodule versions).

Lays the foundation for the Ruby update checker to update git dependencies to the latest commit. Currently, this won't cause any additional updates, since the `UpdaterCheckers::Ruby::Bundler` class will always return `nil` for the updated version of Ruby git dependencies.