### PR TITLE
PHP: Don't check platform requirements during updates

### DIFF
--- a/helpers/php/src/UpdateChecker.php
+++ b/helpers/php/src/UpdateChecker.php
@@ -83,19 +83,21 @@ class UpdateChecker
       ->setUpdate(true)
       ->setUpdateWhitelist([$dependencyName])
       ->setPreferStable(true)
+      ->setExecuteOperations(false)
+      ->setDumpAutoloader(false)
+      ->setRunScripts(false)
+      ->setIgnorePlatformRequirements(true)
       ;
 
     $install->run();
 
     $installedPackages = $installationManager->getInstalledPackages();
-    $updatedPackages = $installationManager->getUpdatedPackages();
-    $uninstalledPackages = $installationManager->getUninstalledPackages();
 
     $updatedPackage = current(array_filter($installedPackages, function($package) use($dependencyName) {
       return $package->getName() == $dependencyName;
     }));
 
-    if ($updatedPackage == FALSE || $updatedPackage->getRepository()->getRepoConfig()["type"] == "vcs") {
+    if ($updatedPackage->getRepository()->getRepoConfig()["type"] == "vcs") {
       return NULL;
     } else {
       return preg_replace('/^([v])/', '', $updatedPackage->getPrettyVersion());

--- a/helpers/php/src/Updater.php
+++ b/helpers/php/src/Updater.php
@@ -60,9 +60,14 @@ class Updater
 
     // For all potential options, see UpdateCommand in composer
     $install
+      ->setWriteLock(true)
       ->setUpdate(true)
       ->setUpdateWhitelist([$dependencyName])
-      ->setWriteLock(true)
+      ->setPreferStable(true)
+      ->setExecuteOperations(false)
+      ->setDumpAutoloader(false)
+      ->setRunScripts(false)
+      ->setIgnorePlatformRequirements(true)
       ;
 
     $install->run();

--- a/lib/dependabot/update_checkers/php/composer.rb
+++ b/lib/dependabot/update_checkers/php/composer.rb
@@ -71,7 +71,7 @@ module Dependabot
               File.write("composer.lock", lockfile.content)
 
               SharedHelpers.run_helper_subprocess(
-                command: "php #{php_helper_path}",
+                command: "php -d memory_limit=-1 #{php_helper_path}",
                 function: "get_latest_resolvable_version",
                 args: [Dir.pwd, dependency.name]
               )
@@ -82,10 +82,6 @@ module Dependabot
           else
             Gem::Version.new(latest_resolvable_version)
           end
-        rescue SharedHelpers::HelperSubprocessFailed
-          # TODO: We shouldn't be suppressing these errors but they're caused
-          # by memory issues that we don't currently have a solution to.
-          nil
         end
 
         def composer_file

--- a/spec/dependabot/file_updaters/php/composer_spec.rb
+++ b/spec/dependabot/file_updaters/php/composer_spec.rb
@@ -79,9 +79,7 @@ RSpec.describe Dependabot::FileUpdaters::Php::Composer do
         JSON.parse(raw).to_json
       end
 
-      it do
-        is_expected.to include "\"monolog/monolog\":\"1.22.1\""
-      end
+      it { is_expected.to include "\"monolog/monolog\":\"1.22.1\"" }
 
       it { is_expected.to include "\"symfony/polyfill-mbstring\":\"1.0.1\"" }
 
@@ -117,8 +115,36 @@ RSpec.describe Dependabot::FileUpdaters::Php::Composer do
       end
 
       it "has details of the updated item" do
-        expect(updated_lockfile_content).
-          to include("\"version\":\"1.22.1\"")
+        expect(updated_lockfile_content).to include("\"version\":\"1.22.1\"")
+      end
+
+      context "when an old version of PHP is specified" do
+        let(:composer_body) do
+          fixture("php", "composer_files", "old_php_specified")
+        end
+        let(:lockfile_body) do
+          fixture("php", "lockfiles", "old_php_specified")
+        end
+
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "illuminate/support",
+            version: "v5.4.36",
+            requirements: [
+              {
+                file: "composer.json",
+                requirement: "^5.2.0",
+                groups: ["runtime"],
+                source: nil
+              }
+            ],
+            package_manager: "composer"
+          )
+        end
+
+        it "has details of the updated item" do
+          expect(updated_lockfile_content).to include("\"version\":\"v5.4.36\"")
+        end
       end
     end
   end

--- a/spec/dependabot/update_checkers/php/composer_spec.rb
+++ b/spec/dependabot/update_checkers/php/composer_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer do
         )
       end
 
-      it { is_expected.to be >= Gem::Version.new("2.2.1") }
+      it { is_expected.to be >= Gem::Version.new("3.0.2") }
     end
 
     context "when an autoload is specified" do
@@ -194,7 +194,34 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer do
         )
       end
 
-      it { is_expected.to be >= Gem::Version.new("5.2.7") }
+      it { is_expected.to be >= Gem::Version.new("5.2.30") }
+    end
+
+    context "when an old version of PHP is specified" do
+      let(:composer_file_content) do
+        fixture("php", "composer_files", "old_php_specified")
+      end
+      let(:lockfile_content) do
+        fixture("php", "lockfiles", "old_php_specified")
+      end
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "illuminate/support",
+          version: "v5.2.7",
+          requirements: [
+            {
+              file: "composer.json",
+              requirement: "^5.2.0",
+              groups: ["runtime"],
+              source: nil
+            }
+          ],
+          package_manager: "composer"
+        )
+      end
+
+      it { is_expected.to be >= Gem::Version.new("5.4.36") }
     end
   end
 

--- a/spec/fixtures/php/composer_files/old_php_specified
+++ b/spec/fixtures/php/composer_files/old_php_specified
@@ -1,0 +1,7 @@
+{
+    "require": {
+        "php": "^5.6.0",
+        "erusev/parsedown": "^1.6.0",
+        "illuminate/support": "^5.2.0"
+    }
+}

--- a/spec/fixtures/php/lockfiles/old_php_specified
+++ b/spec/fixtures/php/lockfiles/old_php_specified
@@ -1,0 +1,279 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "e58cf23f46cf41f36fe82abdab3dedf5",
+    "packages": [
+        {
+            "name": "doctrine/inflector",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/90b2128806bfde671b6952ab8bea493942c1fdae",
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Inflector\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "inflection",
+                "pluralize",
+                "singularize",
+                "string"
+            ],
+            "time": "2015-11-06T14:35:42+00:00"
+        },
+        {
+            "name": "erusev/parsedown",
+            "version": "1.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/erusev/parsedown.git",
+                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/fbe3fe878f4fe69048bb8a52783a09802004f548",
+                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Parsedown": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
+                }
+            ],
+            "description": "Parser for Markdown.",
+            "homepage": "http://parsedown.org",
+            "keywords": [
+                "markdown",
+                "parser"
+            ],
+            "time": "2017-11-14T20:44:03+00:00"
+        },
+        {
+            "name": "illuminate/contracts",
+            "version": "v5.4.36",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/contracts.git",
+                "reference": "67f642e018f3e95fb0b2ebffc206c3200391b1ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/67f642e018f3e95fb0b2ebffc206c3200391b1ab",
+                "reference": "67f642e018f3e95fb0b2ebffc206c3200391b1ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Contracts\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Contracts package.",
+            "homepage": "https://laravel.com",
+            "time": "2017-08-26T23:56:53+00:00"
+        },
+        {
+            "name": "illuminate/support",
+            "version": "v5.4.36",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/support.git",
+                "reference": "feab1d1495fd6d38970bd6c83586ba2ace8f299a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/feab1d1495fd6d38970bd6c83586ba2ace8f299a",
+                "reference": "feab1d1495fd6d38970bd6c83586ba2ace8f299a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "~1.1",
+                "ext-mbstring": "*",
+                "illuminate/contracts": "5.4.*",
+                "paragonie/random_compat": "~1.4|~2.0",
+                "php": ">=5.6.4"
+            },
+            "replace": {
+                "tightenco/collect": "self.version"
+            },
+            "suggest": {
+                "illuminate/filesystem": "Required to use the composer class (5.2.*).",
+                "symfony/process": "Required to use the composer class (~3.2).",
+                "symfony/var-dumper": "Required to use the dd function (~3.2)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                },
+                "files": [
+                    "helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Support package.",
+            "homepage": "https://laravel.com",
+            "time": "2017-08-15T13:25:41+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2017-09-27T21:40:39+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^5.6.0"
+    },
+    "platform-dev": []
+}


### PR DESCRIPTION
Fixes #156.

This might cause us to create updates we shouldn't (i.e., ones that require a higher PHP version than the `composer.json` specifies. We can fix that if/when it occurs, though - it's a better problem to have than not creating updates at all if our PHP install is missing *any* PHP extensions.