### PR TITLE
Java: Add support for projects that inherit from parent POM

### DIFF
--- a/lib/dependabot/file_parsers/java/maven.rb
+++ b/lib/dependabot/file_parsers/java/maven.rb
@@ -9,7 +9,8 @@ module Dependabot
   module FileParsers
     module Java
       class Maven < Dependabot::FileParsers::Base
-        DEPENDENCY_SELECTOR = "dependencies > dependency, plugins > plugin"
+        DEPENDENCY_SELECTOR = "parent, dependencies > dependency,
+                               plugins > plugin"
 
         def parse
           doc = Nokogiri::XML(pom.content)

--- a/lib/dependabot/file_updaters/java/maven.rb
+++ b/lib/dependabot/file_updaters/java/maven.rb
@@ -9,7 +9,8 @@ module Dependabot
     module Java
       class Maven < Dependabot::FileUpdaters::Base
         DECLARATION_REGEX =
-          %r{<dependency>.*?</dependency>|<plugin>.*?</plugin>}m
+          %r{<parent>.*?</parent>|<dependency>.*?</dependency>|
+             <plugin>.*?</plugin>}mx
 
         def self.updated_files_regex
           [/^pom\.xml$/]

--- a/spec/dependabot/file_parsers/java/maven_spec.rb
+++ b/spec/dependabot/file_parsers/java/maven_spec.rb
@@ -152,6 +152,34 @@ RSpec.describe Dependabot::FileParsers::Java::Maven do
       end
     end
 
+    context "for version inherited from a parent pom" do
+      let(:pom_body) { fixture("java", "poms", "pom_with_parent.xml") }
+
+      its(:length) { is_expected.to eq(8) }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq(
+            "org.springframework.boot:spring-boot-starter-parent"
+          )
+          expect(dependency.version).to eq("1.5.9.RELEASE")
+          expect(dependency.requirements).to eq(
+            [
+              {
+                requirement: "1.5.9.RELEASE",
+                file: "pom.xml",
+                groups: [],
+                source: nil
+              }
+            ]
+          )
+        end
+      end
+    end
+
     context "for a version range" do
       let(:pom_body) { fixture("java", "poms", "range_pom.xml") }
 

--- a/spec/dependabot/file_updaters/java/maven_spec.rb
+++ b/spec/dependabot/file_updaters/java/maven_spec.rb
@@ -125,6 +125,52 @@ RSpec.describe Dependabot::FileUpdaters::Java::Maven do
     end
   end
 
+  context "pom with parent pom" do
+    let(:pom_body) { fixture("java", "poms", "pom_with_parent.xml") }
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "org.springframework.boot:spring-boot-starter-parent",
+        version: "1.5.10.RELEASE",
+        requirements: [
+          {
+            file: "pom.xml",
+            requirement: "1.5.10.RELEASE",
+            groups: [],
+            source: nil
+          }
+        ],
+        previous_requirements: [
+          {
+            file: "pom.xml",
+            requirement: "1.5.9.RELEASE",
+            groups: [],
+            source: nil
+          }
+        ],
+        package_manager: "maven"
+      )
+    end
+
+    subject(:updated_files) { updater.updated_dependency_files }
+
+    it "returns DependencyFile objects" do
+      updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+    end
+
+    its(:length) { is_expected.to eq(1) }
+
+    describe "the updated pom file" do
+      subject(:updated_pom_file) do
+        updated_files.find { |f| f.name == "pom.xml" }
+      end
+
+      its(:content) { is_expected.to include "<parent>" }
+      its(:content) do
+        is_expected.to include "<version>1.5.10.RELEASE</version>"
+      end
+    end
+  end
+
   context "pom with plugins" do
     let(:pom_body) { fixture("java", "poms", "plugin_dependencies_pom.xml") }
     let(:dependency) do

--- a/spec/fixtures/java/poms/pom_with_parent.xml
+++ b/spec/fixtures/java/poms/pom_with_parent.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.dependabot</groupId>
+  <artifactId>pom-with-parent</artifactId>
+  <version>0.0.1-RELEASE</version>
+  <name>Dependabot POM that inherits from parent POM</name>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>1.5.9.RELEASE</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+  </properties>
+
+  <dependencies>
+    <!-- Web -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <!-- Persistence -->
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-java8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Ops -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
This add support for projects that inherit from a parent POM. These POMs can manage dependencies, plugins etc. Often used for getting started with Spring Boot projects, e.g. [here in the docs](https://docs.spring.io/spring-boot/docs/current/reference/html/getting-started-first-application.html#getting-started-first-application-pom) or in the official [getting started tutorial](https://spring.io/guides/gs/spring-boot/).

A [project of mine](https://github.com/evenh/coffeebot/blob/master/pom.xml) uses this technique.