### PR TITLE
Remove Gems dependency (replace with Excon calls)

### DIFF
--- a/dependabot-core.gemspec
+++ b/dependabot-core.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "excon", "~> 0.55"
   spec.add_dependency "parseconfig", "~> 1.0.8"
   spec.add_dependency "parser", "~> 2.4.0"
-  spec.add_dependency "gems", "~> 1.0"
   spec.add_dependency "octokit", "~> 4.6"
   spec.add_dependency "gitlab", "~> 4.1"
 

--- a/lib/dependabot/update_checkers/ruby/bundler/version_resolver.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler/version_resolver.rb
@@ -4,7 +4,6 @@ require "bundler_definition_version_patch"
 require "bundler_git_source_patch"
 
 require "excon"
-require "gems"
 
 require "dependabot/update_checkers/ruby/bundler"
 require "dependabot/shared_helpers"
@@ -47,7 +46,14 @@ module Dependabot
           end
 
           def latest_rubygems_version_details
-            latest_info = Gems.info(dependency.name)
+            response =
+              Excon.get(
+                "https://rubygems.org/api/v1/gems/#{dependency.name}.json",
+                idempotent: true,
+                middlewares: SharedHelpers.excon_middleware
+              )
+
+            latest_info = JSON.parse(response.body)
 
             return nil if latest_info["version"].nil?
 


### PR DESCRIPTION
The `gems` gem is unmaintained, and doesn't make automatically retrying requests easy. We only use it for a couple of simple idempotent requests anyway, so can just swap it out for `excon`.

Using `excon`'s idempotent argument means timeouts will automatically be retried, making our use of the Rubygems API more robust. 🎉 