### PR TITLE
[WIP] Add support for `eval_gemfile` in Ruby gemfiles

### DIFF
--- a/lib/dependabot/file_fetchers/ruby/bundler/child_gemfile_finder.rb
+++ b/lib/dependabot/file_fetchers/ruby/bundler/child_gemfile_finder.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "pathname"
+require "parser/current"
+require "dependabot/file_fetchers/ruby/bundler"
+
+module Dependabot
+  module FileFetchers
+    module Ruby
+      class Bundler
+        # Finds the paths of any Gemfiles declared using `eval_gemfile` in the
+        # passed Gemfile.
+        class ChildGemfileFinder
+          def initialize(gemfile:)
+            @gemfile = gemfile
+          end
+
+          def child_gemfile_paths
+            ast = Parser::CurrentRuby.parse(gemfile.content)
+            find_child_gemfile_paths(ast)
+          end
+
+          private
+
+          attr_reader :gemfile
+
+          # rubocop:disable Security/Eval
+          def find_child_gemfile_paths(node)
+            return [] unless node.is_a?(Parser::AST::Node)
+
+            if declares_eval_gemfile?(node)
+              # We use eval here, but we know what we're doing. The FileFetchers
+              # helper method should only ever be run in an isolated environment
+              path = eval(node.children[2].loc.expression.source)
+              path = File.join(current_dir, path) unless current_dir.nil?
+              return [Pathname.new(path).cleanpath.to_path]
+            end
+
+            node.children.flat_map do |child_node|
+              find_child_gemfile_paths(child_node)
+            end
+          end
+          # rubocop:enable Security/Eval
+
+          def current_dir
+            @current_dir ||= gemfile.name.split("/")[0..-2].last
+          end
+
+          def declares_eval_gemfile?(node)
+            return false unless node.is_a?(Parser::AST::Node)
+            node.children[1] == :eval_gemfile
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dependabot/file_parsers/ruby/bundler.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler.rb
@@ -36,7 +36,7 @@ module Dependabot
 
           return dependencies unless gemfile
 
-          [gemfile].each do |file|
+          [gemfile, *evaled_gemfiles].each do |file|
             parsed_gemfile.each do |dep|
               next unless dependency_in_gemfile?(gemfile: file, dependency: dep)
 
@@ -194,6 +194,11 @@ module Dependabot
 
         def gemfile
           @gemfile ||= get_original_file("Gemfile")
+        end
+
+        def evaled_gemfiles
+          # TODO: This isn't robust. Store in the file type when fetching?
+          dependency_files.select { |f| f.name.end_with?("/Gemfile") }
         end
 
         def lockfile

--- a/lib/dependabot/file_parsers/ruby/bundler.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler.rb
@@ -197,8 +197,11 @@ module Dependabot
         end
 
         def evaled_gemfiles
-          # TODO: This isn't robust. Store in the file type when fetching?
-          dependency_files.select { |f| f.name.end_with?("/Gemfile") }
+          dependency_files.
+            reject { |f| f.name.end_with?(".gemspec") }.
+            reject { |f| f.name.end_with?(".lock") }.
+            reject { |f| f.name.end_with?(".ruby-version") }.
+            reject { |f| f.name == "Gemfile" }
         end
 
         def lockfile

--- a/lib/dependabot/file_parsers/ruby/bundler/file_preparer.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler/file_preparer.rb
@@ -23,7 +23,8 @@ module Dependabot
               )
             end
 
-            files += [gemfile, lockfile, ruby_version_file].compact
+            files +=
+              [gemfile, *evaled_gemfiles, lockfile, ruby_version_file].compact
           end
 
           private
@@ -32,6 +33,11 @@ module Dependabot
 
           def gemfile
             dependency_files.find { |f| f.name == "Gemfile" }
+          end
+
+          def evaled_gemfiles
+            # TODO: This isn't robust. Store in the file type when fetching?
+            dependency_files.select { |f| f.name.end_with?("/Gemfile") }
           end
 
           def lockfile

--- a/lib/dependabot/file_parsers/ruby/bundler/file_preparer.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler/file_preparer.rb
@@ -36,8 +36,11 @@ module Dependabot
           end
 
           def evaled_gemfiles
-            # TODO: This isn't robust. Store in the file type when fetching?
-            dependency_files.select { |f| f.name.end_with?("/Gemfile") }
+            dependency_files.
+              reject { |f| f.name.end_with?(".gemspec") }.
+              reject { |f| f.name.end_with?(".lock") }.
+              reject { |f| f.name.end_with?(".ruby-version") }.
+              reject { |f| f.name == "Gemfile" }
           end
 
           def lockfile

--- a/lib/dependabot/file_parsers/ruby/bundler/gemfile_checker.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler/gemfile_checker.rb
@@ -7,6 +7,7 @@ module Dependabot
   module FileParsers
     module Ruby
       class Bundler
+        # Checks whether a dependency is declared in a Gemfile
         class GemfileChecker
           def initialize(dependency:, gemfile:)
             @dependency = dependency

--- a/lib/dependabot/update_checkers/ruby/bundler/requirements_updater.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler/requirements_updater.rb
@@ -34,10 +34,12 @@ module Dependabot
 
           def updated_requirements
             requirements.map do |req|
-              case req[:file]
-              when "Gemfile" then updated_gemfile_requirement(req)
-              when /\.gemspec/ then updated_gemspec_requirement(req)
-              else raise "Unexpected file name: #{req[:file]}"
+              if req[:file].match?(/\.gemspec/)
+                updated_gemspec_requirement(req)
+              else
+                # If a requirement doesn't come from a gemspec, it must be from
+                # a Gemfile.
+                updated_gemfile_requirement(req)
               end
             end
           end

--- a/spec/dependabot/file_fetchers/ruby/bundler/child_gemfile_finder_spec.rb
+++ b/spec/dependabot/file_fetchers/ruby/bundler/child_gemfile_finder_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/file_fetchers/ruby/bundler/child_gemfile_finder"
+
+RSpec.describe Dependabot::FileFetchers::Ruby::Bundler::ChildGemfileFinder do
+  let(:finder) do
+    described_class.new(gemfile: gemfile)
+  end
+
+  let(:gemfile) do
+    Dependabot::DependencyFile.new(content: gemfile_body, name: gemfile_name)
+  end
+  let(:gemfile_name) { "Gemfile" }
+  let(:gemfile_body) { fixture("ruby", "gemfiles", "Gemfile") }
+
+  describe "#child_gemfile_paths" do
+    subject(:child_gemfile_paths) { finder.child_gemfile_paths }
+
+    context "when the file does not include any child Gemfiles" do
+      let(:gemfile_body) { fixture("ruby", "gemfiles", "Gemfile") }
+      it { is_expected.to eq([]) }
+    end
+
+    context "when the file does include a child Gemfile" do
+      context "whose path must be eval-ed" do
+        let(:gemfile_body) { fixture("ruby", "gemfiles", "eval_gemfile") }
+        it { is_expected.to eq(["backend/Gemfile"]) }
+      end
+
+      context "within a group block" do
+        let(:gemfile_body) do
+          "group :development do\neval_gemfile('some_gemfile')\nend"
+        end
+        it { is_expected.to eq(["some_gemfile"]) }
+      end
+
+      context "when this Gemfile is already in a nested directory" do
+        let(:gemfile_body) { fixture("ruby", "gemfiles", "eval_gemfile") }
+        let(:gemfile_name) { "nested/Gemfile" }
+
+        it { is_expected.to eq(["nested/backend/Gemfile"]) }
+      end
+    end
+  end
+end

--- a/spec/dependabot/file_fetchers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_fetchers/ruby/bundler_spec.rb
@@ -135,6 +135,104 @@ RSpec.describe Dependabot::FileFetchers::Ruby::Bundler do
     end
   end
 
+  context "with a child Gemfile" do
+    let(:github_client) { Octokit::Client.new(access_token: "token") }
+    let(:file_fetcher_instance) do
+      described_class.new(repo: "gocardless/bump", github_client: github_client)
+    end
+
+    let(:url) { "https://api.github.com/repos/gocardless/bump/contents/" }
+
+    before do
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+      stub_request(:get, url + "?ref=sha").
+        to_return(
+          status: 200,
+          body: fixture("github", "business_files_no_gemspec.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, url + "Gemfile?ref=sha").
+        to_return(
+          status: 200,
+          body: fixture("github", "gemfile_with_eval_content.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, url + "Gemfile.lock?ref=sha").
+        to_return(status: 404)
+    end
+
+    context "that has a fetchable path" do
+      before do
+        stub_request(:get, url + "backend/Gemfile?ref=sha").
+          to_return(
+            status: 200,
+            body: fixture("github", "gemfile_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+      end
+
+      it "fetches the child Gemfile" do
+        expect(file_fetcher_instance.files.count).to eq(2)
+        expect(file_fetcher_instance.files.map(&:name)).
+          to include("backend/Gemfile")
+      end
+
+      context "and is circular" do
+        before do
+          stub_request(:get, url + "Gemfile?ref=sha").
+            to_return(
+              status: 200,
+              body: fixture("github", "gemfile_with_circular.json"),
+              headers: { "content-type" => "application/json" }
+            )
+        end
+
+        it "only fetches the additional requirements once" do
+          expect(file_fetcher_instance.files.count).to eq(1)
+        end
+      end
+
+      context "and cascades more than once" do
+        before do
+          stub_request(:get, url + "backend/Gemfile?ref=sha").
+            to_return(
+              status: 200,
+              body: fixture("github", "gemfile_with_eval_content.json"),
+              headers: { "content-type" => "application/json" }
+            )
+          stub_request(:get, url + "backend/backend/Gemfile?ref=sha").
+            to_return(
+              status: 200,
+              body: fixture("github", "gemfile_content.json"),
+              headers: { "content-type" => "application/json" }
+            )
+        end
+
+        it "fetches the additional requirements" do
+          expect(file_fetcher_instance.files.count).to eq(3)
+          expect(file_fetcher_instance.files.map(&:name)).
+            to include("backend/Gemfile").
+            and include("backend/backend/Gemfile")
+        end
+      end
+    end
+
+    context "that has an unfetchable path" do
+      before do
+        stub_request(:get, url + "backend/Gemfile?ref=sha").
+          to_return(status: 404)
+      end
+
+      it "raises a DependencyFileNotFound error with details" do
+        expect { file_fetcher_instance.files }.
+          to raise_error(Dependabot::DependencyFileNotFound)
+      end
+    end
+  end
+
   context "with a gemspec" do
     let(:github_client) { Octokit::Client.new(access_token: "token") }
     let(:file_fetcher_instance) do

--- a/spec/dependabot/file_parsers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/bundler_spec.rb
@@ -246,6 +246,22 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
       end
     end
 
+    context "with a Gemfile that uses eval_gemfile" do
+      let(:files) { [gemfile, lockfile, evaled_gemfile] }
+      let(:gemfile_content) { fixture("ruby", "gemfiles", "eval_gemfile") }
+      let(:evaled_gemfile) do
+        Dependabot::DependencyFile.new(
+          name: "backend/Gemfile",
+          content: fixture("ruby", "gemfiles", "only_statesman")
+        )
+      end
+      let(:lockfile_content) do
+        fixture("ruby", "lockfiles", "Gemfile.lock")
+      end
+
+      its(:length) { is_expected.to eq(2) }
+    end
+
     context "with a Gemfile that includes a require" do
       let(:gemfile_content) { fixture("ruby", "gemfiles", "includes_requires") }
       let(:lockfile_content) { fixture("ruby", "lockfiles", "Gemfile.lock") }

--- a/spec/dependabot/update_checkers/ruby/bundler/file_preparer_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler/file_preparer_spec.rb
@@ -233,5 +233,25 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler::FilePreparer do
         its(:content) { is_expected.to include(%(version      = '0.0.1')) }
       end
     end
+
+    describe "the updated child gemfile" do
+      let(:dependency_files) { [gemfile, lockfile, child_gemfile] }
+      let(:child_gemfile) do
+        Dependabot::DependencyFile.new(
+          content: child_gemfile_body,
+          name: "backend/Gemfile"
+        )
+      end
+      let(:gemfile_body) { fixture("ruby", "gemfiles", "eval_gemfile") }
+      let(:child_gemfile_body) { fixture("ruby", "gemfiles", "Gemfile") }
+      let(:version) { "1.4.3" }
+
+      subject do
+        prepared_dependency_files.find { |f| f.name == "backend/Gemfile" }
+      end
+
+      its(:content) { is_expected.to include(%("business", '>= 1.4.3')) }
+      its(:content) { is_expected.to include(%("statesman", "~> 1.2.0")) }
+    end
   end
 end

--- a/spec/dependabot/update_checkers/ruby/bundler/requirements_updater_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler/requirements_updater_spec.rb
@@ -174,6 +174,26 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler::RequirementsUpdater do
           end
         end
       end
+
+      context "with multiple Gemfile declarations" do
+        before { requirements << child_gemfile_requirement }
+        let(:child_gemfile_requirement) do
+          gemfile_requirement.merge(file: "backend/Gemfile")
+        end
+
+        describe "the first Gemfile" do
+          subject { updated_requirements.find { |r| r[:file] == "Gemfile" } }
+          its([:requirement]) { is_expected.to eq("~> 1.5.0") }
+        end
+
+        describe "the child Gemfile" do
+          subject do
+            updated_requirements.find { |r| r[:file] == "backend/Gemfile" }
+          end
+
+          its([:requirement]) { is_expected.to eq("~> 1.5.0") }
+        end
+      end
     end
 
     context "for a gemspec dependency" do

--- a/spec/fixtures/github/gemfile_with_circular.json
+++ b/spec/fixtures/github/gemfile_with_circular.json
@@ -1,0 +1,18 @@
+{
+    "name": "Gemfile",
+    "path": "Gemfile",
+    "sha": "dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+    "size": 291,
+    "url": "https://api.github.com/repos/gocardless/bump/contents/Gemfile?ref=master",
+    "html_url": "https://github.com/gocardless/bump/blob/master/Gemfile",
+    "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+    "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/Gemfile?token=ABF4KfGg6a7sE1n1i2rrhUvqAKRhIkPiks5WD8X5wA%3D%3D",
+    "type": "file",
+    "content": "c291cmNlICJodHRwczovL3J1YnlnZW1zLm9yZyIKCmV2YWxfZ2VtZmlsZSBG\naWxlLmpvaW4oRmlsZS5kaXJuYW1lKF9fRklMRV9fKSwgJ0dlbWZpbGUnKQoK\nZ2VtICJzdGF0ZXNtYW4i\n",
+    "encoding": "base64",
+    "_links": {
+        "self": "https://api.github.com/repos/gocardless/bump/contents/Gemfile?ref=master",
+        "git": "https://api.github.com/repos/gocardless/bump/git/blobs/dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+        "html": "https://github.com/gocardless/bump/blob/master/Gemfile"
+    }
+}

--- a/spec/fixtures/github/gemfile_with_eval_content.json
+++ b/spec/fixtures/github/gemfile_with_eval_content.json
@@ -1,0 +1,18 @@
+{
+    "name": "Gemfile",
+    "path": "Gemfile",
+    "sha": "dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+    "size": 291,
+    "url": "https://api.github.com/repos/gocardless/bump/contents/Gemfile?ref=master",
+    "html_url": "https://github.com/gocardless/bump/blob/master/Gemfile",
+    "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+    "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/Gemfile?token=ABF4KfGg6a7sE1n1i2rrhUvqAKRhIkPiks5WD8X5wA%3D%3D",
+    "type": "file",
+    "content": "c291cmNlICJodHRwczovL3J1YnlnZW1zLm9yZyIKCmV2YWxfZ2VtZmlsZSBG\naWxlLmpvaW4oRmlsZS5kaXJuYW1lKF9fRklMRV9fKSwgJ2JhY2tlbmQvR2Vt\nZmlsZScpCgpnZW0gInN0YXRlc21hbiIK\n",
+    "encoding": "base64",
+    "_links": {
+        "self": "https://api.github.com/repos/gocardless/bump/contents/Gemfile?ref=master",
+        "git": "https://api.github.com/repos/gocardless/bump/git/blobs/dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+        "html": "https://github.com/gocardless/bump/blob/master/Gemfile"
+    }
+}

--- a/spec/fixtures/ruby/gemfiles/eval_gemfile
+++ b/spec/fixtures/ruby/gemfiles/eval_gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+eval_gemfile File.join(File.dirname(__FILE__), 'backend/Gemfile')
+
+gem "business", "~> 1.4.0"

--- a/spec/fixtures/ruby/gemfiles/only_statesman
+++ b/spec/fixtures/ruby/gemfiles/only_statesman
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "statesman", "~> 1.2.0"


### PR DESCRIPTION
Adds support for Ruby gemfiles that use `eval_gemfile`. Relatively uncommon, but the equivalent in Python (`-r some/requirements.txt`) is widely used, so applying the same logic for other languages seems sensible.

Closes https://github.com/dependabot/feedback/issues/18.

**TODO**
- [x] Add support for child gemfiles to `UpdateChecker` (only changes should be to `FilePreparer` and `RequirementsUpdater`)
- [x] Add support for child gemfiles to `FileUpdater`