### PR TITLE
JS: Add basic support for private npm packages

### DIFF
--- a/lib/dependabot/metadata_finders/java_script/yarn.rb
+++ b/lib/dependabot/metadata_finders/java_script/yarn.rb
@@ -48,14 +48,28 @@ module Dependabot
         def npm_listing
           return @npm_listing unless @npm_listing.nil?
 
+          npm_headers =
+            if npm_auth_token
+              { "Authorization" => "Bearer #{npm_auth_token}" }
+            else
+              {}
+            end
+
           # NPM registry expects slashes to be escaped
           response = Excon.get(
             "https://registry.npmjs.org/#{dependency.name.gsub('/', '%2f')}",
+            headers: npm_headers,
             idempotent: true,
             middlewares: SharedHelpers.excon_middleware
           )
 
           @npm_listing = JSON.parse(response.body)
+        end
+
+        def npm_auth_token
+          credentials.
+            find { |cred| cred["registry"] == "registry.npmjs.org" }&.
+            fetch("token")
         end
       end
     end

--- a/lib/dependabot/update_checkers/java_script/yarn.rb
+++ b/lib/dependabot/update_checkers/java_script/yarn.rb
@@ -54,6 +54,7 @@ module Dependabot
         def fetch_latest_version
           npm_response = Excon.get(
             dependency_url,
+            headers: npm_headers,
             idempotent: true,
             middlewares: SharedHelpers.excon_middleware
           )
@@ -80,6 +81,17 @@ module Dependabot
           # NPM registry expects slashes to be escaped
           path = dependency.name.gsub("/", "%2F")
           "https://registry.npmjs.org/#{path}"
+        end
+
+        def npm_headers
+          return {} unless npm_auth_token
+          { "Authorization" => "Bearer #{npm_auth_token}" }
+        end
+
+        def npm_auth_token
+          credentials.
+            find { |cred| cred["registry"] == "registry.npmjs.org" }&.
+            fetch("token")
         end
       end
     end

--- a/spec/dependabot/metadata_finders/java_script/yarn_spec.rb
+++ b/spec/dependabot/metadata_finders/java_script/yarn_spec.rb
@@ -120,6 +120,34 @@ RSpec.describe Dependabot::MetadataFinders::JavaScript::Yarn do
           to have_requested(:get,
                             "https://registry.npmjs.org/@etag%2Fsomething")
       end
+
+      context "that is private" do
+        before do
+          stub_request(:get, "https://registry.npmjs.org/@etag%2Fsomething").
+            to_return(status: 404, body: "{\"error\":\"Not found\"}")
+          stub_request(:get, "https://registry.npmjs.org/@etag%2Fsomething").
+            with(headers: { "Authorization" => "Bearer secret_token" }).
+            to_return(status: 200, body: npm_response)
+        end
+
+        context "with credentials" do
+          let(:credentials) do
+            [
+              {
+                "host" => "github.com",
+                "username" => "x-access-token",
+                "password" => "token"
+              },
+              {
+                "registry" => "registry.npmjs.org",
+                "token" => "secret_token"
+              }
+            ]
+          end
+
+          it { is_expected.to eq("https://github.com/jshttp/etag") }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
That. Uses npm credentials passed to it.

The solution here is temporary - we'll want to accept a users's `.npmrc` at some point in the future so we support registries other than `registry.npmjs.org`. We can cross that bridge when we come to it, though - no reason not to get private packages working in the meantime.