### PR TITLE
Split Ruby FileParser logic out into smaller classes

### DIFF
--- a/lib/dependabot/file_parsers/ruby/bundler/dependency_set.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler/dependency_set.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "dependabot/dependency"
+require "dependabot/file_parsers/ruby/bundler"
+
+module Dependabot
+  module FileParsers
+    module Ruby
+      class Bundler
+        class DependencySet
+          def initialize(dependencies = [])
+            unless dependencies.is_a?(Array) &&
+                   dependencies.all? { |dep| dep.is_a?(Dependency) }
+              raise ArgumentError, "must be an array of Dependency objects"
+            end
+
+            @dependencies = dependencies
+          end
+
+          attr_reader :dependencies
+
+          def <<(dep)
+            unless dep.is_a?(Dependency)
+              raise ArgumentError, "must be a Dependency object"
+            end
+
+            existing_dependency = dependencies.find { |d| d.name == dep.name }
+
+            if existing_dependency
+              return self if existing_dependency.to_h == dep.to_h
+
+              dependencies[dependencies.index(existing_dependency)] =
+                Dependency.new(
+                  name: existing_dependency.name,
+                  version: existing_dependency.version || dep.version,
+                  requirements:
+                    existing_dependency.requirements + dep.requirements,
+                  package_manager: "bundler"
+                )
+            else
+              dependencies << dep
+            end
+            self
+          end
+
+          def +(other)
+            unless other.is_a?(DependencySet)
+              raise ArgumentError, "must be a DependencySet"
+            end
+            other.dependencies.each { |dep| self << dep }
+            self
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dependabot/file_parsers/ruby/bundler/file_preparer.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler/file_preparer.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "dependabot/dependency_file"
+require "dependabot/file_parsers/ruby/bundler"
+
+module Dependabot
+  module FileParsers
+    module Ruby
+      class Bundler
+        class FilePreparer
+          def initialize(dependency_files:)
+            @dependency_files = dependency_files
+          end
+
+          def prepared_dependency_files
+            files = []
+
+            gemspecs.compact.each do |file|
+              files << DependencyFile.new(
+                name: file.name,
+                content: sanitize_gemspec_content(file.content),
+                directory: file.directory
+              )
+            end
+
+            files += [gemfile, lockfile, ruby_version_file].compact
+          end
+
+          private
+
+          attr_reader :dependency_files
+
+          def gemfile
+            dependency_files.find { |f| f.name == "Gemfile" }
+          end
+
+          def lockfile
+            dependency_files.find { |f| f.name == "Gemfile.lock" }
+          end
+
+          def gemspecs
+            dependency_files.select { |f| f.name.end_with?(".gemspec") }
+          end
+
+          def ruby_version_file
+            dependency_files.find { |f| f.name == ".ruby-version" }
+          end
+
+          def sanitize_gemspec_content(gemspec_content)
+            # No need to set the version correctly - this is just an update
+            # check so we're not going to persist any changes to the lockfile.
+            gemspec_content.
+              gsub(/^\s*require.*$/, "").
+              gsub(/=.*VERSION.*$/, "= '0.0.1'")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dependabot/file_parsers/ruby/bundler/gemfile_checker.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler/gemfile_checker.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "parser/current"
+require "dependabot/file_parsers/ruby/bundler"
+
+module Dependabot
+  module FileParsers
+    module Ruby
+      class Bundler
+        class GemfileChecker
+          def initialize(dependency:, gemfile:)
+            @dependency = dependency
+            @gemfile = gemfile
+          end
+
+          def includes_dependency?
+            Parser::CurrentRuby.parse(gemfile.content).children.any? do |node|
+              deep_check_for_gem(node)
+            end
+          end
+
+          private
+
+          attr_reader :dependency, :gemfile
+
+          def deep_check_for_gem(node)
+            return true if declares_targeted_gem?(node)
+            return false unless node.is_a?(Parser::AST::Node)
+            node.children.any? do |child_node|
+              deep_check_for_gem(child_node)
+            end
+          end
+
+          def declares_targeted_gem?(node)
+            return false unless node.is_a?(Parser::AST::Node)
+            return false unless node.children[1] == :gem
+            node.children[2].children.first == dependency.name
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dependabot/file_parsers/ruby/bundler/dependency_set_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/bundler/dependency_set_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/file_parsers/ruby/bundler/dependency_set"
+
+RSpec.describe Dependabot::FileParsers::Ruby::Bundler::DependencySet do
+  let(:dependency_set) { described_class.new }
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "business",
+      version: "1.3",
+      requirements: [{ requirement: "1", file: "a", groups: nil, source: nil }],
+      package_manager: "bundler"
+    )
+  end
+
+  describe ".new" do
+    context "with no argument" do
+      subject { described_class.new }
+      it { is_expected.to be_a(described_class) }
+      its(:dependencies) { is_expected.to eq([]) }
+    end
+
+    context "with an array argument" do
+      subject { described_class.new([dependency]) }
+
+      it { is_expected.to be_a(described_class) }
+      its(:dependencies) { is_expected.to eq([dependency]) }
+
+      context "that contains non-dependency objects" do
+        subject { described_class.new([dependency, :a]) }
+
+        it "raises a helpful error" do
+          expect { described_class.new(:a) }.
+            to raise_error(ArgumentError) do |error|
+              expect(error.message).to include("array of Dependency objects")
+            end
+        end
+      end
+    end
+
+    context "with a non-array argument" do
+      subject { described_class.new(dependency) }
+
+      it "raises a helpful error" do
+        expect { described_class.new(:a) }.
+          to raise_error(ArgumentError) do |error|
+            expect(error.message).to eq "must be an array of Dependency objects"
+          end
+      end
+    end
+  end
+
+  describe "<<" do
+    subject { dependency_set << dependency }
+
+    it { is_expected.to be_a(described_class) }
+    its(:dependencies) { is_expected.to eq([dependency]) }
+
+    context "when a dependency already exists in the set" do
+      before { dependency_set << existing_dependency }
+
+      context "and is identical to the one being added" do
+        let(:existing_dependency) { dependency }
+
+        it { is_expected.to be_a(described_class) }
+        its(:dependencies) { is_expected.to eq([dependency]) }
+      end
+
+      context "and is different to the one being added" do
+        let(:existing_dependency) do
+          Dependabot::Dependency.new(
+            name: "statesman",
+            version: "1.3",
+            requirements: [
+              { requirement: "1", file: "a", groups: nil, source: nil }
+            ],
+            package_manager: "bundler"
+          )
+        end
+
+        it { is_expected.to be_a(described_class) }
+        its(:dependencies) do
+          is_expected.to match_array([existing_dependency, dependency])
+        end
+      end
+
+      context "and is identical, but with different requirements" do
+        let(:existing_dependency) do
+          Dependabot::Dependency.new(
+            name: "business",
+            version: "1.3",
+            requirements: [
+              { requirement: "1", file: "b", groups: nil, source: nil }
+            ],
+            package_manager: "bundler"
+          )
+        end
+
+        it { is_expected.to be_a(described_class) }
+
+        it "has a single dependency with the combined requirements" do
+          expect(subject.dependencies.count).to eq(1)
+          expect(subject.dependencies.first.requirements).
+            to match_array(
+              [
+                { requirement: "1", file: "a", groups: nil, source: nil },
+                { requirement: "1", file: "b", groups: nil, source: nil }
+              ]
+            )
+        end
+      end
+    end
+
+    context "with a non-dependency object" do
+      let(:dependency) { :a }
+
+      it "raises a helpful error" do
+        expect { dependency_set << dependency }.
+          to raise_error(ArgumentError) do |error|
+            expect(error.message).to eq("must be a Dependency object")
+          end
+      end
+    end
+  end
+
+  describe "+" do
+    subject { dependency_set + described_class.new([dependency]) }
+
+    it { is_expected.to be_a(described_class) }
+    its(:dependencies) { is_expected.to eq([dependency]) }
+
+    it "delegates to << " do
+      expect(dependency_set).to receive(:<<).with(dependency).and_call_original
+      subject
+    end
+
+    context "with a non-dependency-set" do
+      it "raises a helpful error" do
+        expect { dependency_set + [dependency] }.
+          to raise_error(ArgumentError) do |error|
+            expect(error.message).to eq("must be a DependencySet")
+          end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ruby FileParser was becoming a big class, and difficult to test. This PR splits out the logic for file preparation, dependency set concatenation, and checking whether a declaration occurs in a given Gemfile.