### PR TITLE
Java: Preemptively download parent POMs, when present, to allow property evaluation

### DIFF
--- a/lib/dependabot/file_parsers/java/maven.rb
+++ b/lib/dependabot/file_parsers/java/maven.rb
@@ -136,13 +136,14 @@ module Dependabot
         end
 
         def pomfiles
+          # Note: this (correctly) excludes any parent POMs that were downloaded
           @pomfiles ||=
             dependency_files.select { |f| f.name.end_with?("pom.xml") }
         end
 
         def internal_dependency_names
           @internal_dependency_names ||=
-            pomfiles.map do |pom|
+            dependency_files.map do |pom|
               doc = Nokogiri::XML(pom.content)
               group_id    = doc.at_css("project > groupId") ||
                             doc.at_css("project > parent > groupId")

--- a/lib/dependabot/file_parsers/java/maven/property_value_finder.rb
+++ b/lib/dependabot/file_parsers/java/maven/property_value_finder.rb
@@ -55,16 +55,11 @@ module Dependabot
 
           attr_reader :dependency_files
 
-          def pomfiles
-            @pomfiles ||=
-              dependency_files.select { |f| f.name.end_with?("pom.xml") }
-          end
-
           def internal_dependency_poms
             return @internal_dependency_poms if @internal_dependency_poms
 
             @internal_dependency_poms = {}
-            pomfiles.each do |pom|
+            dependency_files.each do |pom|
               doc = Nokogiri::XML(pom.content)
               group_id    = doc.at_css("project > groupId") ||
                             doc.at_css("project > parent > groupId")

--- a/lib/dependabot/file_parsers/java/maven/repositories_finder.rb
+++ b/lib/dependabot/file_parsers/java/maven/repositories_finder.rb
@@ -48,11 +48,6 @@ module Dependabot
 
           attr_reader :dependency_files
 
-          def pomfiles
-            @pomfiles ||=
-              dependency_files.select { |f| f.name.end_with?("pom.xml") }
-          end
-
           def parent_pom(pom, repo_urls)
             doc = Nokogiri::XML(pom.content)
             doc.remove_namespaces!
@@ -75,7 +70,7 @@ module Dependabot
             return @internal_dependency_poms if @internal_dependency_poms
 
             @internal_dependency_poms = {}
-            pomfiles.each do |pom|
+            dependency_files.each do |pom|
               doc = Nokogiri::XML(pom.content)
               group_id    = doc.at_css("project > groupId") ||
                             doc.at_css("project > parent > groupId")

--- a/lib/dependabot/file_updaters/java/maven.rb
+++ b/lib/dependabot/file_updaters/java/maven.rb
@@ -31,6 +31,9 @@ module Dependabot
           updated_files = updated_files.reject { |f| pomfiles.include?(f) }
 
           raise "No files changed!" if updated_files.none?
+          if updated_files.any? { |f| f.name.end_with?("pom_parent.xml") }
+            raise "Updated a supporting POM!"
+          end
           updated_files
         end
 

--- a/lib/dependabot/update_checkers/java/maven.rb
+++ b/lib/dependabot/update_checkers/java/maven.rb
@@ -54,7 +54,8 @@ module Dependabot
               property_details(property_name: prop_name, callsite_pom: pom)&.
               fetch(:file)
 
-            declaration_pom_name == "remote_pom.xml"
+            declaration_pom_name == "remote_pom.xml" ||
+              declaration_pom_name.end_with?("pom_parent.xml")
           end
         end
 

--- a/spec/dependabot/file_fetchers/java/maven_spec.rb
+++ b/spec/dependabot/file_fetchers/java/maven_spec.rb
@@ -8,8 +8,13 @@ RSpec.describe Dependabot::FileFetchers::Java::Maven do
 
   let(:source) { { host: "github", repo: "gocardless/bump" } }
   let(:file_fetcher_instance) do
-    described_class.new(source: source, credentials: credentials)
+    described_class.new(
+      source: source,
+      credentials: credentials,
+      directory: directory
+    )
   end
+  let(:directory) { "/" }
   let(:github_url) { "https://api.github.com/" }
   let(:url) { github_url + "repos/gocardless/bump/contents/" }
   let(:credentials) do
@@ -81,6 +86,16 @@ RSpec.describe Dependabot::FileFetchers::Java::Maven do
         to match_array(
           %w(pom.xml util/pom.xml business-app/pom.xml legacy/pom.xml)
         )
+    end
+
+    context "when asked to fetch only a subdirectory" do
+      let(:directory) { "/legacy" }
+
+      it "fetches the relevant poms" do
+        expect(file_fetcher_instance.files.count).to eq(2)
+        expect(file_fetcher_instance.files.map(&:name)).
+          to match_array(%w(pom.xml ../pom_parent.xml))
+      end
     end
 
     context "with a nested multimodule pom" do

--- a/spec/dependabot/file_parsers/java/maven_spec.rb
+++ b/spec/dependabot/file_parsers/java/maven_spec.rb
@@ -304,6 +304,26 @@ RSpec.describe Dependabot::FileParsers::Java::Maven do
       it "fills in the property value correctly" do
         expect(dependencies.map(&:name)).
           to include("uk.me.lwood.sigtran:sigtran-tcap")
+        expect(dependencies.map(&:name)).
+          to include("junit:junit")
+      end
+
+      context "when the parent was downloaded only as a supporting POM" do
+        let(:files) { [pom, parent_pom] }
+        let(:pom_body) { fixture("java", "poms", "sigtran-map.pom") }
+        let(:parent_pom) do
+          Dependabot::DependencyFile.new(
+            name: "../pom_parent.xml",
+            content: fixture("java", "poms", "sigtran.pom")
+          )
+        end
+
+        it "excludes parent dependencies" do
+          expect(dependencies.map(&:name)).
+            to include("uk.me.lwood.sigtran:sigtran-tcap")
+          expect(dependencies.map(&:name)).
+            to_not include("junit:junit")
+        end
       end
     end
 

--- a/spec/dependabot/update_checkers/java/maven_spec.rb
+++ b/spec/dependabot/update_checkers/java/maven_spec.rb
@@ -554,6 +554,30 @@ RSpec.describe Dependabot::UpdateCheckers::Java::Maven do
       end
       it { is_expected.to eq(true) }
 
+      context "that inherits from a parent POM downloaded for support" do
+        let(:dependency_files) { [pom, parent_pom] }
+        let(:pom_body) { fixture("java", "poms", "sigtran-map.pom") }
+        let(:parent_pom) do
+          Dependabot::DependencyFile.new(
+            name: "../pom_parent.xml",
+            content: fixture("java", "poms", "sigtran.pom")
+          )
+        end
+        let(:dependency_name) { "uk.me.lwood.sigtran:sigtran-tcap" }
+        let(:dependency_version) { "0.9-SNAPSHOT" }
+        let(:dependency_requirements) do
+          [{
+            file: "pom.xml",
+            requirement: "0.9-SNAPSHOT",
+            groups: [],
+            source: nil,
+            metadata: { property_name: "project.version" }
+          }]
+        end
+
+        it { is_expected.to eq(false) }
+      end
+
       context "that inherits from a remote POM" do
         let(:pom_body) { fixture("java", "poms", "remote_parent_pom.xml") }
 


### PR DESCRIPTION
Work in progress. Idea is to always download a POM's parents, if they're stored in the same repo, so that we can always do property resolution.

TODO:
- [x] Tests for FileFetcher
- [x] Special handling of files ending in `pom_parent.xml` in `UpdateChecker`