### PR TITLE
Switch to AST parser for updating Ruby requirements in UpdateChecker

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ Metrics/MethodLength:
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+    - dependabot-core.gemspec
 
 Metrics/ParameterLists:
   Max: 10

--- a/dependabot-core.gemspec
+++ b/dependabot-core.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "excon", "~> 0.55"
   spec.add_dependency "gemnasium-parser", "~> 0.1"
   spec.add_dependency "parseconfig", "~> 1.0.8"
+  spec.add_dependency "parser", "~> 2.4.0"
   spec.add_dependency "gems", "~> 1.0"
   spec.add_dependency "octokit", "~> 4.6"
   spec.add_dependency "gitlab", "~> 4.1"

--- a/spec/dependabot/update_checkers/ruby/bundler/file_preparer_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler/file_preparer_spec.rb
@@ -46,6 +46,39 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler::FilePreparer do
         let(:version) { "1.4.3" }
 
         its(:content) { is_expected.to include(%("business", '>= 1.4.3')) }
+        its(:content) { is_expected.to include(%("statesman", "~> 1.2.0")) }
+      end
+
+      context "within a source block" do
+        let(:gemfile_body) do
+          "source 'https://example.com' do\n"\
+          "  gem \"business\", \"~> 1.0\", require: true\n"\
+          "end"
+        end
+        let(:version) { "1.4.3" }
+
+        its(:content) { is_expected.to include(%("business", '>= 1.4.3')) }
+      end
+
+      context "with multiple requirements" do
+        let(:version) { "1.4.3" }
+        let(:gemfile_body) do
+          %(gem "business", ">= 1", "< 3", require: true)
+        end
+        its(:content) do
+          # TODO: This is sloppy, but fine for the update checker
+          is_expected.
+            to eq(%(gem "business", '>= 1.4.3', '>= 1.4.3', require: true))
+        end
+
+        context "given as an array" do
+          let(:gemfile_body) do
+            %(gem "business", [">= 1", "<3"], require: true)
+          end
+          its(:content) do
+            is_expected.to eq(%(gem "business", '>= 1.4.3', require: true))
+          end
+        end
       end
 
       context "with a git source" do


### PR DESCRIPTION
We'll need to use an AST parser when we start doing clever mandate file manipulation (e.g., in https://github.com/dependabot/dependabot-core/pull/84). Let's introduce it now, gradually.