### PR TITLE
Add (failing) spec for Elixir update checking with a bad version requirement

### DIFF
--- a/helpers/elixir/bin/check_update.exs
+++ b/helpers/elixir/bin/check_update.exs
@@ -5,16 +5,24 @@ dependency = String.to_atom(dependency_name)
 
 # Fetch dependencies that needs updating
 {dependency_lock, rest_lock} = Map.split(Mix.Dep.Lock.read, [dependency])
-Mix.Dep.Fetcher.by_name([dependency_name], dependency_lock, rest_lock, [])
 
-# Check the dependency version in the new lock
-{updated_lock, _updated_rest_lock} = Map.split(Mix.Dep.Lock.read, [dependency])
+try do
+  Mix.Dep.Fetcher.by_name([dependency_name], dependency_lock, rest_lock, [])
 
-version =
-  updated_lock
-  |> Map.get(dependency)
-  |> elem(2)
+  # Check the dependency version in the new lock
+  {updated_lock, _updated_rest_lock} = Map.split(Mix.Dep.Lock.read, [dependency])
 
-version = :erlang.term_to_binary({:ok, version})
+  version =
+    updated_lock
+    |> Map.get(dependency)
+    |> elem(2)
 
-IO.write(:stdio, version)
+  version = :erlang.term_to_binary({:ok, version})
+
+  IO.write(:stdio, version)
+rescue
+  error in Hex.Version.InvalidRequirementError ->
+    result = :erlang.term_to_binary({:error, "Invalid requirement: #{error.requirement}"})
+    IO.write(:stdio, result)
+end
+

--- a/helpers/elixir/bin/parse_deps.exs
+++ b/helpers/elixir/bin/parse_deps.exs
@@ -1,4 +1,4 @@
-deps = Mix.Dep.loaded([]) |> Enum.filter(& &1.scm == Hex.SCM)
+deps = Mix.Dep.loaded([]) |> Enum.filter(&(&1.scm == Hex.SCM))
 
 dependencies =
   deps
@@ -14,6 +14,6 @@ dependencies =
     }
   end)
 
-dependencies = :erlang.term_to_binary(dependencies)
+dependencies = :erlang.term_to_binary({:ok, dependencies})
 
 IO.write(:stdio, dependencies)

--- a/lib/dependabot/update_checkers/elixir/hex.rb
+++ b/lib/dependabot/update_checkers/elixir/hex.rb
@@ -70,6 +70,16 @@ module Dependabot
 
           return if @latest_resolvable_version.nil?
           version_class.new(latest_resolvable_version)
+        rescue SharedHelpers::HelperSubprocessFailed => error
+          handle_hex_errors(error)
+        end
+
+        def handle_hex_errors(error)
+          if error.message.start_with?("Invalid requirement")
+            raise Dependabot::DependencyFileNotResolvable, error.message
+          else
+            raise error
+          end
         end
 
         def prepared_mixfile_content

--- a/lib/dependabot/update_checkers/elixir/hex.rb
+++ b/lib/dependabot/update_checkers/elixir/hex.rb
@@ -75,11 +75,8 @@ module Dependabot
         end
 
         def handle_hex_errors(error)
-          if error.message.start_with?("Invalid requirement")
-            raise Dependabot::DependencyFileNotResolvable, error.message
-          else
-            raise error
-          end
+          raise error unless error.message.start_with?("Invalid requirement")
+          raise Dependabot::DependencyFileNotResolvable, error.message
         end
 
         def prepared_mixfile_content

--- a/spec/dependabot/file_parsers/elixir/hex_spec.rb
+++ b/spec/dependabot/file_parsers/elixir/hex_spec.rb
@@ -126,5 +126,12 @@ RSpec.describe Dependabot::FileParsers::Elixir::Hex do
 
       its(:length) { is_expected.to eq(2) }
     end
+
+    context "with a bad specification" do
+      let(:mixfile_body) { fixture("elixir", "mixfiles", "bad_spec") }
+      let(:lockfile_body) { fixture("elixir", "lockfiles", "exact_version") }
+
+      its(:length) { is_expected.to eq(2) }
+    end
   end
 end

--- a/spec/dependabot/update_checkers/elixir/hex_spec.rb
+++ b/spec/dependabot/update_checkers/elixir/hex_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require "dependabot/dependency"
 require "dependabot/dependency_file"
 require "dependabot/update_checkers/elixir/hex"
+require "dependabot/errors"
 require_relative "../shared_examples_for_update_checkers"
 
 RSpec.describe Dependabot::UpdateCheckers::Elixir::Hex do
@@ -155,6 +156,16 @@ RSpec.describe Dependabot::UpdateCheckers::Elixir::Hex do
           )
         end
         it { is_expected.to be >= Gem::Version.new("1.4.3") }
+      end
+    end
+
+    context "with a dependency with a bad specification" do
+      let(:mixfile_body) { fixture("elixir", "mixfiles", "bad_spec") }
+      let(:lockfile_body) { fixture("elixir", "lockfiles", "exact_version") }
+
+      it "raises a Dependabot::DependencyFileNotResolvable error" do
+        expect { checker.latest_resolvable_version }.
+          to raise_error(Dependabot::DependencyFileNotResolvable)
       end
     end
   end

--- a/spec/dependabot/update_checkers/ruby/bundler_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler_spec.rb
@@ -742,7 +742,7 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
           )
         end
 
-        it "raises a Dependabot::SharedHelpers::ChildProcessFailed error" do
+        it "raises a Dependabot::DependencyFileNotResolvable error" do
           expect { checker.latest_resolvable_version }.
             to raise_error(Dependabot::DependencyFileNotResolvable)
         end

--- a/spec/fixtures/elixir/mixfiles/bad_spec
+++ b/spec/fixtures/elixir/mixfiles/bad_spec
@@ -1,0 +1,24 @@
+defmodule DependabotTest.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :dependabot_test,
+      version: "0.1.0",
+      elixir: "~> 1.5",
+      start_permanent: Mix.env == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:plug, "1.0-beta"},
+      {:phoenix, "== 1.2.1"}
+    ]
+  end
+end


### PR DESCRIPTION
This needs a change to our Elixir code so that it bubbles errors up to Ruby.

This can likely be done by using:
- The [arguments to System](https://hexdocs.pm/elixir/System.html#cmd/3)
- A conditional in `run.exs` to return an `"error"` (just needs to have the text of the error) to Ruby if the exit code of the command was non-zero