### PR TITLE
Perform package.json update in Ruby (and avoid changing package.json format)

### DIFF
--- a/helpers/npm/lib/updater.js
+++ b/helpers/npm/lib/updater.js
@@ -29,13 +29,6 @@ async function updateDependencyFiles(
   const readFile = fileName =>
     fs.readFileSync(path.join(directory, fileName)).toString();
 
-  // Read the original manifest, and update the dependency specification
-  const manifest = JSON.parse(readFile("package.json"));
-
-  // JSONify the new package.json, and write ready for npm install to pick up
-  const updatedManifest = JSON.stringify(manifest, null, 2) + "\n";
-  fs.writeFileSync(path.join(directory, "package.json"), updatedManifest);
-
   await runAsync(npm, npm.load, [{ loglevel: "silent" }]);
 
   // dryRun mode prevents the actual install
@@ -58,10 +51,7 @@ async function updateDependencyFiles(
 
   const updatedLockfile = readFile("package-lock.json");
 
-  return {
-    "package.json": updatedManifest,
-    "package-lock.json": updatedLockfile
-  };
+  return { "package-lock.json": updatedLockfile };
 }
 
 function runAsync(obj, method, args) {

--- a/helpers/npm/lib/updater.js
+++ b/helpers/npm/lib/updater.js
@@ -1,10 +1,11 @@
 /* DEPENDENCY FILE UPDATER
  *
  * Inputs:
- *  - directory containing a package.json and a package-lock.json
- *  - dependency name
- *  - new dependency version
- *  - previous requirements for this dependency
+ *  - directory containing an up-to-date package.json and a package-lock.json
+ *    to be updated
+ *  - name of the dependency to be updated
+ *  - new dependency version (unused)
+ *  - previous requirements for this dependency (unused)
  *
  * Outputs:
  *  - updated package.json and package-lock.json files
@@ -23,14 +24,13 @@ async function updateDependencyFiles(
   directory,
   depName,
   desiredVersion,
-  workspaces
+  requirements
 ) {
   const readFile = fileName =>
     fs.readFileSync(path.join(directory, fileName)).toString();
 
   // Read the original manifest, and update the dependency specification
   const manifest = JSON.parse(readFile("package.json"));
-  updateVersionInManifest(manifest, depName, desiredVersion);
 
   // JSONify the new package.json, and write ready for npm install to pick up
   const updatedManifest = JSON.stringify(manifest, null, 2) + "\n";
@@ -64,31 +64,6 @@ async function updateDependencyFiles(
   };
 }
 
-function updateVersionPattern(currentPattern, desiredVersion) {
-  const versionRegex = /[0-9]+(\.[A-Za-z0-9\-_]+)*/;
-  return currentPattern.replace(versionRegex, oldVersion => {
-    const oldParts = oldVersion.split(".");
-    const newParts = desiredVersion.split(".");
-    return oldParts
-      .slice(0, newParts.length)
-      .map((part, i) => (part.match(/^x\b/) ? "x" : newParts[i]))
-      .join(".");
-  });
-}
-
-function updateVersionInManifest(manifest, depName, desiredVersion) {
-  const depTypes = ["dependencies", "devDependencies", "optionalDependencies"];
-  for (let depType of depTypes) {
-    if ((manifest[depType] || {})[depName]) {
-      manifest[depType][depName] = updateVersionPattern(
-        manifest[depType][depName],
-        desiredVersion
-      );
-      return;
-    }
-  }
-}
-
 function runAsync(obj, method, args) {
   return new Promise((resolve, reject) => {
     const cb = (err, ...returnValues) => {
@@ -110,4 +85,4 @@ function muteStderr() {
   };
 }
 
-module.exports = { updateDependencyFiles, updateVersionPattern };
+module.exports = { updateDependencyFiles };

--- a/helpers/npm/test/fixtures/updater/original/package.json
+++ b/helpers/npm/test/fixtures/updater/original/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "is-positive": "^3.1.0",
-    "left-pad": "^1.0.0"
+    "left-pad": "^1.1.3"
   },
   "engines": {
     "node": "0.0.1"

--- a/helpers/npm/test/fixtures/updater/updated/package.json
+++ b/helpers/npm/test/fixtures/updater/updated/package.json
@@ -1,9 +1,0 @@
-{
-  "dependencies": {
-    "is-positive": "^3.1.0",
-    "left-pad": "^1.1.3"
-  },
-  "engines": {
-    "node": "0.0.1"
-  }
-}

--- a/helpers/npm/test/updater.test.js
+++ b/helpers/npm/test/updater.test.js
@@ -27,16 +27,14 @@ describe("updater", () => {
     await fs.copy(srcLockfile, `${destDir}/package-lock.json`);
   }
 
-  it("generates an updated package.json and package-lock.json", async () => {
+  it("generates an updated package-lock.json", async () => {
     await copyDependencies("original", tempDir);
 
-    const result = await updateDependencyFiles(tempDir, "left-pad", "1.1.3");
+    const result = await updateDependencyFiles(tempDir, "left-pad");
     expect(result).toEqual({
-      "package.json": helpers.loadFixture("updater/updated/package.json"),
       "package-lock.json": helpers.loadFixture(
         "updater/updated/package-lock.json"
       )
     });
   });
 });
-

--- a/helpers/npm/test/updater.test.js
+++ b/helpers/npm/test/updater.test.js
@@ -40,36 +40,3 @@ describe("updater", () => {
   });
 });
 
-describe("updateVersionPattern", () => {
-  it("handles exact versions", () => {
-    expect(updateVersionPattern("1.2.3", "4.5.6")).toEqual("4.5.6");
-  });
-
-  it("handles unspecific patterns", () => {
-    expect(updateVersionPattern("1", "4.5.6")).toEqual("4");
-  });
-
-  it("handles unspecific versions", () => {
-    expect(updateVersionPattern("1.2.3", "4")).toEqual("4");
-  });
-
-  it("handles caret versions", () => {
-    expect(updateVersionPattern("^1.2.3", "4.5.6")).toEqual("^4.5.6");
-  });
-
-  it("handles pre-release versions", () => {
-    expect(updateVersionPattern("^1.2.3-rc1", "4.5.6")).toEqual("^4.5.6");
-  });
-
-  it("handles pre-release versions using four places", () => {
-    expect(updateVersionPattern("^1.2.3.rc1", "4.5.6")).toEqual("^4.5.6");
-  });
-
-  it("handles x.x versions", () => {
-    expect(updateVersionPattern("^1.x.x-rc1", "4.5.6")).toEqual("^4.x.x");
-  });
-
-  it("handles x.x versions using four places", () => {
-    expect(updateVersionPattern("^1.x.x.rc1", "4.5.6")).toEqual("^4.x.x");
-  });
-});

--- a/helpers/yarn/lib/updater.js
+++ b/helpers/yarn/lib/updater.js
@@ -152,11 +152,9 @@ async function updateDependencyFile(
   await add2.init();
 
   const updatedYarnLock = readFile("yarn.lock");
-  const updatedPackageJson = readFile(requirements.file);
 
   return {
-    "yarn.lock": recoverVersionComments(originalYarnLock, updatedYarnLock),
-    [requirements.file]: updatedPackageJson
+    "yarn.lock": recoverVersionComments(originalYarnLock, updatedYarnLock)
   };
 }
 

--- a/helpers/yarn/lib/updater.js
+++ b/helpers/yarn/lib/updater.js
@@ -133,7 +133,6 @@ async function updateDependencyFile(
   // Find the old dependency pattern from the package.json, so we can construct
   // a new pattern that contains the new version but maintains the old format
   const currentPattern = (await allDependencyPatterns(config))[depName];
-  const newPattern = updateVersionPattern(currentPattern, desiredVersion);
 
   const lockfile = await Lockfile.fromDirectory(directory, reporter);
 
@@ -148,7 +147,7 @@ async function updateDependencyFile(
   // Repeat the process to set the right pattern in the lockfile
   // TODO: REFACTOR ME!
   const lockfile2 = await Lockfile.fromDirectory(directory, reporter);
-  const args2 = [`${depName}@${newPattern}`];
+  const args2 = [`${depName}@${currentPattern}`];
   const add2 = new LightweightAdd(args2, flags, config, reporter, lockfile2);
   await add2.init();
 
@@ -161,16 +160,4 @@ async function updateDependencyFile(
   };
 }
 
-function updateVersionPattern(currentPattern, desiredVersion) {
-  const versionRegex = /[0-9]+(\.[A-Za-z0-9\-_]+)*/;
-  return currentPattern.replace(versionRegex, oldVersion => {
-    const oldParts = oldVersion.split(".");
-    const newParts = desiredVersion.split(".");
-    return oldParts
-      .slice(0, newParts.length)
-      .map((part, i) => (part.match(/^x\b/) ? "x" : newParts[i]))
-      .join(".");
-  });
-}
-
-module.exports = { updateDependencyFiles, updateVersionPattern };
+module.exports = { updateDependencyFiles };

--- a/helpers/yarn/test/fixtures/updater/original/package.json
+++ b/helpers/yarn/test/fixtures/updater/original/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "is-positive": "^3.1.0",
-    "left-pad": "^1.0.0"
+    "left-pad": "^1.1.3"
   }
 }

--- a/helpers/yarn/test/fixtures/updater/updated/package.json
+++ b/helpers/yarn/test/fixtures/updater/updated/package.json
@@ -1,6 +1,0 @@
-{
-  "dependencies": {
-    "is-positive": "^3.1.0",
-    "left-pad": "^1.1.3"
-  }
-}

--- a/helpers/yarn/test/fixtures/updater/with-version-comments/package.json
+++ b/helpers/yarn/test/fixtures/updater/with-version-comments/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "left-pad": "^1.0.0"
+    "left-pad": "^1.1.3"
   }
 }

--- a/helpers/yarn/test/updater.test.js
+++ b/helpers/yarn/test/updater.test.js
@@ -27,14 +27,13 @@ describe("updater", () => {
     await fs.copy(srcYarnLock, `${destDir}/yarn.lock`);
   }
 
-  it("generates an updated package.json and yarn.lock", async () => {
+  it("generates an updated yarn.lock", async () => {
     await copyDependencies("original", tempDir);
 
     const result = await updateDependencyFiles(tempDir, "left-pad", "1.1.3", [
       { file: "package.json", groups: ["dependencies"] }
     ]);
     expect(result).toEqual({
-      "package.json": helpers.loadFixture("updater/updated/package.json"),
       "yarn.lock": helpers.loadFixture("updater/updated/yarn.lock")
     });
   });
@@ -73,4 +72,3 @@ describe("updater", () => {
     }
   });
 });
-

--- a/helpers/yarn/test/updater.test.js
+++ b/helpers/yarn/test/updater.test.js
@@ -74,36 +74,3 @@ describe("updater", () => {
   });
 });
 
-describe("updateVersionPattern", () => {
-  it("handles exact versions", () => {
-    expect(updateVersionPattern("1.2.3", "4.5.6")).toEqual("4.5.6");
-  });
-
-  it("handles unspecific patterns", () => {
-    expect(updateVersionPattern("1", "4.5.6")).toEqual("4");
-  });
-
-  it("handles unspecific versions", () => {
-    expect(updateVersionPattern("1.2.3", "4")).toEqual("4");
-  });
-
-  it("handles caret versions", () => {
-    expect(updateVersionPattern("^1.2.3", "4.5.6")).toEqual("^4.5.6");
-  });
-
-  it("handles pre-release versions", () => {
-    expect(updateVersionPattern("^1.2.3-rc1", "4.5.6")).toEqual("^4.5.6");
-  });
-
-  it("handles pre-release versions using four places", () => {
-    expect(updateVersionPattern("^1.2.3.rc1", "4.5.6")).toEqual("^4.5.6");
-  });
-
-  it("handles x.x versions", () => {
-    expect(updateVersionPattern("^1.x.x-rc1", "4.5.6")).toEqual("^4.x.x");
-  });
-
-  it("handles x.x versions using four places", () => {
-    expect(updateVersionPattern("^1.x.x.rc1", "4.5.6")).toEqual("^4.x.x");
-  });
-});

--- a/lib/dependabot/file_updaters/base.rb
+++ b/lib/dependabot/file_updaters/base.rb
@@ -31,6 +31,17 @@ module Dependabot
         dependency_files.find { |f| f.name == filename }
       end
 
+      def file_changed?(file)
+        dependencies.any? { |dep| requirement_changed?(file, dep) }
+      end
+
+      def requirement_changed?(file, dependency)
+        changed_requirements =
+          dependency.requirements - dependency.previous_requirements
+
+        changed_requirements.any? { |f| f[:file] == file.name }
+      end
+
       def updated_file(file:, content:)
         updated_file = file.dup
         updated_file.content = content

--- a/lib/dependabot/file_updaters/ruby/bundler.rb
+++ b/lib/dependabot/file_updaters/ruby/bundler.rb
@@ -97,17 +97,6 @@ module Dependabot
             reject { |f| f.name == "Gemfile" }
         end
 
-        def file_changed?(file)
-          dependencies.any? { |dep| requirement_changed?(file, dep) }
-        end
-
-        def requirement_changed?(file, dependency)
-          changed_requirements =
-            dependency.requirements - dependency.previous_requirements
-
-          changed_requirements.any? { |f| f[:file] == file.name }
-        end
-
         def remove_git_source?(dependency)
           old_gemfile_req =
             dependency.previous_requirements.find { |f| f[:file] == "Gemfile" }

--- a/spec/dependabot/file_updaters/java_script/npm_spec.rb
+++ b/spec/dependabot/file_updaters/java_script/npm_spec.rb
@@ -44,6 +44,9 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Npm do
       version: "0.0.2",
       package_manager: "npm",
       requirements: [
+        { file: "package.json", requirement: "^0.0.2", groups: [], source: nil }
+      ],
+      previous_requirements: [
         { file: "package.json", requirement: "^0.0.1", groups: [], source: nil }
       ]
     )
@@ -84,7 +87,15 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Npm do
             requirements: [
               {
                 file: "package.json",
-                requirement: "^0.0.1",
+                requirement: "0.2.x",
+                groups: [],
+                source: nil
+              }
+            ],
+            previous_requirements: [
+              {
+                file: "package.json",
+                requirement: "0.1.x",
                 groups: [],
                 source: nil
               }
@@ -118,6 +129,14 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Npm do
             version: "1.3.1",
             package_manager: "npm",
             requirements: [
+              {
+                file: "package.json",
+                requirement: "^1.3.1",
+                groups: [],
+                source: nil
+              }
+            ],
+            previous_requirements: [
               {
                 file: "package.json",
                 requirement: "^1.2.1",
@@ -178,6 +197,14 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Npm do
             version: "1.3.1",
             package_manager: "npm",
             requirements: [
+              {
+                file: "package.json",
+                requirement: "^1.3.1",
+                groups: [],
+                source: nil
+              }
+            ],
+            previous_requirements: [
               {
                 file: "package.json",
                 requirement: "^1.2.1",

--- a/spec/dependabot/file_updaters/java_script/npm_spec.rb
+++ b/spec/dependabot/file_updaters/java_script/npm_spec.rb
@@ -164,6 +164,16 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Npm do
 
         its(:content) { is_expected.to include "\"etag\": \"^1.0.0\"" }
       end
+
+      context "with non-standard whitespace" do
+        let(:package_json_body) do
+          fixture("javascript", "package_files", "non_standard_whitespace.json")
+        end
+
+        its(:content) do
+          is_expected.to include %("*.js": ["eslint --fix", "git add"])
+        end
+      end
     end
 
     describe "the updated lockfile" do

--- a/spec/dependabot/file_updaters/java_script/yarn_spec.rb
+++ b/spec/dependabot/file_updaters/java_script/yarn_spec.rb
@@ -240,6 +240,16 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
         its(:content) { is_expected.to include "\"etag\": \"^1.0.0\"" }
       end
 
+      context "with non-standard whitespace" do
+        let(:package_json_body) do
+          fixture("javascript", "package_files", "non_standard_whitespace.json")
+        end
+
+        its(:content) do
+          is_expected.to include %("*.js": ["eslint --fix", "git add"])
+        end
+      end
+
       context "with workspaces" do
         let(:files) { [package_json, lockfile, package1, other_package] }
         let(:package_json_body) do

--- a/spec/dependabot/file_updaters/java_script/yarn_spec.rb
+++ b/spec/dependabot/file_updaters/java_script/yarn_spec.rb
@@ -45,6 +45,9 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
       version: "0.0.2",
       package_manager: "yarn",
       requirements: [
+        { file: "package.json", requirement: "^0.0.2", groups: [], source: nil }
+      ],
+      previous_requirements: [
         { file: "package.json", requirement: "^0.0.1", groups: [], source: nil }
       ]
     )
@@ -85,6 +88,14 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
             requirements: [
               {
                 file: "package.json",
+                requirement: "0.2.x",
+                groups: [],
+                source: nil
+              }
+            ],
+            previous_requirements: [
+              {
+                file: "package.json",
                 requirement: "0.1.x",
                 groups: [],
                 source: nil
@@ -106,6 +117,14 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
             version: "0.2.1",
             package_manager: "yarn",
             requirements: [
+              {
+                file: "package.json",
+                requirement: "*",
+                groups: [],
+                source: nil
+              }
+            ],
+            previous_requirements: [
               {
                 file: "package.json",
                 requirement: "*",
@@ -136,6 +155,14 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
             requirements: [
               {
                 file: "package.json",
+                requirement: "^1.8.1",
+                groups: [],
+                source: nil
+              }
+            ],
+            previous_requirements: [
+              {
+                file: "package.json",
                 requirement: "^1.0.0",
                 groups: [],
                 source: nil
@@ -157,7 +184,7 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
         end
       end
 
-      context "with a path-based dependency" do
+      context "with a path-based dependency (not this dependency)" do
         let(:files) { [package_json, lockfile, path_dep] }
         let(:package_json_body) do
           fixture("javascript", "package_files", "path_dependency.json")
@@ -177,6 +204,14 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
             version: "1.3.1",
             package_manager: "yarn",
             requirements: [
+              {
+                file: "package.json",
+                requirement: "^1.3.1",
+                groups: [],
+                source: nil
+              }
+            ],
+            previous_requirements: [
               {
                 file: "package.json",
                 requirement: "^1.2.1",
@@ -237,6 +272,26 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
             requirements: [
               {
                 file: "package.json",
+                requirement: "^1.3.1",
+                groups: [],
+                source: nil
+              },
+              {
+                file: "packages/package1/package.json",
+                requirement: "^1.3.1",
+                groups: [],
+                source: nil
+              },
+              {
+                file: "other_package/package.json",
+                requirement: "^1.3.1",
+                groups: [],
+                source: nil
+              }
+            ],
+            previous_requirements: [
+              {
+                file: "package.json",
                 requirement: "^1.2.0",
                 groups: [],
                 source: nil
@@ -283,6 +338,14 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
                   groups: [],
                   source: nil
                 }
+              ],
+              previous_requirements: [
+                {
+                  file: "packages/package1/package.json",
+                  requirement: "0.3.0",
+                  groups: [],
+                  source: nil
+                }
               ]
             )
           end
@@ -300,6 +363,14 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
               version: "1.8.1",
               package_manager: "yarn",
               requirements: [
+                {
+                  file: "packages/package1/package.json",
+                  requirement: "^1.8.1",
+                  groups: ["devDependencies"],
+                  source: nil
+                }
+              ],
+              previous_requirements: [
                 {
                   file: "packages/package1/package.json",
                   requirement: "^1.1.0",
@@ -359,6 +430,14 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
             requirements: [
               {
                 file: "package.json",
+                requirement: "^1.3.1",
+                groups: [],
+                source: nil
+              }
+            ],
+            previous_requirements: [
+              {
+                file: "package.json",
                 requirement: "^1.2.1",
                 groups: [],
                 source: nil
@@ -380,6 +459,14 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
             version: "0.2.1",
             package_manager: "yarn",
             requirements: [
+              {
+                file: "package.json",
+                requirement: "*",
+                groups: [],
+                source: nil
+              }
+            ],
+            previous_requirements: [
               {
                 file: "package.json",
                 requirement: "*",
@@ -434,6 +521,26 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
             requirements: [
               {
                 file: "package.json",
+                requirement: "^1.3.1",
+                groups: [],
+                source: nil
+              },
+              {
+                file: "packages/package1/package.json",
+                requirement: "^1.3.1",
+                groups: [],
+                source: nil
+              },
+              {
+                file: "other_package/package.json",
+                requirement: "^1.3.1",
+                groups: [],
+                source: nil
+              }
+            ],
+            previous_requirements: [
+              {
+                file: "package.json",
                 requirement: "^1.2.0",
                 groups: [],
                 source: nil
@@ -471,6 +578,14 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::Yarn do
                 {
                   file: "packages/package1/package.json",
                   requirement: "0.4.0",
+                  groups: [],
+                  source: nil
+                }
+              ],
+              previous_requirements: [
+                {
+                  file: "packages/package1/package.json",
+                  requirement: "0.3.0",
                   groups: [],
                   source: nil
                 }

--- a/spec/dependabot/update_checkers/java_script/yarn_spec.rb
+++ b/spec/dependabot/update_checkers/java_script/yarn_spec.rb
@@ -434,9 +434,21 @@ RSpec.describe Dependabot::UpdateCheckers::JavaScript::Yarn do
         its([:requirement]) { is_expected.to eq("1.5") }
       end
 
+      context "and only the major part was previously specified" do
+        let(:original_requirement) { "1" }
+        let(:latest_resolvable_version) { Gem::Version.new("4.5.0") }
+        its([:requirement]) { is_expected.to eq("4") }
+      end
+
       context "and the new version has fewer digits than the old one§" do
         let(:original_requirement) { "1.1.0.1" }
         its([:requirement]) { is_expected.to eq("1.5.0") }
+      end
+
+      context "and the new version has much fewer digits than the old one§" do
+        let(:original_requirement) { "1.1.0.1" }
+        let(:latest_resolvable_version) { Gem::Version.new("4") }
+        its([:requirement]) { is_expected.to eq("4") }
       end
 
       context "and a caret was previously specified" do
@@ -449,8 +461,13 @@ RSpec.describe Dependabot::UpdateCheckers::JavaScript::Yarn do
         its([:requirement]) { is_expected.to eq("^1.5.0") }
       end
 
+      context "and a pre-release was previously specified with four places" do
+        let(:original_requirement) { "^1.2.3.rc1" }
+        its([:requirement]) { is_expected.to eq("^1.5.0") }
+      end
+
       context "and an x.x was previously specified" do
-        let(:original_requirement) { "^0.x.x-rc1" }
+        let(:original_requirement) { "^0.x.x" }
         its([:requirement]) { is_expected.to eq("^1.x.x") }
       end
 

--- a/spec/fixtures/javascript/package_files/non_standard_whitespace.json
+++ b/spec/fixtures/javascript/package_files/non_standard_whitespace.json
@@ -1,0 +1,28 @@
+{
+    "name": "{{ name }}",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/waltfy/PROTO_TEST.git"
+    },
+    "author": "",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/waltfy/PROTO_TEST/issues"
+    },
+    "homepage": "https://github.com/waltfy/PROTO_TEST#readme",
+    "dependencies": {
+      "fetch-factory": "^0.0.1"
+    },
+    "devDependencies": {
+      "etag": "^1.0.0"
+    },
+    "lint-staged": {
+        "*.js": ["eslint --fix", "git add"]
+    }
+}


### PR DESCRIPTION
Previously we were updating the `package.json` file by calling `yarn add` or by manually altering it in the npm `updater.js` file.

There's no need not to do this update in Ruby, and doing so will speed things up if/when we allow JS repos without a lockfile. It also makes it easier to debug, and to use regexes to do the update (and therefore preserve file formatting).