### PR TITLE
Elixir: Add support for git-source dependencies

### DIFF
--- a/helpers/elixir/bin/check_update.exs
+++ b/helpers/elixir/bin/check_update.exs
@@ -26,6 +26,6 @@ rescue
     IO.write(:stdio, result)
 
   error in Mix.Error ->
-    result = :erlang.term_to_binary({:error, "Dependency resolution failed"})
+    result = :erlang.term_to_binary({:error, "Dependency resolution failed: #{error.message}"})
     IO.write(:stdio, result)
 end

--- a/helpers/elixir/bin/check_update.exs
+++ b/helpers/elixir/bin/check_update.exs
@@ -4,13 +4,13 @@
 dependency = String.to_atom(dependency_name)
 
 # Fetch dependencies that needs updating
-{dependency_lock, rest_lock} = Map.split(Mix.Dep.Lock.read, [dependency])
+{dependency_lock, rest_lock} = Map.split(Mix.Dep.Lock.read(), [dependency])
 
 try do
   Mix.Dep.Fetcher.by_name([dependency_name], dependency_lock, rest_lock, [])
 
   # Check the dependency version in the new lock
-  {updated_lock, _updated_rest_lock} = Map.split(Mix.Dep.Lock.read, [dependency])
+  {updated_lock, _updated_rest_lock} = Map.split(Mix.Dep.Lock.read(), [dependency])
 
   version =
     updated_lock
@@ -24,5 +24,8 @@ rescue
   error in Hex.Version.InvalidRequirementError ->
     result = :erlang.term_to_binary({:error, "Invalid requirement: #{error.requirement}"})
     IO.write(:stdio, result)
-end
 
+  error in Mix.Error ->
+    result = :erlang.term_to_binary({:error, "Dependency resolution failed"})
+    IO.write(:stdio, result)
+end

--- a/lib/dependabot/update_checkers/elixir/hex.rb
+++ b/lib/dependabot/update_checkers/elixir/hex.rb
@@ -119,8 +119,13 @@ module Dependabot
         end
 
         def handle_hex_errors(error)
-          raise error unless error.message.start_with?("Invalid requirement")
-          raise Dependabot::DependencyFileNotResolvable, error.message
+          if git_dependency? && error.message.include?("resolution failed")
+            return nil
+          end
+          if error.message.start_with?("Invalid requirement")
+            raise Dependabot::DependencyFileNotResolvable, error.message
+          end
+          raise error
         end
 
         def write_temporary_dependency_files(unlock_requirement:)

--- a/lib/dependabot/update_checkers/elixir/hex.rb
+++ b/lib/dependabot/update_checkers/elixir/hex.rb
@@ -29,7 +29,10 @@ module Dependabot
         def latest_resolvable_version
           @latest_resolvable_version ||=
             if git_dependency?
-              nil # TODO: Implement this!
+              # TODO: we should be updating the ref here if pinned to a
+              # version-like ref. For now, this setup means we at least get
+              # branch updates, though.
+              fetch_latest_resolvable_version(unlock_requirement: false)
             else
               fetch_latest_resolvable_version(unlock_requirement: true)
             end
@@ -37,11 +40,7 @@ module Dependabot
 
         def latest_resolvable_version_with_no_unlock
           @latest_resolvable_version_with_no_unlock ||=
-            if git_dependency?
-              nil # TODO: Implement this!
-            else
-              fetch_latest_resolvable_version(unlock_requirement: false)
-            end
+            fetch_latest_resolvable_version(unlock_requirement: false)
         end
 
         def updated_requirements
@@ -111,6 +110,9 @@ module Dependabot
             end
 
           return if latest_resolvable_version.nil?
+          if latest_resolvable_version.match?(/^[0-9a-f]{40}$/)
+            return latest_resolvable_version
+          end
           version_class.new(latest_resolvable_version)
         rescue SharedHelpers::HelperSubprocessFailed => error
           handle_hex_errors(error)

--- a/spec/dependabot/file_updaters/elixir/hex_spec.rb
+++ b/spec/dependabot/file_updaters/elixir/hex_spec.rb
@@ -317,6 +317,55 @@ RSpec.describe Dependabot::FileUpdaters::Elixir::Hex do
           )
         end
       end
+
+      context "with a git dependency" do
+        let(:mixfile_body) do
+          fixture("elixir", "mixfiles", "git_source_no_tag")
+        end
+        let(:lockfile_body) do
+          fixture("elixir", "lockfiles", "git_source_no_tag")
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "phoenix",
+            version: "463e9d282e999fff1737cc6ca09074cf3dbca4ff",
+            previous_version: "178ce1a2344515e9145599970313fcc190d4b881",
+            requirements: [
+              {
+                requirement: nil,
+                file: "mix.exs",
+                groups: [],
+                source: {
+                  type: "git",
+                  url: "https://github.com/phoenixframework/phoenix.git",
+                  branch: "master",
+                  ref: nil
+                }
+              }
+            ],
+            previous_requirements: [
+              {
+                requirement: nil,
+                file: "mix.exs",
+                groups: [],
+                source: {
+                  type: "git",
+                  url: "https://github.com/phoenixframework/phoenix.git",
+                  branch: "master",
+                  ref: nil
+                }
+              }
+            ],
+            package_manager: "hex"
+          )
+        end
+
+        it "updates the dependency version in the lockfile" do
+          expect(updated_lockfile_content).to include("phoenix.git")
+          expect(updated_lockfile_content).
+            to_not include("178ce1a2344515e9145599970313fcc190d4b881")
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/elixir/lockfiles/git_source_no_tag
+++ b/spec/fixtures/elixir/lockfiles/git_source_no_tag
@@ -1,0 +1,6 @@
+%{"cors_plug": {:hex, :cors_plug, "1.2.1", "bbe1381a52e4a16e609cf3c4cbfde6884726a58b9a1a205db104dbdfc542f447", [:mix], [{:plug, "> 0.8.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [], [], "hexpm"},
+  "phoenix": {:git, "https://github.com/phoenixframework/phoenix.git", "178ce1a2344515e9145599970313fcc190d4b881", [ref: "v1.2.0"]},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [], [], "hexpm"},
+  "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [], [], "hexpm"}}

--- a/spec/fixtures/elixir/lockfiles/git_source_no_tag_blocked
+++ b/spec/fixtures/elixir/lockfiles/git_source_no_tag_blocked
@@ -1,0 +1,5 @@
+%{"mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [], [], "hexpm"},
+  "phoenix": {:git, "https://github.com/phoenixframework/phoenix.git", "178ce1a2344515e9145599970313fcc190d4b881", []},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [], [], "hexpm"},
+  "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [], [], "hexpm"}}

--- a/spec/fixtures/elixir/mixfiles/git_source_no_tag
+++ b/spec/fixtures/elixir/mixfiles/git_source_no_tag
@@ -1,0 +1,24 @@
+defmodule DependabotTest.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :dependabot_test,
+      version: "0.1.0",
+      elixir: "~> 1.5",
+      start_permanent: Mix.env == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:cors_plug, "~> 1.2.0"},
+      {:phoenix, github: "phoenixframework/phoenix"}
+    ]
+  end
+end

--- a/spec/fixtures/elixir/mixfiles/git_source_no_tag_blocked
+++ b/spec/fixtures/elixir/mixfiles/git_source_no_tag_blocked
@@ -1,0 +1,24 @@
+defmodule DependabotTest.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :dependabot_test,
+      version: "0.1.0",
+      elixir: "~> 1.5",
+      start_permanent: Mix.env == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:plug, "1.2.0"},
+      {:phoenix, github: "phoenixframework/phoenix"}
+    ]
+  end
+end


### PR DESCRIPTION
First cut of support for git-based dependencies in Elixir. This will allow Dependabot to keep dependencies that point at a branch up-to-date.