### PR TITLE
Python: Use Pipenv's new --keep-outdated option instead of freezing Pipfile

### DIFF
--- a/helpers/python/lib/pipfile_updater.py
+++ b/helpers/python/lib/pipfile_updater.py
@@ -2,7 +2,7 @@ import json
 import os
 
 def update(directory):
-   os.system("cd {0} && pipenv lock".format(directory))
+   os.system("cd {0} && pipenv lock --keep-outdated".format(directory))
 
    lockfile = open(directory + "/Pipfile.lock", "r").read()
    return json.dumps({ "result": { "Pipfile.lock": lockfile } })

--- a/spec/dependabot/file_updaters/python/pipfile_spec.rb
+++ b/spec/dependabot/file_updaters/python/pipfile_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Dependabot::FileUpdaters::Python::Pipfile do
       describe "with dependency names that need to be normalised" do
         let(:dependency) do
           Dependabot::Dependency.new(
-            name: "Requests",
+            name: "requests",
             version: "2.18.4",
             previous_version: "2.18.0",
             package_manager: "pipfile",


### PR DESCRIPTION
Much cleaner!