### PR TITLE
Use pyenv to manage Python version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: dependabot/dependabot-core:0.1.1
+      - image: dependabot/dependabot-core:0.1.2
     working_directory: ~/dependabot-core
     steps:
       - checkout
@@ -17,7 +17,7 @@ jobs:
       - run: cd helpers/yarn && yarn install
       - run: cd helpers/npm && yarn install
       - run: cd helpers/php && composer install
-      - run: cd helpers/python && pip install -r requirements.txt
+      - run: cd helpers/python && eval "$(pyenv init -)" && pip install -r requirements.txt
       - run: cd helpers/elixir && mix deps.get
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run: cd helpers/yarn && yarn install
       - run: cd helpers/npm && yarn install
       - run: cd helpers/php && composer install
-      - run: cd helpers/python && eval "$(pyenv init -)" && pip install -r requirements.txt
+      - run: cd helpers/python && pyenv exec pip install -r requirements.txt
       - run: cd helpers/elixir && mix deps.get
 
       - save_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Gemfile.lock
 /helpers/php/vendor
 /helpers/php/.php_cs.cache
 vendor
+.DS_Store
 *.pyc
 /helpers/elixir/deps
 /helpers/elixir/_build

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,16 @@ RUN apt-get update \
       unzip \
       locales \
       openssh-client \
+      make \
+      libssl-dev \
+      libbz2-dev \
+      libreadline-dev \
+      libsqlite3-dev \
+      llvm \
+      libncurses5-dev \
+      libncursesw5-dev \
+      xz-utils \
+      tk-dev \
     && locale-gen en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
@@ -34,10 +44,14 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3173AA6 \
 
 ### PYTHON
 
-# Install Python 3.6 and Pip
-RUN apt-get install -y python3.6 python3.6-dev \
-    && ln -s /usr/bin/python3.6 /usr/local/bin/python \
-    && curl -s https://bootstrap.pypa.io/get-pip.py | python
+# Install pyenv with Python 3.6
+RUN git clone https://github.com/pyenv/pyenv.git /usr/local/.pyenv
+ENV PYENV_ROOT=/usr/local/.pyenv
+ENV PATH="$PYENV_ROOT/bin:$PATH"
+RUN eval "$(pyenv init -)" \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc \
+    && pyenv install 3.6.5 \
+    && pyenv global 3.6.5
 
 
 ### JAVASCRIPT

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,14 +44,11 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3173AA6 \
 
 ### PYTHON
 
-# Install pyenv with Python 3.6
+# Install Python 3.6 with pyenv. Using pyenv lets us support multiple Pythons
 RUN git clone https://github.com/pyenv/pyenv.git /usr/local/.pyenv
 ENV PYENV_ROOT=/usr/local/.pyenv
 ENV PATH="$PYENV_ROOT/bin:$PATH"
-RUN eval "$(pyenv init -)" \
-    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc \
-    && pyenv install 3.6.5 \
-    && pyenv global 3.6.5
+RUN pyenv install 3.6.5 && pyenv global 3.6.5
 
 
 ### JAVASCRIPT

--- a/helpers/python/lib/pipfile_updater.py
+++ b/helpers/python/lib/pipfile_updater.py
@@ -2,9 +2,9 @@ import json
 import os
 
 def update(directory):
-   os.system("cd {0} && pipenv lock --keep-outdated 2>/dev/null".format(directory))
-   os.system("cd {0} && pipenv lock --keep-outdated --requirements > requirements.txt 2>/dev/null".format(directory))
-   os.system("cd {0} && pipenv lock --keep-outdated --dev > requirements-dev.txt 2>/dev/null".format(directory))
+   os.system("cd {0} && eval \"$(pyenv init -)\" && PIPENV_YES=true pipenv lock --keep-outdated >/dev/null 2>&1".format(directory))
+   os.system("cd {0} && eval \"$(pyenv init -)\" && PIPENV_YES=true pipenv lock --keep-outdated --requirements > requirements.txt >/dev/null 2>&1".format(directory))
+   os.system("cd {0} && eval \"$(pyenv init -)\" && PIPENV_YES=true pipenv lock --keep-outdated --dev > requirements-dev.txt >/dev/null 2>&1".format(directory))
 
    lockfile = open(directory + "/Pipfile.lock", "r").read()
    requirements = open(directory + "/requirements.txt", "r").read()

--- a/helpers/python/lib/pipfile_updater.py
+++ b/helpers/python/lib/pipfile_updater.py
@@ -2,9 +2,9 @@ import json
 import os
 
 def update(directory):
-   os.system("cd {0} && eval \"$(pyenv init -)\" && PIPENV_YES=true pipenv lock --keep-outdated >/dev/null 2>&1".format(directory))
-   os.system("cd {0} && eval \"$(pyenv init -)\" && PIPENV_YES=true pipenv lock --keep-outdated --requirements > requirements.txt >/dev/null 2>&1".format(directory))
-   os.system("cd {0} && eval \"$(pyenv init -)\" && PIPENV_YES=true pipenv lock --keep-outdated --dev > requirements-dev.txt >/dev/null 2>&1".format(directory))
+   os.system("cd {0} && PIPENV_YES=true pyenv exec pipenv lock --keep-outdated >/dev/null 2>&1".format(directory))
+   os.system("cd {0} && PIPENV_YES=true pyenv exec pipenv lock --keep-outdated --requirements > requirements.txt >/dev/null 2>&1".format(directory))
+   os.system("cd {0} && PIPENV_YES=true pyenv exec pipenv lock --keep-outdated --dev > requirements-dev.txt >/dev/null 2>&1".format(directory))
 
    lockfile = open(directory + "/Pipfile.lock", "r").read()
    requirements = open(directory + "/requirements.txt", "r").read()

--- a/helpers/python/requirements.txt
+++ b/helpers/python/requirements.txt
@@ -1,4 +1,4 @@
 pip==10.0.1
 hashin==0.13.0
-pipenv==11.10.1
+-e git://github.com/greysteil/pipenv.git@1a196c1c9fa71ea459c4de1a44d1b02d8577e838#egg=pipenv
 pipfile==0.0.2

--- a/lib/dependabot/file_parsers/python/pip.rb
+++ b/lib/dependabot/file_parsers/python/pip.rb
@@ -142,8 +142,7 @@ module Dependabot
             write_temporary_dependency_files
 
             SharedHelpers.run_helper_subprocess(
-              command: "eval \"$(pyenv init -)\" && "\
-                       "python #{python_helper_path}",
+              command: "pyenv exec python #{python_helper_path}",
               function: "parse_requirements",
               args: [Dir.pwd]
             )
@@ -160,8 +159,7 @@ module Dependabot
             write_temporary_dependency_files
 
             SharedHelpers.run_helper_subprocess(
-              command: "eval \"$(pyenv init -)\" && "\
-                       "python #{python_helper_path}",
+              command: "pyenv exec python #{python_helper_path}",
               function: "parse_setup",
               args: [Dir.pwd]
             )

--- a/lib/dependabot/file_parsers/python/pip.rb
+++ b/lib/dependabot/file_parsers/python/pip.rb
@@ -142,7 +142,8 @@ module Dependabot
             write_temporary_dependency_files
 
             SharedHelpers.run_helper_subprocess(
-              command: "python3.6 #{python_helper_path}",
+              command: "eval \"$(pyenv init -)\" && "\
+                       "python #{python_helper_path}",
               function: "parse_requirements",
               args: [Dir.pwd]
             )
@@ -159,7 +160,8 @@ module Dependabot
             write_temporary_dependency_files
 
             SharedHelpers.run_helper_subprocess(
-              command: "python3.6 #{python_helper_path}",
+              command: "eval \"$(pyenv init -)\" && "\
+                       "python #{python_helper_path}",
               function: "parse_setup",
               args: [Dir.pwd]
             )

--- a/lib/dependabot/file_updaters/python/pip.rb
+++ b/lib/dependabot/file_updaters/python/pip.rb
@@ -144,8 +144,7 @@ module Dependabot
 
         def package_hashes_for(name:, version:, algorithm:)
           SharedHelpers.run_helper_subprocess(
-            command: "eval \"$(pyenv init -)\" && "\
-                     "python #{python_helper_path}",
+            command: "pyenv exec python #{python_helper_path}",
             function: "get_dependency_hash",
             args: [name, version, algorithm]
           ).map { |h| "--hash=#{algorithm}:#{h['hash']}" }
@@ -241,8 +240,7 @@ module Dependabot
             write_temporary_dependency_files(pipfile_content)
 
             SharedHelpers.run_helper_subprocess(
-              command:  "eval \"$(pyenv init -)\" && "\
-                        "python #{python_helper_path}",
+              command:  "pyenv exec python #{python_helper_path}",
               function: "update_pipfile",
               args: [dir]
             )
@@ -267,8 +265,7 @@ module Dependabot
           SharedHelpers.in_a_temporary_directory do |dir|
             File.write(File.join(dir, "Pipfile"), pipfile_content)
             SharedHelpers.run_helper_subprocess(
-              command:  "eval \"$(pyenv init -)\" && "\
-                        "python #{python_helper_path}",
+              command:  "pyenv exec python #{python_helper_path}",
               function: "get_pipfile_hash",
               args: [dir]
             )

--- a/lib/dependabot/update_checkers/python/pip/pipfile_version_resolver.rb
+++ b/lib/dependabot/update_checkers/python/pip/pipfile_version_resolver.rb
@@ -51,7 +51,9 @@ module Dependabot
                 # Whilst calling `lock` avoids doing an install as part of the
                 # pipenv flow, an install is still done by pip-tools in order
                 # to resolve the dependencies. That means this is slow.
-                run_pipenv_command("pipenv lock")
+                run_pipenv_command(
+                  "eval \"$(pyenv init -)\" && PIPENV_YES=true pipenv lock"
+                )
 
                 updated_lockfile = JSON.parse(File.read("Pipfile.lock"))
                 updated_lockfile.dig(
@@ -86,24 +88,10 @@ module Dependabot
 
           def pipfile_content
             content = pipfile.content
-            content = remove_python_requirement(content)
             content = freeze_other_dependencies(content)
             content = unlock_target_dependency(content)
             content = add_private_sources(content)
             content
-          end
-
-          def remove_python_requirement(pipfile_content)
-            # It's not idea to remove the Python version, but unless we start
-            # running multiple Python versions in production there's no
-            # alternative.
-            pipfile_object = TomlRB.parse(pipfile_content)
-
-            return pipfile_content unless pipfile_object["requires"]
-            pipfile_object["requires"].delete("python_full_version")
-            pipfile_object["requires"].delete("python_version")
-
-            TomlRB.dump(pipfile_object)
           end
 
           def freeze_other_dependencies(pipfile_content)

--- a/lib/dependabot/update_checkers/python/pip/pipfile_version_resolver.rb
+++ b/lib/dependabot/update_checkers/python/pip/pipfile_version_resolver.rb
@@ -51,9 +51,7 @@ module Dependabot
                 # Whilst calling `lock` avoids doing an install as part of the
                 # pipenv flow, an install is still done by pip-tools in order
                 # to resolve the dependencies. That means this is slow.
-                run_pipenv_command(
-                  "eval \"$(pyenv init -)\" && PIPENV_YES=true pipenv lock"
-                )
+                run_pipenv_command("PIPENV_YES=true pyenv exec pipenv lock")
 
                 updated_lockfile = JSON.parse(File.read("Pipfile.lock"))
                 updated_lockfile.dig(


### PR DESCRIPTION
The idea here is to piggy-back off of pipenv's automatic use of pyenv to install the right Python version. The install typically takes < 3 minutes, and will only happen once per update run, and only if the user specifies a Python version that we don't have (currently we only have 3.6.5).

More details in https://github.com/skylines-project/skylines/pull/734.