### PR TITLE
python: extract dependencies from `setup_requires` and `extras_require`

### DIFF
--- a/helpers/python/lib/parser.py
+++ b/helpers/python/lib/parser.py
@@ -65,7 +65,7 @@ def parse(directory):
                     continue
                 for req in kwargs.get(arg):
                     parse_requirement(req)
-            for reqs in chain.from_iterable(kwargs.get('extras_require', {}).values()):
+            for req in chain.from_iterable(kwargs.get('extras_require', {}).values()):
                 parse_requirement(req)
         setuptools.setup = setup
 

--- a/spec/dependabot/file_parsers/python/pip_spec.rb
+++ b/spec/dependabot/file_parsers/python/pip_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
       end
 
       # setup.py dependencies get imported
-      its(:length) { is_expected.to eq(13) }
+      its(:length) { is_expected.to eq(14) }
 
       describe "the first dependency" do
         subject(:dependency) { dependencies.first }
@@ -392,19 +392,19 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
         )
       end
 
-      its(:length) { is_expected.to eq(13) }
+      its(:length) { is_expected.to eq(14) }
 
       describe "the first dependency" do
         subject(:dependency) { dependencies.first }
 
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
-          expect(dependency.name).to eq("boto3")
-          expect(dependency.version).to eq("1.3.1")
+          expect(dependency.name).to eq("numpy")
+          expect(dependency.version).to eq("1.11.0")
           expect(dependency.requirements).to eq(
             [
               {
-                requirement: "==1.3.1",
+                requirement: "==1.11.0",
                 file: "setup.py",
                 groups: [],
                 source: nil
@@ -422,7 +422,7 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
           )
         end
 
-        its(:length) { is_expected.to eq(11) }
+        its(:length) { is_expected.to eq(12) }
       end
 
       context "with a `print` statement" do
@@ -433,7 +433,7 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
           )
         end
 
-        its(:length) { is_expected.to eq(13) }
+        its(:length) { is_expected.to eq(14) }
       end
 
       context "with an `open` statement" do
@@ -444,7 +444,7 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
           )
         end
 
-        its(:length) { is_expected.to eq(13) }
+        its(:length) { is_expected.to eq(14) }
       end
 
       context "with the setup.py from requests" do
@@ -466,7 +466,7 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
           )
         end
 
-        its(:length) { is_expected.to eq(13) }
+        its(:length) { is_expected.to eq(14) }
       end
     end
   end

--- a/spec/dependabot/file_parsers/python/pip_spec.rb
+++ b/spec/dependabot/file_parsers/python/pip_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
       end
 
       # setup.py dependencies get imported
-      its(:length) { is_expected.to eq(14) }
+      its(:length) { is_expected.to eq(15) }
 
       describe "the first dependency" do
         subject(:dependency) { dependencies.first }
@@ -392,10 +392,30 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
         )
       end
 
-      its(:length) { is_expected.to eq(14) }
+      its(:length) { is_expected.to eq(15) }
 
-      describe "the first dependency" do
-        subject(:dependency) { dependencies.first }
+      describe "an install_requires dependencies" do
+        subject(:dependency) { dependencies.find { |d| d.name == "boto3" } }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("boto3")
+          expect(dependency.version).to eq("1.3.1")
+          expect(dependency.requirements).to eq(
+            [
+              {
+                requirement: "==1.3.1",
+                file: "setup.py",
+                groups: [],
+                source: nil
+              }
+            ]
+          )
+        end
+      end
+
+      describe "a setup_requires dependencies" do
+        subject(:dependency) { dependencies.find { |d| d.name == "numpy" } }
 
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
@@ -405,6 +425,46 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
             [
               {
                 requirement: "==1.11.0",
+                file: "setup.py",
+                groups: [],
+                source: nil
+              }
+            ]
+          )
+        end
+      end
+
+      describe "a tests_require dependencies" do
+        subject(:dependency) { dependencies.find { |d| d.name == "responses" } }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("responses")
+          expect(dependency.version).to eq("0.5.1")
+          expect(dependency.requirements).to eq(
+            [
+              {
+                requirement: "==0.5.1",
+                file: "setup.py",
+                groups: [],
+                source: nil
+              }
+            ]
+          )
+        end
+      end
+
+      describe "an extras_require dependencies" do
+        subject(:dependency) { dependencies.find { |d| d.name == "flask" } }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("flask")
+          expect(dependency.version).to eq("0.12.2")
+          expect(dependency.requirements).to eq(
+            [
+              {
+                requirement: "==0.12.2",
                 file: "setup.py",
                 groups: [],
                 source: nil
@@ -455,7 +515,7 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
           )
         end
 
-        its(:length) { is_expected.to eq(10) }
+        its(:length) { is_expected.to eq(13) }
       end
 
       context "with an import of a config file" do

--- a/spec/fixtures/python/setup_files/setup.py
+++ b/spec/fixtures/python/setup_files/setup.py
@@ -15,7 +15,6 @@ setup(name='python-package',
           'boto3==1.3.1',
           'flake8 > 2.5.4, < 3.0.0',
           'gocardless_pro',
-          'numpy>=1.11.0',
           'pandas==0.19.2',
           'pep8==1.7.0',
           'psycopg2==2.6.1',
@@ -27,5 +26,10 @@ setup(name='python-package',
       tests_require=[
           'pytest==2.9.1',
           'responses==0.5.1',
-      ]
-      )
+      ],
+      extras_require=dict(
+          API=[
+              'flask==0.12.2',
+          ],
+      ),
+)


### PR DESCRIPTION
This pull-requests intends to add support to the standard
`setup_requires` and `extras_require` sections in setup.py.

`setup_requires` allows one to declare packages required at installation
time wheras `extras_require` is to declare additional dependencies when
an optional feature is activated, for instance: `pip install foo[API]`