### PR TITLE
Update git tags for Rust dependencies

### DIFF
--- a/spec/dependabot/file_updaters/rust/cargo_spec.rb
+++ b/spec/dependabot/file_updaters/rust/cargo_spec.rb
@@ -135,6 +135,51 @@ RSpec.describe Dependabot::FileUpdaters::Rust::Cargo do
             end
           end
 
+          context "with a git dependency" do
+            context "with an updated tag" do
+              let(:manifest_fixture_name) { "git_dependency_with_tag" }
+              let(:lockfile_fixture_name) { "git_dependency_with_tag" }
+              let(:dependency_name) { "utf8-ranges" }
+              let(:dependency_version) do
+                "83141b376b93484341c68fbca3ca110ae5cd2708"
+              end
+              let(:dependency_previous_version) do
+                "d5094c7e9456f2965dec20de671094a98c6929c2"
+              end
+              let(:requirements) do
+                [{
+                  file: "Cargo.toml",
+                  requirement: nil,
+                  groups: ["dependencies"],
+                  source: {
+                    type: "git",
+                    url: "https://github.com/BurntSushi/utf8-ranges",
+                    branch: nil,
+                    ref: "1.0.0"
+                  }
+                }]
+              end
+              let(:previous_requirements) do
+                [{
+                  file: "Cargo.toml",
+                  requirement: nil,
+                  groups: ["dependencies"],
+                  source: {
+                    type: "git",
+                    url: "https://github.com/BurntSushi/utf8-ranges",
+                    branch: nil,
+                    ref: "0.1.3"
+                  }
+                }]
+              end
+
+              it "updates the dependency version in the lockfile" do
+                expect(updated_manifest_content).
+                  to include(', tag = "1.0.0" }')
+              end
+            end
+          end
+
           context "with a feature dependency" do
             let(:manifest_fixture_name) { "feature_dependency" }
             let(:lockfile_fixture_name) { "feature_dependency" }
@@ -244,6 +289,48 @@ RSpec.describe Dependabot::FileUpdaters::Rust::Cargo do
         it "updates the dependency version in the lockfile" do
           expect(updated_lockfile_content).
             to include("utf8-ranges#47afd3c09c6583afdf4083fc9644f6f64172c8f8")
+        end
+
+        context "with an updated tag" do
+          let(:manifest_fixture_name) { "git_dependency_with_tag" }
+          let(:lockfile_fixture_name) { "git_dependency_with_tag" }
+          let(:dependency_version) do
+            "83141b376b93484341c68fbca3ca110ae5cd2708"
+          end
+          let(:dependency_previous_version) do
+            "d5094c7e9456f2965dec20de671094a98c6929c2"
+          end
+          let(:requirements) do
+            [{
+              file: "Cargo.toml",
+              requirement: nil,
+              groups: ["dependencies"],
+              source: {
+                type: "git",
+                url: "https://github.com/BurntSushi/utf8-ranges",
+                branch: nil,
+                ref: "1.0.0"
+              }
+            }]
+          end
+          let(:previous_requirements) do
+            [{
+              file: "Cargo.toml",
+              requirement: nil,
+              groups: ["dependencies"],
+              source: {
+                type: "git",
+                url: "https://github.com/BurntSushi/utf8-ranges",
+                branch: nil,
+                ref: "0.1.3"
+              }
+            }]
+          end
+
+          it "updates the dependency version in the lockfile" do
+            expect(updated_lockfile_content).
+              to include("?tag=1.0.0#83141b376b93484341c68fbca3ca110ae5cd2708")
+          end
         end
       end
 

--- a/spec/dependabot/update_checkers/rust/cargo/requirements_updater_spec.rb
+++ b/spec/dependabot/update_checkers/rust/cargo/requirements_updater_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Dependabot::UpdateCheckers::Rust::Cargo::RequirementsUpdater do
     described_class.new(
       requirements: requirements,
       library: library,
+      updated_source: updated_source,
       latest_version: latest_version,
       latest_resolvable_version: latest_resolvable_version
     )
@@ -41,8 +42,39 @@ RSpec.describe Dependabot::UpdateCheckers::Rust::Cargo::RequirementsUpdater do
     end
 
     context "with no requirement string (e.g., for a git dependency)" do
-      let(:req_string) { nil }
-      its([:requirement]) { is_expected.to eq(nil) }
+      let(:requirements) { [cargo_req] }
+
+      let(:latest_resolvable_version) do
+        "aa218f56b14c9653891f9e74264a383fa43fefbd"
+      end
+      let(:cargo_req) do
+        {
+          file: "Cargo.toml",
+          requirement: nil,
+          groups: [],
+          source: {
+            type: "git",
+            url: "https://github.com/BurntSushi/utf8-ranges",
+            branch: "master",
+            ref: nil
+          }
+        }
+      end
+      let(:updated_source) do
+        {
+          type: "git",
+          url: "https://github.com/BurntSushi/utf8-ranges",
+          branch: "master",
+          ref: nil
+        }
+      end
+      it { is_expected.to eq(cargo_req) }
+
+      context "when asked to update the source" do
+        let(:updated_source) { { type: "git", ref: "v1.5.0" } }
+        before { cargo_req.merge!(source: { type: "git", ref: "v1.2.0" }) }
+        its([:source]) { is_expected.to eq(updated_source) }
+      end
     end
 
     context "for an app requirement" do

--- a/spec/dependabot/update_checkers/rust/cargo_spec.rb
+++ b/spec/dependabot/update_checkers/rust/cargo_spec.rb
@@ -402,6 +402,7 @@ RSpec.describe Dependabot::UpdateCheckers::Rust::Cargo do
         to receive(:new).
         with(
           requirements: requirements,
+          updated_source: nil,
           latest_version: "0.1.40",
           latest_resolvable_version: "0.1.40",
           library: false

--- a/spec/dependabot/update_checkers/rust/cargo_spec.rb
+++ b/spec/dependabot/update_checkers/rust/cargo_spec.rb
@@ -285,7 +285,8 @@ RSpec.describe Dependabot::UpdateCheckers::Rust::Cargo do
           }
         end
 
-        it { is_expected.to eq(dependency_version) }
+        # The SHA of the next version tag
+        it { is_expected.to eq("83141b376b93484341c68fbca3ca110ae5cd2708") }
       end
 
       context "when the latest version is blocked" do


### PR DESCRIPTION
If a Rust dependency is specified with a git source and a tag, and the tag looks like a version, check whether there is a later tag we can update to.