### PR TITLE
Use Elixir standard library instead of Erlang

### DIFF
--- a/helpers/elixir/bin/do_update.exs
+++ b/helpers/elixir/bin/do_update.exs
@@ -4,10 +4,12 @@
 dependency = String.to_atom(dependency_name)
 
 # Fetch dependencies that needs updating
-{dependency_lock, rest_lock} = Map.split(Mix.Dep.Lock.read, [dependency])
+{dependency_lock, rest_lock} = Map.split(Mix.Dep.Lock.read(), [dependency])
 Mix.Dep.Fetcher.by_name([dependency_name], dependency_lock, rest_lock, [])
 
-lockfile_content = :file.read_file("mix.lock")
-lockfile_content = :erlang.term_to_binary(lockfile_content)
+lockfile_content =
+  "mix.lock"
+  |> File.read()
+  |> :erlang.term_to_binary()
 
 IO.write(:stdio, lockfile_content)


### PR DESCRIPTION
Replaced the call to the Erlang `:file` module by a call to the Elixir `File` module. Also used pipes to make the code a bit cleaner.