### PR TITLE
Handle requirements-dev.txt Python file

### DIFF
--- a/helpers/python/lib/parser.py
+++ b/helpers/python/lib/parser.py
@@ -1,8 +1,9 @@
 from itertools import chain
-import json
-import re
+import glob
 import io
+import json
 import os.path
+import re
 
 import setuptools
 import pip.req.req_file
@@ -12,10 +13,10 @@ from pip.req.req_install import InstallRequirement
 def parse(directory):
     # Parse the requirements.txt
     requirement_packages = []
-    if os.path.isfile(directory + '/requirements.txt'):
+    for reqs_file in glob.glob(os.path.join(directory, 'requirements*.txt')):
         try:
             requirements = pip.req.req_file.parse_requirements(
-                directory + '/requirements.txt',
+                reqs_file,
                 session=PipSession()
             )
             for install_req in requirements:

--- a/lib/dependabot/file_parsers/python/pip.rb
+++ b/lib/dependabot/file_parsers/python/pip.rb
@@ -65,6 +65,7 @@ module Dependabot
         end
 
         def check_required_files
+          return if get_original_file("requirements-dev.txt")
           return if get_original_file("requirements.txt")
           return if get_original_file("setup.py")
           raise "No requirements.txt or setup.py!"

--- a/lib/dependabot/file_updaters/python/pip.rb
+++ b/lib/dependabot/file_updaters/python/pip.rb
@@ -30,6 +30,7 @@ module Dependabot
         private
 
         def check_required_files
+          return if get_original_file("requirements-dev.txt")
           return if get_original_file("requirements.txt")
           return if get_original_file("setup.py")
           raise "No requirements.txt or setup.py!"

--- a/spec/dependabot/file_parsers/python/pip_spec.rb
+++ b/spec/dependabot/file_parsers/python/pip_spec.rb
@@ -283,6 +283,38 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
       end
     end
 
+    context "with requirements-dev.txt" do
+      let(:file) { [requirements] }
+      let(:requirements) do
+        Dependabot::DependencyFile.new(
+          name: "requirements-dev.txt",
+          content: fixture("python", "requirements", "version_specified.txt")
+        )
+      end
+
+      its(:length) { is_expected.to eq(2) }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("psycopg2")
+          expect(dependency.version).to eq("2.6.1")
+          expect(dependency.requirements).to eq(
+            [
+              {
+                requirement: "==2.6.1",
+                file: "requirements-dev.txt",
+                groups: [],
+                source: nil
+              }
+            ]
+          )
+        end
+      end
+    end
+
     context "with reference to its setup.py" do
       let(:files) { [requirements, setup_file] }
       let(:requirements) do


### PR DESCRIPTION
Python parser now actually extracts dependencies from any file
matching the `requirements-*.txt` glob expression.

`requirements-dev.txt` is definitely something dependabot
should handle but I am not sure if there are other
*standard* filenames.