### PR TITLE
Improve how we extract filenames in the Python parser

### DIFF
--- a/helpers/python/lib/parser.py
+++ b/helpers/python/lib/parser.py
@@ -1,5 +1,6 @@
 import json
 import re
+import os.path
 
 import pip.req.req_file
 from pip.download import PipSession
@@ -11,13 +12,14 @@ def parse(directory):
     )
 
     packages = []
-    reg = r'.*' + re.escape(directory + '/')
-
     try:
         for install_req in requirements:
             if (not install_req.original_link and install_req.is_pinned):
                 specifier = next(iter(install_req.specifier))
-                rel_path = re.sub(reg, '', install_req.comes_from.split(' ')[1])
+
+                pattern = r"-[cr] (.*) \(line \d+\)"
+                abs_path = re.search(pattern, install_req.comes_from).group(1)
+                rel_path = os.path.relpath(abs_path, directory)
 
                 packages.append({
                     "name": install_req.name,


### PR DESCRIPTION
Paths with spaces work properly now, and using `os.path.relpath` is preferred over using `re.sub` for reletavising the path.