### PR TITLE
Use `build` prefix if semantic commits are in use

### DIFF
--- a/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/lib/dependabot/pull_request_creator/message_builder.rb
@@ -6,7 +6,8 @@ require "dependabot/pull_request_creator"
 module Dependabot
   class PullRequestCreator
     class MessageBuilder
-      SEMANTIC_PREFIXES = %w(chore docs feat fix refactor style test).freeze
+      SEMANTIC_PREFIXES = %w(build chore ci docs feat fix perf refactor style
+                             test).freeze
       attr_reader :repo_name, :dependencies, :files, :github_client,
                   :pr_message_footer
 
@@ -27,7 +28,7 @@ module Dependabot
         return library_pr_name if library?
 
         pr_name = ""
-        pr_name += "chore(dependencies): " if using_semantic_commit_messages?
+        pr_name += "build: " if using_semantic_commit_messages?
 
         pr_name +=
           if dependencies.count == 1
@@ -76,7 +77,7 @@ module Dependabot
 
       def library_pr_name
         pr_name = ""
-        pr_name += "chore(dependencies): " if using_semantic_commit_messages?
+        pr_name += "build: " if using_semantic_commit_messages?
 
         pr_name +=
           if dependencies.count == 1

--- a/spec/dependabot/pull_request_creator_spec.rb
+++ b/spec/dependabot/pull_request_creator_spec.rb
@@ -1008,7 +1008,7 @@ RSpec.describe Dependabot::PullRequestCreator do
             body: {
               base: "master",
               head: "dependabot/bundler/business-1.5.0",
-              title: "chore(dependencies): Bump business from 1.4.0 to 1.5.0",
+              title: "build: Bump business from 1.4.0 to 1.5.0",
               body: "Bumps [business](https://github.com/gocardless/business) "\
                     "from 1.4.0 to 1.5.0.\n- [Release notes]"\
                     "(https://github.com/gocardless/business/releases?after="\
@@ -1025,7 +1025,7 @@ RSpec.describe Dependabot::PullRequestCreator do
           with(body: {
                  parents: ["basecommitsha"],
                  tree: "cd8274d15fa3ae2ab983129fb037999f264ba9a7",
-                 message: /\Achore\(dependencies\): Bump/
+                 message: /\Abuild: Bump/
                })
       end
     end


### PR DESCRIPTION
Angular changed their semantic commit message prefixes in January 2017 ([PR](https://github.com/angular/angular/pull/13991)). This PR updates Dependabot to use the relevant new prefix (`build`).