### PR TITLE
Handle nested Ruby path dependencies

### DIFF
--- a/lib/dependabot/file_fetchers/ruby/bundler/path_gemspec_finder.rb
+++ b/lib/dependabot/file_fetchers/ruby/bundler/path_gemspec_finder.rb
@@ -39,7 +39,7 @@ module Dependabot
               rescue StandardError
                 return []
               end
-              return [clean_path(path, node)]
+              return [clean_path(path)]
             end
 
             relevant_child_nodes(node).flat_map do |child_node|
@@ -59,15 +59,11 @@ module Dependabot
             !path_node_for_gem_declaration(node).nil?
           end
 
-          def clean_path(path, node)
+          def clean_path(path)
             if Pathname.new(path).absolute?
               base_path = Pathname.new(File.expand_path(Dir.pwd))
               path = Pathname.new(path).relative_path_from(base_path).to_s
             end
-            path = File.join(
-              path,
-              "#{gem_name_for_gem_declaration(node)}.gemspec"
-            )
             path = File.join(current_dir, path) unless current_dir.nil?
             Pathname.new(path).cleanpath.to_path
           end
@@ -100,10 +96,6 @@ module Dependabot
             return unless path_hash_pair
 
             path_hash_pair.children.last
-          end
-
-          def gem_name_for_gem_declaration(node)
-            node.children[2].children.first
           end
 
           def key_from_hash_pair(node)

--- a/spec/dependabot/file_fetchers/ruby/bundler/path_gemspec_finder_spec.rb
+++ b/spec/dependabot/file_fetchers/ruby/bundler/path_gemspec_finder_spec.rb
@@ -24,17 +24,17 @@ RSpec.describe Dependabot::FileFetchers::Ruby::Bundler::PathGemspecFinder do
 
     context "when the file does include a path gemspec" do
       let(:gemfile_body) { fixture("ruby", "gemfiles", "path_source") }
-      it { is_expected.to eq(["plugins/example/example.gemspec"]) }
+      it { is_expected.to eq(["plugins/example"]) }
 
       context "whose path must be eval-ed" do
         let(:gemfile_body) { fixture("ruby", "gemfiles", "path_source_eval") }
-        it { is_expected.to eq(["plugins/example/example.gemspec"]) }
+        it { is_expected.to eq(["plugins/example"]) }
       end
 
       context "when this Gemfile is already in a nested directory" do
         let(:gemfile_name) { "nested/Gemfile" }
 
-        it { is_expected.to eq(["nested/plugins/example/example.gemspec"]) }
+        it { is_expected.to eq(["nested/plugins/example"]) }
       end
 
       context "that is behind a conditional that is false" do

--- a/spec/dependabot/file_fetchers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_fetchers/ruby/bundler_spec.rb
@@ -153,6 +153,13 @@ RSpec.describe Dependabot::FileFetchers::Ruby::Bundler do
 
     context "that has a fetchable path" do
       before do
+        stub_request(:get, url + "plugins/bump-core?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "contents_ruby_path_directory.json"),
+            headers: { "content-type" => "application/json" }
+          )
         stub_request(:get, url + "plugins/bump-core/bump-core.gemspec?ref=sha").
           with(headers: { "Authorization" => "token token" }).
           to_return(
@@ -166,6 +173,40 @@ RSpec.describe Dependabot::FileFetchers::Ruby::Bundler do
         expect(file_fetcher_instance.files.count).to eq(3)
         expect(file_fetcher_instance.files.map(&:name)).
           to include("plugins/bump-core/bump-core.gemspec")
+      end
+
+      context "that is nested" do
+        before do
+          stub_request(:get, url + "plugins/bump-core?ref=sha").
+            with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body:
+                fixture("github", "contents_ruby_nested_path_directory.json"),
+              headers: { "content-type" => "application/json" }
+            )
+          stub_request(:get, url + "plugins/bump-core/bump-core?ref=sha").
+            with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "contents_ruby_path_directory.json"),
+              headers: { "content-type" => "application/json" }
+            )
+          stub_request(
+            :get, url + "plugins/bump-core/bump-core/bump-core.gemspec?ref=sha"
+          ).with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "gemspec_content.json"),
+              headers: { "content-type" => "application/json" }
+            )
+        end
+
+        it "fetches gemspec from path dependency" do
+          expect(file_fetcher_instance.files.count).to eq(3)
+          expect(file_fetcher_instance.files.map(&:name)).
+            to include("plugins/bump-core/bump-core/bump-core.gemspec")
+        end
       end
 
       context "without a Gemfile.lock" do
@@ -189,6 +230,13 @@ RSpec.describe Dependabot::FileFetchers::Ruby::Bundler do
 
     context "that has an unfetchable path" do
       before do
+        stub_request(:get, url + "plugins/bump-core?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "contents_ruby_path_directory.json"),
+            headers: { "content-type" => "application/json" }
+          )
         stub_request(:get, url + "plugins/bump-core/bump-core.gemspec?ref=sha").
           with(headers: { "Authorization" => "token token" }).
           to_return(status: 404)

--- a/spec/fixtures/github/contents_ruby_nested_path_directory.json
+++ b/spec/fixtures/github/contents_ruby_nested_path_directory.json
@@ -1,0 +1,18 @@
+[
+    {
+        "name": "bump-core",
+        "path": "bump-core",
+        "sha": "7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+        "size": 917,
+        "url": "https://api.github.com/repos/gocardless/business/contents/bump-core?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/bump-core",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/bump-core",
+        "type": "dir",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/bump-core?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+            "html": "https://github.com/gocardless/business/blob/master/bump-core"
+        }
+    }
+]

--- a/spec/fixtures/github/contents_ruby_path_directory.json
+++ b/spec/fixtures/github/contents_ruby_path_directory.json
@@ -1,0 +1,18 @@
+[
+    {
+        "name": "bump-core.gemspec",
+        "path": "bump-core.gemspec",
+        "sha": "7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+        "size": 917,
+        "url": "https://api.github.com/repos/gocardless/business/contents/bump-core.gemspec?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/bump-core.gemspec",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/bump-core.gemspec",
+        "type": "file",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/bump-core.gemspec?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+            "html": "https://github.com/gocardless/business/blob/master/bump-core.gemspec"
+        }
+    }
+]


### PR DESCRIPTION
Handle path dependencies when the `gemspec` is in a nested one level deep. For example, `gem 'my_gem', path: 'vendored_gems'` with the gemspec at `vendored_gems/my_gem/my_gem.gemspec`.

TODO: Add a spec for this case.