### PR TITLE
Implement Java version comparison

### DIFF
--- a/lib/dependabot/utils/java/requirement.rb
+++ b/lib/dependabot/utils/java/requirement.rb
@@ -1,14 +1,35 @@
 # frozen_string_literal: true
 
+require "dependabot/utils/java/version"
+
 module Dependabot
   module Utils
     module Java
       class Requirement < Gem::Requirement
+        def self.parse(obj)
+          if obj.is_a?(Gem::Version)
+            return ["=", Utils::Java::Version.new(obj.to_s)]
+          end
+
+          unless (matches = PATTERN.match(obj.to_s))
+            msg = "Illformed requirement [#{obj.inspect}]"
+            raise BadRequirementError, msg
+          end
+
+          return DefaultRequirement if matches[1] == ">=" && matches[2] == "0"
+          [matches[1] || "=", Utils::Java::Version.new(matches[2])]
+        end
+
         # For consistency with other langauges, we define a requirements array.
         # Java doesn't have an `OR` separator for requirements, so it always
         # contains a single element.
         def self.requirements_array(requirement_string)
           [new(requirement_string)]
+        end
+
+        def satisfied_by?(version)
+          version = Utils::Java::Version.new(version.to_s)
+          super
         end
       end
     end

--- a/lib/dependabot/utils/java/version.rb
+++ b/lib/dependabot/utils/java/version.rb
@@ -33,7 +33,24 @@ module Dependabot
           @version_string
         end
 
+        def prerelease?
+          tokens.any? do |token|
+            next false unless NAMED_QUALIFIERS_HIERARCHY[token]
+            NAMED_QUALIFIERS_HIERARCHY[token] < 6
+          end
+        end
+
         private
+
+        def tokens
+          @tokens ||=
+            begin
+              version = @version_string.to_s
+              version = fill_tokens(version)
+              version = trim_version(version)
+              split_into_prefixed_tokens(version).map { |t| t[1..-1] }
+            end
+        end
 
         def <=>(other)
           version = @version_string.to_s

--- a/lib/dependabot/utils/java/version.rb
+++ b/lib/dependabot/utils/java/version.rb
@@ -45,7 +45,7 @@ module Dependabot
         def tokens
           @tokens ||=
             begin
-              version = @version_string.to_s
+              version = @version_string.to_s.downcase
               version = fill_tokens(version)
               version = trim_version(version)
               split_into_prefixed_tokens(version).map { |t| t[1..-1] }
@@ -53,12 +53,12 @@ module Dependabot
         end
 
         def <=>(other)
-          version = @version_string.to_s
+          version = @version_string.to_s.downcase
           version = fill_tokens(version)
           version = trim_version(version)
           prefixed_tokens = split_into_prefixed_tokens(version)
 
-          other_version = other.to_s
+          other_version = other.to_s.downcase
           other_version = fill_tokens(other_version)
           other_version = trim_version(other_version)
           other_prefixed_tokens = split_into_prefixed_tokens(other_version)
@@ -142,16 +142,6 @@ module Dependabot
           token = token.to_i if token.match?(/^\d+$/)
           other_token = other_token.to_i if other_token.match?(/^\d+$/)
           token <=> other_token
-        end
-
-        def normalise_token(token)
-          return "a" if token == "alpha"
-          return "b" if token == "beta"
-          return "m" if token == "milestone"
-          return "rc" if token == "cr"
-          return "rc" if token == "cr"
-          return "final" if token == "ga"
-          token
         end
       end
     end

--- a/lib/dependabot/utils/java/version.rb
+++ b/lib/dependabot/utils/java/version.rb
@@ -9,6 +9,21 @@ module Dependabot
   module Utils
     module Java
       class Version < Gem::Version
+        NULL_VALUES = %w(0 final ga).freeze
+        PREFIXED_TOKEN_HIERARCHY = {
+          "." => { qualifier: 1, number: 4 },
+          "-" => { qualifier: 2, number: 3 }
+        }.freeze
+        NAMED_QUALIFIERS_HIERARCHY = {
+          "a"        => 1, "alpha"     => 1,
+          "b"        => 2, "beta"      => 2,
+          "m"        => 3, "milestone" => 3,
+          "rc"       => 4, "cr"        => 4,
+          "snapshot" => 5,
+          "ga"       => 6, "" => 6, "final" => 6,
+          "sp"       => 7
+        }.freeze
+
         def initialize(version)
           @version_string = version.to_s
           super(version.to_s.tr("_", "-"))
@@ -18,7 +33,109 @@ module Dependabot
           @version_string
         end
 
-        # TODO: We almost certainly need to override version comparison here
+        private
+
+        def <=>(other)
+          version = @version_string.to_s
+          version = fill_tokens(version)
+          version = trim_version(version)
+          prefixed_tokens = split_into_prefixed_tokens(version)
+
+          other_version = other.to_s
+          other_version = fill_tokens(other_version)
+          other_version = trim_version(other_version)
+          other_prefixed_tokens = split_into_prefixed_tokens(other_version)
+
+          prefixed_tokens, other_prefixed_tokens =
+            pad_for_comparison(prefixed_tokens, other_prefixed_tokens)
+
+          prefixed_tokens.count.times.each do |index|
+            comp = compare_prefixed_token(
+              prefix: prefixed_tokens[index][0],
+              token: prefixed_tokens[index][1..-1] || "",
+              other_prefix: other_prefixed_tokens[index][0],
+              other_token: other_prefixed_tokens[index][1..-1] || ""
+            )
+            return comp unless comp.zero?
+          end
+
+          0
+        end
+
+        def fill_tokens(version)
+          # Add separators when transitioning from digits to characters
+          version = version.gsub(/(\d)([A-Za-z])/, '\1-\2')
+          version = version.gsub(/([A-Za-z])(\d)/, '\1-\2')
+
+          # Replace empty tokens with 0
+          version = version.gsub(/([\.\-])([\.\-])/, '\10\2')
+          version = version.gsub(/^([\.\-])/, '0\1')
+          version.gsub(/([\.\-])$/, '\10')
+        end
+
+        def trim_version(version)
+          version.split("-").map do |v|
+            parts = v.split(".")
+            parts = parts[0..-2] while NULL_VALUES.include?(parts&.last)
+            parts&.join(".")
+          end.compact.reject(&:empty?).join("-")
+        end
+
+        def split_into_prefixed_tokens(version)
+          ".#{version}".split(/(?=[\-\.])/)
+        end
+
+        def pad_for_comparison(prefixed_tokens, other_prefixed_tokens)
+          prefixed_tokens = prefixed_tokens.dup
+          other_prefixed_tokens = other_prefixed_tokens.dup
+
+          longest = [prefixed_tokens, other_prefixed_tokens].max_by(&:count)
+          shortest = [prefixed_tokens, other_prefixed_tokens].min_by(&:count)
+
+          longest.count.times do |index|
+            next unless shortest[index].nil?
+            shortest[index] = longest[index].start_with?(".") ? ".0" : "-"
+          end
+
+          [prefixed_tokens, other_prefixed_tokens]
+        end
+
+        def compare_prefixed_token(prefix:, token:, other_prefix:, other_token:)
+          token_type = token.match?(/^\d+$/) ? :number : :qualifier
+          other_token_type = other_token.match?(/^\d+$/) ? :number : :qualifier
+
+          hierarchy = PREFIXED_TOKEN_HIERARCHY.fetch(prefix).fetch(token_type)
+          other_hierarchy =
+            PREFIXED_TOKEN_HIERARCHY.fetch(other_prefix).fetch(other_token_type)
+
+          hierarchy_comparison = hierarchy <=> other_hierarchy
+          return hierarchy_comparison unless hierarchy_comparison.zero?
+
+          compare_token(token: token, other_token: other_token)
+        end
+
+        def compare_token(token:, other_token:)
+          if (token_hierarchy = NAMED_QUALIFIERS_HIERARCHY[token])
+            return -1 unless NAMED_QUALIFIERS_HIERARCHY[other_token]
+            return token_hierarchy <=> NAMED_QUALIFIERS_HIERARCHY[other_token]
+          end
+
+          return 1 if NAMED_QUALIFIERS_HIERARCHY[other_token]
+
+          token = token.to_i if token.match?(/^\d+$/)
+          other_token = other_token.to_i if other_token.match?(/^\d+$/)
+          token <=> other_token
+        end
+
+        def normalise_token(token)
+          return "a" if token == "alpha"
+          return "b" if token == "beta"
+          return "m" if token == "milestone"
+          return "rc" if token == "cr"
+          return "rc" if token == "cr"
+          return "final" if token == "ga"
+          token
+        end
       end
     end
   end

--- a/spec/dependabot/update_checkers/java/maven/version_finder_spec.rb
+++ b/spec/dependabot/update_checkers/java/maven/version_finder_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Dependabot::UpdateCheckers::Java::Maven::VersionFinder do
 
   describe "#versions" do
     subject { finder.versions }
-    its(:count) { is_expected.to eq(62) }
+    its(:count) { is_expected.to eq(63) }
     its(:first) { is_expected.to eq(version_class.new("10.0-rc1")) }
-    its(:last) { is_expected.to eq(version_class.new("23.6-jre")) }
+    its(:last) { is_expected.to eq(version_class.new("23.7-jre-rc1")) }
   end
 end

--- a/spec/dependabot/update_checkers/java/maven_spec.rb
+++ b/spec/dependabot/update_checkers/java/maven_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe Dependabot::UpdateCheckers::Java::Maven do
       it { is_expected.to eq(version_class.new("23.6-jre")) }
     end
 
-    context "when the user doesn't want a pre-release" do
-      let(:dependency_version) { "18.0" }
-      it { is_expected.to eq(version_class.new("23.0")) }
+    context "when the user wants a pre-release" do
+      let(:dependency_version) { "18.0-beta" }
+      it { is_expected.to eq(version_class.new("23.7-jre-rc1")) }
     end
 
     context "when there are date-based versions" do
@@ -83,7 +83,7 @@ RSpec.describe Dependabot::UpdateCheckers::Java::Maven do
 
     context "when the current version isn't normal" do
       let(:dependency_version) { "RELEASE802" }
-      it { is_expected.to eq(version_class.new("23.0")) }
+      it { is_expected.to eq(version_class.new("23.6-jre")) }
     end
 
     context "when the version comes from a property" do

--- a/spec/dependabot/utils/java/requirement_spec.rb
+++ b/spec/dependabot/utils/java/requirement_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/utils/java/requirement"
+require "dependabot/utils/java/version"
+
+RSpec.describe Dependabot::Utils::Java::Requirement do
+  subject(:requirement) { described_class.new(requirement_string) }
+  let(:requirement_string) { ">=1.0.0" }
+
+  describe ".new" do
+    subject { described_class.new(requirement_string) }
+
+    context "with a pre-release version" do
+      let(:requirement_string) { "1.3.alpha" }
+      it { is_expected.to be_satisfied_by(Gem::Version.new("1.3.a")) }
+    end
+  end
+
+  describe "#satisfied_by?" do
+    subject { requirement.satisfied_by?(version) }
+
+    context "with a Gem::Version" do
+      context "for the current version" do
+        let(:version) { Gem::Version.new("1.0.0") }
+        it { is_expected.to eq(true) }
+
+        context "when the requirement includes a post-release" do
+          let(:requirement_string) { ">=1.0.0u2" }
+          it { is_expected.to eq(false) }
+        end
+      end
+
+      context "for an out-of-range version" do
+        let(:version) { Gem::Version.new("0.9.0") }
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    context "with a Utils::Java::Version" do
+      let(:version) do
+        Dependabot::Utils::Java::Version.new(version_string)
+      end
+
+      context "for the current version" do
+        let(:version_string) { "1.0.0" }
+        it { is_expected.to eq(true) }
+
+        context "for a post-release version" do
+          let(:version_string) { "1.0.0u2" }
+          it { is_expected.to eq(true) }
+        end
+
+        context "for a pre-release sting" do
+          let(:requirement_string) { "1.0.0-alpha" }
+          it { is_expected.to eq(false) }
+        end
+      end
+
+      context "for an out-of-range version" do
+        let(:version_string) { "0.9.0" }
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
+end

--- a/spec/dependabot/utils/java/version_spec.rb
+++ b/spec/dependabot/utils/java/version_spec.rb
@@ -31,6 +31,152 @@ RSpec.describe Dependabot::Utils::Java::Version do
     end
   end
 
+  describe "#<=>" do
+    subject { version.send(:"<=>", other_version) }
+
+    context "compared to a Gem::Version" do
+      context "that is lower" do
+        let(:other_version) { Gem::Version.new("0.9.0") }
+        it { is_expected.to eq(1) }
+      end
+
+      context "that is equal" do
+        let(:other_version) { Gem::Version.new("1.0.0") }
+        it { is_expected.to eq(0) }
+      end
+
+      context "that is greater" do
+        let(:other_version) { Gem::Version.new("1.1.0") }
+        it { is_expected.to eq(-1) }
+      end
+    end
+
+    context "compared to a Utils::Java::Version" do
+      context "that is lower" do
+        let(:other_version) { described_class.new("0.9.0") }
+        it { is_expected.to eq(1) }
+      end
+
+      context "that is equal" do
+        let(:other_version) { described_class.new("1.0.0") }
+        it { is_expected.to eq(0) }
+      end
+
+      context "that is greater" do
+        let(:other_version) { described_class.new("1.1.0") }
+        it { is_expected.to eq(-1) }
+      end
+
+      context "that is a post-release" do
+        let(:other_version) { described_class.new("1.0.0u1") }
+        it { is_expected.to eq(-1) }
+      end
+
+      context "that is a pre-release" do
+        let(:other_version) { described_class.new("1.0.0a1") }
+        it { is_expected.to eq(1) }
+      end
+
+      describe "from the spec" do
+        context "number padding" do
+          let(:version) { described_class.new("1") }
+          let(:other_version) { described_class.new("1.1") }
+          it { is_expected.to eq(-1) }
+        end
+
+        context "qualifier padding" do
+          let(:version) { described_class.new("1-snapshot") }
+          let(:other_version) { described_class.new("1") }
+          it { is_expected.to eq(-1) }
+        end
+
+        context "qualifier padding 1" do
+          let(:version) { described_class.new("1") }
+          let(:other_version) { described_class.new("1-sp") }
+          it { is_expected.to eq(-1) }
+        end
+
+        context "switching" do
+          let(:version) { described_class.new("1-foo2") }
+          let(:other_version) { described_class.new("1-foo10") }
+          it { is_expected.to eq(-1) }
+        end
+
+        context "prefixes" do
+          let(:version) { described_class.new("1.foo") }
+          let(:other_version) { described_class.new("1-foo") }
+          it { is_expected.to eq(-1) }
+        end
+
+        context "prefixes2" do
+          let(:version) { described_class.new("1-foo") }
+          let(:other_version) { described_class.new("1-1") }
+          it { is_expected.to eq(-1) }
+        end
+
+        context "prefixes3" do
+          let(:version) { described_class.new("1-1") }
+          let(:other_version) { described_class.new("1.1") }
+          it { is_expected.to eq(-1) }
+        end
+
+        context "null values" do
+          let(:version) { described_class.new("1.ga") }
+          let(:other_version) { described_class.new("1-ga") }
+          it { is_expected.to eq(0) }
+        end
+
+        context "null values 2" do
+          let(:version) { described_class.new("1-ga") }
+          let(:other_version) { described_class.new("1-0") }
+          it { is_expected.to eq(0) }
+        end
+
+        context "null values 3" do
+          let(:version) { described_class.new("1-0") }
+          let(:other_version) { described_class.new("1.0") }
+          it { is_expected.to eq(0) }
+        end
+
+        context "null values 4" do
+          let(:version) { described_class.new("1.0") }
+          let(:other_version) { described_class.new("1") }
+          it { is_expected.to eq(0) }
+        end
+
+        context "post releases" do
+          let(:version) { described_class.new("1-sp") }
+          let(:other_version) { described_class.new("1-ga") }
+          it { is_expected.to eq(1) }
+        end
+
+        context "post releases" do
+          let(:version) { described_class.new("1-sp.1") }
+          let(:other_version) { described_class.new("1-ga.1") }
+          it { is_expected.to eq(1) }
+        end
+
+        context "null values (again)" do
+          let(:version) { described_class.new("1-sp-1") }
+          let(:other_version) { described_class.new("1-ga-1") }
+          it { is_expected.to eq(-1) }
+        end
+
+        context "null values (again 2)" do
+          let(:version) { described_class.new("1-ga-1") }
+          let(:other_version) { described_class.new("1-1") }
+          it { is_expected.to eq(0) }
+        end
+
+        context "named values" do
+          let(:version) { described_class.new("1-a1") }
+          let(:other_version) { described_class.new("1-alpha-1") }
+          it { is_expected.to eq(0) }
+        end
+      end
+    end
+  end
+
   describe "compatibility with Gem::Requirement" do
     subject { requirement.satisfied_by?(version) }
     let(:requirement) { Gem::Requirement.new(">= 1.0.0") }

--- a/spec/dependabot/utils/java/version_spec.rb
+++ b/spec/dependabot/utils/java/version_spec.rb
@@ -31,6 +31,45 @@ RSpec.describe Dependabot::Utils::Java::Version do
     end
   end
 
+  describe "#prerelease?" do
+    subject { version.prerelease? }
+
+    context "with an alpha" do
+      let(:version_string) { "1.0.0-alpha" }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a capitalised alpha" do
+      let(:version_string) { "1.0.0-Alpha" }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with an alpha separated with a ." do
+      let(:version_string) { "1.0.0.alpha" }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with an alpha with no separator" do
+      let(:version_string) { "1.0.0alpha" }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with an alligator" do
+      let(:version_string) { "1.0.0alligator" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "with a release" do
+      let(:version_string) { "1.0.0" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "with a post-release" do
+      let(:version_string) { "1.0.0.sp7" }
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe "#<=>" do
     subject { version.send(:"<=>", other_version) }
 
@@ -144,13 +183,25 @@ RSpec.describe Dependabot::Utils::Java::Version do
           it { is_expected.to eq(0) }
         end
 
+        context "case insensitivity" do
+          let(:version) { described_class.new("1.0.FINAL") }
+          let(:other_version) { described_class.new("1") }
+          it { is_expected.to eq(0) }
+        end
+
+        context "case insensitivity 2" do
+          let(:version) { described_class.new("1.something") }
+          let(:other_version) { described_class.new("1.SOMETHING") }
+          it { is_expected.to eq(0) }
+        end
+
         context "post releases" do
           let(:version) { described_class.new("1-sp") }
           let(:other_version) { described_class.new("1-ga") }
           it { is_expected.to eq(1) }
         end
 
-        context "post releases" do
+        context "post releases 2" do
           let(:version) { described_class.new("1-sp.1") }
           let(:other_version) { described_class.new("1-ga.1") }
           it { is_expected.to eq(1) }

--- a/spec/fixtures/java/maven_central_metadata/with_release.xml
+++ b/spec/fixtures/java/maven_central_metadata/with_release.xml
@@ -73,6 +73,7 @@
       <version>23.5-jre</version>
       <version>23.6-android</version>
       <version>23.6-jre</version>
+      <version>23.7-jre-rc1</version>
     </versions>
     <lastUpdated>20171221012203</lastUpdated>
   </versioning>


### PR DESCRIPTION
Java's implementation of version comparison is a little different to other languages. This PR implements it in full, and will ensure we don't accidentally downgrade versions.