### PR TITLE
Private docker registries

### DIFF
--- a/lib/dependabot/file_parsers/docker/docker.rb
+++ b/lib/dependabot/file_parsers/docker/docker.rb
@@ -3,7 +3,6 @@
 require "docker_registry2"
 
 require "dependabot/dependency"
-require "dependabot/errors"
 require "dependabot/file_parsers/base"
 
 module Dependabot

--- a/spec/dependabot/file_parsers/docker/docker_spec.rb
+++ b/spec/dependabot/file_parsers/docker/docker_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe Dependabot::FileParsers::Docker::Docker do
 
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
-          expect(dependency.name).to eq("ubuntu")
+          expect(dependency.name).to eq("myreg/ubuntu")
           expect(dependency.version).to eq("17.04")
           expect(dependency.requirements).to eq(expected_requirements)
         end

--- a/spec/dependabot/file_parsers/docker/docker_spec.rb
+++ b/spec/dependabot/file_parsers/docker/docker_spec.rb
@@ -247,10 +247,27 @@ RSpec.describe Dependabot::FileParsers::Docker::Docker do
     context "with a private registry and a tag" do
       let(:dockerfile_body) { fixture("docker", "dockerfiles", "private_tag") }
 
-      # TODO: support private registries
-      it "raises a helpful error message" do
-        expect { parser.parse }.
-          to raise_error(Dependabot::PrivateSourceNotReachable)
+      its(:length) { is_expected.to eq(1) }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+        let(:expected_requirements) do
+          [
+            {
+              requirement: nil,
+              groups: [],
+              file: "Dockerfile",
+              source: { type: "tag", registry: "registry-host.io:5000" }
+            }
+          ]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("ubuntu")
+          expect(dependency.version).to eq("17.04")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
       end
     end
   end

--- a/spec/fixtures/docker/dockerfiles/private_tag
+++ b/spec/fixtures/docker/dockerfiles/private_tag
@@ -1,4 +1,4 @@
-FROM registry-host.io:5000/ubuntu:17.04
+FROM registry-host.io:5000/myreg/ubuntu:17.04
 
 ### SYSTEM DEPENDENCIES
 


### PR DESCRIPTION
If details for a private Docker registry are provided as a credential, there's no reason we shouldn't be able to bump the version of the base image in the Dockerfile.