### PR TITLE
EditorConfig should use 'space' not 'spaces'

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*]
 indent_size = 2
 translate_tabs_to_spaces = true
-indent_style = spaces
+indent_style = space
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
The valid option for `indent_style` is `space` not `spaces` per the [documentation](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#indent_style) :-)