### PR TITLE
Refactored and cleaned up PHP code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@
 Gemfile.lock
 /helpers/yarn/node_modules
 /helpers/npm/node_modules
+/helpers/php/vendor
+/helpers/php/.php_cs.cache
 vendor
 *.pyc

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ test:
     - bundle exec rubocop
     - cd helpers/yarn && node_modules/.bin/eslint lib test bin
     - cd helpers/npm && node_modules/.bin/eslint lib test bin
-    - cd helpers/php && bin/php-cs-fixer fix
+    - cd helpers/php && vendor/bin/php-cs-fixer fix
   override:
     - bundle exec rspec spec
     - cd helpers/yarn && node_modules/.bin/jest

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ test:
     - bundle exec rubocop
     - cd helpers/yarn && node_modules/.bin/eslint lib test bin
     - cd helpers/npm && node_modules/.bin/eslint lib test bin
-    - cd helpers/php && vendor/bin/php-cs-fixer fix
+    - cd helpers/php && vendor/bin/php-cs-fixer fix --dry-run
   override:
     - bundle exec rspec spec
     - cd helpers/yarn && node_modules/.bin/jest

--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,7 @@ test:
     - bundle exec rubocop
     - cd helpers/yarn && node_modules/.bin/eslint lib test bin
     - cd helpers/npm && node_modules/.bin/eslint lib test bin
+    - cd helpers/php && bin/php-cs-fixer fix
   override:
     - bundle exec rspec spec
     - cd helpers/yarn && node_modules/.bin/jest

--- a/helpers/php/.php_cs
+++ b/helpers/php/.php_cs
@@ -1,0 +1,34 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/src')
+    ->in(__DIR__ . '/bin');
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'blank_line_after_opening_tag' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'declare_strict_types' => true,
+        'increment_style' => ['style' => 'post'],
+        'is_null' => ['use_yoda_style' => false],
+        'list_syntax' => ['syntax' => 'short'],
+        'method_argument_space' => ['ensure_fully_multiline' => true],
+        'modernize_types_casting' => true,
+        'no_multiline_whitespace_before_semicolons' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'ordered_imports' => true,
+        'phpdoc_align' => false,
+        'phpdoc_order' => true,
+        'php_unit_construct' => true,
+        'php_unit_dedicate_assert' => true,
+        'single_line_comment_style' => true,
+        'ternary_to_null_coalescing' => true,
+        'yoda_style' => false,
+        'void_return' => true,
+    ])
+    ->setFinder($finder)
+    ->setUsingCache(true)
+    ->setRiskyAllowed(true);

--- a/helpers/php/bin/run.php
+++ b/helpers/php/bin/run.php
@@ -15,6 +15,8 @@ $request = json_decode(file_get_contents('php://stdin'), true);
 // it checking huge numbers of dependency combinations and causing OOM issues.
 ini_set('memory_limit', '1536M');
 
+date_default_timezone_set('Europe/London');
+
 try {
     switch ($request['function']) {
         case 'update':

--- a/helpers/php/bin/run.php
+++ b/helpers/php/bin/run.php
@@ -1,32 +1,33 @@
 <?php
 
+declare(strict_types=1);
 require dirname(__FILE__) . '/../src/UpdateChecker.php';
 require dirname(__FILE__) . '/../src/Updater.php';
 
 // Get details of the process to run from STDIN. It will have a `function`
 // and an `args` method, as passed in by UpdateCheckers::Php
-$request = json_decode(file_get_contents("php://stdin"));
+$request = json_decode(file_get_contents('php://stdin'));
 
 // Increase the default memory limit. Calling `composer update` is otherwise
 // vulnerable to scenarios where there are unconstrained versions, resulting in
 // it checking huge numbers of dependency combinations and causing OOM issues.
-ini_set('memory_limit','1536M');
+ini_set('memory_limit', '1536M');
 
 try {
-  switch ($request->function) {
-    case "update":
+    switch ($request->function) {
+    case 'update':
       $updatedFiles = Updater::update($request->args);
-      fwrite(STDOUT, json_encode(["result" => $updatedFiles]));
+      fwrite(STDOUT, json_encode(['result' => $updatedFiles]));
       break;
-    case "get_latest_resolvable_version":
+    case 'get_latest_resolvable_version':
       $latestVersion = UpdateChecker::get_latest_resolvable_version($request->args);
-      fwrite(STDOUT, json_encode(["result" => $latestVersion]));
+      fwrite(STDOUT, json_encode(['result' => $latestVersion]));
       break;
     default:
-      fwrite(STDOUT, "{\"error\": \"Invalid function ".$request->{'function'}."\" }");
+      fwrite(STDOUT, '{"error": "Invalid function ' . $request->{'function'} . '" }');
       exit(1);
   }
 } catch (\Exception $e) {
-  fwrite(STDOUT, json_encode(["error" => $e->getMessage()]));
-  exit(1);
+    fwrite(STDOUT, json_encode(['error' => $e->getMessage()]));
+    exit(1);
 }

--- a/helpers/php/bin/run.php
+++ b/helpers/php/bin/run.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 // Get details of the process to run from STDIN. It will have a `function`
 // and an `args` method, as passed in by UpdateCheckers::Php
-$request = json_decode(file_get_contents('php://stdin'));
+$request = json_decode(file_get_contents('php://stdin'), true);
 
 // Increase the default memory limit. Calling `composer update` is otherwise
 // vulnerable to scenarios where there are unconstrained versions, resulting in
@@ -16,17 +16,17 @@ $request = json_decode(file_get_contents('php://stdin'));
 ini_set('memory_limit', '1536M');
 
 try {
-    switch ($request->function) {
+    switch ($request['function']) {
         case 'update':
-            $updatedFiles = Updater::update($request->args);
+            $updatedFiles = Updater::update($request['args']);
             fwrite(STDOUT, json_encode(['result' => $updatedFiles]));
             break;
         case 'get_latest_resolvable_version':
-            $latestVersion = UpdateChecker::get_latest_resolvable_version($request->args);
+            $latestVersion = UpdateChecker::get_latest_resolvable_version($request['args']);
             fwrite(STDOUT, json_encode(['result' => $latestVersion]));
             break;
         default:
-            fwrite(STDOUT, '{"error": "Invalid function ' . $request->{'function'} . '" }');
+            fwrite(STDOUT, '{"error": "Invalid function ' . $request['function'] . '" }');
             exit(1);
     }
 } catch (\Exception $e) {

--- a/helpers/php/bin/run.php
+++ b/helpers/php/bin/run.php
@@ -1,8 +1,10 @@
 <?php
 
 declare(strict_types=1);
-require dirname(__FILE__) . '/../src/UpdateChecker.php';
-require dirname(__FILE__) . '/../src/Updater.php';
+
+namespace Dependabot\PHP;
+
+require __DIR__ . '/../vendor/autoload.php';
 
 // Get details of the process to run from STDIN. It will have a `function`
 // and an `args` method, as passed in by UpdateCheckers::Php

--- a/helpers/php/bin/run.php
+++ b/helpers/php/bin/run.php
@@ -17,18 +17,18 @@ ini_set('memory_limit', '1536M');
 
 try {
     switch ($request->function) {
-    case 'update':
-      $updatedFiles = Updater::update($request->args);
-      fwrite(STDOUT, json_encode(['result' => $updatedFiles]));
-      break;
-    case 'get_latest_resolvable_version':
-      $latestVersion = UpdateChecker::get_latest_resolvable_version($request->args);
-      fwrite(STDOUT, json_encode(['result' => $latestVersion]));
-      break;
-    default:
-      fwrite(STDOUT, '{"error": "Invalid function ' . $request->{'function'} . '" }');
-      exit(1);
-  }
+        case 'update':
+            $updatedFiles = Updater::update($request->args);
+            fwrite(STDOUT, json_encode(['result' => $updatedFiles]));
+            break;
+        case 'get_latest_resolvable_version':
+            $latestVersion = UpdateChecker::get_latest_resolvable_version($request->args);
+            fwrite(STDOUT, json_encode(['result' => $latestVersion]));
+            break;
+        default:
+            fwrite(STDOUT, '{"error": "Invalid function ' . $request->{'function'} . '" }');
+            exit(1);
+    }
 } catch (\Exception $e) {
     fwrite(STDOUT, json_encode(['error' => $e->getMessage()]));
     exit(1);

--- a/helpers/php/bin/run.php
+++ b/helpers/php/bin/run.php
@@ -22,7 +22,7 @@ try {
             fwrite(STDOUT, json_encode(['result' => $updatedFiles]));
             break;
         case 'get_latest_resolvable_version':
-            $latestVersion = UpdateChecker::get_latest_resolvable_version($request['args']);
+            $latestVersion = UpdateChecker::getLatestResolvableVersion($request['args']);
             fwrite(STDOUT, json_encode(['result' => $latestVersion]));
             break;
         default:

--- a/helpers/php/composer.json
+++ b/helpers/php/composer.json
@@ -8,7 +8,7 @@
     },
     "autoload": {
         "psr-4": {
-            "\\Dependabot\\PHP\\": "src/"
+            "Dependabot\\PHP\\": "src/"
         }
     }
 }

--- a/helpers/php/composer.json
+++ b/helpers/php/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
-        "composer/composer": "1.5.5"
+        "composer/composer": "1.5.5",
+        "php": "^7.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.9"

--- a/helpers/php/composer.json
+++ b/helpers/php/composer.json
@@ -1,5 +1,8 @@
 {
     "require": {
         "composer/composer": "1.5.5"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.9"
     }
 }

--- a/helpers/php/composer.json
+++ b/helpers/php/composer.json
@@ -5,5 +5,10 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.9"
+    },
+    "autoload": {
+        "psr-4": {
+            "\\Dependabot\\PHP\\": "src/"
+        }
     }
 }

--- a/helpers/php/composer.lock
+++ b/helpers/php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "11b1a76d1dc5bd7f0138267c83c6db9e",
+    "content-hash": "ca3982d992c219b0ce6a185a8466d4b2",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -847,7 +847,636 @@
             "time": "2017-04-12T14:13:17+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "5beebb01b025c94e93686b7a0ed3edae81fe3e7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/5beebb01b025c94e93686b7a0ed3edae81fe3e7f",
+                "reference": "5beebb01b025c94e93686b7a0ed3edae81fe3e7f",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2017-07-22T10:58:02+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "454ddbe65da6a9297446f442bad244e8a99a9a38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/454ddbe65da6a9297446f442bad244e8a99a9a38",
+                "reference": "454ddbe65da6a9297446f442bad244e8a99a9a38",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^1.4",
+                "doctrine/annotations": "^1.2",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "gecko-packages/gecko-php-unit": "^2.0 || ^3.0",
+                "php": "^5.6 || >=7.0 <7.3",
+                "php-cs-fixer/diff": "^1.2",
+                "symfony/console": "^3.2 || ^4.0",
+                "symfony/event-dispatcher": "^3.0 || ^4.0",
+                "symfony/filesystem": "^3.0 || ^4.0",
+                "symfony/finder": "^3.0 || ^4.0",
+                "symfony/options-resolver": "^3.0 || ^4.0",
+                "symfony/polyfill-php70": "^1.0",
+                "symfony/polyfill-php72": "^1.4",
+                "symfony/process": "^3.0 || ^4.0",
+                "symfony/stopwatch": "^3.0 || ^4.0"
+            },
+            "conflict": {
+                "hhvm": "*"
+            },
+            "require-dev": {
+                "johnkary/phpunit-speedtrap": "^1.1 || ^2.0@dev",
+                "justinrainbow/json-schema": "^5.0",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.0",
+                "php-cs-fixer/accessible-object": "^1.0",
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "symfony/phpunit-bridge": "^3.2.2 || ^4.0"
+            },
+            "suggest": {
+                "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "classmap": [
+                    "tests/Test/Assert/AssertTokensTrait.php",
+                    "tests/Test/AbstractFixerTestCase.php",
+                    "tests/Test/AbstractIntegrationTestCase.php",
+                    "tests/Test/IntegrationCase.php",
+                    "tests/Test/IntegrationCaseFactory.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2017-12-08T16:36:20+00:00"
+        },
+        {
+            "name": "gecko-packages/gecko-php-unit",
+            "version": "v3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GeckoPackages/GeckoPHPUnit.git",
+                "reference": "6a866551dffc2154c1b091bae3a7877d39c25ca3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GeckoPackages/GeckoPHPUnit/zipball/6a866551dffc2154c1b091bae3a7877d39c25ca3",
+                "reference": "6a866551dffc2154c1b091bae3a7877d39c25ca3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-dom": "When testing with xml.",
+                "ext-libxml": "When testing with xml.",
+                "phpunit/phpunit": "This is an extension for it so make sure you have it some way."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GeckoPackages\\PHPUnit\\": "src/PHPUnit"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Additional PHPUnit asserts and constraints.",
+            "homepage": "https://github.com/GeckoPackages",
+            "keywords": [
+                "extension",
+                "filesystem",
+                "phpunit"
+            ],
+            "time": "2017-08-23T07:46:41+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2017-09-27T21:40:39+00:00"
+        },
+        {
+            "name": "php-cs-fixer/diff",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/diff.git",
+                "reference": "f0ef6133d674137e902fdf8a6f2e8e97e14a087b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/f0ef6133d674137e902fdf8a6f2e8e97e14a087b",
+                "reference": "f0ef6133d674137e902fdf8a6f2e8e97e14a087b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.4.3",
+                "symfony/process": "^3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "SpacePossum"
+                }
+            ],
+            "description": "sebastian/diff v2 backport support for PHP5.6",
+            "homepage": "https://github.com/PHP-CS-Fixer",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2017-10-19T09:58:18+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "6223fb2b68e7059e8d5843c0103999a84e7275cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/6223fb2b68e7059e8d5843c0103999a84e7275cf",
+                "reference": "6223fb2b68e7059e8d5843c0103999a84e7275cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/stopwatch": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-11-09T17:30:28+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "ef617a2867c7d889d4ecee3c29595698d87474a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/ef617a2867c7d889d4ecee3c29595698d87474a4",
+                "reference": "ef617a2867c7d889d4ecee3c29595698d87474a4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony OptionsResolver Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "time": "2017-11-07T14:45:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php70",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php70.git",
+                "reference": "0442b9c0596610bd24ae7b5f0a6cdbbc16d9fcff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/0442b9c0596610bd24ae7b5f0a6cdbbc16d9fcff",
+                "reference": "0442b9c0596610bd24ae7b5f0a6cdbbc16d9fcff",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "~1.0|~2.0",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php70\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2017-10-11T12:05:26+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "6de4f4884b97abbbed9f0a84a95ff2ff77254254"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/6de4f4884b97abbbed9f0a84a95ff2ff77254254",
+                "reference": "6de4f4884b97abbbed9f0a84a95ff2ff77254254",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2017-10-11T12:05:26+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "ac0e49150555c703fef6b696d8eaba1db7a3ca03"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/ac0e49150555c703fef6b696d8eaba1db7a3ca03",
+                "reference": "ac0e49150555c703fef6b696d8eaba1db7a3ca03",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-11-09T12:45:29+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/helpers/php/composer.lock
+++ b/helpers/php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca3982d992c219b0ce6a185a8466d4b2",
+    "content-hash": "51a9e3a8225bf123980802ce1c5e1865",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1482,6 +1482,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^7.1"
+    },
     "platform-dev": []
 }

--- a/helpers/php/src/DependabotInstallationManager.php
+++ b/helpers/php/src/DependabotInstallationManager.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dependabot\PHP;
+
+use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\DependencyResolver\Operation\UninstallOperation;
+use Composer\DependencyResolver\Operation\UpdateOperation;
+use Composer\Installer\InstallationManager;
+use Composer\Repository\RepositoryInterface;
+
+class DependabotInstallationManager extends InstallationManager
+{
+    private $installed = [];
+    private $updated = [];
+    private $uninstalled = [];
+
+    public function install(RepositoryInterface $repo, InstallOperation $operation): void
+    {
+        parent::install($repo, $operation);
+        $this->installed[] = $operation->getPackage();
+    }
+
+    public function update(RepositoryInterface $repo, UpdateOperation $operation): void
+    {
+        parent::update($repo, $operation);
+        $this->updated[] = [$operation->getInitialPackage(), $operation->getTargetPackage()];
+    }
+
+    public function uninstall(RepositoryInterface $repo, UninstallOperation $operation): void
+    {
+        parent::uninstall($repo, $operation);
+        $this->uninstalled[] = $operation->getPackage();
+    }
+
+    public function getInstalledPackages()
+    {
+        return $this->installed;
+    }
+
+    public function getUpdatedPackages()
+    {
+        return $this->updated;
+    }
+
+    public function getUninstalledPackages()
+    {
+        return $this->uninstalled;
+    }
+}

--- a/helpers/php/src/DependabotInstallationManager.php
+++ b/helpers/php/src/DependabotInstallationManager.php
@@ -8,6 +8,7 @@ use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\Installer\InstallationManager;
+use Composer\Package\PackageInterface;
 use Composer\Repository\RepositoryInterface;
 
 class DependabotInstallationManager extends InstallationManager
@@ -34,17 +35,26 @@ class DependabotInstallationManager extends InstallationManager
         $this->uninstalled[] = $operation->getPackage();
     }
 
-    public function getInstalledPackages()
+    /**
+     * @return PackageInterface[]
+     */
+    public function getInstalledPackages(): array
     {
         return $this->installed;
     }
 
-    public function getUpdatedPackages()
+    /**
+     * @return PackageInterface[]
+     */
+    public function getUpdatedPackages(): array
     {
         return $this->updated;
     }
 
-    public function getUninstalledPackages()
+    /**
+     * @return PackageInterface[]
+     */
+    public function getUninstalledPackages(): array
     {
         return $this->uninstalled;
     }

--- a/helpers/php/src/UpdateChecker.php
+++ b/helpers/php/src/UpdateChecker.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace Dependabot\PHP;
 
+use Composer\Factory;
+use Composer\Installer;
+use Composer\IO\NullIO;
+
 class UpdateChecker
 {
     public static function getLatestResolvableVersion($args)
     {
         [$workingDirectory, $dependencyName, $githubToken] = $args;
 
-        $io = new \Composer\IO\NullIO();
-        $composer = \Composer\Factory::create($io, $workingDirectory . '/composer.json');
+        $io = new NullIO();
+        $composer = Factory::create($io, $workingDirectory . '/composer.json');
 
         $config = $composer->getConfig();
 
@@ -21,7 +25,7 @@ class UpdateChecker
         }
 
         $installationManager = new DependabotInstallationManager();
-        $install = new \Composer\Installer(
+        $install = new Installer(
             $io,
             $config,
             $composer->getPackage(),

--- a/helpers/php/src/UpdateChecker.php
+++ b/helpers/php/src/UpdateChecker.php
@@ -6,7 +6,7 @@ namespace Dependabot\PHP;
 
 class UpdateChecker
 {
-    public static function get_latest_resolvable_version($args)
+    public static function getLatestResolvableVersion($args)
     {
         [$workingDirectory, $dependencyName, $githubToken] = $args;
 

--- a/helpers/php/src/UpdateChecker.php
+++ b/helpers/php/src/UpdateChecker.php
@@ -10,7 +10,6 @@ class UpdateChecker
     {
         [$workingDirectory, $dependencyName, $githubToken] = $args;
 
-        date_default_timezone_set('Europe/London');
         $io = new \Composer\IO\NullIO();
         $composer = \Composer\Factory::create($io, $workingDirectory . '/composer.json');
 

--- a/helpers/php/src/UpdateChecker.php
+++ b/helpers/php/src/UpdateChecker.php
@@ -23,26 +23,26 @@ class UpdateChecker
 
         $installationManager = new DependabotInstallationManager();
         $install = new \Composer\Installer(
-      $io,
-      $config,
-      $composer->getPackage(),
-      $composer->getDownloadManager(),
-      $composer->getRepositoryManager(),
-      $composer->getLocker(),
-      $installationManager,
-      $composer->getEventDispatcher(),
-      $composer->getAutoloadGenerator()
-    );
+            $io,
+            $config,
+            $composer->getPackage(),
+            $composer->getDownloadManager(),
+            $composer->getRepositoryManager(),
+            $composer->getLocker(),
+            $installationManager,
+            $composer->getEventDispatcher(),
+            $composer->getAutoloadGenerator()
+        );
 
         // For all potential options, see UpdateCommand in composer
         $install
-      ->setDryRun(true)
-      ->setUpdate(true)
-      ->setUpdateWhitelist([$dependencyName])
-      ->setExecuteOperations(false)
-      ->setDumpAutoloader(false)
-      ->setRunScripts(false)
-      ->setIgnorePlatformRequirements(true);
+            ->setDryRun(true)
+            ->setUpdate(true)
+            ->setUpdateWhitelist([$dependencyName])
+            ->setExecuteOperations(false)
+            ->setDumpAutoloader(false)
+            ->setRunScripts(false)
+            ->setIgnorePlatformRequirements(true);
 
         $install->run();
 

--- a/helpers/php/src/UpdateChecker.php
+++ b/helpers/php/src/UpdateChecker.php
@@ -7,10 +7,11 @@ namespace Dependabot\PHP;
 use Composer\Factory;
 use Composer\Installer;
 use Composer\IO\NullIO;
+use Composer\Package\PackageInterface;
 
 class UpdateChecker
 {
-    public static function getLatestResolvableVersion($args)
+    public static function getLatestResolvableVersion(array $args): ?string
     {
         [$workingDirectory, $dependencyName, $githubToken] = $args;
 
@@ -51,7 +52,7 @@ class UpdateChecker
 
         $installedPackages = $installationManager->getInstalledPackages();
 
-        $updatedPackage = current(array_filter($installedPackages, function ($package) use ($dependencyName) {
+        $updatedPackage = current(array_filter($installedPackages, function (PackageInterface $package) use ($dependencyName) {
             return $package->getName() == $dependencyName;
         }));
 

--- a/helpers/php/src/UpdateChecker.php
+++ b/helpers/php/src/UpdateChecker.php
@@ -1,53 +1,8 @@
 <?php
 
 declare(strict_types=1);
-require __DIR__ . '/../vendor/autoload.php';
 
-use Composer\DependencyResolver\Operation\InstallOperation;
-use Composer\DependencyResolver\Operation\UninstallOperation;
-use Composer\DependencyResolver\Operation\UpdateOperation;
-use Composer\Installer\InstallationManager;
-use Composer\Repository\RepositoryInterface;
-
-class DependabotInstallationManager extends InstallationManager
-{
-    private $installed = [];
-    private $updated = [];
-    private $uninstalled = [];
-
-    public function install(RepositoryInterface $repo, InstallOperation $operation): void
-    {
-        parent::install($repo, $operation);
-        $this->installed[] = $operation->getPackage();
-    }
-
-    public function update(RepositoryInterface $repo, UpdateOperation $operation): void
-    {
-        parent::update($repo, $operation);
-        $this->updated[] = [$operation->getInitialPackage(), $operation->getTargetPackage()];
-    }
-
-    public function uninstall(RepositoryInterface $repo, UninstallOperation $operation): void
-    {
-        parent::uninstall($repo, $operation);
-        $this->uninstalled[] = $operation->getPackage();
-    }
-
-    public function getInstalledPackages()
-    {
-        return $this->installed;
-    }
-
-    public function getUpdatedPackages()
-    {
-        return $this->updated;
-    }
-
-    public function getUninstalledPackages()
-    {
-        return $this->uninstalled;
-    }
-}
+namespace Dependabot\PHP;
 
 class UpdateChecker
 {

--- a/helpers/php/src/UpdateChecker.php
+++ b/helpers/php/src/UpdateChecker.php
@@ -17,7 +17,6 @@ class UpdateChecker
 
         $io = new NullIO();
         $composer = Factory::create($io, $workingDirectory . '/composer.json');
-
         $config = $composer->getConfig();
 
         if ($githubToken) {

--- a/helpers/php/src/Updater.php
+++ b/helpers/php/src/Updater.php
@@ -26,36 +26,34 @@ class Updater
             $io->loadConfiguration($config);
         }
 
-        $installationManager = new DependabotInstallationManager();
-
         $install = new \Composer\Installer(
-      $io,
-      $config,
-      $composer->getPackage(),
-      $composer->getDownloadManager(),
-      $composer->getRepositoryManager(),
-      $composer->getLocker(),
-      $composer->getInstallationManager(),
-      $composer->getEventDispatcher(),
-      $composer->getAutoloadGenerator()
-    );
+            $io,
+            $config,
+            $composer->getPackage(),
+            $composer->getDownloadManager(),
+            $composer->getRepositoryManager(),
+            $composer->getLocker(),
+            $composer->getInstallationManager(),
+            $composer->getEventDispatcher(),
+            $composer->getAutoloadGenerator()
+        );
 
         // For all potential options, see UpdateCommand in composer
         $install
-      ->setWriteLock(true)
-      ->setUpdate(true)
-      ->setUpdateWhitelist([$dependencyName])
-      ->setExecuteOperations(false)
-      ->setDumpAutoloader(false)
-      ->setRunScripts(false)
-      ->setIgnorePlatformRequirements(true);
+            ->setWriteLock(true)
+            ->setUpdate(true)
+            ->setUpdateWhitelist([$dependencyName])
+            ->setExecuteOperations(false)
+            ->setDumpAutoloader(false)
+            ->setRunScripts(false)
+            ->setIgnorePlatformRequirements(true);
 
         $install->run();
 
         $result = [
-      'composer.json' => file_get_contents('composer.json'),
-      'composer.lock' => file_get_contents('composer.lock'),
-    ];
+            'composer.json' => file_get_contents('composer.json'),
+            'composer.lock' => file_get_contents('composer.lock'),
+        ];
 
         chdir($originalDir);
 

--- a/helpers/php/src/Updater.php
+++ b/helpers/php/src/Updater.php
@@ -10,7 +10,7 @@ use Composer\IO\NullIO;
 
 class Updater
 {
-    public static function update($args)
+    public static function update(array $args): array
     {
         [$workingDirectory, $dependencyName, $dependencyVersion, $githubToken] = $args;
 

--- a/helpers/php/src/Updater.php
+++ b/helpers/php/src/Updater.php
@@ -1,6 +1,9 @@
 <?php
 
 declare(strict_types=1);
+
+namespace Dependabot\PHP;
+
 class Updater
 {
     public static function update($args)

--- a/helpers/php/src/Updater.php
+++ b/helpers/php/src/Updater.php
@@ -15,7 +15,6 @@ class Updater
         // in the root of the project
         $originalDir = getcwd();
         chdir($workingDirectory);
-        date_default_timezone_set('Europe/London');
         $io = new \Composer\IO\NullIO();
         $composer = \Composer\Factory::create($io);
 

--- a/helpers/php/src/Updater.php
+++ b/helpers/php/src/Updater.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Dependabot\PHP;
 
+use Composer\Factory;
+use Composer\Installer;
+use Composer\IO\NullIO;
+
 class Updater
 {
     public static function update($args)
@@ -15,8 +19,8 @@ class Updater
         // in the root of the project
         $originalDir = getcwd();
         chdir($workingDirectory);
-        $io = new \Composer\IO\NullIO();
-        $composer = \Composer\Factory::create($io);
+        $io = new NullIO();
+        $composer = Factory::create($io);
 
         $config = $composer->getConfig();
 
@@ -25,7 +29,7 @@ class Updater
             $io->loadConfiguration($config);
         }
 
-        $install = new \Composer\Installer(
+        $install = new Installer(
             $io,
             $config,
             $composer->getPackage(),

--- a/helpers/php/src/Updater.php
+++ b/helpers/php/src/Updater.php
@@ -19,9 +19,9 @@ class Updater
         // in the root of the project
         $originalDir = getcwd();
         chdir($workingDirectory);
+
         $io = new NullIO();
         $composer = Factory::create($io);
-
         $config = $composer->getConfig();
 
         if ($githubToken) {

--- a/helpers/php/src/Updater.php
+++ b/helpers/php/src/Updater.php
@@ -1,30 +1,31 @@
 <?php
 
+declare(strict_types=1);
 class Updater
 {
-  public static function update($args)
-  {
-    list($workingDirectory, $dependencyName, $dependencyVersion, $githubToken) = $args;
+    public static function update($args)
+    {
+        [$workingDirectory, $dependencyName, $dependencyVersion, $githubToken] = $args;
 
-    // Change working directory to the one provided, this ensures that we
-    // install dependencies into the working dir, rather than a vendor folder
-    // in the root of the project
-    $originalDir = getcwd();
-    chdir($workingDirectory);
-    date_default_timezone_set("Europe/London");
-    $io = new \Composer\IO\NullIO();
-    $composer = \Composer\Factory::create($io);
+        // Change working directory to the one provided, this ensures that we
+        // install dependencies into the working dir, rather than a vendor folder
+        // in the root of the project
+        $originalDir = getcwd();
+        chdir($workingDirectory);
+        date_default_timezone_set('Europe/London');
+        $io = new \Composer\IO\NullIO();
+        $composer = \Composer\Factory::create($io);
 
-    $config = $composer->getConfig();
+        $config = $composer->getConfig();
 
-    if ($githubToken) {
-      $config->merge(array('config' => array('github-oauth' => array('github.com' => $githubToken))));
-      $io->loadConfiguration($config);
-    }
+        if ($githubToken) {
+            $config->merge(['config' => ['github-oauth' => ['github.com' => $githubToken]]]);
+            $io->loadConfiguration($config);
+        }
 
-    $installationManager = new DependabotInstallationManager();
+        $installationManager = new DependabotInstallationManager();
 
-    $install = new \Composer\Installer(
+        $install = new \Composer\Installer(
       $io,
       $config,
       $composer->getPackage(),
@@ -36,26 +37,25 @@ class Updater
       $composer->getAutoloadGenerator()
     );
 
-    // For all potential options, see UpdateCommand in composer
-    $install
+        // For all potential options, see UpdateCommand in composer
+        $install
       ->setWriteLock(true)
       ->setUpdate(true)
       ->setUpdateWhitelist([$dependencyName])
       ->setExecuteOperations(false)
       ->setDumpAutoloader(false)
       ->setRunScripts(false)
-      ->setIgnorePlatformRequirements(true)
-      ;
+      ->setIgnorePlatformRequirements(true);
 
-    $install->run();
+        $install->run();
 
-    $result = [
-      "composer.json" => file_get_contents('composer.json'),
-      "composer.lock" => file_get_contents('composer.lock'),
+        $result = [
+      'composer.json' => file_get_contents('composer.json'),
+      'composer.lock' => file_get_contents('composer.lock'),
     ];
 
-    chdir($originalDir);
+        chdir($originalDir);
 
-    return $result;
-  }
+        return $result;
+    }
 }


### PR DESCRIPTION
This does the following:

* Uses php-cs-fixer to automatically fix / verify style issues
* Keeps with the 1 class per file for PSR-4.
* Uses composer autoloading in run.php instead of the update classes themselves.
* Moves the setting of the timezone to run.php so it is centralized
* Uses PSR-2 & additional style standards including renaming the snake_case method to camelCase

The only thing that isn't done here is to introduce tests. That would be another great thing to add in which I can look into.

Not sure if this PR is wanted or not, but I didn't spend a lot of time on it anyways.
