### PR TITLE
Consider ignored versions when generating PHP update PRs

### DIFF
--- a/helpers/php/bin/run.php
+++ b/helpers/php/bin/run.php
@@ -38,6 +38,10 @@ try {
             $latestVersion = UpdateChecker::getLatestResolvableVersion($request['args']);
             fwrite(STDOUT, json_encode(['result' => $latestVersion]));
             break;
+        case 'get_content_hash':
+            $content_hash = Hasher::getContentHash($request['args']);
+            fwrite(STDOUT, json_encode(['result' => $content_hash]));
+            break;
         default:
             fwrite(STDOUT, '{"error": "Invalid function ' . $request['function'] . '" }');
             exit(1);

--- a/helpers/php/src/Hasher.php
+++ b/helpers/php/src/Hasher.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dependabot\PHP;
+
+use Composer\Factory;
+
+class Hasher
+{
+    public static function getContentHash(array $args): ?string
+    {
+        [$workingDirectory] = $args;
+
+        $io = new ExceptionIO();
+        $composer = Factory::create($io, $workingDirectory . '/composer.json');
+        $locker = $composer->getLocker();
+
+        return $locker->getContentHash(file_get_contents(Factory::getComposerFile()));
+    }
+}

--- a/lib/dependabot/update_checkers/java_script/npm_and_yarn/version_resolver.rb
+++ b/lib/dependabot/update_checkers/java_script/npm_and_yarn/version_resolver.rb
@@ -14,8 +14,8 @@ module Dependabot
       class NpmAndYarn
         class VersionResolver
           def initialize(dependency:, credentials:, dependency_files:)
-            @dependency = dependency
-            @credentials = credentials
+            @dependency       = dependency
+            @credentials      = credentials
             @dependency_files = dependency_files
           end
 

--- a/lib/dependabot/update_checkers/python/pip/pip_compile_version_resolver.rb
+++ b/lib/dependabot/update_checkers/python/pip/pip_compile_version_resolver.rb
@@ -19,11 +19,11 @@ module Dependabot
 
           def initialize(dependency:, dependency_files:, credentials:,
                          unlock_requirement:, latest_allowable_version:)
-            @dependency = dependency
-            @dependency_files = dependency_files
-            @credentials = credentials
+            @dependency               = dependency
+            @dependency_files         = dependency_files
+            @credentials              = credentials
             @latest_allowable_version = latest_allowable_version
-            @unlock_requirement = unlock_requirement
+            @unlock_requirement       = unlock_requirement
           end
 
           def latest_resolvable_version

--- a/lib/dependabot/update_checkers/python/pip/pipfile_version_resolver.rb
+++ b/lib/dependabot/update_checkers/python/pip/pipfile_version_resolver.rb
@@ -29,11 +29,11 @@ module Dependabot
 
           def initialize(dependency:, dependency_files:, credentials:,
                          unlock_requirement:, latest_allowable_version:)
-            @dependency = dependency
-            @dependency_files = dependency_files
-            @credentials = credentials
+            @dependency               = dependency
+            @dependency_files         = dependency_files
+            @credentials              = credentials
             @latest_allowable_version = latest_allowable_version
-            @unlock_requirement = unlock_requirement
+            @unlock_requirement       = unlock_requirement
 
             check_private_sources_are_reachable
           end

--- a/lib/dependabot/update_checkers/ruby/bundler/version_resolver.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler/version_resolver.rb
@@ -31,9 +31,9 @@ module Dependabot
 
           def initialize(dependency:, dependency_files:, credentials:,
                          ignored_versions:)
-            @dependency = dependency
+            @dependency       = dependency
             @dependency_files = dependency_files
-            @credentials = credentials
+            @credentials      = credentials
             @ignored_versions = ignored_versions
           end
 

--- a/spec/dependabot/file_updaters/php/composer_spec.rb
+++ b/spec/dependabot/file_updaters/php/composer_spec.rb
@@ -542,7 +542,7 @@ RSpec.describe Dependabot::FileUpdaters::Php::Composer do
         let(:dependency) do
           Dependabot::Dependency.new(
             name: "illuminate/support",
-            version: "v5.6.23",
+            version: "5.6.23",
             requirements: [
               {
                 file: "composer.json",
@@ -551,7 +551,7 @@ RSpec.describe Dependabot::FileUpdaters::Php::Composer do
                 source: nil
               }
             ],
-            previous_version: "v5.2.1",
+            previous_version: "5.2.0",
             previous_requirements: [
               {
                 file: "composer.json",
@@ -566,6 +566,44 @@ RSpec.describe Dependabot::FileUpdaters::Php::Composer do
 
         it "has details of the updated item" do
           expect(updated_lockfile_content).to include("\"version\":\"v5.6.23\"")
+          expect(updated_lockfile_content).
+            to include("ba383d0a3bf6aa0b7a1307fdc4aa46ba")
+        end
+      end
+
+      context "updating to a specific version when reqs would allow higher" do
+        let(:manifest_fixture_name) { "subdependency_update_required" }
+        let(:lockfile_fixture_name) { "subdependency_update_required" }
+
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "illuminate/support",
+            version: "5.3.0",
+            requirements: [
+              {
+                file: "composer.json",
+                requirement: "^5.2.0",
+                groups: ["runtime"],
+                source: nil
+              }
+            ],
+            previous_version: "5.2.0",
+            previous_requirements: [
+              {
+                file: "composer.json",
+                requirement: "^5.2.0",
+                groups: ["runtime"],
+                source: nil
+              }
+            ],
+            package_manager: "composer"
+          )
+        end
+
+        it "has details of the updated item" do
+          expect(updated_lockfile_content).to include("\"version\":\"v5.3.0\"")
+          expect(updated_lockfile_content).
+            to include("e244eda135819216ac30441464e27d4d")
         end
       end
     end

--- a/spec/dependabot/update_checkers/php/composer/version_resolver_spec.rb
+++ b/spec/dependabot/update_checkers/php/composer/version_resolver_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer::VersionResolver do
       credentials: credentials,
       dependency: dependency,
       dependency_files: dependency_files,
+      latest_allowable_version: latest_allowable_version,
       requirements_to_unlock: requirements_to_unlock
     )
   end
@@ -55,6 +56,7 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer::VersionResolver do
       source: nil
     }]
   end
+  let(:latest_allowable_version) { Gem::Version.new("6.0.0") }
   let(:dependency_name) { "symfony/translation" }
   let(:dependency_version) { "4.0.7" }
   let(:string_req) { "^4.0" }

--- a/spec/dependabot/update_checkers/php/composer_spec.rb
+++ b/spec/dependabot/update_checkers/php/composer_spec.rb
@@ -671,7 +671,7 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer do
       let(:manifest_fixture_name) { "subdependency_update_required" }
       let(:lockfile_fixture_name) { "subdependency_update_required" }
       let(:dependency_name) { "illuminate/support" }
-      let(:dependency_version) { "5.2.7" }
+      let(:dependency_version) { "5.2.0" }
       let(:requirements) do
         [{
           file: "composer.json",

--- a/spec/fixtures/php/lockfiles/subdependency_update_required
+++ b/spec/fixtures/php/lockfiles/subdependency_update_required
@@ -4,37 +4,37 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e58cf23f46cf41f36fe82abdab3dedf5",
+    "content-hash": "e244eda135819216ac30441464e27d4d",
     "packages": [
         {
             "name": "doctrine/inflector",
-            "version": "v1.1.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae"
+                "reference": "5527a48b7313d15261292c149e55e26eae771b0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/90b2128806bfde671b6952ab8bea493942c1fdae",
-                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5527a48b7313d15261292c149e55e26eae771b0a",
+                "reference": "5527a48b7313d15261292c149e55e26eae771b0a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Inflector\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -71,23 +71,24 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06T14:35:42+00:00"
+            "time": "2018-01-09T20:05:19+00:00"
         },
         {
             "name": "erusev/parsedown",
-            "version": "1.6.4",
+            "version": "1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/erusev/parsedown.git",
-                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548"
+                "reference": "92e9c27ba0e74b8b028b111d1b6f956a15c01fc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown/zipball/fbe3fe878f4fe69048bb8a52783a09802004f548",
-                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/92e9c27ba0e74b8b028b111d1b6f956a15c01fc1",
+                "reference": "92e9c27ba0e74b8b028b111d1b6f956a15c01fc1",
                 "shasum": ""
             },
             "require": {
+                "ext-mbstring": "*",
                 "php": ">=5.3.0"
             },
             "require-dev": {
@@ -116,29 +117,29 @@
                 "markdown",
                 "parser"
             ],
-            "time": "2017-11-14T20:44:03+00:00"
+            "time": "2018-03-08T01:11:30+00:00"
         },
         {
             "name": "illuminate/contracts",
-            "version": "v5.4.36",
+            "version": "v5.2.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "67f642e018f3e95fb0b2ebffc206c3200391b1ab"
+                "reference": "22bde7b048a33c702d9737fc1446234fff9b1363"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/67f642e018f3e95fb0b2ebffc206c3200391b1ab",
-                "reference": "67f642e018f3e95fb0b2ebffc206c3200391b1ab",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/22bde7b048a33c702d9737fc1446234fff9b1363",
+                "reference": "22bde7b048a33c702d9737fc1446234fff9b1363",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.4"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.4-dev"
+                    "dev-master": "5.2-dev"
                 }
             },
             "autoload": {
@@ -157,42 +158,41 @@
                 }
             ],
             "description": "The Illuminate Contracts package.",
-            "homepage": "https://laravel.com",
-            "time": "2017-08-26T23:56:53+00:00"
+            "homepage": "http://laravel.com",
+            "time": "2016-08-08T11:46:08+00:00"
         },
         {
             "name": "illuminate/support",
-            "version": "v5.4.36",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "feab1d1495fd6d38970bd6c83586ba2ace8f299a"
+                "reference": "0b25fb20b0c75392b0b3848fe067275c51235e37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/feab1d1495fd6d38970bd6c83586ba2ace8f299a",
-                "reference": "feab1d1495fd6d38970bd6c83586ba2ace8f299a",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/0b25fb20b0c75392b0b3848fe067275c51235e37",
+                "reference": "0b25fb20b0c75392b0b3848fe067275c51235e37",
                 "shasum": ""
             },
             "require": {
-                "doctrine/inflector": "~1.1",
+                "doctrine/inflector": "~1.0",
                 "ext-mbstring": "*",
-                "illuminate/contracts": "5.4.*",
-                "paragonie/random_compat": "~1.4|~2.0",
-                "php": ">=5.6.4"
-            },
-            "replace": {
-                "tightenco/collect": "self.version"
+                "illuminate/contracts": "5.2.*",
+                "php": ">=5.5.9"
             },
             "suggest": {
                 "illuminate/filesystem": "Required to use the composer class (5.2.*).",
-                "symfony/process": "Required to use the composer class (~3.2).",
-                "symfony/var-dumper": "Required to use the dd function (~3.2)."
+                "jeremeamia/superclosure": "Required to be able to serialize closures (~2.2).",
+                "paragonie/random_compat": "Provides a compatible interface like PHP7's random_bytes() in PHP 5 projects (~1.1).",
+                "symfony/polyfill-php56": "Required to use the hash_equals function on PHP 5.5 (~1.0).",
+                "symfony/process": "Required to use the composer class (2.8.*|3.0.*).",
+                "symfony/var-dumper": "Improves the dd function (2.8.*|3.0.*)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.4-dev"
+                    "dev-master": "5.2-dev"
                 }
             },
             "autoload": {
@@ -210,60 +210,12 @@
             "authors": [
                 {
                     "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
+                    "email": "taylorotwell@gmail.com"
                 }
             ],
             "description": "The Illuminate Support package.",
-            "homepage": "https://laravel.com",
-            "time": "2017-08-15T13:25:41+00:00"
-        },
-        {
-            "name": "paragonie/random_compat",
-            "version": "v2.0.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
-                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*|5.*"
-            },
-            "suggest": {
-                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "lib/random.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
-                    "homepage": "https://paragonie.com"
-                }
-            ],
-            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
-            "keywords": [
-                "csprng",
-                "pseudorandom",
-                "random"
-            ],
-            "time": "2017-09-27T21:40:39+00:00"
+            "homepage": "http://laravel.com",
+            "time": "2015-12-07T16:09:55+00:00"
         }
     ],
     "packages-dev": [],

--- a/spec/fixtures/php/packagist_responses/dependabot:dummy-pkg-a.json
+++ b/spec/fixtures/php/packagist_responses/dependabot:dummy-pkg-a.json
@@ -1,0 +1,162 @@
+{
+    "packages": {
+        "dependabot/dummy-pkg-a": {
+            "dev-master": {
+                "authors": [],
+                "description": "A dummy package for testing Dependabot",
+                "dist": {
+                    "reference": "9c25d3578b388e6fed14f38bf0e24fe107f9e486",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/dependabot/php-dummy-pkg-a/zipball/9c25d3578b388e6fed14f38bf0e24fe107f9e486"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "dependabot/dummy-pkg-a",
+                "source": {
+                    "reference": "9c25d3578b388e6fed14f38bf0e24fe107f9e486",
+                    "type": "git",
+                    "url": "https://github.com/dependabot/php-dummy-pkg-a.git"
+                },
+                "time": "2017-06-08T12:52:54+00:00",
+                "type": "library",
+                "uid": 1434800,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            },
+            "v1.0.0": {
+                "authors": [],
+                "description": "A dummy package for testing Dependabot",
+                "dist": {
+                    "reference": "2d02479d73bdea5754b0e17c67945109816eb9b0",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/dependabot/php-dummy-pkg-a/zipball/2d02479d73bdea5754b0e17c67945109816eb9b0"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "dependabot/dummy-pkg-a",
+                "source": {
+                    "reference": "2d02479d73bdea5754b0e17c67945109816eb9b0",
+                    "type": "git",
+                    "url": "https://github.com/dependabot/php-dummy-pkg-a.git"
+                },
+                "time": "2017-06-08T12:49:30+00:00",
+                "type": "library",
+                "uid": 1434795,
+                "version": "v1.0.0",
+                "version_normalized": "1.0.0.0"
+            },
+            "v1.0.1": {
+                "authors": [],
+                "description": "A dummy package for testing Dependabot",
+                "dist": {
+                    "reference": "9dfbb7a7f5083a7cf3acb48ae15ce6a3d7c3ea9c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/dependabot/php-dummy-pkg-a/zipball/9dfbb7a7f5083a7cf3acb48ae15ce6a3d7c3ea9c"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "dependabot/dummy-pkg-a",
+                "source": {
+                    "reference": "9dfbb7a7f5083a7cf3acb48ae15ce6a3d7c3ea9c",
+                    "type": "git",
+                    "url": "https://github.com/dependabot/php-dummy-pkg-a.git"
+                },
+                "time": "2017-06-08T12:51:01+00:00",
+                "type": "library",
+                "uid": 1434796,
+                "version": "v1.0.1",
+                "version_normalized": "1.0.1.0"
+            },
+            "v1.1.0": {
+                "authors": [],
+                "description": "A dummy package for testing Dependabot",
+                "dist": {
+                    "reference": "249843f1d2636fa408d01bdd6aeb43ce2c453198",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/dependabot/php-dummy-pkg-a/zipball/249843f1d2636fa408d01bdd6aeb43ce2c453198"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "dependabot/dummy-pkg-a",
+                "source": {
+                    "reference": "249843f1d2636fa408d01bdd6aeb43ce2c453198",
+                    "type": "git",
+                    "url": "https://github.com/dependabot/php-dummy-pkg-a.git"
+                },
+                "time": "2017-06-08T12:52:04+00:00",
+                "type": "library",
+                "uid": 1434797,
+                "version": "v1.1.0",
+                "version_normalized": "1.1.0.0"
+            },
+            "v2.0.0": {
+                "authors": [],
+                "description": "A dummy package for testing Dependabot",
+                "dist": {
+                    "reference": "183c190aa576256c768a04ff2163c208e0dd81d1",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/dependabot/php-dummy-pkg-a/zipball/183c190aa576256c768a04ff2163c208e0dd81d1"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "dependabot/dummy-pkg-a",
+                "source": {
+                    "reference": "183c190aa576256c768a04ff2163c208e0dd81d1",
+                    "type": "git",
+                    "url": "https://github.com/dependabot/php-dummy-pkg-a.git"
+                },
+                "time": "2017-06-08T12:52:19+00:00",
+                "type": "library",
+                "uid": 1434798,
+                "version": "v2.0.0",
+                "version_normalized": "2.0.0.0"
+            },
+            "v2.1.0-RC1": {
+                "authors": [],
+                "description": "A dummy package for testing Dependabot",
+                "dist": {
+                    "reference": "9c25d3578b388e6fed14f38bf0e24fe107f9e486",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/dependabot/php-dummy-pkg-a/zipball/9c25d3578b388e6fed14f38bf0e24fe107f9e486"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "dependabot/dummy-pkg-a",
+                "source": {
+                    "reference": "9c25d3578b388e6fed14f38bf0e24fe107f9e486",
+                    "type": "git",
+                    "url": "https://github.com/dependabot/php-dummy-pkg-a.git"
+                },
+                "time": "2017-06-08T12:52:54+00:00",
+                "type": "library",
+                "uid": 1434799,
+                "version": "v2.1.0-RC1",
+                "version_normalized": "2.1.0.0-RC1"
+            }
+        }
+    }
+}

--- a/spec/fixtures/php/packagist_responses/doctrine:dbal.json
+++ b/spec/fixtures/php/packagist_responses/doctrine:dbal.json
@@ -1,0 +1,5243 @@
+{
+    "packages": {
+        "doctrine/dbal": {
+            "2.0.x-dev": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "c1e4ec6670c95d5af72cd884fb71f8c711bee9c9",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/c1e4ec6670c95d5af72cd884fb71f8c711bee9c9"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "c1e4ec6670c95d5af72cd884fb71f8c711bee9c9",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2011-10-11T09:29:06+00:00",
+                "type": "library",
+                "uid": 5239,
+                "version": "2.0.x-dev",
+                "version_normalized": "2.0.9999999.9999999-dev"
+            },
+            "2.1.5": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "ae358bd94ec09d7d3ad92ca7820e67825ad9e5f4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/ae358bd94ec09d7d3ad92ca7820e67825ad9e5f4"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "ae358bd94ec09d7d3ad92ca7820e67825ad9e5f4",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2011-11-21T14:56:03+00:00",
+                "type": "library",
+                "uid": 5240,
+                "version": "2.1.5",
+                "version_normalized": "2.1.5.0"
+            },
+            "2.1.6": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "148a049df448af9772259e69a034e51c0c080805",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/148a049df448af9772259e69a034e51c0c080805"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "148a049df448af9772259e69a034e51c0c080805",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-01-29T16:45:37+00:00",
+                "type": "library",
+                "uid": 5241,
+                "version": "2.1.6",
+                "version_normalized": "2.1.6.0"
+            },
+            "2.1.7": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "64650385987dee6be046b8fa2485ff4d7663f814",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/64650385987dee6be046b8fa2485ff4d7663f814"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "64650385987dee6be046b8fa2485ff4d7663f814",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-05-27T19:17:18+00:00",
+                "type": "library",
+                "uid": 12916,
+                "version": "2.1.7",
+                "version_normalized": "2.1.7.0"
+            },
+            "2.1.x-dev": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "76799960a54af583e82bedcf246e8c9c18006e94",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/76799960a54af583e82bedcf246e8c9c18006e94"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "76799960a54af583e82bedcf246e8c9c18006e94",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-05-27T19:17:18+00:00",
+                "type": "library",
+                "uid": 5242,
+                "version": "2.1.x-dev",
+                "version_normalized": "2.1.9999999.9999999-dev"
+            },
+            "2.2.0": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "32f5d4e1bbea493d8c5828f9d951e25420182e16",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/32f5d4e1bbea493d8c5828f9d951e25420182e16"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.2.0,<=2.2.99",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "32f5d4e1bbea493d8c5828f9d951e25420182e16",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-01-29T11:19:23+00:00",
+                "type": "library",
+                "uid": 5248,
+                "version": "2.2.0",
+                "version_normalized": "2.2.0.0"
+            },
+            "2.2.0-BETA2": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "3dc1b22e12368bc3bd5aaa72a7d4f75f61273223",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/3dc1b22e12368bc3bd5aaa72a7d4f75f61273223"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "3dc1b22e12368bc3bd5aaa72a7d4f75f61273223",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-01-03T20:40:42+00:00",
+                "type": "library",
+                "uid": 5244,
+                "version": "2.2.0-BETA2",
+                "version_normalized": "2.2.0.0-beta2"
+            },
+            "2.2.0-RC1": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "201d7f37337b474a1c5cdfe34fd7b564dc15edab",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/201d7f37337b474a1c5cdfe34fd7b564dc15edab"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "201d7f37337b474a1c5cdfe34fd7b564dc15edab",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-01-16T12:47:22+00:00",
+                "type": "library",
+                "uid": 5245,
+                "version": "2.2.0-RC1",
+                "version_normalized": "2.2.0.0-RC1"
+            },
+            "2.2.0-RC2": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "62f87f681802651d7b374e609a8f0169cbcbe46d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/62f87f681802651d7b374e609a8f0169cbcbe46d"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "62f87f681802651d7b374e609a8f0169cbcbe46d",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-01-22T12:47:15+00:00",
+                "type": "library",
+                "uid": 5246,
+                "version": "2.2.0-RC2",
+                "version_normalized": "2.2.0.0-RC2"
+            },
+            "2.2.0-RC3": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "485ed6556520443b6ab024284e6992a84e64a40c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/485ed6556520443b6ab024284e6992a84e64a40c"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "485ed6556520443b6ab024284e6992a84e64a40c",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-01-22T16:53:18+00:00",
+                "type": "library",
+                "uid": 5247,
+                "version": "2.2.0-RC3",
+                "version_normalized": "2.2.0.0-RC3"
+            },
+            "2.2.0-beta1": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "29b714b7fe72641d749ae90324a5759853fe09b0",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/29b714b7fe72641d749ae90324a5759853fe09b0"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "29b714b7fe72641d749ae90324a5759853fe09b0",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2011-12-19T19:02:52+00:00",
+                "type": "library",
+                "uid": 5243,
+                "version": "2.2.0-beta1",
+                "version_normalized": "2.2.0.0-beta1"
+            },
+            "2.2.1": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "e01f7468d85167120afc8210b23123a2788fd3c3",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/e01f7468d85167120afc8210b23123a2788fd3c3"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.2.0,<=2.2.99",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "e01f7468d85167120afc8210b23123a2788fd3c3",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-01-29T14:19:29+00:00",
+                "type": "library",
+                "uid": 5249,
+                "version": "2.2.1",
+                "version_normalized": "2.2.1.0"
+            },
+            "2.2.2": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "ee8f64111d03df2dbf3c106214514fce4a9857ab",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/ee8f64111d03df2dbf3c106214514fce4a9857ab"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.2.0,<=2.2.99",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "ee8f64111d03df2dbf3c106214514fce4a9857ab",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-04-13T07:56:12+00:00",
+                "type": "library",
+                "uid": 10719,
+                "version": "2.2.2",
+                "version_normalized": "2.2.2.0"
+            },
+            "2.2.x-dev": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "7331fdbf662a3c8f541100017e3a1db9e10507fe",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/7331fdbf662a3c8f541100017e3a1db9e10507fe"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "LGPL"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.2.0,<=2.2.99",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "7331fdbf662a3c8f541100017e3a1db9e10507fe",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-11-25T18:06:51+00:00",
+                "type": "library",
+                "uid": 5250,
+                "version": "2.2.x-dev",
+                "version_normalized": "2.2.9999999.9999999-dev"
+            },
+            "2.3.0": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "30dc433ea08f4863479700492bdb70c3b06440bd",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/30dc433ea08f4863479700492bdb70c3b06440bd"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.3.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.3.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "30dc433ea08f4863479700492bdb70c3b06440bd",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-09-20T05:56:37+00:00",
+                "type": "library",
+                "uid": 19699,
+                "version": "2.3.0",
+                "version_normalized": "2.3.0.0"
+            },
+            "2.3.0-BETA1": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "5a2c14c8e5f2a240d35171819e88bb04ce11fd1e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/5a2c14c8e5f2a240d35171819e88bb04ce11fd1e"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.3.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.3.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "5a2c14c8e5f2a240d35171819e88bb04ce11fd1e",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-07-16T13:14:05+00:00",
+                "type": "library",
+                "uid": 15278,
+                "version": "2.3.0-BETA1",
+                "version_normalized": "2.3.0.0-beta1"
+            },
+            "2.3.0-RC1": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "a2da6c6f8a10f352976ff38a9643e538126b6f33",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/a2da6c6f8a10f352976ff38a9643e538126b6f33"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.3.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.3.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "a2da6c6f8a10f352976ff38a9643e538126b6f33",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-07-29T10:50:46+00:00",
+                "type": "library",
+                "uid": 15935,
+                "version": "2.3.0-RC1",
+                "version_normalized": "2.3.0.0-RC1"
+            },
+            "2.3.0-RC2": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "375506dfa70f82a32cefa293145ffdc652d79a45",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/375506dfa70f82a32cefa293145ffdc652d79a45"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.3.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.3.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "375506dfa70f82a32cefa293145ffdc652d79a45",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-08-29T14:08:48+00:00",
+                "type": "library",
+                "uid": 17912,
+                "version": "2.3.0-RC2",
+                "version_normalized": "2.3.0.0-RC2"
+            },
+            "2.3.0-RC3": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "52675ebf7e8afe01af656cfbfe6bb1d7c40514a2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/52675ebf7e8afe01af656cfbfe6bb1d7c40514a2"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.3.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.3.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "52675ebf7e8afe01af656cfbfe6bb1d7c40514a2",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-09-05T17:36:29+00:00",
+                "type": "library",
+                "uid": 18343,
+                "version": "2.3.0-RC3",
+                "version_normalized": "2.3.0.0-RC3"
+            },
+            "2.3.0-RC4": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "f760aa4f4dcbccacefc7e5cdc93f28b61581aaed",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/f760aa4f4dcbccacefc7e5cdc93f28b61581aaed"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.3.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.3.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "f760aa4f4dcbccacefc7e5cdc93f28b61581aaed",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-09-17T11:50:07+00:00",
+                "type": "library",
+                "uid": 19411,
+                "version": "2.3.0-RC4",
+                "version_normalized": "2.3.0.0-RC4"
+            },
+            "2.3.1": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "256a61096174eac3c3f5c5e1c219ff811b5bf8e6",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/256a61096174eac3c3f5c5e1c219ff811b5bf8e6"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.3.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.3.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "256a61096174eac3c3f5c5e1c219ff811b5bf8e6",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2012-12-04T21:06:56+00:00",
+                "type": "library",
+                "uid": 27314,
+                "version": "2.3.1",
+                "version_normalized": "2.3.1.0"
+            },
+            "2.3.2": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "e59abccfe82c7c36b6a6ca2b3e5e34ac70dee370",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/e59abccfe82c7c36b6a6ca2b3e5e34ac70dee370"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.3.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.3.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "e59abccfe82c7c36b6a6ca2b3e5e34ac70dee370",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2013-01-07T20:03:43+00:00",
+                "type": "library",
+                "uid": 30998,
+                "version": "2.3.2",
+                "version_normalized": "2.3.2.0"
+            },
+            "2.3.3": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "85e52224cb8489ba5f1f13e4b42e77980628fc43",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/85e52224cb8489ba5f1f13e4b42e77980628fc43"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.3.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.3.0,<2.5-dev",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "85e52224cb8489ba5f1f13e4b42e77980628fc43",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2013-03-24T19:16:29+00:00",
+                "type": "library",
+                "uid": 44728,
+                "version": "2.3.3",
+                "version_normalized": "2.3.3.0"
+            },
+            "2.3.4": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "2a37b007dda8e21bdbb8fa445be8fa0064199e13",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/2a37b007dda8e21bdbb8fa445be8fa0064199e13"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.3.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.3.0,<2.5-dev",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "2a37b007dda8e21bdbb8fa445be8fa0064199e13",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2013-05-11T07:45:37+00:00",
+                "type": "library",
+                "uid": 54537,
+                "version": "2.3.4",
+                "version_normalized": "2.3.4.0"
+            },
+            "2.3.5": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "d5067b0b7e5ef59ba165dcc116c539400bf957ff",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/d5067b0b7e5ef59ba165dcc116c539400bf957ff"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.3.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.3.0,<2.5-dev",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "d5067b0b7e5ef59ba165dcc116c539400bf957ff",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2014-09-15T11:44:29+00:00",
+                "type": "library",
+                "uid": 235253,
+                "version": "2.3.5",
+                "version_normalized": "2.3.5.0"
+            },
+            "2.3.x-dev": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "6b0002cd1349904c5b089ae059e26a2406d1309e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/6b0002cd1349904c5b089ae059e26a2406d1309e"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.3.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.3.0,<2.5-dev",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "6b0002cd1349904c5b089ae059e26a2406d1309e",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "time": "2014-09-15T11:48:05+00:00",
+                "type": "library",
+                "uid": 15279,
+                "version": "2.3.x-dev",
+                "version_normalized": "2.3.9999999.9999999-dev"
+            },
+            "2.4.0-BETA1": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "38b1a340c5ec7c58be1883696c1f956bed5b7f0c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/38b1a340c5ec7c58be1883696c1f956bed5b7f0c"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.4.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.4.x-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "38b1a340c5ec7c58be1883696c1f956bed5b7f0c",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2013-03-24T18:47:03+00:00",
+                "type": "library",
+                "uid": 44723,
+                "version": "2.4.0-BETA1",
+                "version_normalized": "2.4.0.0-beta1"
+            },
+            "2.4.0-BETA2": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "cb20a39058179b2ab054602dcef84ae67a9fb7f8",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/cb20a39058179b2ab054602dcef84ae67a9fb7f8"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.4.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.4.*@beta",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "cb20a39058179b2ab054602dcef84ae67a9fb7f8",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "Allows use of the command line interface"
+                },
+                "time": "2013-05-11T08:21:40+00:00",
+                "type": "library",
+                "uid": 54542,
+                "version": "2.4.0-BETA2",
+                "version_normalized": "2.4.0.0-beta2"
+            },
+            "2.4.0-RC1": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "c9615c43d81c69cc1f366ab9184305642a047685",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/c9615c43d81c69cc1f366ab9184305642a047685"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.4.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.4.*@beta",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "c9615c43d81c69cc1f366ab9184305642a047685",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "Allows use of the command line interface"
+                },
+                "time": "2013-05-27T19:17:11+00:00",
+                "type": "library",
+                "uid": 57731,
+                "version": "2.4.0-RC1",
+                "version_normalized": "2.4.0.0-RC1"
+            },
+            "2.4.0-RC2": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "3253f7a1c13a2177d925bd0f6ee8387c5dd9c57a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/3253f7a1c13a2177d925bd0f6ee8387c5dd9c57a"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.4.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.4.*@beta",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "3253f7a1c13a2177d925bd0f6ee8387c5dd9c57a",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "Allows use of the command line interface"
+                },
+                "time": "2013-06-25T17:49:29+00:00",
+                "type": "library",
+                "uid": 65871,
+                "version": "2.4.0-RC2",
+                "version_normalized": "2.4.0.0-RC2"
+            },
+            "2.4.x-dev": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "f5b85d182799c539d1a56aa145977aa2c43dfe1a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/f5b85d182799c539d1a56aa145977aa2c43dfe1a"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "~2.4",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*",
+                    "symfony/console": "~2.0"
+                },
+                "source": {
+                    "reference": "f5b85d182799c539d1a56aa145977aa2c43dfe1a",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2016-01-05T22:19:09+00:00",
+                "type": "library",
+                "uid": 65874,
+                "version": "2.4.x-dev",
+                "version_normalized": "2.4.9999999.9999999-dev"
+            },
+            "2.5.x-dev": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "de23082f09b907ecc1593dd35fbdc49a392c50eb",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/de23082f09b907ecc1593dd35fbdc49a392c50eb"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "de23082f09b907ecc1593dd35fbdc49a392c50eb",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2018-04-02T10:40:57+00:00",
+                "type": "library",
+                "uid": 227229,
+                "version": "2.5.x-dev",
+                "version_normalized": "2.5.9999999.9999999-dev"
+            },
+            "2.6.x-dev": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "3591db5a402bbcf255e35441d0f150fde44c64ba",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/3591db5a402bbcf255e35441d0f150fde44c64ba"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.6.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ext-pdo": "*",
+                    "php": "^7.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^5.4.6",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "3591db5a402bbcf255e35441d0f150fde44c64ba",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2018-03-29T19:35:01+00:00",
+                "type": "library",
+                "uid": 1513839,
+                "version": "2.6.x-dev",
+                "version_normalized": "2.6.9999999.9999999-dev"
+            },
+            "2.7.x-dev": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "bd5e190a8281c59a539bd1f7a394fda541df16cd",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/bd5e190a8281c59a539bd1f7a394fda541df16cd"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.7.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ext-pdo": "*",
+                    "php": "^7.1"
+                },
+                "require-dev": {
+                    "doctrine/coding-standard": "^4.0",
+                    "phpunit/phpunit": "^7.0",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "^2.0.5||^3.0",
+                    "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+                },
+                "source": {
+                    "reference": "bd5e190a8281c59a539bd1f7a394fda541df16cd",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2018-05-02T03:12:03+00:00",
+                "type": "library",
+                "uid": 2063912,
+                "version": "2.7.x-dev",
+                "version_normalized": "2.7.9999999.9999999-dev"
+            },
+            "dev-develop": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "fe64a72f816bc1bbf2c09921fd2184e476704505",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/fe64a72f816bc1bbf2c09921fd2184e476704505"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "3.0.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ocramius/package-versions": "^1.2",
+                    "php": "^7.2"
+                },
+                "require-dev": {
+                    "doctrine/coding-standard": "^4.0",
+                    "phpunit/phpunit": "^7.1.2",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "^2.0.5||^3.0",
+                    "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+                },
+                "source": {
+                    "reference": "fe64a72f816bc1bbf2c09921fd2184e476704505",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2018-05-13T19:22:53+00:00",
+                "type": "library",
+                "uid": 1006110,
+                "version": "dev-develop",
+                "version_normalized": "dev-develop"
+            },
+            "dev-develop-pre-2018-01-02": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "7a712e9cf588f5e171deddd00de82583721cb867",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/7a712e9cf588f5e171deddd00de82583721cb867"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.6.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ext-pdo": "*",
+                    "php": "^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^5.4.6",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "7a712e9cf588f5e171deddd00de82583721cb867",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2017-09-11T05:49:10+00:00",
+                "type": "library",
+                "uid": 1821532,
+                "version": "dev-develop-pre-2018-01-02",
+                "version_normalized": "dev-develop-pre-2018-01-02"
+            },
+            "dev-develop-pre-2018-01-25": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "7fb41ab205dd00af79bf8f5351a125fa479097e3",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/7fb41ab205dd00af79bf8f5351a125fa479097e3"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "3.0.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "php": "^7.2"
+                },
+                "require-dev": {
+                    "doctrine/coding-standard": "^1.0",
+                    "phpunit/phpunit": "^6.3",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "squizlabs/php_codesniffer": "^3.0",
+                    "symfony/console": "^2.0.5||^3.0",
+                    "symfony/phpunit-bridge": "^3.3"
+                },
+                "source": {
+                    "reference": "7fb41ab205dd00af79bf8f5351a125fa479097e3",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2018-01-25T06:39:16+00:00",
+                "type": "library",
+                "uid": 1911853,
+                "version": "dev-develop-pre-2018-01-25",
+                "version_normalized": "dev-develop-pre-2018-01-25"
+            },
+            "dev-develop-pre-2018-02-01": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "2f085fc00d1a70e2e8fb7298c496bc9a58c68f79",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/2f085fc00d1a70e2e8fb7298c496bc9a58c68f79"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "3.0.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ocramius/package-versions": "^1.2",
+                    "php": "^7.2"
+                },
+                "require-dev": {
+                    "doctrine/coding-standard": "~2.0.0",
+                    "phpunit/phpunit": "^6.3",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "^2.0.5||^3.0",
+                    "symfony/phpunit-bridge": "^3.3"
+                },
+                "source": {
+                    "reference": "2f085fc00d1a70e2e8fb7298c496bc9a58c68f79",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2018-01-29T07:30:12+00:00",
+                "type": "library",
+                "uid": 1911854,
+                "version": "dev-develop-pre-2018-02-01",
+                "version_normalized": "dev-develop-pre-2018-02-01"
+            },
+            "dev-develop-pre-2018-04-27": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "1c916864bea54af08c6353e8942d27f6e8053363",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/1c916864bea54af08c6353e8942d27f6e8053363"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "3.0.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ocramius/package-versions": "^1.2",
+                    "php": "^7.2"
+                },
+                "require-dev": {
+                    "doctrine/coding-standard": "^4.0",
+                    "phpunit/phpunit": "^7.1.2",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "^2.0.5||^3.0",
+                    "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+                },
+                "source": {
+                    "reference": "1c916864bea54af08c6353e8942d27f6e8053363",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2018-04-21T03:58:47+00:00",
+                "type": "library",
+                "uid": 2142674,
+                "version": "dev-develop-pre-2018-04-27",
+                "version_normalized": "dev-develop-pre-2018-04-27"
+            },
+            "dev-feature/docs-cleanup": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "589b47d2d93ebe15ba4e2f8814f2b2af309be81c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/589b47d2d93ebe15ba4e2f8814f2b2af309be81c"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.8.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ext-pdo": "*",
+                    "php": "^7.1"
+                },
+                "require-dev": {
+                    "doctrine/coding-standard": "^4.0",
+                    "phpunit/phpunit": "^7.1.2",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "^2.0.5||^3.0",
+                    "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+                },
+                "source": {
+                    "reference": "589b47d2d93ebe15ba4e2f8814f2b2af309be81c",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2018-04-11T04:00:58+00:00",
+                "type": "library",
+                "uid": 2074132,
+                "version": "dev-feature/docs-cleanup",
+                "version_normalized": "dev-feature/docs-cleanup"
+            },
+            "dev-hotfix/#714-disable-prepares-on-pgsql-for-php-5.6": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "cbf95ea095f093d179b3807a4a3e022a06a3f422",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/cbf95ea095f093d179b3807a4a3e022a06a3f422"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.6-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "cbf95ea095f093d179b3807a4a3e022a06a3f422",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2014-11-07T09:19:03+00:00",
+                "type": "library",
+                "uid": 265166,
+                "version": "dev-hotfix/#714-disable-prepares-on-pgsql-for-php-5.6",
+                "version_normalized": "dev-hotfix/#714-disable-prepares-on-pgsql-for-php-5.6"
+            },
+            "dev-master": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "f4f987d72549dfa43bd2d129a2e274d8e4196686",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/f4f987d72549dfa43bd2d129a2e274d8e4196686"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.8.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ext-pdo": "*",
+                    "php": "^7.1"
+                },
+                "require-dev": {
+                    "doctrine/coding-standard": "^4.0",
+                    "phpunit/phpunit": "^7.1.2",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "^2.0.5||^3.0",
+                    "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+                },
+                "source": {
+                    "reference": "f4f987d72549dfa43bd2d129a2e274d8e4196686",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2018-05-24T17:04:01+00:00",
+                "type": "library",
+                "uid": 5251,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            },
+            "dev-snapshot/develop/2018-04-17": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "fe6bd764d80b85c86f2995a259bc35dc53fb557c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/fe6bd764d80b85c86f2995a259bc35dc53fb557c"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "3.0.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ocramius/package-versions": "^1.2",
+                    "php": "^7.2"
+                },
+                "require-dev": {
+                    "doctrine/coding-standard": "^4.0",
+                    "phpunit/phpunit": "^7.0",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "^2.0.5||^3.0",
+                    "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+                },
+                "source": {
+                    "reference": "fe6bd764d80b85c86f2995a259bc35dc53fb557c",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2018-04-13T22:50:06+00:00",
+                "type": "library",
+                "uid": 2106568,
+                "version": "dev-snapshot/develop/2018-04-17",
+                "version_normalized": "dev-snapshot/develop/2018-04-17"
+            },
+            "dev-snapshot/develop/2018-05-13": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "85bb696b26e633372555cbab2e5780ffcc6dd1ea",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/85bb696b26e633372555cbab2e5780ffcc6dd1ea"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "3.0.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ocramius/package-versions": "^1.2",
+                    "php": "^7.2"
+                },
+                "require-dev": {
+                    "doctrine/coding-standard": "^4.0",
+                    "phpunit/phpunit": "^7.1.2",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "^2.0.5||^3.0",
+                    "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+                },
+                "source": {
+                    "reference": "85bb696b26e633372555cbab2e5780ffcc6dd1ea",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2018-05-02T03:14:22+00:00",
+                "type": "library",
+                "uid": 2196786,
+                "version": "dev-snapshot/develop/2018-05-13",
+                "version_normalized": "dev-snapshot/develop/2018-05-13"
+            },
+            "dev-sql-92-standard-unique-constraint": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "216921cef95ff7a1460307f86127c537adb08948",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/216921cef95ff7a1460307f86127c537adb08948"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.6.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "~2.4",
+                    "php": "^5.6 || ^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^5.4.6",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "216921cef95ff7a1460307f86127c537adb08948",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2016-09-08T00:59:44+00:00",
+                "type": "library",
+                "uid": 985149,
+                "version": "dev-sql-92-standard-unique-constraint",
+                "version_normalized": "dev-sql-92-standard-unique-constraint"
+            },
+            "v2.4.0": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "3eb557f144ec41e6e84997e43acb1946c92fbc88",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/3eb557f144ec41e6e84997e43acb1946c92fbc88"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "~2.4",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*",
+                    "symfony/console": "~2.0"
+                },
+                "source": {
+                    "reference": "3eb557f144ec41e6e84997e43acb1946c92fbc88",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "Allows use of the command line interface"
+                },
+                "time": "2013-09-07T10:49:18+00:00",
+                "type": "library",
+                "uid": 82652,
+                "version": "v2.4.0",
+                "version_normalized": "2.4.0.0"
+            },
+            "v2.4.1": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "328357bd9eea9d671fe5fff0737f01953bfe66a0",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/328357bd9eea9d671fe5fff0737f01953bfe66a0"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "~2.4",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*",
+                    "symfony/console": "~2.0"
+                },
+                "source": {
+                    "reference": "328357bd9eea9d671fe5fff0737f01953bfe66a0",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "Allows use of the command line interface"
+                },
+                "time": "2013-11-12T12:38:28+00:00",
+                "type": "library",
+                "uid": 100210,
+                "version": "v2.4.1",
+                "version_normalized": "2.4.1.0"
+            },
+            "v2.4.2": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "fec965d330c958e175c39e61c3f6751955af32d0",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/fec965d330c958e175c39e61c3f6751955af32d0"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "~2.4",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*",
+                    "symfony/console": "~2.0"
+                },
+                "source": {
+                    "reference": "fec965d330c958e175c39e61c3f6751955af32d0",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "Allows use of the command line interface"
+                },
+                "time": "2014-01-01T16:43:57+00:00",
+                "type": "library",
+                "uid": 115574,
+                "version": "v2.4.2",
+                "version_normalized": "2.4.2.0"
+            },
+            "v2.4.3": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "0368bc031976126e5d36d37d2c56155092b6575b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/0368bc031976126e5d36d37d2c56155092b6575b"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "~2.4",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*",
+                    "symfony/console": "~2.0"
+                },
+                "source": {
+                    "reference": "0368bc031976126e5d36d37d2c56155092b6575b",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2014-10-16T11:56:49+00:00",
+                "type": "library",
+                "uid": 251792,
+                "version": "v2.4.3",
+                "version_normalized": "2.4.3.0"
+            },
+            "v2.4.4": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "a370e5b95e509a7809d11f3d280acfc9310d464b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/a370e5b95e509a7809d11f3d280acfc9310d464b"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "~2.4",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*",
+                    "symfony/console": "~2.0"
+                },
+                "source": {
+                    "reference": "a370e5b95e509a7809d11f3d280acfc9310d464b",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2015-01-12T21:57:01+00:00",
+                "type": "library",
+                "uid": 304643,
+                "version": "v2.4.4",
+                "version_normalized": "2.4.4.0"
+            },
+            "v2.4.5": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "5a1f4bf34d61d997ccd9f0539fbc14c7a772aa16",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/5a1f4bf34d61d997ccd9f0539fbc14c7a772aa16"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "~2.4",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*",
+                    "symfony/console": "~2.0"
+                },
+                "source": {
+                    "reference": "5a1f4bf34d61d997ccd9f0539fbc14c7a772aa16",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2016-01-05T22:18:20+00:00",
+                "type": "library",
+                "uid": 645920,
+                "version": "v2.4.5",
+                "version_normalized": "2.4.5.0"
+            },
+            "v2.5.0": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "71140662c0a954602e81271667b6e03d9f53ea34",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/71140662c0a954602e81271667b6e03d9f53ea34"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.6-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "71140662c0a954602e81271667b6e03d9f53ea34",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2014-12-04T21:57:15+00:00",
+                "type": "library",
+                "uid": 282789,
+                "version": "v2.5.0",
+                "version_normalized": "2.5.0.0"
+            },
+            "v2.5.0-BETA2": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "ba9aa63e3bf8be398d02db34394b3db8302ae124",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/ba9aa63e3bf8be398d02db34394b3db8302ae124"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.4.*",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "ba9aa63e3bf8be398d02db34394b3db8302ae124",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "Allows use of the command line interface"
+                },
+                "time": "2014-01-01T16:39:15+00:00",
+                "type": "library",
+                "uid": 115572,
+                "version": "v2.5.0-BETA2",
+                "version_normalized": "2.5.0.0-beta2"
+            },
+            "v2.5.0-BETA3": {
+                "authors": [
+                    {
+                        "email": "jonwage@gmail.com",
+                        "homepage": "http://www.jwage.com/",
+                        "name": "Jonathan Wage",
+                        "role": "Creator"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "homepage": "http://www.instaclick.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "812dd9dab5412f63d28da8b24868059f6dc45b56",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/812dd9dab5412f63d28da8b24868059f6dc45b56"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.4.*",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "812dd9dab5412f63d28da8b24868059f6dc45b56",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "Allows use of the command line interface"
+                },
+                "time": "2014-02-16T21:34:25+00:00",
+                "type": "library",
+                "uid": 134467,
+                "version": "v2.5.0-BETA3",
+                "version_normalized": "2.5.0.0-beta3"
+            },
+            "v2.5.0-RC1": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "22069a07a4127360ef3205eeafb51e366864489d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/22069a07a4127360ef3205eeafb51e366864489d"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.4.*",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.0.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "22069a07a4127360ef3205eeafb51e366864489d",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2014-09-01T10:28:36+00:00",
+                "type": "library",
+                "uid": 227230,
+                "version": "v2.5.0-RC1",
+                "version_normalized": "2.5.0.0-RC1"
+            },
+            "v2.5.0-RC2": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "f7dbc5dfdefa1a2b536ee4c0bc3e98dab37e8b53",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/f7dbc5dfdefa1a2b536ee4c0bc3e98dab37e8b53"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "2.4.*",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.0.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "f7dbc5dfdefa1a2b536ee4c0bc3e98dab37e8b53",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2014-09-11T21:07:20+00:00",
+                "type": "library",
+                "uid": 233500,
+                "version": "v2.5.0-RC2",
+                "version_normalized": "2.5.0.0-RC2"
+            },
+            "v2.5.1": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "628c2256b646ae2417d44e063bce8aec5199d48d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/628c2256b646ae2417d44e063bce8aec5199d48d"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.6-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "628c2256b646ae2417d44e063bce8aec5199d48d",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2015-01-12T21:52:47+00:00",
+                "type": "library",
+                "uid": 304641,
+                "version": "v2.5.1",
+                "version_normalized": "2.5.1.0"
+            },
+            "v2.5.10": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "fc376f7a61498e18520cd6fa083752a4ca08072b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/fc376f7a61498e18520cd6fa083752a4ca08072b"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "fc376f7a61498e18520cd6fa083752a4ca08072b",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2017-01-23T23:17:10+00:00",
+                "type": "library",
+                "uid": 1189760,
+                "version": "v2.5.10",
+                "version_normalized": "2.5.10.0"
+            },
+            "v2.5.11": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "1b1effbddbdc0f40d1c8f849f44bcddac4f52a48",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/1b1effbddbdc0f40d1c8f849f44bcddac4f52a48"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "1b1effbddbdc0f40d1c8f849f44bcddac4f52a48",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2017-02-04T21:20:13+00:00",
+                "type": "library",
+                "uid": 1213668,
+                "version": "v2.5.11",
+                "version_normalized": "2.5.11.0"
+            },
+            "v2.5.12": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "7b9e911f9d8b30d43b96853dab26898c710d8f44",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/7b9e911f9d8b30d43b96853dab26898c710d8f44"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "7b9e911f9d8b30d43b96853dab26898c710d8f44",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2017-02-08T12:53:47+00:00",
+                "type": "library",
+                "uid": 1220622,
+                "version": "v2.5.12",
+                "version_normalized": "2.5.12.0"
+            },
+            "v2.5.13": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "729340d8d1eec8f01bff708e12e449a3415af873",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/729340d8d1eec8f01bff708e12e449a3415af873"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "729340d8d1eec8f01bff708e12e449a3415af873",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2017-07-22T20:44:48+00:00",
+                "type": "library",
+                "uid": 1513731,
+                "version": "v2.5.13",
+                "version_normalized": "2.5.13.0"
+            },
+            "v2.5.2": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "01dbcbc5cd0a913d751418e635434a18a2f2a75c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/01dbcbc5cd0a913d751418e635434a18a2f2a75c"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.6-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "01dbcbc5cd0a913d751418e635434a18a2f2a75c",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2015-09-16T16:29:33+00:00",
+                "type": "library",
+                "uid": 523531,
+                "version": "v2.5.2",
+                "version_normalized": "2.5.2.0"
+            },
+            "v2.5.3": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "2fbcea96eae34a53183377cdbb0b9bec33974648",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/2fbcea96eae34a53183377cdbb0b9bec33974648"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.7-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "2fbcea96eae34a53183377cdbb0b9bec33974648",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2015-12-25T16:28:24+00:00",
+                "type": "library",
+                "uid": 634662,
+                "version": "v2.5.3",
+                "version_normalized": "2.5.3.0"
+            },
+            "v2.5.4": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/abbdfd1cff43a7b99d027af3be709bc8fc7d4769"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.7-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*"
+                },
+                "source": {
+                    "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2016-01-05T22:11:12+00:00",
+                "type": "library",
+                "uid": 645912,
+                "version": "v2.5.4",
+                "version_normalized": "2.5.4.0"
+            },
+            "v2.5.5": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "9f8c05cd5225a320d56d4bfdb4772f10d045a0c9",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/9f8c05cd5225a320d56d4bfdb4772f10d045a0c9"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.7-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "9f8c05cd5225a320d56d4bfdb4772f10d045a0c9",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2016-09-09T19:13:33+00:00",
+                "type": "library",
+                "uid": 986923,
+                "version": "v2.5.5",
+                "version_normalized": "2.5.5.0"
+            },
+            "v2.5.6": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "a526d0df58daa8ab6802244bf3227f532e0deb45",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/a526d0df58daa8ab6802244bf3227f532e0deb45"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "a526d0df58daa8ab6802244bf3227f532e0deb45",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2016-12-04T05:53:43+00:00",
+                "type": "library",
+                "uid": 1169889,
+                "version": "v2.5.6",
+                "version_normalized": "2.5.6.0"
+            },
+            "v2.5.7": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "3a351369582dade60c750e2cef540eb7b568e6b3",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/3a351369582dade60c750e2cef540eb7b568e6b3"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "3a351369582dade60c750e2cef540eb7b568e6b3",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2017-01-14T21:05:28+00:00",
+                "type": "library",
+                "uid": 1173574,
+                "version": "v2.5.7",
+                "version_normalized": "2.5.7.0"
+            },
+            "v2.5.8": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "6314d55f60f85f0295c90688397b75c13faf9f0e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/6314d55f60f85f0295c90688397b75c13faf9f0e"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "6314d55f60f85f0295c90688397b75c13faf9f0e",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2017-01-17T17:48:38+00:00",
+                "type": "library",
+                "uid": 1178552,
+                "version": "v2.5.8",
+                "version_normalized": "2.5.8.0"
+            },
+            "v2.5.9": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "0d2f8187d4b4c7b72d8e2acba359e25c36feaf5e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/0d2f8187d4b4c7b72d8e2acba359e25c36feaf5e"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.5.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "4.*",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "0d2f8187d4b4c7b72d8e2acba359e25c36feaf5e",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2017-01-19T13:27:33+00:00",
+                "type": "library",
+                "uid": 1182793,
+                "version": "v2.5.9",
+                "version_normalized": "2.5.9.0"
+            },
+            "v2.6.0": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "498760e55195ccaf08076cb9100a2972ba74c001",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/498760e55195ccaf08076cb9100a2972ba74c001"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.6.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ext-pdo": "*",
+                    "php": "^7.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^5.4.6",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "498760e55195ccaf08076cb9100a2972ba74c001",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2017-07-23T01:02:22+00:00",
+                "type": "library",
+                "uid": 1513837,
+                "version": "v2.6.0",
+                "version_normalized": "2.6.0.0"
+            },
+            "v2.6.1": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "1a086f853425b1f5349775ce57e45a772d2d2ba5",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/1a086f853425b1f5349775ce57e45a772d2d2ba5"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.6.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ext-pdo": "*",
+                    "php": "^7.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^5.4.6",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "1a086f853425b1f5349775ce57e45a772d2d2ba5",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2017-07-28T10:40:18+00:00",
+                "type": "library",
+                "uid": 1524060,
+                "version": "v2.6.1",
+                "version_normalized": "2.6.1.0"
+            },
+            "v2.6.2": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "1a4ee83a5a709555f2c6f9057a3aacf892451c7e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/1a4ee83a5a709555f2c6f9057a3aacf892451c7e"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.6.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ext-pdo": "*",
+                    "php": "^7.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^5.4.6",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "1a4ee83a5a709555f2c6f9057a3aacf892451c7e",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2017-08-28T11:02:56+00:00",
+                "type": "library",
+                "uid": 1578123,
+                "version": "v2.6.2",
+                "version_normalized": "2.6.2.0"
+            },
+            "v2.6.3": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "e3eed9b1facbb0ced3a0995244843a189e7d1b13",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/e3eed9b1facbb0ced3a0995244843a189e7d1b13"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.6.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ext-pdo": "*",
+                    "php": "^7.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^5.4.6",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "2.*||^3.0"
+                },
+                "source": {
+                    "reference": "e3eed9b1facbb0ced3a0995244843a189e7d1b13",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2017-11-19T13:38:54+00:00",
+                "type": "library",
+                "uid": 1736012,
+                "version": "v2.6.3",
+                "version_normalized": "2.6.3.0"
+            },
+            "v2.7.0": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "f76bf5ef631cec551a86c2291fc749534febebf1",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/f76bf5ef631cec551a86c2291fc749534febebf1"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.7.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ext-pdo": "*",
+                    "php": "^7.1"
+                },
+                "require-dev": {
+                    "doctrine/coding-standard": "^4.0",
+                    "phpunit/phpunit": "^7.0",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "^2.0.5||^3.0",
+                    "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+                },
+                "source": {
+                    "reference": "f76bf5ef631cec551a86c2291fc749534febebf1",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2018-04-01T23:33:17+00:00",
+                "type": "library",
+                "uid": 2063992,
+                "version": "v2.7.0",
+                "version_normalized": "2.7.0.0"
+            },
+            "v2.7.1": {
+                "authors": [
+                    {
+                        "email": "roman@code-factory.org",
+                        "name": "Roman Borschel"
+                    },
+                    {
+                        "email": "kontakt@beberlei.de",
+                        "name": "Benjamin Eberlei"
+                    },
+                    {
+                        "email": "guilhermeblanco@gmail.com",
+                        "name": "Guilherme Blanco"
+                    },
+                    {
+                        "email": "jonwage@gmail.com",
+                        "name": "Jonathan Wage"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "bin": [
+                    "bin/doctrine-dbal"
+                ],
+                "description": "Database Abstraction Layer",
+                "dist": {
+                    "reference": "11037b4352c008373561dc6fc836834eed80c3b5",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/doctrine/dbal/zipball/11037b4352c008373561dc6fc836834eed80c3b5"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.7.x-dev"
+                    }
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "doctrine/dbal",
+                "require": {
+                    "doctrine/common": "^2.7.1",
+                    "ext-pdo": "*",
+                    "php": "^7.1"
+                },
+                "require-dev": {
+                    "doctrine/coding-standard": "^4.0",
+                    "phpunit/phpunit": "^7.0",
+                    "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                    "symfony/console": "^2.0.5||^3.0",
+                    "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+                },
+                "source": {
+                    "reference": "11037b4352c008373561dc6fc836834eed80c3b5",
+                    "type": "git",
+                    "url": "https://github.com/doctrine/dbal.git"
+                },
+                "suggest": {
+                    "symfony/console": "For helpful console commands such as SQL execution and import of files."
+                },
+                "time": "2018-04-07T18:44:18+00:00",
+                "type": "library",
+                "uid": 2076394,
+                "version": "v2.7.1",
+                "version_normalized": "2.7.1.0"
+            }
+        },
+        "vortgo/dbal-laravel-enum": {
+            "2.5.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "DBAL package for laravel migrations. Added field type - enum",
+                "dist": {
+                    "reference": "56c0e655b85c2b2f831c0f60d284ad062d7e7467",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/vortgo/dbal/zipball/56c0e655b85c2b2f831c0f60d284ad062d7e7467"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject",
+                    "enum",
+                    "laravel"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "vortgo/dbal-laravel-enum",
+                "replace": {
+                    "doctrine/dbal": "*"
+                },
+                "require": {
+                    "php": "^5.6 || ^7.0"
+                },
+                "source": {
+                    "reference": "56c0e655b85c2b2f831c0f60d284ad062d7e7467",
+                    "type": "git",
+                    "url": "https://github.com/vortgo/dbal.git"
+                },
+                "time": "2016-10-21T10:54:33+00:00",
+                "type": "library",
+                "uid": 1046928,
+                "version": "2.5.x-dev",
+                "version_normalized": "2.5.9999999.9999999-dev"
+            },
+            "v2.5.6": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "Doctrine\\DBAL\\": "lib/"
+                    }
+                },
+                "description": "DBAL package for laravel migrations. Added field type - enum",
+                "dist": {
+                    "reference": "56c0e655b85c2b2f831c0f60d284ad062d7e7467",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/vortgo/dbal/zipball/56c0e655b85c2b2f831c0f60d284ad062d7e7467"
+                },
+                "homepage": "http://www.doctrine-project.org",
+                "keywords": [
+                    "database",
+                    "persistence",
+                    "dbal",
+                    "queryobject",
+                    "enum",
+                    "laravel"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "vortgo/dbal-laravel-enum",
+                "replace": {
+                    "doctrine/dbal": "*"
+                },
+                "require": {
+                    "php": "^5.6 || ^7.0"
+                },
+                "source": {
+                    "reference": "56c0e655b85c2b2f831c0f60d284ad062d7e7467",
+                    "type": "git",
+                    "url": "https://github.com/vortgo/dbal.git"
+                },
+                "time": "2016-10-21T10:54:33+00:00",
+                "type": "library",
+                "uid": 1047375,
+                "version": "v2.5.6",
+                "version_normalized": "2.5.6.0"
+            }
+        }
+    }
+}

--- a/spec/fixtures/php/packagist_responses/longman:telegram-bot.json
+++ b/spec/fixtures/php/packagist_responses/longman:telegram-bot.json
@@ -1,0 +1,3555 @@
+{
+    "packages": {
+        "longman/telegram-bot": {
+            "0.0.1": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramApi\\": "src/"
+                    }
+                },
+                "description": "PHP library for convert KA letters to LAT and back",
+                "dist": {
+                    "reference": "065e653962399e8f35a9cae99051a1132a833af5",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/065e653962399e8f35a9cae99051a1132a833af5"
+                },
+                "homepage": "https://github.com/akalongman/kautilities",
+                "keywords": [
+                    "translit",
+                    "converter",
+                    "string",
+                    "utilities",
+                    "ka",
+                    "georgia"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "php": ">=5.3.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "065e653962399e8f35a9cae99051a1132a833af5",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-06-26T15:26:00+00:00",
+                "type": "library",
+                "uid": 448130,
+                "version": "0.0.1",
+                "version_normalized": "0.0.1.0"
+            },
+            "0.0.10": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "9ccfccd4f68b0fc5d7d6f492e1f4d8e6acc4a495",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/9ccfccd4f68b0fc5d7d6f492e1f4d8e6acc4a495"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "hoa/math": "~0.0",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "9ccfccd4f68b0fc5d7d6f492e1f4d8e6acc4a495",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-07-30T16:03:10+00:00",
+                "type": "library",
+                "uid": 477613,
+                "version": "0.0.10",
+                "version_normalized": "0.0.10.0"
+            },
+            "0.0.11": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "f83b2b2e8be57d97df2aa9a22cc19c8382695051",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/f83b2b2e8be57d97df2aa9a22cc19c8382695051"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "hoa/math": "~0.0",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "f83b2b2e8be57d97df2aa9a22cc19c8382695051",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-07-31T09:39:09+00:00",
+                "type": "library",
+                "uid": 478074,
+                "version": "0.0.11",
+                "version_normalized": "0.0.11.0"
+            },
+            "0.0.12": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "5924a7f19c6e8aa877b57eb8a7fd7ab3225430f8",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/5924a7f19c6e8aa877b57eb8a7fd7ab3225430f8"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "hoa/math": "~0.0",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "5924a7f19c6e8aa877b57eb8a7fd7ab3225430f8",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-08-04T07:20:33+00:00",
+                "type": "library",
+                "uid": 481324,
+                "version": "0.0.12",
+                "version_normalized": "0.0.12.0"
+            },
+            "0.0.13": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "fc2a8ca61034363700c18255b066a28187041174",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/fc2a8ca61034363700c18255b066a28187041174"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "hoa/math": "~0.0",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "fc2a8ca61034363700c18255b066a28187041174",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-08-11T07:56:22+00:00",
+                "type": "library",
+                "uid": 487554,
+                "version": "0.0.13",
+                "version_normalized": "0.0.13.0"
+            },
+            "0.0.14": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "0f17dc908be96682d54d3335cbd73b42dffcb396",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/0f17dc908be96682d54d3335cbd73b42dffcb396"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "0f17dc908be96682d54d3335cbd73b42dffcb396",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-08-25T19:46:12+00:00",
+                "type": "library",
+                "uid": 501990,
+                "version": "0.0.14",
+                "version_normalized": "0.0.14.0"
+            },
+            "0.0.15": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "235fd8203e3a529ed392f96d3dcda12868de6177",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/235fd8203e3a529ed392f96d3dcda12868de6177"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "235fd8203e3a529ed392f96d3dcda12868de6177",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-08-31T20:25:36+00:00",
+                "type": "library",
+                "uid": 507628,
+                "version": "0.0.15",
+                "version_normalized": "0.0.15.0"
+            },
+            "0.0.2": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "c9efa152a2cf1f69c787d66714216a6565539022",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/c9efa152a2cf1f69c787d66714216a6565539022"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "php": ">=5.3.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "c9efa152a2cf1f69c787d66714216a6565539022",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-06-30T13:20:23+00:00",
+                "type": "library",
+                "uid": 448143,
+                "version": "0.0.2",
+                "version_normalized": "0.0.2.0"
+            },
+            "0.0.3": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "f1d366b71d61f1d3f54561bbc92ea5cdb790fd82",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/f1d366b71d61f1d3f54561bbc92ea5cdb790fd82"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-pdo": "*",
+                    "php": ">=5.3.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "f1d366b71d61f1d3f54561bbc92ea5cdb790fd82",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-07-02T23:11:04+00:00",
+                "type": "library",
+                "uid": 451174,
+                "version": "0.0.3",
+                "version_normalized": "0.0.3.0"
+            },
+            "0.0.3.1": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "4d4395768a1a30e641c44733dfe1bea4b22d2683",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/4d4395768a1a30e641c44733dfe1bea4b22d2683"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-pdo": "*",
+                    "php": ">=5.3.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "4d4395768a1a30e641c44733dfe1bea4b22d2683",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-07-04T13:57:02+00:00",
+                "type": "library",
+                "uid": 837671,
+                "version": "0.0.3.1",
+                "version_normalized": "0.0.3.1"
+            },
+            "0.0.4": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "e7c9e56f84c3ad43afc8d154ef360a177c989d88",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/e7c9e56f84c3ad43afc8d154ef360a177c989d88"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-pdo": "*",
+                    "hoa/math": "~0.0",
+                    "php": ">=5.3.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "e7c9e56f84c3ad43afc8d154ef360a177c989d88",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-07-03T13:42:59+00:00",
+                "type": "library",
+                "uid": 451718,
+                "version": "0.0.4",
+                "version_normalized": "0.0.4.0"
+            },
+            "0.0.5": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "80ce39808e9585baba9e8582db12dfac34f3d1d1",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/80ce39808e9585baba9e8582db12dfac34f3d1d1"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-pdo": "*",
+                    "hoa/math": "~0.0",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "80ce39808e9585baba9e8582db12dfac34f3d1d1",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-07-06T18:10:09+00:00",
+                "type": "library",
+                "uid": 454043,
+                "version": "0.0.5",
+                "version_normalized": "0.0.5.0"
+            },
+            "0.0.5.1": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "ac19ac11bfe29d377b6361043043e9b1adf104d0",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/ac19ac11bfe29d377b6361043043e9b1adf104d0"
+                },
+                "homepage": "https://github.com/MBoretto/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "ac19ac11bfe29d377b6361043043e9b1adf104d0",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-07-07T12:29:59+00:00",
+                "type": "library",
+                "uid": 837673,
+                "version": "0.0.5.1",
+                "version_normalized": "0.0.5.1"
+            },
+            "0.0.6": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "25c689b465774e839b84afa048636db8aed88bb9",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/25c689b465774e839b84afa048636db8aed88bb9"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "hoa/math": "~0.0",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "25c689b465774e839b84afa048636db8aed88bb9",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-07-09T07:29:05+00:00",
+                "type": "library",
+                "uid": 456604,
+                "version": "0.0.6",
+                "version_normalized": "0.0.6.0"
+            },
+            "0.0.7": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "2b2939029a16860f0428f60f6fc7c4696c283b73",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/2b2939029a16860f0428f60f6fc7c4696c283b73"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "hoa/math": "~0.0",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "2b2939029a16860f0428f60f6fc7c4696c283b73",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-07-09T07:41:56+00:00",
+                "type": "library",
+                "uid": 456617,
+                "version": "0.0.7",
+                "version_normalized": "0.0.7.0"
+            },
+            "0.0.8": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "f1f4c75ef5ec3106fc3da24392b05633b60f21ab",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/f1f4c75ef5ec3106fc3da24392b05633b60f21ab"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "hoa/math": "~0.0",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "f1f4c75ef5ec3106fc3da24392b05633b60f21ab",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-07-10T08:22:20+00:00",
+                "type": "library",
+                "uid": 457694,
+                "version": "0.0.8",
+                "version_normalized": "0.0.8.0"
+            },
+            "0.0.9": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "e5ccb10cd3b2a648fe71c38feca2ebb92f3e1ef0",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/e5ccb10cd3b2a648fe71c38feca2ebb92f3e1ef0"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "hoa/math": "~0.0",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "e5ccb10cd3b2a648fe71c38feca2ebb92f3e1ef0",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-07-20T08:36:11+00:00",
+                "type": "library",
+                "uid": 466400,
+                "version": "0.0.9",
+                "version_normalized": "0.0.9.0"
+            },
+            "0.05": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "1ea92b9176f140582d1079ee3dfbfb1042945540",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/1ea92b9176f140582d1079ee3dfbfb1042945540"
+                },
+                "homepage": "https://github.com/mboretto/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "1ea92b9176f140582d1079ee3dfbfb1042945540",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-07-07T11:50:17+00:00",
+                "type": "library",
+                "uid": 837676,
+                "version": "0.05",
+                "version_normalized": "0.05.0.0"
+            },
+            "0.16.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "85b16d60a361f97f249689ff3d1f27bb0475f6a1",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/85b16d60a361f97f249689ff3d1f27bb0475f6a1"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "85b16d60a361f97f249689ff3d1f27bb0475f6a1",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-09-03T06:16:04+00:00",
+                "type": "library",
+                "uid": 510244,
+                "version": "0.16.0",
+                "version_normalized": "0.16.0.0"
+            },
+            "0.17.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "606cf1218b06532932605843f3fb7115bd4d7c12",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/606cf1218b06532932605843f3fb7115bd4d7c12"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "606cf1218b06532932605843f3fb7115bd4d7c12",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-09-08T20:43:17+00:00",
+                "type": "library",
+                "uid": 515872,
+                "version": "0.17.0",
+                "version_normalized": "0.17.0.0"
+            },
+            "0.17.1": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "e65b0663d0c6fb8e4f6c5eb46854c8a33ba28efb",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/e65b0663d0c6fb8e4f6c5eb46854c8a33ba28efb"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "e65b0663d0c6fb8e4f6c5eb46854c8a33ba28efb",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-09-15T19:13:17+00:00",
+                "type": "library",
+                "uid": 522499,
+                "version": "0.17.1",
+                "version_normalized": "0.17.1.0"
+            },
+            "0.17.2": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "441f32de735fc9577cd75be9bfed83c98ca9ae56",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/441f32de735fc9577cd75be9bfed83c98ca9ae56"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "441f32de735fc9577cd75be9bfed83c98ca9ae56",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-09-21T21:49:58+00:00",
+                "type": "library",
+                "uid": 528516,
+                "version": "0.17.2",
+                "version_normalized": "0.17.2.0"
+            },
+            "0.18.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "2be7b3c3ea50961620d1aca46474d9f8bc4f5e15",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/2be7b3c3ea50961620d1aca46474d9f8bc4f5e15"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "2be7b3c3ea50961620d1aca46474d9f8bc4f5e15",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-10-02T22:00:38+00:00",
+                "type": "library",
+                "uid": 539692,
+                "version": "0.18.0",
+                "version_normalized": "0.18.0.0"
+            },
+            "0.20.1": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "f4b203bd31ad6735e4618ee83fa0e3b9153754b9",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/f4b203bd31ad6735e4618ee83fa0e3b9153754b9"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "f4b203bd31ad6735e4618ee83fa0e3b9153754b9",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-10-13T20:38:56+00:00",
+                "type": "library",
+                "uid": 550334,
+                "version": "0.20.1",
+                "version_normalized": "0.20.1.0"
+            },
+            "0.21.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.ge",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "89413a16f28ae9865f486722a1f514ca79fe90a0",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/89413a16f28ae9865f486722a1f514ca79fe90a0"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.4.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "4.1.*",
+                    "squizlabs/php_codesniffer": "2.3.*"
+                },
+                "source": {
+                    "reference": "89413a16f28ae9865f486722a1f514ca79fe90a0",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-10-20T22:04:04+00:00",
+                "type": "library",
+                "uid": 557738,
+                "version": "0.21.0",
+                "version_normalized": "0.21.0.0"
+            },
+            "0.22.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "5d3a1209afdfab9d59e9ac6678c4e6e037dfd1a3",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/5d3a1209afdfab9d59e9ac6678c4e6e037dfd1a3"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "~4.1",
+                    "squizlabs/php_codesniffer": "~2.3"
+                },
+                "source": {
+                    "reference": "5d3a1209afdfab9d59e9ac6678c4e6e037dfd1a3",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-11-24T20:45:46+00:00",
+                "type": "library",
+                "uid": 597230,
+                "version": "0.22.0",
+                "version_normalized": "0.22.0.0"
+            },
+            "0.23.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "f9a90f355ccea9785b94c24232c3af464f1b0678",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/f9a90f355ccea9785b94c24232c3af464f1b0678"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "~4.1",
+                    "squizlabs/php_codesniffer": "~2.3"
+                },
+                "source": {
+                    "reference": "f9a90f355ccea9785b94c24232c3af464f1b0678",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-12-09T08:18:45+00:00",
+                "type": "library",
+                "uid": 615557,
+                "version": "0.23.0",
+                "version_normalized": "0.23.0.0"
+            },
+            "0.24.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "56bf8fc8bd4172f55dbd6577e919bb57f0b8bf8d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/56bf8fc8bd4172f55dbd6577e919bb57f0b8bf8d"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "~4.1",
+                    "squizlabs/php_codesniffer": "~2.3"
+                },
+                "source": {
+                    "reference": "56bf8fc8bd4172f55dbd6577e919bb57f0b8bf8d",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2015-12-20T09:57:11+00:00",
+                "type": "library",
+                "uid": 628699,
+                "version": "0.24.0",
+                "version_normalized": "0.24.0.0"
+            },
+            "0.25.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "d203e1131c53704f10f7a73040e5bc1341f7a0d9",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/d203e1131c53704f10f7a73040e5bc1341f7a0d9"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "~4.1",
+                    "squizlabs/php_codesniffer": "~2.3"
+                },
+                "source": {
+                    "reference": "d203e1131c53704f10f7a73040e5bc1341f7a0d9",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-01-05T01:14:40+00:00",
+                "type": "library",
+                "uid": 644635,
+                "version": "0.25.0",
+                "version_normalized": "0.25.0.0"
+            },
+            "0.26.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "adcc20418100a294221c2586a6eae5232c174911",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/adcc20418100a294221c2586a6eae5232c174911"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "~4.1",
+                    "squizlabs/php_codesniffer": "~2.3"
+                },
+                "source": {
+                    "reference": "adcc20418100a294221c2586a6eae5232c174911",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-01-05T17:12:01+00:00",
+                "type": "library",
+                "uid": 645615,
+                "version": "0.26.0",
+                "version_normalized": "0.26.0.0"
+            },
+            "0.27.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "f11c153c590df266e7d528230dd82b30573c1c61",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/f11c153c590df266e7d528230dd82b30573c1c61"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "~4.1",
+                    "squizlabs/php_codesniffer": "~2.3"
+                },
+                "source": {
+                    "reference": "f11c153c590df266e7d528230dd82b30573c1c61",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-01-24T16:39:39+00:00",
+                "type": "library",
+                "uid": 670229,
+                "version": "0.27.0",
+                "version_normalized": "0.27.0.0"
+            },
+            "0.28.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "6312cc2abe6effedb6af1e12cb1b79cf1edf0728",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/6312cc2abe6effedb6af1e12cb1b79cf1edf0728"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "~4.1",
+                    "squizlabs/php_codesniffer": "~2.3"
+                },
+                "source": {
+                    "reference": "6312cc2abe6effedb6af1e12cb1b79cf1edf0728",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-02-15T10:44:45+00:00",
+                "type": "library",
+                "uid": 735364,
+                "version": "0.28.0",
+                "version_normalized": "0.28.0.0"
+            },
+            "0.29": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "999ee2e7b154be1c9fb2f6ea9cc3d1d640303a80",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/999ee2e7b154be1c9fb2f6ea9cc3d1d640303a80"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpspec/phpspec": "~2.1",
+                    "phpunit/phpunit": "~4.1",
+                    "squizlabs/php_codesniffer": "~2.3"
+                },
+                "source": {
+                    "reference": "999ee2e7b154be1c9fb2f6ea9cc3d1d640303a80",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-03-22T18:41:50+00:00",
+                "type": "library",
+                "uid": 747504,
+                "version": "0.29",
+                "version_normalized": "0.29.0.0"
+            },
+            "0.30": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "3b97af626a64d9fd0c62de171fc9264a87328348",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/3b97af626a64d9fd0c62de171fc9264a87328348"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "3b97af626a64d9fd0c62de171fc9264a87328348",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-04-12T05:16:55+00:00",
+                "type": "library",
+                "uid": 774287,
+                "version": "0.30",
+                "version_normalized": "0.30.0.0"
+            },
+            "0.31": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "a29336e726d610a6507e678fffa3e330b74a83f4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/a29336e726d610a6507e678fffa3e330b74a83f4"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "a29336e726d610a6507e678fffa3e330b74a83f4",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-04-19T22:38:14+00:00",
+                "type": "library",
+                "uid": 785523,
+                "version": "0.31",
+                "version_normalized": "0.31.0.0"
+            },
+            "0.32": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "e5b6d415f94afd664dae1239062f1145467e44d7",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/e5b6d415f94afd664dae1239062f1145467e44d7"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "e5b6d415f94afd664dae1239062f1145467e44d7",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-05-13T17:59:55+00:00",
+                "type": "library",
+                "uid": 820130,
+                "version": "0.32",
+                "version_normalized": "0.32.0.0"
+            },
+            "0.33": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "0ebd95c40797ffff2faefd58e3734ca905f1606b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/0ebd95c40797ffff2faefd58e3734ca905f1606b"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "0ebd95c40797ffff2faefd58e3734ca905f1606b",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-05-29T14:42:56+00:00",
+                "type": "library",
+                "uid": 841133,
+                "version": "0.33",
+                "version_normalized": "0.33.0.0"
+            },
+            "0.34": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "e8400d6646fe14f0974237da5dc1377af0404bea",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/e8400d6646fe14f0974237da5dc1377af0404bea"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "e8400d6646fe14f0974237da5dc1377af0404bea",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-07-01T21:11:38+00:00",
+                "type": "library",
+                "uid": 885949,
+                "version": "0.34",
+                "version_normalized": "0.34.0.0"
+            },
+            "0.35": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "d97f386209ccb5ab802ee55a20f8c7b5306a1595",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/d97f386209ccb5ab802ee55a20f8c7b5306a1595"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "d97f386209ccb5ab802ee55a20f8c7b5306a1595",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-07-30T08:36:15+00:00",
+                "type": "library",
+                "uid": 926158,
+                "version": "0.35",
+                "version_normalized": "0.35.0.0"
+            },
+            "0.36": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "ef9e39444ca917e952591f4042417749233ebe98",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/ef9e39444ca917e952591f4042417749233ebe98"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "ef9e39444ca917e952591f4042417749233ebe98",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-11-25T20:40:52+00:00",
+                "type": "library",
+                "uid": 1099427,
+                "version": "0.36",
+                "version_normalized": "0.36.0.0"
+            },
+            "0.37": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "904d42d33f8c28292e4863d4d220c50ee9a39a7d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/904d42d33f8c28292e4863d4d220c50ee9a39a7d"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "904d42d33f8c28292e4863d4d220c50ee9a39a7d",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-12-13T22:33:23+00:00",
+                "type": "library",
+                "uid": 1126702,
+                "version": "0.37",
+                "version_normalized": "0.37.0.0"
+            },
+            "0.37.1": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "4b2edc594ead9cd2f9067d9791d69af1f56c2737",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/4b2edc594ead9cd2f9067d9791d69af1f56c2737"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "4b2edc594ead9cd2f9067d9791d69af1f56c2737",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-12-24T11:55:47+00:00",
+                "type": "library",
+                "uid": 1141285,
+                "version": "0.37.1",
+                "version_normalized": "0.37.1.0"
+            },
+            "0.38.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "112a61b41224a96b5202a350f904239845ddc741",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/112a61b41224a96b5202a350f904239845ddc741"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "112a61b41224a96b5202a350f904239845ddc741",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-12-25T04:05:50+00:00",
+                "type": "library",
+                "uid": 1141659,
+                "version": "0.38.0",
+                "version_normalized": "0.38.0.0"
+            },
+            "0.38.1": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "1c54e2c0e3eaa6eb335671edc02164d03e14147b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/1c54e2c0e3eaa6eb335671edc02164d03e14147b"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "1c54e2c0e3eaa6eb335671edc02164d03e14147b",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-12-25T13:14:23+00:00",
+                "type": "library",
+                "uid": 1141837,
+                "version": "0.38.1",
+                "version_normalized": "0.38.1.0"
+            },
+            "0.39.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "518e9dd861f3dafcf6272856043e941bc59fa6dc",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/518e9dd861f3dafcf6272856043e941bc59fa6dc"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "518e9dd861f3dafcf6272856043e941bc59fa6dc",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-01-20T22:51:43+00:00",
+                "type": "library",
+                "uid": 1185324,
+                "version": "0.39.0",
+                "version_normalized": "0.39.0.0"
+            },
+            "0.40.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "2649b143f4743e5b7c75d161dabf5098e4116765",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/2649b143f4743e5b7c75d161dabf5098e4116765"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "2649b143f4743e5b7c75d161dabf5098e4116765",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-02-20T21:48:11+00:00",
+                "type": "library",
+                "uid": 1243029,
+                "version": "0.40.0",
+                "version_normalized": "0.40.0.0"
+            },
+            "0.40.1": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "b0833a890be48c8f32dda6e2eb8143fc8aab5d70",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/b0833a890be48c8f32dda6e2eb8143fc8aab5d70"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "b0833a890be48c8f32dda6e2eb8143fc8aab5d70",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-03-07T08:55:09+00:00",
+                "type": "library",
+                "uid": 1268601,
+                "version": "0.40.1",
+                "version_normalized": "0.40.1.0"
+            },
+            "0.41.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "3fdc3c10cf2101c6ffb87e486eb1f65c057b4f7a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/3fdc3c10cf2101c6ffb87e486eb1f65c057b4f7a"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "3fdc3c10cf2101c6ffb87e486eb1f65c057b4f7a",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-03-25T16:48:06+00:00",
+                "type": "library",
+                "uid": 1307590,
+                "version": "0.41.0",
+                "version_normalized": "0.41.0.0"
+            },
+            "0.42.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "25d74af0f47393f1784ab5f02f3fcffaf03d06ff",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/25d74af0f47393f1784ab5f02f3fcffaf03d06ff"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "25d74af0f47393f1784ab5f02f3fcffaf03d06ff",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-04-09T20:11:46+00:00",
+                "type": "library",
+                "uid": 1335159,
+                "version": "0.42.0",
+                "version_normalized": "0.42.0.0"
+            },
+            "0.43.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "9d4d020fed98f4f0f57eb30c690c3a382b73ca26",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/9d4d020fed98f4f0f57eb30c690c3a382b73ca26"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.2",
+                    "monolog/monolog": "^1.22",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.1",
+                    "squizlabs/php_codesniffer": "^2.8"
+                },
+                "source": {
+                    "reference": "9d4d020fed98f4f0f57eb30c690c3a382b73ca26",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-04-17T11:24:07+00:00",
+                "type": "library",
+                "uid": 1346809,
+                "version": "0.43.0",
+                "version_normalized": "0.43.0.0"
+            },
+            "0.44.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "0bdd7a73f8766af980a2fd59c1b3886b28a916fb",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/0bdd7a73f8766af980a2fd59c1b3886b28a916fb"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.2",
+                    "monolog/monolog": "^1.22",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.1",
+                    "squizlabs/php_codesniffer": "^2.8"
+                },
+                "source": {
+                    "reference": "0bdd7a73f8766af980a2fd59c1b3886b28a916fb",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-04-25T18:35:02+00:00",
+                "type": "library",
+                "uid": 1361756,
+                "version": "0.44.0",
+                "version_normalized": "0.44.0.0"
+            },
+            "0.44.1": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "e522050a5e2ac73a4c0fa47705896da0df37de3a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/e522050a5e2ac73a4c0fa47705896da0df37de3a"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.2",
+                    "monolog/monolog": "^1.22",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.1",
+                    "squizlabs/php_codesniffer": "^2.8"
+                },
+                "source": {
+                    "reference": "e522050a5e2ac73a4c0fa47705896da0df37de3a",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-04-25T21:28:23+00:00",
+                "type": "library",
+                "uid": 1361941,
+                "version": "0.44.1",
+                "version_normalized": "0.44.1.0"
+            },
+            "0.45.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "6d1075280c5df13d02cca0893433138ea927e6b4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/6d1075280c5df13d02cca0893433138ea927e6b4"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.2",
+                    "monolog/monolog": "^1.22",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.1",
+                    "squizlabs/php_codesniffer": "^2.8"
+                },
+                "source": {
+                    "reference": "6d1075280c5df13d02cca0893433138ea927e6b4",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-06-25T09:25:56+00:00",
+                "type": "library",
+                "uid": 1462374,
+                "version": "0.45.0",
+                "version_normalized": "0.45.0.0"
+            },
+            "0.46.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "fae82d961b0d10138f836b6c7ec43bf39ef3d445",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/fae82d961b0d10138f836b6c7ec43bf39ef3d445"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.2",
+                    "monolog/monolog": "^1.22",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.1",
+                    "squizlabs/php_codesniffer": "^2.8"
+                },
+                "source": {
+                    "reference": "fae82d961b0d10138f836b6c7ec43bf39ef3d445",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-07-15T21:21:54+00:00",
+                "type": "library",
+                "uid": 1501678,
+                "version": "0.46.0",
+                "version_normalized": "0.46.0.0"
+            },
+            "0.47.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "75d992c3d2d13305593c72cdaa8fdbdc01901b45",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/75d992c3d2d13305593c72cdaa8fdbdc01901b45"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.2",
+                    "monolog/monolog": "^1.22",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.1",
+                    "squizlabs/php_codesniffer": "^2.8"
+                },
+                "source": {
+                    "reference": "75d992c3d2d13305593c72cdaa8fdbdc01901b45",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-08-06T11:24:13+00:00",
+                "type": "library",
+                "uid": 1540057,
+                "version": "0.47.0",
+                "version_normalized": "0.47.0.0"
+            },
+            "0.47.1": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "e7303ed0702a3340b6344eb47270a8801bb564d6",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/e7303ed0702a3340b6344eb47270a8801bb564d6"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.2",
+                    "monolog/monolog": "^1.22",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.1",
+                    "squizlabs/php_codesniffer": "^2.8"
+                },
+                "source": {
+                    "reference": "e7303ed0702a3340b6344eb47270a8801bb564d6",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-08-06T15:28:26+00:00",
+                "type": "library",
+                "uid": 1540295,
+                "version": "0.47.1",
+                "version_normalized": "0.47.1.0"
+            },
+            "0.48.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "8fbc070b002cd39e016527a92ede7c21cf85e73a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/8fbc070b002cd39e016527a92ede7c21cf85e73a"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.2",
+                    "monolog/monolog": "^1.22",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.1",
+                    "squizlabs/php_codesniffer": "^2.8"
+                },
+                "source": {
+                    "reference": "8fbc070b002cd39e016527a92ede7c21cf85e73a",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-08-26T18:18:20+00:00",
+                "type": "library",
+                "uid": 1575948,
+                "version": "0.48.0",
+                "version_normalized": "0.48.0.0"
+            },
+            "0.49.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "04de592d06843e05f200dff4fa77360123343580",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/04de592d06843e05f200dff4fa77360123343580"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.2",
+                    "monolog/monolog": "^1.22",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.1",
+                    "squizlabs/php_codesniffer": "^2.8"
+                },
+                "source": {
+                    "reference": "04de592d06843e05f200dff4fa77360123343580",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-09-17T14:44:32+00:00",
+                "type": "library",
+                "uid": 1615805,
+                "version": "0.49.0",
+                "version_normalized": "0.49.0.0"
+            },
+            "0.50.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP Telegram bot",
+                "dist": {
+                    "reference": "54823db1306a791830a7915072f03ff84fd7c4f3",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/54823db1306a791830a7915072f03ff84fd7c4f3"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.2",
+                    "monolog/monolog": "^1.22",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.1",
+                    "squizlabs/php_codesniffer": "^2.8"
+                },
+                "source": {
+                    "reference": "54823db1306a791830a7915072f03ff84fd7c4f3",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-10-17T12:09:43+00:00",
+                "type": "library",
+                "uid": 1670323,
+                "version": "0.50.0",
+                "version_normalized": "0.50.0.0"
+            },
+            "0.51.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP Telegram bot",
+                "dist": {
+                    "reference": "3e7af92ff356c3dd999c85f18d4acf33894407de",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/3e7af92ff356c3dd999c85f18d4acf33894407de"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.2",
+                    "monolog/monolog": "^1.22",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.1",
+                    "squizlabs/php_codesniffer": "^2.8"
+                },
+                "source": {
+                    "reference": "3e7af92ff356c3dd999c85f18d4acf33894407de",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2017-12-05T11:39:05+00:00",
+                "type": "library",
+                "uid": 1765435,
+                "version": "0.51.0",
+                "version_normalized": "0.51.0.0"
+            },
+            "0.52.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP Telegram bot",
+                "dist": {
+                    "reference": "f7cac58dcf4efd766f4737f40bba473ced0d4cc8",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/f7cac58dcf4efd766f4737f40bba473ced0d4cc8"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.2",
+                    "monolog/monolog": "^1.22",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.1",
+                    "squizlabs/php_codesniffer": "^2.8"
+                },
+                "source": {
+                    "reference": "f7cac58dcf4efd766f4737f40bba473ced0d4cc8",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2018-01-07T23:39:21+00:00",
+                "type": "library",
+                "uid": 1829469,
+                "version": "0.52.0",
+                "version_normalized": "0.52.0.0"
+            },
+            "0.53.0": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP Telegram bot",
+                "dist": {
+                    "reference": "ed50346851088a13f2af27e067d3f595b900b55f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/ed50346851088a13f2af27e067d3f595b900b55f"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.3",
+                    "monolog/monolog": "^1.23",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.5|^7.0",
+                    "squizlabs/php_codesniffer": "^3.2"
+                },
+                "source": {
+                    "reference": "ed50346851088a13f2af27e067d3f595b900b55f",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2018-03-31T22:35:18+00:00",
+                "type": "library",
+                "uid": 2053437,
+                "version": "0.53.0",
+                "version_normalized": "0.53.0.0"
+            },
+            "dev-develop": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP Telegram bot",
+                "dist": {
+                    "reference": "5676b756513cb73edd63009137e90879401cc7ef",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/5676b756513cb73edd63009137e90879401cc7ef"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.3",
+                    "monolog/monolog": "^1.23",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.5|^7.0",
+                    "squizlabs/php_codesniffer": "^3.2"
+                },
+                "source": {
+                    "reference": "5676b756513cb73edd63009137e90879401cc7ef",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2018-05-23T08:27:35+00:00",
+                "type": "library",
+                "uid": 481471,
+                "version": "dev-develop",
+                "version_normalized": "dev-develop"
+            },
+            "dev-feature/refactor-app-design": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP Telegram bot",
+                "dist": {
+                    "reference": "84977ea7793b89c3abc26dae8bc7f1a02cabc84a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/84977ea7793b89c3abc26dae8bc7f1a02cabc84a"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.3",
+                    "illuminate/config": "5.4.*|5.5.*|5.6.*",
+                    "illuminate/container": "5.4.*|5.5.*|5.6.*",
+                    "illuminate/http": "5.4.*|5.5.*|5.6.*",
+                    "illuminate/support": "5.4.*|5.5.*|5.6.*",
+                    "monolog/monolog": "^1.23",
+                    "php": ">=5.6.4|^7.0"
+                },
+                "require-dev": {
+                    "longman/php-code-style": "^1.0",
+                    "phpunit/phpunit": "^4.8|^5.7|^6.5|^7.0",
+                    "squizlabs/php_codesniffer": "^3.2",
+                    "symfony/var-dumper": "3.4.*|~4.0"
+                },
+                "source": {
+                    "reference": "84977ea7793b89c3abc26dae8bc7f1a02cabc84a",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2018-04-22T17:24:10+00:00",
+                "type": "library",
+                "uid": 2119939,
+                "version": "dev-feature/refactor-app-design",
+                "version_normalized": "dev-feature/refactor-app-design"
+            },
+            "dev-hotfix": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "904d42d33f8c28292e4863d4d220c50ee9a39a7d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/904d42d33f8c28292e4863d4d220c50ee9a39a7d"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "904d42d33f8c28292e4863d4d220c50ee9a39a7d",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-12-13T22:33:23+00:00",
+                "type": "library",
+                "uid": 510101,
+                "version": "dev-hotfix",
+                "version_normalized": "dev-hotfix"
+            },
+            "dev-import": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP telegram bot",
+                "dist": {
+                    "reference": "7d22a63f0af117b28d14ad5141135b1df459cb26",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/7d22a63f0af117b28d14ad5141135b1df459cb26"
+                },
+                "homepage": "https://github.com/akalongman/php-telegram-bot",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "~6.0",
+                    "monolog/monolog": "^1.19",
+                    "php": ">=5.5.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.8",
+                    "squizlabs/php_codesniffer": "~2.5"
+                },
+                "source": {
+                    "reference": "7d22a63f0af117b28d14ad5141135b1df459cb26",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2016-07-27T08:49:09+00:00",
+                "type": "library",
+                "uid": 894792,
+                "version": "dev-import",
+                "version_normalized": "dev-import"
+            },
+            "dev-master": {
+                "authors": [
+                    {
+                        "email": "akalongman@gmail.com",
+                        "homepage": "http://longman.me",
+                        "name": "Avtandil Kikabidze aka LONGMAN",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Longman\\TelegramBot\\": "src/"
+                    }
+                },
+                "description": "PHP Telegram bot",
+                "dist": {
+                    "reference": "ed50346851088a13f2af27e067d3f595b900b55f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/ed50346851088a13f2af27e067d3f595b900b55f"
+                },
+                "homepage": "https://github.com/php-telegram-bot/core",
+                "keywords": [
+                    "api",
+                    "bot",
+                    "telegram"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "longman/telegram-bot",
+                "require": {
+                    "ext-curl": "*",
+                    "ext-mbstring": "*",
+                    "ext-pdo": "*",
+                    "guzzlehttp/guzzle": "^6.3",
+                    "monolog/monolog": "^1.23",
+                    "php": "^5.5|^7.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^4.8|^5.7|^6.5|^7.0",
+                    "squizlabs/php_codesniffer": "^3.2"
+                },
+                "source": {
+                    "reference": "ed50346851088a13f2af27e067d3f595b900b55f",
+                    "type": "git",
+                    "url": "https://github.com/php-telegram-bot/core.git"
+                },
+                "time": "2018-03-31T22:35:18+00:00",
+                "type": "library",
+                "uid": 448131,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            }
+        }
+    }
+}

--- a/spec/fixtures/php/packagist_responses/monolog:monolog.json
+++ b/spec/fixtures/php/packagist_responses/monolog:monolog.json
@@ -1,0 +1,2790 @@
+{
+    "packages": {
+        "monolog/monolog": {
+            "1.0.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "description": "Logging for PHP 5.3",
+                "dist": {
+                    "reference": "433b98d4218c181bae01865901aac045585e8a1a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/433b98d4218c181bae01865901aac045585e8a1a"
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0"
+                },
+                "source": {
+                    "reference": "433b98d4218c181bae01865901aac045585e8a1a",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "time": "2011-07-07T16:21:02+00:00",
+                "type": "library",
+                "uid": 5151,
+                "version": "1.0.0",
+                "version_normalized": "1.0.0.0"
+            },
+            "1.0.0-RC1": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "description": "Logging for PHP 5.3",
+                "dist": {
+                    "reference": "5e651a82b4b03d267da6084720ada0cd398c8d16",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5e651a82b4b03d267da6084720ada0cd398c8d16"
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0"
+                },
+                "source": {
+                    "reference": "5e651a82b4b03d267da6084720ada0cd398c8d16",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "time": "2011-07-01T19:29:40+00:00",
+                "type": "library",
+                "uid": 34388,
+                "version": "1.0.0-RC1",
+                "version_normalized": "1.0.0.0-RC1"
+            },
+            "1.0.1": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "description": "Logging for PHP 5.3",
+                "dist": {
+                    "reference": "303b8a83c87d5c6d749926cf02620465a5dcd0f2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/303b8a83c87d5c6d749926cf02620465a5dcd0f2"
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0"
+                },
+                "source": {
+                    "reference": "303b8a83c87d5c6d749926cf02620465a5dcd0f2",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "time": "2011-08-25T20:42:58+00:00",
+                "type": "library",
+                "uid": 5152,
+                "version": "1.0.1",
+                "version_normalized": "1.0.1.0"
+            },
+            "1.0.2": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Monolog": "src/"
+                    }
+                },
+                "description": "Logging for PHP 5.3",
+                "dist": {
+                    "reference": "b704c49a3051536f67f2d39f13568f74615b9922",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b704c49a3051536f67f2d39f13568f74615b9922"
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0"
+                },
+                "source": {
+                    "reference": "b704c49a3051536f67f2d39f13568f74615b9922",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "time": "2011-10-24T09:39:02+00:00",
+                "type": "library",
+                "uid": 5153,
+                "version": "1.0.2",
+                "version_normalized": "1.0.2.0"
+            },
+            "1.1.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Monolog": "src/"
+                    }
+                },
+                "description": "Logging for PHP 5.3",
+                "dist": {
+                    "reference": "abc80e0db8ad31c03b373977fc997e980800f9c2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/abc80e0db8ad31c03b373977fc997e980800f9c2"
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0"
+                },
+                "require-dev": {
+                    "mlehner/gelf-php": "1.0.*"
+                },
+                "source": {
+                    "reference": "abc80e0db8ad31c03b373977fc997e980800f9c2",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server"
+                },
+                "time": "2012-04-23T16:27:40+00:00",
+                "type": "library",
+                "uid": 11074,
+                "version": "1.1.0",
+                "version_normalized": "1.1.0.0"
+            },
+            "1.10.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "25b16e801979098cb2f120e697bfce454b18bf23",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/25b16e801979098cb2f120e697bfce454b18bf23"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.10.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "~2.4, >2.4.8",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "phpunit/phpunit": "~3.7.0",
+                    "raven/raven": "~0.5",
+                    "ruflin/elastica": "0.90.*"
+                },
+                "source": {
+                    "reference": "25b16e801979098cb2f120e697bfce454b18bf23",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                },
+                "time": "2014-06-04T16:30:04+00:00",
+                "type": "library",
+                "uid": 183340,
+                "version": "1.10.0",
+                "version_normalized": "1.10.0.0"
+            },
+            "1.11.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "ec3961874c43840e96da3a8a1ed20d8c73d7e5aa",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/ec3961874c43840e96da3a8a1ed20d8c73d7e5aa"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.11.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "~2.4, >2.4.8",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "phpunit/phpunit": "~3.7.0",
+                    "raven/raven": "~0.5",
+                    "ruflin/elastica": "0.90.*",
+                    "videlalvaro/php-amqplib": "~2.4"
+                },
+                "source": {
+                    "reference": "ec3961874c43840e96da3a8a1ed20d8c73d7e5aa",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                },
+                "time": "2014-09-30T13:30:58+00:00",
+                "type": "library",
+                "uid": 243161,
+                "version": "1.11.0",
+                "version_normalized": "1.11.0.0"
+            },
+            "1.12.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1fbe8c2641f2b163addf49cc5e18f144bec6b19f"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.12.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "~2.4, >2.4.8",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "phpunit/phpunit": "~4.0",
+                    "raven/raven": "~0.5",
+                    "ruflin/elastica": "0.90.*",
+                    "videlalvaro/php-amqplib": "~2.4"
+                },
+                "source": {
+                    "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                },
+                "time": "2014-12-29T21:29:35+00:00",
+                "type": "library",
+                "uid": 296518,
+                "version": "1.12.0",
+                "version_normalized": "1.12.0.0"
+            },
+            "1.13.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "c41c218e239b50446fd883acb1ecfd4b770caeae",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c41c218e239b50446fd883acb1ecfd4b770caeae"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.13.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "~2.4, >2.4.8",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "phpunit/phpunit": "~4.0",
+                    "raven/raven": "~0.5",
+                    "ruflin/elastica": "0.90.*",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "videlalvaro/php-amqplib": "~2.4"
+                },
+                "source": {
+                    "reference": "c41c218e239b50446fd883acb1ecfd4b770caeae",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                },
+                "time": "2015-03-05T01:12:12+00:00",
+                "type": "library",
+                "uid": 348286,
+                "version": "1.13.0",
+                "version_normalized": "1.13.0.0"
+            },
+            "1.13.1": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c31a2c4e8db5da8b46c74cf275d7f109c0f249ac"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.13.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "~2.4, >2.4.8",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "phpunit/phpunit": "~4.0",
+                    "raven/raven": "~0.5",
+                    "ruflin/elastica": "0.90.*",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "videlalvaro/php-amqplib": "~2.4"
+                },
+                "source": {
+                    "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                },
+                "time": "2015-03-09T09:58:04+00:00",
+                "type": "library",
+                "uid": 354135,
+                "version": "1.13.1",
+                "version_normalized": "1.13.1.0"
+            },
+            "1.14.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "b287fbbe1ca27847064beff2bad7fb6920bf08cc",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b287fbbe1ca27847064beff2bad7fb6920bf08cc"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.14.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "raven/raven": "~0.8",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "videlalvaro/php-amqplib": "~2.4"
+                },
+                "source": {
+                    "reference": "b287fbbe1ca27847064beff2bad7fb6920bf08cc",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                },
+                "time": "2015-06-19T13:29:54+00:00",
+                "type": "library",
+                "uid": 438539,
+                "version": "1.14.0",
+                "version_normalized": "1.14.0.0"
+            },
+            "1.15.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "dc5150cc608f2334c72c3b6a553ec9668a4156b0",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/dc5150cc608f2334c72c3b6a553ec9668a4156b0"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.15.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "raven/raven": "~0.8",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "videlalvaro/php-amqplib": "~2.4"
+                },
+                "source": {
+                    "reference": "dc5150cc608f2334c72c3b6a553ec9668a4156b0",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                },
+                "time": "2015-07-12T13:54:09+00:00",
+                "type": "library",
+                "uid": 459596,
+                "version": "1.15.0",
+                "version_normalized": "1.15.0.0"
+            },
+            "1.16.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "c0c0b4bee3aabce7182876b0d912ef2595563db7",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c0c0b4bee3aabce7182876b0d912ef2595563db7"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.16.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "raven/raven": "~0.8",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "videlalvaro/php-amqplib": "~2.4"
+                },
+                "source": {
+                    "reference": "c0c0b4bee3aabce7182876b0d912ef2595563db7",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                },
+                "time": "2015-08-09T17:44:44+00:00",
+                "type": "library",
+                "uid": 486369,
+                "version": "1.16.0",
+                "version_normalized": "1.16.0.0"
+            },
+            "1.17.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "877ae631713cc961952df713ae785735b90df682",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/877ae631713cc961952df713ae785735b90df682"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.16.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "raven/raven": "~0.11",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "videlalvaro/php-amqplib": "~2.4"
+                },
+                "source": {
+                    "reference": "877ae631713cc961952df713ae785735b90df682",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                },
+                "time": "2015-08-30T11:40:25+00:00",
+                "type": "library",
+                "uid": 506342,
+                "version": "1.17.0",
+                "version_normalized": "1.17.0.0"
+            },
+            "1.17.1": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "0524c87587ab85bc4c2d6f5b41253ccb930a5422",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/0524c87587ab85bc4c2d6f5b41253ccb930a5422"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.16.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "raven/raven": "~0.11",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "videlalvaro/php-amqplib": "~2.4"
+                },
+                "source": {
+                    "reference": "0524c87587ab85bc4c2d6f5b41253ccb930a5422",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                },
+                "time": "2015-08-31T09:17:37+00:00",
+                "type": "library",
+                "uid": 507060,
+                "version": "1.17.1",
+                "version_normalized": "1.17.1.0"
+            },
+            "1.17.2": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "bee7f0dc9c3e0b69a6039697533dca1e845c8c24",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bee7f0dc9c3e0b69a6039697533dca1e845c8c24"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.16.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "jakub-onderka/php-parallel-lint": "0.9",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "raven/raven": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "videlalvaro/php-amqplib": "~2.4"
+                },
+                "source": {
+                    "reference": "bee7f0dc9c3e0b69a6039697533dca1e845c8c24",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                },
+                "time": "2015-10-14T12:51:02+00:00",
+                "type": "library",
+                "uid": 550950,
+                "version": "1.17.2",
+                "version_normalized": "1.17.2.0"
+            },
+            "1.18.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "e19b764b5c855580e8ffa7e615f72c10fd2f99cc",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e19b764b5c855580e8ffa7e615f72c10fd2f99cc"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "jakub-onderka/php-parallel-lint": "0.9",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "raven/raven": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "videlalvaro/php-amqplib": "~2.4"
+                },
+                "source": {
+                    "reference": "e19b764b5c855580e8ffa7e615f72c10fd2f99cc",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                },
+                "time": "2016-03-01T18:00:40+00:00",
+                "type": "library",
+                "uid": 719359,
+                "version": "1.18.0",
+                "version_normalized": "1.18.0.0"
+            },
+            "1.18.1": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "a5f2734e8c16f3aa21b3da09715d10e15b4d2d45",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/a5f2734e8c16f3aa21b3da09715d10e15b4d2d45"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "jakub-onderka/php-parallel-lint": "0.9",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "raven/raven": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "videlalvaro/php-amqplib": "~2.4"
+                },
+                "source": {
+                    "reference": "a5f2734e8c16f3aa21b3da09715d10e15b4d2d45",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                },
+                "time": "2016-03-13T16:08:35+00:00",
+                "type": "library",
+                "uid": 735276,
+                "version": "1.18.1",
+                "version_normalized": "1.18.1.0"
+            },
+            "1.18.2": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "064b38c16790249488e7a8b987acf1c9d7383c09",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/064b38c16790249488e7a8b987acf1c9d7383c09"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "jakub-onderka/php-parallel-lint": "0.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "raven/raven": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "~5.3"
+                },
+                "source": {
+                    "reference": "064b38c16790249488e7a8b987acf1c9d7383c09",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                },
+                "time": "2016-04-02T13:12:58+00:00",
+                "type": "library",
+                "uid": 761695,
+                "version": "1.18.2",
+                "version_normalized": "1.18.2.0"
+            },
+            "1.19.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5f56ed5212dc509c8dc8caeba2715732abb32dbf"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "jakub-onderka/php-parallel-lint": "0.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "raven/raven": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "~5.3"
+                },
+                "source": {
+                    "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                },
+                "time": "2016-04-12T18:29:35+00:00",
+                "type": "library",
+                "uid": 775623,
+                "version": "1.19.0",
+                "version_normalized": "1.19.0.0"
+            },
+            "1.2.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Monolog": "src/"
+                    }
+                },
+                "description": "Logging for PHP 5.3",
+                "dist": {
+                    "reference": "7940ae31ce4687d875d2bb5aa277bb3802203fe1",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/7940ae31ce4687d875d2bb5aa277bb3802203fe1"
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0"
+                },
+                "require-dev": {
+                    "mlehner/gelf-php": "1.0.*"
+                },
+                "source": {
+                    "reference": "7940ae31ce4687d875d2bb5aa277bb3802203fe1",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server"
+                },
+                "time": "2012-08-18T17:27:13+00:00",
+                "type": "library",
+                "uid": 17167,
+                "version": "1.2.0",
+                "version_normalized": "1.2.0.0"
+            },
+            "1.2.1": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Monolog": "src/"
+                    }
+                },
+                "description": "Logging for PHP 5.3",
+                "dist": {
+                    "reference": "d16496318c3e08e3bccfc3866e104e49cf25488a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/d16496318c3e08e3bccfc3866e104e49cf25488a"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.3.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0"
+                },
+                "require-dev": {
+                    "mlehner/gelf-php": "1.0.*"
+                },
+                "source": {
+                    "reference": "d16496318c3e08e3bccfc3866e104e49cf25488a",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server"
+                },
+                "time": "2012-08-29T11:53:20+00:00",
+                "type": "library",
+                "uid": 17888,
+                "version": "1.2.1",
+                "version_normalized": "1.2.1.0"
+            },
+            "1.20.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "55841909e2bcde01b5318c35f2b74f8ecc86e037",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/55841909e2bcde01b5318c35f2b74f8ecc86e037"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "jakub-onderka/php-parallel-lint": "0.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "sentry/sentry": "^0.13",
+                    "swiftmailer/swiftmailer": "~5.3"
+                },
+                "source": {
+                    "reference": "55841909e2bcde01b5318c35f2b74f8ecc86e037",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server"
+                },
+                "time": "2016-07-02T14:02:10+00:00",
+                "type": "library",
+                "uid": 886205,
+                "version": "1.20.0",
+                "version_normalized": "1.20.0.0"
+            },
+            "1.21.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f42fbdfd53e306bda545845e4dbfd3e72edb4952"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "jakub-onderka/php-parallel-lint": "0.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "sentry/sentry": "^0.13",
+                    "swiftmailer/swiftmailer": "~5.3"
+                },
+                "source": {
+                    "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server"
+                },
+                "time": "2016-07-29T03:23:52+00:00",
+                "type": "library",
+                "uid": 928751,
+                "version": "1.21.0",
+                "version_normalized": "1.21.0.0"
+            },
+            "1.22.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "bad29cb8d18ab0315e6c477751418a82c850d558",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bad29cb8d18ab0315e6c477751418a82c850d558"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "jakub-onderka/php-parallel-lint": "0.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "sentry/sentry": "^0.13",
+                    "swiftmailer/swiftmailer": "~5.3"
+                },
+                "source": {
+                    "reference": "bad29cb8d18ab0315e6c477751418a82c850d558",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server"
+                },
+                "time": "2016-11-26T00:15:39+00:00",
+                "type": "library",
+                "uid": 1099516,
+                "version": "1.22.0",
+                "version_normalized": "1.22.0.0"
+            },
+            "1.22.1": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1e044bc4b34e91743943479f1be7a1d5eb93add0"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "jakub-onderka/php-parallel-lint": "0.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "sentry/sentry": "^0.13",
+                    "swiftmailer/swiftmailer": "~5.3"
+                },
+                "source": {
+                    "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server"
+                },
+                "time": "2017-03-13T07:08:03+00:00",
+                "type": "library",
+                "uid": 1278871,
+                "version": "1.22.1",
+                "version_normalized": "1.22.1.0"
+            },
+            "1.23.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd8c787753b3a2ad11bc60c063cff1358a32a3b4"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "jakub-onderka/php-parallel-lint": "0.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "sentry/sentry": "^0.13",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0"
+                },
+                "source": {
+                    "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server"
+                },
+                "time": "2017-06-19T01:22:40+00:00",
+                "type": "library",
+                "uid": 1451918,
+                "version": "1.23.0",
+                "version_normalized": "1.23.0.0"
+            },
+            "1.3.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Monolog": "src/"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "25a97abf904120a386c546be11c3b58f1f9e6f37",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/25a97abf904120a386c546be11c3b58f1f9e6f37"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.3.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "doctrine/couchdb": "dev-master",
+                    "mlehner/gelf-php": "1.0.*",
+                    "raven/raven": "0.3.*"
+                },
+                "source": {
+                    "reference": "25a97abf904120a386c546be11c3b58f1f9e6f37",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server"
+                },
+                "time": "2013-01-07T20:26:46+00:00",
+                "type": "library",
+                "uid": 31072,
+                "version": "1.3.0",
+                "version_normalized": "1.3.0.0"
+            },
+            "1.3.1": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Monolog": "src/"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "47eb599b4aad36b66e818ed72ebf939e2fb311be",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/47eb599b4aad36b66e818ed72ebf939e2fb311be"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.3.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "doctrine/couchdb": "dev-master",
+                    "mlehner/gelf-php": "1.0.*",
+                    "raven/raven": "0.3.*"
+                },
+                "source": {
+                    "reference": "47eb599b4aad36b66e818ed72ebf939e2fb311be",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server"
+                },
+                "time": "2013-01-11T10:23:20+00:00",
+                "type": "library",
+                "uid": 31615,
+                "version": "1.3.1",
+                "version_normalized": "1.3.1.0"
+            },
+            "1.4.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Monolog": "src/"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "32fe28af60b4da9a5b0cef024138afacc0c01eeb",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/32fe28af60b4da9a5b0cef024138afacc0c01eeb"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.4.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "doctrine/couchdb": "dev-master",
+                    "mlehner/gelf-php": "1.0.*",
+                    "raven/raven": "0.3.*"
+                },
+                "source": {
+                    "reference": "32fe28af60b4da9a5b0cef024138afacc0c01eeb",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server"
+                },
+                "time": "2013-02-13T18:06:51+00:00",
+                "type": "library",
+                "uid": 37441,
+                "version": "1.4.0",
+                "version_normalized": "1.4.0.0"
+            },
+            "1.4.1": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Monolog": "src/"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "3295de82be06b3bbcd336983ddf8c50724430180",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/3295de82be06b3bbcd336983ddf8c50724430180"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.4.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "doctrine/couchdb": "dev-master",
+                    "mlehner/gelf-php": "1.0.*",
+                    "raven/raven": "0.3.*"
+                },
+                "source": {
+                    "reference": "3295de82be06b3bbcd336983ddf8c50724430180",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server"
+                },
+                "time": "2013-04-01T10:04:58+00:00",
+                "type": "library",
+                "uid": 46264,
+                "version": "1.4.1",
+                "version_normalized": "1.4.1.0"
+            },
+            "1.5.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Monolog": "src/"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "583618d5cd2115a52101694aca87afb182b3e567",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/583618d5cd2115a52101694aca87afb182b3e567"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.4.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "doctrine/couchdb": "dev-master",
+                    "mlehner/gelf-php": "1.0.*",
+                    "raven/raven": "0.3.*"
+                },
+                "source": {
+                    "reference": "583618d5cd2115a52101694aca87afb182b3e567",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server"
+                },
+                "time": "2013-04-23T10:09:48+00:00",
+                "type": "library",
+                "uid": 50373,
+                "version": "1.5.0",
+                "version_normalized": "1.5.0.0"
+            },
+            "1.6.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Monolog": "src/"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "f72392d0e6eb855118f5a84e89ac2d257c704abd",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f72392d0e6eb855118f5a84e89ac2d257c704abd"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.6.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "doctrine/couchdb": "dev-master",
+                    "mlehner/gelf-php": "1.0.*",
+                    "raven/raven": "0.5.*"
+                },
+                "source": {
+                    "reference": "f72392d0e6eb855118f5a84e89ac2d257c704abd",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server"
+                },
+                "time": "2013-07-28T22:38:30+00:00",
+                "type": "library",
+                "uid": 72464,
+                "version": "1.6.0",
+                "version_normalized": "1.6.0.0"
+            },
+            "1.7.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "Monolog": "src/"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "6225b22de9dcf36546be3a0b2fa8e3d986153f57",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/6225b22de9dcf36546be3a0b2fa8e3d986153f57"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.7.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "~2.4.8",
+                    "doctrine/couchdb": "dev-master",
+                    "mlehner/gelf-php": "1.0.*",
+                    "phpunit/phpunit": "~3.7.0",
+                    "raven/raven": "0.5.*",
+                    "ruflin/elastica": "0.90.*"
+                },
+                "source": {
+                    "reference": "6225b22de9dcf36546be3a0b2fa8e3d986153f57",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                },
+                "time": "2013-11-14T19:48:31+00:00",
+                "type": "library",
+                "uid": 101157,
+                "version": "1.7.0",
+                "version_normalized": "1.7.0.0"
+            },
+            "1.8.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "392ef35fd470638e08d0160d6b1cbab63cb23174",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/392ef35fd470638e08d0160d6b1cbab63cb23174"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.8.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "~2.4, >2.4.8",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "phpunit/phpunit": "~3.7.0",
+                    "raven/raven": "~0.5",
+                    "ruflin/elastica": "0.90.*"
+                },
+                "source": {
+                    "reference": "392ef35fd470638e08d0160d6b1cbab63cb23174",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                },
+                "time": "2014-03-23T19:50:26+00:00",
+                "type": "library",
+                "uid": 148914,
+                "version": "1.8.0",
+                "version_normalized": "1.8.0.0"
+            },
+            "1.9.0": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "1afc39690e7414412face1f8cbf67b73db34485c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1afc39690e7414412face1f8cbf67b73db34485c"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.9.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "~2.4, >2.4.8",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "phpunit/phpunit": "~3.7.0",
+                    "raven/raven": "~0.5",
+                    "ruflin/elastica": "0.90.*"
+                },
+                "source": {
+                    "reference": "1afc39690e7414412face1f8cbf67b73db34485c",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                },
+                "time": "2014-04-20T16:41:26+00:00",
+                "type": "library",
+                "uid": 161381,
+                "version": "1.9.0",
+                "version_normalized": "1.9.0.0"
+            },
+            "1.9.1": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano",
+                        "role": "Developer"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "65026b610f8c19e61d7242f600530677b0466aac",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/65026b610f8c19e61d7242f600530677b0466aac"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.9.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "~2.4, >2.4.8",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "phpunit/phpunit": "~3.7.0",
+                    "raven/raven": "~0.5",
+                    "ruflin/elastica": "0.90.*"
+                },
+                "source": {
+                    "reference": "65026b610f8c19e61d7242f600530677b0466aac",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                },
+                "time": "2014-04-24T13:29:03+00:00",
+                "type": "library",
+                "uid": 163177,
+                "version": "1.9.1",
+                "version_normalized": "1.9.1.0"
+            },
+            "1.x-dev": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd8c787753b3a2ad11bc60c063cff1358a32a3b4"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "~1.0",
+                    "jakub-onderka/php-parallel-lint": "0.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit": "~4.5",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "sentry/sentry": "^0.13",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0"
+                },
+                "source": {
+                    "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server"
+                },
+                "time": "2017-06-19T01:22:40+00:00",
+                "type": "library",
+                "uid": 627655,
+                "version": "1.x-dev",
+                "version_normalized": "1.9999999.9999999.9999999-dev"
+            },
+            "dev-master": {
+                "authors": [
+                    {
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "name": "Jordi Boggiano"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "dist": {
+                    "reference": "7b992836275e09ed63c63fe33ca9993e515e6c5d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/7b992836275e09ed63c63fe33ca9993e515e6c5d"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "http://github.com/Seldaek/monolog",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "monolog/monolog",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "require": {
+                    "php": "^7.0",
+                    "psr/log": "^1.0.1"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "jakub-onderka/php-parallel-lint": "^0.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^5.7",
+                    "predis/predis": "^1.1",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "sentry/sentry": "^0.13",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0"
+                },
+                "source": {
+                    "reference": "7b992836275e09ed63c63fe33ca9993e515e6c5d",
+                    "type": "git",
+                    "url": "https://github.com/Seldaek/monolog.git"
+                },
+                "suggest": {
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server"
+                },
+                "time": "2017-06-19T10:29:40+00:00",
+                "type": "library",
+                "uid": 5154,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            }
+        },
+        "notadd/wechat": {
+            "dev-master": {
+                "authors": [
+                    {
+                        "email": "notadd@ibenchu.com",
+                        "name": "Notadd"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Notadd\\Wechat\\": "src/"
+                    }
+                },
+                "description": "Notadd's Wechat Module.",
+                "dist": {
+                    "reference": "e3f684cd225f3fadf21953c0289cb8426baad0e5",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/notadd/wechat/zipball/e3f684cd225f3fadf21953c0289cb8426baad0e5"
+                },
+                "homepage": "https://notadd.com",
+                "keywords": [
+                    "framework",
+                    "cms",
+                    "member",
+                    "notadd"
+                ],
+                "license": [
+                    "Apache-2.0"
+                ],
+                "name": "notadd/wechat",
+                "replace": {
+                    "guzzlehttp/guzzle": "*",
+                    "guzzlehttp/promises": "*",
+                    "guzzlehttp/psr7": "*",
+                    "monolog/monolog": "*",
+                    "psr/container": "*",
+                    "psr/http-message": "*",
+                    "psr/log": "*",
+                    "symfony/http-foundation": "*",
+                    "symfony/polyfill-mbstring": "*",
+                    "symfony/psr-http-message-bridge": "*"
+                },
+                "require": {
+                    "overtrue/wechat": "~3.1",
+                    "php": ">=7.0"
+                },
+                "require-dev": {
+                    "notadd/installers": "0.14.*",
+                    "notadd/testing": "0.4.*",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "e3f684cd225f3fadf21953c0289cb8426baad0e5",
+                    "type": "git",
+                    "url": "https://github.com/notadd/wechat.git"
+                },
+                "time": "2017-11-13T04:23:05+00:00",
+                "type": "notadd-module",
+                "uid": 1108963,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            }
+        },
+        "phpointless/monolol": {
+            "1.0.0": {
+                "authors": [
+                    {
+                        "email": "contact@romain-renaud.fr",
+                        "name": "Romain Renaud"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Monolol\\": "lib"
+                    }
+                },
+                "description": "PSR-3 compliant lol-gger",
+                "dist": {
+                    "reference": "1991e6b72b52229dc43147fd2c208f21896021bb",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/PHPointless/monolol/zipball/1991e6b72b52229dc43147fd2c208f21896021bb"
+                },
+                "homepage": "",
+                "keywords": [
+                    "PSR3",
+                    "LoL",
+                    "lol-gging"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpointless/monolol",
+                "provide": {
+                    "monolog/monolog": "1.12"
+                },
+                "require": {
+                    "monolog/monolog": "~1.12"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.5"
+                },
+                "source": {
+                    "reference": "1991e6b72b52229dc43147fd2c208f21896021bb",
+                    "type": "git",
+                    "url": "https://github.com/PHPointless/monolol.git"
+                },
+                "time": "2015-03-04T13:27:14+00:00",
+                "type": "library",
+                "uid": 347741,
+                "version": "1.0.0",
+                "version_normalized": "1.0.0.0"
+            }
+        }
+    }
+}

--- a/spec/fixtures/php/packagist_responses/neos:flow.json
+++ b/spec/fixtures/php/packagist_responses/neos:flow.json
@@ -1,0 +1,20926 @@
+{
+    "packages": {
+        "neos/flow": {
+            "2.0.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "d306441d2a8e9c382c8a0f9f235778433570822f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/d306441d2a8e9c382c8a0f9f235778433570822f"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/fluid": "2.0.*",
+                    "typo3/party": "2.0.*"
+                },
+                "source": {
+                    "reference": "d306441d2a8e9c382c8a0f9f235778433570822f",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2013-06-25T15:04:19+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098573,
+                "version": "2.0.0",
+                "version_normalized": "2.0.0.0"
+            },
+            "2.0.0-beta1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "f3f951d292cc13c0ba05f163725049ba65f6bb49",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/f3f951d292cc13c0ba05f163725049ba65f6bb49"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/data-fixtures": "*",
+                    "doctrine/migrations": "*",
+                    "doctrine/orm": "~2.3",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "~2.2",
+                    "symfony/yaml": "~2.1",
+                    "typo3/flow-composer-installers": "*",
+                    "typo3/fluid": "2.0.*",
+                    "typo3/party": "2.0.*"
+                },
+                "source": {
+                    "reference": "f3f951d292cc13c0ba05f163725049ba65f6bb49",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "time": "2012-12-12T21:49:44+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098570,
+                "version": "2.0.0-beta1",
+                "version_normalized": "2.0.0.0-beta1"
+            },
+            "2.0.0-beta2": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "879146c0ba839b98165dd9be0984bd5acfdd239e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/879146c0ba839b98165dd9be0984bd5acfdd239e"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/data-fixtures": "*",
+                    "doctrine/migrations": "*",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/fluid": "2.0.*",
+                    "typo3/party": "2.0.*"
+                },
+                "source": {
+                    "reference": "879146c0ba839b98165dd9be0984bd5acfdd239e",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "time": "2013-04-22T08:29:12+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098571,
+                "version": "2.0.0-beta2",
+                "version_normalized": "2.0.0.0-beta2"
+            },
+            "2.0.0-beta3": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "4baea3ec8930562d683c98df9b4a06338c9043fa",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/4baea3ec8930562d683c98df9b4a06338c9043fa"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/fluid": "2.0.*",
+                    "typo3/party": "2.0.*"
+                },
+                "source": {
+                    "reference": "4baea3ec8930562d683c98df9b4a06338c9043fa",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2013-05-02T15:43:23+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098572,
+                "version": "2.0.0-beta3",
+                "version_normalized": "2.0.0.0-beta3"
+            },
+            "2.0.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "dccd73c2648acdebce51fa50f95346bcc2147ff7",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/dccd73c2648acdebce51fa50f95346bcc2147ff7"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/fluid": "2.0.*",
+                    "typo3/party": "2.0.*"
+                },
+                "source": {
+                    "reference": "dccd73c2648acdebce51fa50f95346bcc2147ff7",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2013-12-10T15:20:38+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098574,
+                "version": "2.0.1",
+                "version_normalized": "2.0.1.0"
+            },
+            "2.0.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "91ee756ea64e2bee595001071e773a9aff73d97d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/91ee756ea64e2bee595001071e773a9aff73d97d"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/fluid": "2.0.*",
+                    "typo3/party": "2.0.*"
+                },
+                "source": {
+                    "reference": "91ee756ea64e2bee595001071e773a9aff73d97d",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-03-04T14:35:28+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098575,
+                "version": "2.0.2",
+                "version_normalized": "2.0.2.0"
+            },
+            "2.0.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "e03e6a89fe4f66acc46602e562ca84609389d7fa",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/e03e6a89fe4f66acc46602e562ca84609389d7fa"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/fluid": "2.0.*",
+                    "typo3/party": "2.0.*"
+                },
+                "source": {
+                    "reference": "e03e6a89fe4f66acc46602e562ca84609389d7fa",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2015-07-23T16:24:02+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098657,
+                "version": "2.0.x-dev",
+                "version_normalized": "2.0.9999999.9999999-dev"
+            },
+            "2.1.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "af480c020111570a8dbc976c53b712bdd9250ee6",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/af480c020111570a8dbc976c53b712bdd9250ee6"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.1.*",
+                    "typo3/fluid": "2.1.*",
+                    "typo3/party": "2.1.*"
+                },
+                "source": {
+                    "reference": "af480c020111570a8dbc976c53b712bdd9250ee6",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2013-12-10T15:54:29+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098578,
+                "version": "2.1.0",
+                "version_normalized": "2.1.0.0"
+            },
+            "2.1.0-RC1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "8f2906ff8d5dd61b89b0ac342091d6244d849e05",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8f2906ff8d5dd61b89b0ac342091d6244d849e05"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.1.0-RC1",
+                    "typo3/fluid": "2.1.0-RC1",
+                    "typo3/party": "2.1.0-RC1"
+                },
+                "source": {
+                    "reference": "8f2906ff8d5dd61b89b0ac342091d6244d849e05",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2013-12-09T22:22:21+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098577,
+                "version": "2.1.0-RC1",
+                "version_normalized": "2.1.0.0-RC1"
+            },
+            "2.1.0-beta1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "b31fef91cfb6451164481417ece5ef8a9bb2a941",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/b31fef91cfb6451164481417ece5ef8a9bb2a941"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.1.*@dev",
+                    "typo3/fluid": "2.1.*@dev",
+                    "typo3/party": "2.1.*@dev"
+                },
+                "source": {
+                    "reference": "b31fef91cfb6451164481417ece5ef8a9bb2a941",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2013-12-04T17:13:09+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098576,
+                "version": "2.1.0-beta1",
+                "version_normalized": "2.1.0.0-beta1"
+            },
+            "2.1.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "0eed374191cfd264fbe46e1ae533c9c8addb190a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/0eed374191cfd264fbe46e1ae533c9c8addb190a"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.1.*",
+                    "typo3/fluid": "2.1.*",
+                    "typo3/party": "2.1.*"
+                },
+                "source": {
+                    "reference": "0eed374191cfd264fbe46e1ae533c9c8addb190a",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-03-04T16:52:32+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098579,
+                "version": "2.1.1",
+                "version_normalized": "2.1.1.0"
+            },
+            "2.1.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "c944d1c0addd1ed4e4c971e689c561d61fa9adbf",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/c944d1c0addd1ed4e4c971e689c561d61fa9adbf"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.1.*",
+                    "typo3/fluid": "2.1.*",
+                    "typo3/party": "2.1.*"
+                },
+                "source": {
+                    "reference": "c944d1c0addd1ed4e4c971e689c561d61fa9adbf",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-04-03T10:07:30+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098580,
+                "version": "2.1.2",
+                "version_normalized": "2.1.2.0"
+            },
+            "2.1.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "c660d444df418db1ff03c3fb75b75bdf28b2be39",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/c660d444df418db1ff03c3fb75b75bdf28b2be39"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "1.0.x-dev#f623eff82515f55d18199706851895ced831cba0",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.1.*",
+                    "typo3/fluid": "2.1.*",
+                    "typo3/party": "2.1.*"
+                },
+                "source": {
+                    "reference": "c660d444df418db1ff03c3fb75b75bdf28b2be39",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2015-05-29T15:03:59+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098581,
+                "version": "2.1.3",
+                "version_normalized": "2.1.3.0"
+            },
+            "2.1.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "66236b8ea292b21052593d2878954866042ce2b3",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/66236b8ea292b21052593d2878954866042ce2b3"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.1.*",
+                    "typo3/fluid": "2.1.*",
+                    "typo3/party": "2.1.*"
+                },
+                "source": {
+                    "reference": "66236b8ea292b21052593d2878954866042ce2b3",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2015-05-30T07:01:01+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098582,
+                "version": "2.1.4",
+                "version_normalized": "2.1.4.0"
+            },
+            "2.1.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "d7c8fa520dec85b527533439d79f08b6c38fbd55",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/d7c8fa520dec85b527533439d79f08b6c38fbd55"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.1.*",
+                    "typo3/fluid": "2.1.*",
+                    "typo3/party": "2.1.*"
+                },
+                "source": {
+                    "reference": "d7c8fa520dec85b527533439d79f08b6c38fbd55",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2015-07-02T14:09:44+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098583,
+                "version": "2.1.5",
+                "version_normalized": "2.1.5.0"
+            },
+            "2.1.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "6cc3d0750d7940a25b064d920164f95cc91f218a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/6cc3d0750d7940a25b064d920164f95cc91f218a"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.1.*",
+                    "typo3/fluid": "2.1.*",
+                    "typo3/party": "2.1.*"
+                },
+                "source": {
+                    "reference": "6cc3d0750d7940a25b064d920164f95cc91f218a",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2016-04-20T13:44:33+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098658,
+                "version": "2.1.x-dev",
+                "version_normalized": "2.1.9999999.9999999-dev"
+            },
+            "2.2.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "4788a13aade1c6cbaf373db2767ef0f49b7f164d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/4788a13aade1c6cbaf373db2767ef0f49b7f164d"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.2.*",
+                    "typo3/fluid": "2.2.*",
+                    "typo3/party": "2.2.*"
+                },
+                "source": {
+                    "reference": "4788a13aade1c6cbaf373db2767ef0f49b7f164d",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-06-18T10:15:35+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098588,
+                "version": "2.2.0",
+                "version_normalized": "2.2.0.0"
+            },
+            "2.2.0-beta1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "faff1652f1a56a945c1ad4069aba98dcc4a9a186",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/faff1652f1a56a945c1ad4069aba98dcc4a9a186"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.2.0-beta1",
+                    "typo3/fluid": "2.2.0-beta1",
+                    "typo3/party": "2.2.0-beta1"
+                },
+                "source": {
+                    "reference": "faff1652f1a56a945c1ad4069aba98dcc4a9a186",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-03-06T22:05:54+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098584,
+                "version": "2.2.0-beta1",
+                "version_normalized": "2.2.0.0-beta1"
+            },
+            "2.2.0-beta2": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "8c8bb91dcad8d9a80a5478dfff6af36b72f9ec90",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8c8bb91dcad8d9a80a5478dfff6af36b72f9ec90"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.2.0-beta2",
+                    "typo3/fluid": "2.2.0-beta2",
+                    "typo3/party": "2.2.0-beta2"
+                },
+                "source": {
+                    "reference": "8c8bb91dcad8d9a80a5478dfff6af36b72f9ec90",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-04-02T14:25:05+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098585,
+                "version": "2.2.0-beta2",
+                "version_normalized": "2.2.0.0-beta2"
+            },
+            "2.2.0-beta3": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "1dc319f2c122c895d983b8c0c3cacce45f266786",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/1dc319f2c122c895d983b8c0c3cacce45f266786"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.2.0-beta3",
+                    "typo3/fluid": "2.2.0-beta3",
+                    "typo3/party": "2.2.0-beta3"
+                },
+                "source": {
+                    "reference": "1dc319f2c122c895d983b8c0c3cacce45f266786",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-04-10T17:07:45+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098586,
+                "version": "2.2.0-beta3",
+                "version_normalized": "2.2.0.0-beta3"
+            },
+            "2.2.0-beta4": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "c6f2f4c12707924d1631047846732d7965c3dc24",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/c6f2f4c12707924d1631047846732d7965c3dc24"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.2.0-beta4",
+                    "typo3/fluid": "2.2.0-beta4",
+                    "typo3/party": "2.2.0-beta4"
+                },
+                "source": {
+                    "reference": "c6f2f4c12707924d1631047846732d7965c3dc24",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-05-26T18:41:42+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098587,
+                "version": "2.2.0-beta4",
+                "version_normalized": "2.2.0.0-beta4"
+            },
+            "2.2.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "777a59837281a61317370f086ff2d6a11919af20",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/777a59837281a61317370f086ff2d6a11919af20"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.2.*",
+                    "typo3/fluid": "2.2.*",
+                    "typo3/party": "2.2.*"
+                },
+                "source": {
+                    "reference": "777a59837281a61317370f086ff2d6a11919af20",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-08-26T08:49:39+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098589,
+                "version": "2.2.1",
+                "version_normalized": "2.2.1.0"
+            },
+            "2.2.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "ffd7f46eec61a2295ef594af883151d7e56c7e42",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/ffd7f46eec61a2295ef594af883151d7e56c7e42"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.2.*",
+                    "typo3/fluid": "2.2.*",
+                    "typo3/party": "2.2.*"
+                },
+                "source": {
+                    "reference": "ffd7f46eec61a2295ef594af883151d7e56c7e42",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-09-02T11:47:08+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098590,
+                "version": "2.2.2",
+                "version_normalized": "2.2.2.0"
+            },
+            "2.2.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "7dd0bfcf6fd88d08436492faedb0b44ae8987cb4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/7dd0bfcf6fd88d08436492faedb0b44ae8987cb4"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.2.*",
+                    "typo3/fluid": "2.2.*",
+                    "typo3/party": "2.2.*"
+                },
+                "source": {
+                    "reference": "7dd0bfcf6fd88d08436492faedb0b44ae8987cb4",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2015-03-27T06:44:30+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098591,
+                "version": "2.2.3",
+                "version_normalized": "2.2.3.0"
+            },
+            "2.2.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "c3718306ff4f15596baa9820fc093f5afec80afe",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/c3718306ff4f15596baa9820fc093f5afec80afe"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "1.0.x-dev#f623eff82515f55d18199706851895ced831cba0",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.2.*",
+                    "typo3/fluid": "2.2.*",
+                    "typo3/party": "2.2.*"
+                },
+                "source": {
+                    "reference": "c3718306ff4f15596baa9820fc093f5afec80afe",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2015-05-29T14:48:45+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098592,
+                "version": "2.2.4",
+                "version_normalized": "2.2.4.0"
+            },
+            "2.2.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "1d82b9a035f21aa92c48b6f7ac63b6621a5fb9ae",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/1d82b9a035f21aa92c48b6f7ac63b6621a5fb9ae"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "1.0.x-dev#f623eff82515f55d18199706851895ced831cba0",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.2.*",
+                    "typo3/fluid": "2.2.*",
+                    "typo3/party": "2.2.*"
+                },
+                "source": {
+                    "reference": "1d82b9a035f21aa92c48b6f7ac63b6621a5fb9ae",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2015-05-29T15:00:12+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098593,
+                "version": "2.2.5",
+                "version_normalized": "2.2.5.0"
+            },
+            "2.2.6": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "cb6dbf20b47ec2ed0f317fda52c04178cfb2fe27",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/cb6dbf20b47ec2ed0f317fda52c04178cfb2fe27"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.2.*",
+                    "typo3/fluid": "2.2.*",
+                    "typo3/party": "2.2.*"
+                },
+                "source": {
+                    "reference": "cb6dbf20b47ec2ed0f317fda52c04178cfb2fe27",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2015-05-30T06:52:52+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098594,
+                "version": "2.2.6",
+                "version_normalized": "2.2.6.0"
+            },
+            "2.2.7": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "ec8250ac3f85cc7f32561d779f646628561be9c4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/ec8250ac3f85cc7f32561d779f646628561be9c4"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.2.*",
+                    "typo3/fluid": "2.2.*",
+                    "typo3/party": "2.2.*"
+                },
+                "source": {
+                    "reference": "ec8250ac3f85cc7f32561d779f646628561be9c4",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2015-07-02T14:08:15+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098595,
+                "version": "2.2.7",
+                "version_normalized": "2.2.7.0"
+            },
+            "2.2.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "378f50c7ab6d752f78ad7413ac3fcaf333517b97",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/378f50c7ab6d752f78ad7413ac3fcaf333517b97"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/dom-crawler": "2.2.*",
+                    "symfony/yaml": "2.1.*",
+                    "typo3/eel": "2.2.*",
+                    "typo3/fluid": "2.2.*",
+                    "typo3/party": "2.2.*"
+                },
+                "source": {
+                    "reference": "378f50c7ab6d752f78ad7413ac3fcaf333517b97",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2016-12-15T11:54:42+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098659,
+                "version": "2.2.x-dev",
+                "version_normalized": "2.2.9999999.9999999-dev"
+            },
+            "2.3.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "106f942230e73a0ef37e71a6ac64fcb47b0a7a10",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/106f942230e73a0ef37e71a6ac64fcb47b0a7a10"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "2.3.*",
+                    "typo3/fluid": "2.3.*",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "106f942230e73a0ef37e71a6ac64fcb47b0a7a10",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-12-10T23:22:29+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098599,
+                "version": "2.3.0",
+                "version_normalized": "2.3.0.0"
+            },
+            "2.3.0-beta1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "dd507be96e58e7c3168aef69cee3633a07fefa30",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/dd507be96e58e7c3168aef69cee3633a07fefa30"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "2.3.0-beta1",
+                    "typo3/fluid": "2.3.0-beta1",
+                    "typo3/party": "2.3.0-beta1"
+                },
+                "source": {
+                    "reference": "dd507be96e58e7c3168aef69cee3633a07fefa30",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-11-14T07:47:15+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098596,
+                "version": "2.3.0-beta1",
+                "version_normalized": "2.3.0.0-beta1"
+            },
+            "2.3.0-beta2": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "8b2b93aa675f3ca5e3ed52fa8f38e437263f8087",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8b2b93aa675f3ca5e3ed52fa8f38e437263f8087"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "2.3.0-beta2",
+                    "typo3/fluid": "2.3.0-beta2",
+                    "typo3/party": "2.3.0-beta2"
+                },
+                "source": {
+                    "reference": "8b2b93aa675f3ca5e3ed52fa8f38e437263f8087",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-11-26T10:51:40+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098597,
+                "version": "2.3.0-beta2",
+                "version_normalized": "2.3.0.0-beta2"
+            },
+            "2.3.0-beta3": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "b3430e47625a795b636ae02cf82753dd8f785550",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/b3430e47625a795b636ae02cf82753dd8f785550"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "2.3.0-beta3",
+                    "typo3/fluid": "2.3.0-beta3",
+                    "typo3/party": "2.3.0-beta3"
+                },
+                "source": {
+                    "reference": "b3430e47625a795b636ae02cf82753dd8f785550",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2014-12-03T22:10:39+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098598,
+                "version": "2.3.0-beta3",
+                "version_normalized": "2.3.0.0-beta3"
+            },
+            "2.3.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "104358a9baed66948719f4496b53d615d3a36024",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/104358a9baed66948719f4496b53d615d3a36024"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "2.3.*",
+                    "typo3/fluid": "2.3.*",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "104358a9baed66948719f4496b53d615d3a36024",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM"
+                },
+                "time": "2015-01-02T11:38:17+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098600,
+                "version": "2.3.1",
+                "version_normalized": "2.3.1.0"
+            },
+            "2.3.10": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "bc73da32be8d1f42810e2ac70aeaea7de6f23d33",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/bc73da32be8d1f42810e2ac70aeaea7de6f23d33"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.4.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "~2.3.0",
+                    "typo3/fluid": "~2.3.0",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "bc73da32be8d1f42810e2ac70aeaea7de6f23d33",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2015-12-18T08:33:27+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098609,
+                "version": "2.3.10",
+                "version_normalized": "2.3.10.0"
+            },
+            "2.3.11": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "302f423fb6348b21a59aace60f7e7dc4b472b072",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/302f423fb6348b21a59aace60f7e7dc4b472b072"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.4.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "~2.3.0",
+                    "typo3/fluid": "~2.3.0",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "302f423fb6348b21a59aace60f7e7dc4b472b072",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2016-01-14T15:35:07+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098610,
+                "version": "2.3.11",
+                "version_normalized": "2.3.11.0"
+            },
+            "2.3.12": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "ee1a2f8c70311251566a9f8c2c46b870ce19cd47",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/ee1a2f8c70311251566a9f8c2c46b870ce19cd47"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.4.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "~2.3.0",
+                    "typo3/fluid": "~2.3.0",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "ee1a2f8c70311251566a9f8c2c46b870ce19cd47",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2016-03-16T06:24:22+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098611,
+                "version": "2.3.12",
+                "version_normalized": "2.3.12.0"
+            },
+            "2.3.13": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "369c06e067c4c0ed1a66bbd03dae53436e3ccdfa",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/369c06e067c4c0ed1a66bbd03dae53436e3ccdfa"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.4.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "~2.3.0",
+                    "typo3/fluid": "~2.3.0",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "369c06e067c4c0ed1a66bbd03dae53436e3ccdfa",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2016-05-09T10:11:49+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098612,
+                "version": "2.3.13",
+                "version_normalized": "2.3.13.0"
+            },
+            "2.3.14": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "1694532175e36838f75686acf9fa73c107c2cd24",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/1694532175e36838f75686acf9fa73c107c2cd24"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.4.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "~2.3.0",
+                    "typo3/fluid": "~2.3.0",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "1694532175e36838f75686acf9fa73c107c2cd24",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2016-05-29T08:04:41+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098613,
+                "version": "2.3.14",
+                "version_normalized": "2.3.14.0"
+            },
+            "2.3.15": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "66c5ca315585f6ee681197b3d79b226dceb375cf",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/66c5ca315585f6ee681197b3d79b226dceb375cf"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.4.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "~2.3.0",
+                    "typo3/fluid": "~2.3.0",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "66c5ca315585f6ee681197b3d79b226dceb375cf",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2016-06-17T06:49:35+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098614,
+                "version": "2.3.15",
+                "version_normalized": "2.3.15.0"
+            },
+            "2.3.16": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "b12b9299c15c9cd546b850ad704317e90a254db4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/b12b9299c15c9cd546b850ad704317e90a254db4"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.4.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "~2.3.0",
+                    "typo3/fluid": "~2.3.0",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "b12b9299c15c9cd546b850ad704317e90a254db4",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2016-11-01T12:29:19+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098615,
+                "version": "2.3.16",
+                "version_normalized": "2.3.16.0"
+            },
+            "2.3.17": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "223830b80216f77de8a2c677348dc91c05b36a3b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/223830b80216f77de8a2c677348dc91c05b36a3b"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.4.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "~2.3.0",
+                    "typo3/fluid": "~2.3.0",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "223830b80216f77de8a2c677348dc91c05b36a3b",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2017-04-01T10:04:27+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1320741,
+                "version": "2.3.17",
+                "version_normalized": "2.3.17.0"
+            },
+            "2.3.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "d60936f9a779b0f66361b3e5fab09acbdb2bb969",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/d60936f9a779b0f66361b3e5fab09acbdb2bb969"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "2.3.*",
+                    "typo3/fluid": "2.3.*",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "d60936f9a779b0f66361b3e5fab09acbdb2bb969",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2015-03-04T21:09:22+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098601,
+                "version": "2.3.2",
+                "version_normalized": "2.3.2.0"
+            },
+            "2.3.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "d3e2bfdf3b1bd891ea1c3a33bb2166f62e707a1a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/d3e2bfdf3b1bd891ea1c3a33bb2166f62e707a1a"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "2.3.*",
+                    "typo3/fluid": "2.3.*",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "d3e2bfdf3b1bd891ea1c3a33bb2166f62e707a1a",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2015-03-25T15:05:00+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098602,
+                "version": "2.3.3",
+                "version_normalized": "2.3.3.0"
+            },
+            "2.3.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "0201919de3cb0bc1f57f5271514af4d241506ccc",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/0201919de3cb0bc1f57f5271514af4d241506ccc"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "1.0.x-dev#f623eff82515f55d18199706851895ced831cba0",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "2.3.*",
+                    "typo3/fluid": "2.3.*",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "0201919de3cb0bc1f57f5271514af4d241506ccc",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2015-05-29T14:41:58+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098603,
+                "version": "2.3.4",
+                "version_normalized": "2.3.4.0"
+            },
+            "2.3.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "1863e68bda013b2e06f98b12bbcba2ca7e6389dc",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/1863e68bda013b2e06f98b12bbcba2ca7e6389dc"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "2.3.*",
+                    "typo3/fluid": "2.3.*",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "1863e68bda013b2e06f98b12bbcba2ca7e6389dc",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2015-05-30T06:38:38+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098604,
+                "version": "2.3.5",
+                "version_normalized": "2.3.5.0"
+            },
+            "2.3.6": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "a14655bbb19257a2006eaae537abfe9d556f2966",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/a14655bbb19257a2006eaae537abfe9d556f2966"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "2.3.*",
+                    "typo3/fluid": "2.3.*",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "a14655bbb19257a2006eaae537abfe9d556f2966",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2015-07-02T14:06:39+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098605,
+                "version": "2.3.6",
+                "version_normalized": "2.3.6.0"
+            },
+            "2.3.7": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "d5cfa80d40ec6f0dd7a8a725ee050bd680e23eb4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/d5cfa80d40ec6f0dd7a8a725ee050bd680e23eb4"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "~2.3.0",
+                    "typo3/fluid": "~2.3.0",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "d5cfa80d40ec6f0dd7a8a725ee050bd680e23eb4",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2015-11-23T09:54:21+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098606,
+                "version": "2.3.7",
+                "version_normalized": "2.3.7.0"
+            },
+            "2.3.8": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "6693ff73bf58821d91c1415534978f11cfa1b034",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/6693ff73bf58821d91c1415534978f11cfa1b034"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.3.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "~2.3.0",
+                    "typo3/fluid": "~2.3.0",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "6693ff73bf58821d91c1415534978f11cfa1b034",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2015-11-23T20:33:05+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098607,
+                "version": "2.3.8",
+                "version_normalized": "2.3.8.0"
+            },
+            "2.3.9": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "e3d79ce13ea62cf0220f7526f243ebaf5b9d861d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/e3d79ce13ea62cf0220f7526f243ebaf5b9d861d"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.4.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "~2.3.0",
+                    "typo3/fluid": "~2.3.0",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "e3d79ce13ea62cf0220f7526f243ebaf5b9d861d",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2015-12-17T10:04:43+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098608,
+                "version": "2.3.9",
+                "version_normalized": "2.3.9.0"
+            },
+            "2.3.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "1467fa154f03f8d79d09190a135891727fd629a5",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/1467fa154f03f8d79d09190a135891727fd629a5"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "1.0.0-alpha3",
+                    "doctrine/orm": "2.4.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-session": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.3.2",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "~2.3.0",
+                    "typo3/fluid": "~2.3.0",
+                    "typo3/party": "2.3.*"
+                },
+                "source": {
+                    "reference": "1467fa154f03f8d79d09190a135891727fd629a5",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine"
+                },
+                "time": "2017-05-12T09:14:08+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098660,
+                "version": "2.3.x-dev",
+                "version_normalized": "2.3.9999999.9999999-dev"
+            },
+            "3.0.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "8e5d01a3ffcfc37c528b691768625ca1ce70fe86",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8e5d01a3ffcfc37c528b691768625ca1ce70fe86"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "~1.0.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "3.0.*",
+                    "typo3/fluid": "3.0.*"
+                },
+                "source": {
+                    "reference": "8e5d01a3ffcfc37c528b691768625ca1ce70fe86",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2015-08-11T14:17:21+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098623,
+                "version": "3.0.0",
+                "version_normalized": "3.0.0.0"
+            },
+            "3.0.0-beta1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "9aea7a6f00121b73ef676c62adcee561c1eaddbc",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/9aea7a6f00121b73ef676c62adcee561c1eaddbc"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "2.4.*",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.5.0",
+                    "symfony/console": "2.*",
+                    "symfony/dom-crawler": "2.5.*",
+                    "symfony/yaml": "2.5.*",
+                    "typo3/eel": "3.0.0-beta1",
+                    "typo3/fluid": "3.0.0-beta1"
+                },
+                "source": {
+                    "reference": "9aea7a6f00121b73ef676c62adcee561c1eaddbc",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2015-02-27T08:01:10+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098616,
+                "version": "3.0.0-beta1",
+                "version_normalized": "3.0.0.0-beta1"
+            },
+            "3.0.0-beta2": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "28f7b5067e997210be5073645138c6990c767180",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/28f7b5067e997210be5073645138c6990c767180"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "dev-master",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "3.0.0-beta2",
+                    "typo3/fluid": "3.0.0-beta2"
+                },
+                "source": {
+                    "reference": "28f7b5067e997210be5073645138c6990c767180",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2015-05-12T07:56:24+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098617,
+                "version": "3.0.0-beta2",
+                "version_normalized": "3.0.0.0-beta2"
+            },
+            "3.0.0-beta3": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "0fde5e2ec62f1ade4c82eece62b5dadec76c3a82",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/0fde5e2ec62f1ade4c82eece62b5dadec76c3a82"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "~1.0.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "3.0.0-beta3",
+                    "typo3/fluid": "3.0.0-beta3"
+                },
+                "source": {
+                    "reference": "0fde5e2ec62f1ade4c82eece62b5dadec76c3a82",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2015-06-01T12:49:29+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098618,
+                "version": "3.0.0-beta3",
+                "version_normalized": "3.0.0.0-beta3"
+            },
+            "3.0.0-beta4": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "fb5fe05914663c32fd13100fe1e078e28599a2aa",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/fb5fe05914663c32fd13100fe1e078e28599a2aa"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "~1.0.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "3.0.0-beta4",
+                    "typo3/fluid": "3.0.0-beta4"
+                },
+                "source": {
+                    "reference": "fb5fe05914663c32fd13100fe1e078e28599a2aa",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2015-07-03T10:44:48+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098619,
+                "version": "3.0.0-beta4",
+                "version_normalized": "3.0.0.0-beta4"
+            },
+            "3.0.0-beta5": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "65be3106c13b076573d540964143835911196654",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/65be3106c13b076573d540964143835911196654"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "~1.0.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "3.0.0-beta5",
+                    "typo3/fluid": "3.0.0-beta5"
+                },
+                "source": {
+                    "reference": "65be3106c13b076573d540964143835911196654",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2015-07-15T20:56:43+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098620,
+                "version": "3.0.0-beta5",
+                "version_normalized": "3.0.0.0-beta5"
+            },
+            "3.0.0-beta6": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "12c8acd47e3dbd1e8ac6740e39f5dcb7427f7fc5",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/12c8acd47e3dbd1e8ac6740e39f5dcb7427f7fc5"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "~1.0.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "3.0.0-beta6",
+                    "typo3/fluid": "3.0.0-beta6"
+                },
+                "source": {
+                    "reference": "12c8acd47e3dbd1e8ac6740e39f5dcb7427f7fc5",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2015-07-23T13:47:20+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098621,
+                "version": "3.0.0-beta6",
+                "version_normalized": "3.0.0.0-beta6"
+            },
+            "3.0.0-rc1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "TYPO3 Flow Application Framework",
+                "dist": {
+                    "reference": "d1a57d84d0f9ed5445aae9b051a649ea7ffdc7a8",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/d1a57d84d0f9ed5445aae9b051a649ea7ffdc7a8"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "LGPL-3.0+"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "composer/installers": "~1.0.2",
+                    "doctrine/migrations": "~1.0.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "3.0.*",
+                    "typo3/fluid": "3.0.*"
+                },
+                "source": {
+                    "reference": "d1a57d84d0f9ed5445aae9b051a649ea7ffdc7a8",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2015-07-31T11:53:01+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098622,
+                "version": "3.0.0-rc1",
+                "version_normalized": "3.0.0.0-RC1"
+            },
+            "3.0.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "920a57294c740471c8c77d049888d540eb76a6b5",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/920a57294c740471c8c77d049888d540eb76a6b5"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "~1.0.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "920a57294c740471c8c77d049888d540eb76a6b5",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2015-11-23T10:31:32+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098624,
+                "version": "3.0.1",
+                "version_normalized": "3.0.1.0"
+            },
+            "3.0.10": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "aa11dab2c75a064d678968b8681fe5ae1b847540",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/aa11dab2c75a064d678968b8681fe5ae1b847540"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "aa11dab2c75a064d678968b8681fe5ae1b847540",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-11-01T12:32:25+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098633,
+                "version": "3.0.10",
+                "version_normalized": "3.0.10.0"
+            },
+            "3.0.11": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "64ffe08004d4fcb1863bc4b610397342e739d655",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/64ffe08004d4fcb1863bc4b610397342e739d655"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "64ffe08004d4fcb1863bc4b610397342e739d655",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-04-01T10:11:19+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1320791,
+                "version": "3.0.11",
+                "version_normalized": "3.0.11.0"
+            },
+            "3.0.12": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "3b67b35bb663875ffa9844fba8c00958efcf46bc",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/3b67b35bb663875ffa9844fba8c00958efcf46bc"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "3b67b35bb663875ffa9844fba8c00958efcf46bc",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-04-11T19:26:54+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1338697,
+                "version": "3.0.12",
+                "version_normalized": "3.0.12.0"
+            },
+            "3.0.13": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "04c8f9b5141526eba50e05b2adce4fbdf8c3e66a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/04c8f9b5141526eba50e05b2adce4fbdf8c3e66a"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "04c8f9b5141526eba50e05b2adce4fbdf8c3e66a",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-06-20T09:04:35+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1453748,
+                "version": "3.0.13",
+                "version_normalized": "3.0.13.0"
+            },
+            "3.0.14": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "8fb51a6b9f234a66483c364a17aa1c970466f6e2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8fb51a6b9f234a66483c364a17aa1c970466f6e2"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "8fb51a6b9f234a66483c364a17aa1c970466f6e2",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-07-07T14:09:51+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1488287,
+                "version": "3.0.14",
+                "version_normalized": "3.0.14.0"
+            },
+            "3.0.15": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "3254e7d733930e9eb34be8c296ddb0cc6e4be1ac",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/3254e7d733930e9eb34be8c296ddb0cc6e4be1ac"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "3254e7d733930e9eb34be8c296ddb0cc6e4be1ac",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-07-27T15:50:10+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1522650,
+                "version": "3.0.15",
+                "version_normalized": "3.0.15.0"
+            },
+            "3.0.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "556677410767eaf5299b3914d7097e5341583788",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/556677410767eaf5299b3914d7097e5341583788"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/migrations": "~1.0.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "556677410767eaf5299b3914d7097e5341583788",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2015-11-23T20:52:32+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098625,
+                "version": "3.0.2",
+                "version_normalized": "3.0.2.0"
+            },
+            "3.0.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "a6a409076a589aa77c64a7dd0986cc8289e72b3c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/a6a409076a589aa77c64a7dd0986cc8289e72b3c"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.0.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "a6a409076a589aa77c64a7dd0986cc8289e72b3c",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2015-12-11T01:32:20+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098626,
+                "version": "3.0.3",
+                "version_normalized": "3.0.3.0"
+            },
+            "3.0.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "094837f69458dae44ffa4743632067458eb59298",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/094837f69458dae44ffa4743632067458eb59298"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.0.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "094837f69458dae44ffa4743632067458eb59298",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2015-12-17T10:34:48+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098627,
+                "version": "3.0.4",
+                "version_normalized": "3.0.4.0"
+            },
+            "3.0.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "7b8520d9266b0e2b1242e4192ccf9b82ecfe5a50",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/7b8520d9266b0e2b1242e4192ccf9b82ecfe5a50"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.0.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "7b8520d9266b0e2b1242e4192ccf9b82ecfe5a50",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-01-14T15:58:30+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098628,
+                "version": "3.0.5",
+                "version_normalized": "3.0.5.0"
+            },
+            "3.0.6": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "534b09a217facdc20fceb5ba7ac05d25e33e3754",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/534b09a217facdc20fceb5ba7ac05d25e33e3754"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "534b09a217facdc20fceb5ba7ac05d25e33e3754",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-03-16T06:48:15+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098629,
+                "version": "3.0.6",
+                "version_normalized": "3.0.6.0"
+            },
+            "3.0.7": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "0b0cda8a50c6c3453f3d3eafa6e19d257d4d70a7",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/0b0cda8a50c6c3453f3d3eafa6e19d257d4d70a7"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "0b0cda8a50c6c3453f3d3eafa6e19d257d4d70a7",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-05-09T10:36:09+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098630,
+                "version": "3.0.7",
+                "version_normalized": "3.0.7.0"
+            },
+            "3.0.8": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "60a9801ee0dfbc5821e4aade70ab8085abd33102",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/60a9801ee0dfbc5821e4aade70ab8085abd33102"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "60a9801ee0dfbc5821e4aade70ab8085abd33102",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-05-29T08:50:43+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098631,
+                "version": "3.0.8",
+                "version_normalized": "3.0.8.0"
+            },
+            "3.0.9": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "e484a107dfb560f1305c814fa092640e50dd48b9",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/e484a107dfb560f1305c814fa092640e50dd48b9"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "e484a107dfb560f1305c814fa092640e50dd48b9",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-06-17T10:34:00+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098632,
+                "version": "3.0.9",
+                "version_normalized": "3.0.9.0"
+            },
+            "3.0.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "a0355e65282f612bb1fab35ca8b22ecf9eb4dbd4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/a0355e65282f612bb1fab35ca8b22ecf9eb4dbd4"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": ">=5.5.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.0.0",
+                    "typo3/fluid": "~3.0.0"
+                },
+                "source": {
+                    "reference": "a0355e65282f612bb1fab35ca8b22ecf9eb4dbd4",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-07-28T20:27:18+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098661,
+                "version": "3.0.x-dev",
+                "version_normalized": "3.0.9999999.9999999-dev"
+            },
+            "3.1.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "dd36934b70546207470d58097d801a9967a01c9e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/dd36934b70546207470d58097d801a9967a01c9e"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.0.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "dd36934b70546207470d58097d801a9967a01c9e",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2015-12-22T09:42:16+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098634,
+                "version": "3.1.0",
+                "version_normalized": "3.1.0.0"
+            },
+            "3.1.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "4844aaad0e8313eb3b97ed75dbd57d1ddaa7450d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/4844aaad0e8313eb3b97ed75dbd57d1ddaa7450d"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.0.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "4844aaad0e8313eb3b97ed75dbd57d1ddaa7450d",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-01-14T16:22:12+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098635,
+                "version": "3.1.1",
+                "version_normalized": "3.1.1.0"
+            },
+            "3.1.10": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "eb0f25b16eae6236f6f32128288d231b9466646a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/eb0f25b16eae6236f6f32128288d231b9466646a"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "eb0f25b16eae6236f6f32128288d231b9466646a",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-04-11T19:27:58+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1338721,
+                "version": "3.1.10",
+                "version_normalized": "3.1.10.0"
+            },
+            "3.1.11": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "8947f4e9a63144e211bd6581e57d02357574682a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8947f4e9a63144e211bd6581e57d02357574682a"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "8947f4e9a63144e211bd6581e57d02357574682a",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-06-20T09:20:48+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1453783,
+                "version": "3.1.11",
+                "version_normalized": "3.1.11.0"
+            },
+            "3.1.12": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "6140f0ed83ff9c0651a398067c047b44db0db39f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/6140f0ed83ff9c0651a398067c047b44db0db39f"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "6140f0ed83ff9c0651a398067c047b44db0db39f",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-07-07T14:41:12+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1488351,
+                "version": "3.1.12",
+                "version_normalized": "3.1.12.0"
+            },
+            "3.1.13": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "e2a59464436315823fbe59fdfa4079200f38e779",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/e2a59464436315823fbe59fdfa4079200f38e779"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "e2a59464436315823fbe59fdfa4079200f38e779",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-07-27T15:53:54+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1522701,
+                "version": "3.1.13",
+                "version_normalized": "3.1.13.0"
+            },
+            "3.1.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "ec344502f04e116282b756c4f3f843668f9227e2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/ec344502f04e116282b756c4f3f843668f9227e2"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "ec344502f04e116282b756c4f3f843668f9227e2",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-03-16T07:12:13+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098636,
+                "version": "3.1.2",
+                "version_normalized": "3.1.2.0"
+            },
+            "3.1.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "299c8f9ef8ca902c093cda39041402ff5d944a25",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/299c8f9ef8ca902c093cda39041402ff5d944a25"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "299c8f9ef8ca902c093cda39041402ff5d944a25",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-05-09T11:01:18+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098637,
+                "version": "3.1.3",
+                "version_normalized": "3.1.3.0"
+            },
+            "3.1.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "86b01a1c1ac6226ae86d001bb35dba2d1e65bc6d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/86b01a1c1ac6226ae86d001bb35dba2d1e65bc6d"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "86b01a1c1ac6226ae86d001bb35dba2d1e65bc6d",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-05-29T11:36:07+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098638,
+                "version": "3.1.4",
+                "version_normalized": "3.1.4.0"
+            },
+            "3.1.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "bf7d5c55efc1657958a6bcb2e827f8d856f449dc",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/bf7d5c55efc1657958a6bcb2e827f8d856f449dc"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "bf7d5c55efc1657958a6bcb2e827f8d856f449dc",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-06-17T11:02:40+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098639,
+                "version": "3.1.5",
+                "version_normalized": "3.1.5.0"
+            },
+            "3.1.6": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "d24f7494d033aa240316e9f620e446bd77a66825",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/d24f7494d033aa240316e9f620e446bd77a66825"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "d24f7494d033aa240316e9f620e446bd77a66825",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-09-29T16:34:18+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098640,
+                "version": "3.1.6",
+                "version_normalized": "3.1.6.0"
+            },
+            "3.1.7": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "fd6649bdcddfc1e544d05a549c1b11f616fd7309",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/fd6649bdcddfc1e544d05a549c1b11f616fd7309"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "fd6649bdcddfc1e544d05a549c1b11f616fd7309",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-11-01T12:09:05+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098641,
+                "version": "3.1.7",
+                "version_normalized": "3.1.7.0"
+            },
+            "3.1.8": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "9db93310293f9682e4307a220cf2dc2312198349",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/9db93310293f9682e4307a220cf2dc2312198349"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "9db93310293f9682e4307a220cf2dc2312198349",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-12-05T14:52:39+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1115844,
+                "version": "3.1.8",
+                "version_normalized": "3.1.8.0"
+            },
+            "3.1.9": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "63481f789c8790ca1d67e19033ecbfdf220ea9ef",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/63481f789c8790ca1d67e19033ecbfdf220ea9ef"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "63481f789c8790ca1d67e19033ecbfdf220ea9ef",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-04-01T10:16:26+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1320804,
+                "version": "3.1.9",
+                "version_normalized": "3.1.9.0"
+            },
+            "3.1.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "b01530c6617eaa4711c5895fa5d6c599fe2164ad",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/b01530c6617eaa4711c5895fa5d6c599fe2164ad"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.1.0",
+                    "typo3/fluid": "~3.1.0"
+                },
+                "source": {
+                    "reference": "b01530c6617eaa4711c5895fa5d6c599fe2164ad",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-09-21T19:55:27+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098662,
+                "version": "3.1.x-dev",
+                "version_normalized": "3.1.9999999.9999999-dev"
+            },
+            "3.2.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "84f7ee4053f48dd3d04747521aaa4b0820af9237",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/84f7ee4053f48dd3d04747521aaa4b0820af9237"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "84f7ee4053f48dd3d04747521aaa4b0820af9237",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-05-04T09:16:47+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098642,
+                "version": "3.2.0",
+                "version_normalized": "3.2.0.0"
+            },
+            "3.2.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "109512256ac126ee62956e6966f6e14754b20ae1",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/109512256ac126ee62956e6966f6e14754b20ae1"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "109512256ac126ee62956e6966f6e14754b20ae1",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-05-09T11:48:18+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098643,
+                "version": "3.2.1",
+                "version_normalized": "3.2.1.0"
+            },
+            "3.2.10": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "09bdbe8b291937b920c527ff27d74ceb97e76583",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/09bdbe8b291937b920c527ff27d74ceb97e76583"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "09bdbe8b291937b920c527ff27d74ceb97e76583",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-03-10T08:49:28+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1274840,
+                "version": "3.2.10",
+                "version_normalized": "3.2.10.0"
+            },
+            "3.2.11": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "8112c7159ade3e3faa315b383884502ca32a6ec0",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8112c7159ade3e3faa315b383884502ca32a6ec0"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "8112c7159ade3e3faa315b383884502ca32a6ec0",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-04-01T10:20:42+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1320847,
+                "version": "3.2.11",
+                "version_normalized": "3.2.11.0"
+            },
+            "3.2.12": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "98b7184f409db8c138ba71791798521cdea9ecf8",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/98b7184f409db8c138ba71791798521cdea9ecf8"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "98b7184f409db8c138ba71791798521cdea9ecf8",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-04-03T08:24:13+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1323479,
+                "version": "3.2.12",
+                "version_normalized": "3.2.12.0"
+            },
+            "3.2.13": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "280fdc2541884c04cec73bf4f8124b79f1576bca",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/280fdc2541884c04cec73bf4f8124b79f1576bca"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "280fdc2541884c04cec73bf4f8124b79f1576bca",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-04-11T19:29:03+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1338765,
+                "version": "3.2.13",
+                "version_normalized": "3.2.13.0"
+            },
+            "3.2.14": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "2c96df6abdfc63f03f1dcd139d85e84e0a639fb9",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/2c96df6abdfc63f03f1dcd139d85e84e0a639fb9"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "2c96df6abdfc63f03f1dcd139d85e84e0a639fb9",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-06-20T09:25:23+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1453820,
+                "version": "3.2.14",
+                "version_normalized": "3.2.14.0"
+            },
+            "3.2.15": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "14276e11ca9ae313ef35467f97e6d9c144f7c06f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/14276e11ca9ae313ef35467f97e6d9c144f7c06f"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "14276e11ca9ae313ef35467f97e6d9c144f7c06f",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-07-07T14:43:54+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1488418,
+                "version": "3.2.15",
+                "version_normalized": "3.2.15.0"
+            },
+            "3.2.16": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "75b128c0a8dc5c480a569050d9550dcd6ff86b91",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/75b128c0a8dc5c480a569050d9550dcd6ff86b91"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "75b128c0a8dc5c480a569050d9550dcd6ff86b91",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-07-27T16:03:24+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1522743,
+                "version": "3.2.16",
+                "version_normalized": "3.2.16.0"
+            },
+            "3.2.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "7681fe08bb1e327c9c4301be0da29bd204edfaa1",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/7681fe08bb1e327c9c4301be0da29bd204edfaa1"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "7681fe08bb1e327c9c4301be0da29bd204edfaa1",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-05-13T13:07:56+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098644,
+                "version": "3.2.2",
+                "version_normalized": "3.2.2.0"
+            },
+            "3.2.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "566d1c2bb4d6d36f233c7000c64050e22c1c631a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/566d1c2bb4d6d36f233c7000c64050e22c1c631a"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "566d1c2bb4d6d36f233c7000c64050e22c1c631a",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-05-29T13:12:30+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098645,
+                "version": "3.2.3",
+                "version_normalized": "3.2.3.0"
+            },
+            "3.2.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "38e3a1f630feee1cd33dc05841d6502f1d03fa7e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/38e3a1f630feee1cd33dc05841d6502f1d03fa7e"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^1.0.1",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "38e3a1f630feee1cd33dc05841d6502f1d03fa7e",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-06-17T11:47:13+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098646,
+                "version": "3.2.4",
+                "version_normalized": "3.2.4.0"
+            },
+            "3.2.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "f902d2794f070dec168e409162143bed967bef47",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/f902d2794f070dec168e409162143bed967bef47"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "f902d2794f070dec168e409162143bed967bef47",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-08-23T13:10:52+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098647,
+                "version": "3.2.5",
+                "version_normalized": "3.2.5.0"
+            },
+            "3.2.6": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "8075845f714304c527b0e6cbebc22d69c5b1da67",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8075845f714304c527b0e6cbebc22d69c5b1da67"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "8075845f714304c527b0e6cbebc22d69c5b1da67",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-09-29T16:32:02+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098648,
+                "version": "3.2.6",
+                "version_normalized": "3.2.6.0"
+            },
+            "3.2.7": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "5e7175daaee8b1adbe0d18951fb4947a55a7de82",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/5e7175daaee8b1adbe0d18951fb4947a55a7de82"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "5e7175daaee8b1adbe0d18951fb4947a55a7de82",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-11-01T12:11:13+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098649,
+                "version": "3.2.7",
+                "version_normalized": "3.2.7.0"
+            },
+            "3.2.8": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "8de1d6cdd24c23522120151895273dba5daa3ccd",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8de1d6cdd24c23522120151895273dba5daa3ccd"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "8de1d6cdd24c23522120151895273dba5daa3ccd",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-12-05T16:02:50+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1115858,
+                "version": "3.2.8",
+                "version_normalized": "3.2.8.0"
+            },
+            "3.2.9": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "f3809eda169a3b575d7265e8d3f6583db1d6c9c3",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/f3809eda169a3b575d7265e8d3f6583db1d6c9c3"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "f3809eda169a3b575d7265e8d3f6583db1d6c9c3",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-02-14T15:23:09+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1232107,
+                "version": "3.2.9",
+                "version_normalized": "3.2.9.0"
+            },
+            "3.2.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "bdc134a371a9481cddde2767d1ccf17cd60b8380",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/bdc134a371a9481cddde2767d1ccf17cd60b8380"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.4.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.2.0",
+                    "neos/utility-arrays": "~3.2.0",
+                    "neos/utility-files": "~3.2.0",
+                    "neos/utility-lock": "~3.2.0",
+                    "neos/utility-mediatypes": "~3.2.0",
+                    "neos/utility-objecthandling": "~3.2.0",
+                    "neos/utility-opcodecache": "~3.2.0",
+                    "neos/utility-pdo": "~3.2.0",
+                    "neos/utility-schema": "~3.2.0",
+                    "neos/utility-unicode": "~3.2.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.0",
+                    "symfony/dom-crawler": "~2.5.0",
+                    "symfony/yaml": "~2.5.0",
+                    "typo3/eel": "~3.2.0",
+                    "typo3/fluid": "~3.2.0"
+                },
+                "source": {
+                    "reference": "bdc134a371a9481cddde2767d1ccf17cd60b8380",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-09-21T19:56:22+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098663,
+                "version": "3.2.x-dev",
+                "version_normalized": "3.2.9999999.9999999-dev"
+            },
+            "3.3.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "b8e681a9bf09f093ebf2af71edb97c8281d4a9ae",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/b8e681a9bf09f093ebf2af71edb97c8281d4a9ae"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "*",
+                    "neos/utility-arrays": "*",
+                    "neos/utility-files": "*",
+                    "neos/utility-lock": "*",
+                    "neos/utility-mediatypes": "*",
+                    "neos/utility-objecthandling": "*",
+                    "neos/utility-opcodecache": "*",
+                    "neos/utility-pdo": "*",
+                    "neos/utility-schema": "*",
+                    "neos/utility-unicode": "*",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "b8e681a9bf09f093ebf2af71edb97c8281d4a9ae",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-08-22T14:44:27+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098650,
+                "version": "3.3.0",
+                "version_normalized": "3.3.0.0"
+            },
+            "3.3.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "2cfe8b7ff6e7075c93efede0c6e9cbc64f3d52ce",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/2cfe8b7ff6e7075c93efede0c6e9cbc64f3d52ce"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "*",
+                    "neos/utility-arrays": "*",
+                    "neos/utility-files": "*",
+                    "neos/utility-lock": "*",
+                    "neos/utility-mediatypes": "*",
+                    "neos/utility-objecthandling": "*",
+                    "neos/utility-opcodecache": "*",
+                    "neos/utility-pdo": "*",
+                    "neos/utility-schema": "*",
+                    "neos/utility-unicode": "*",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "2cfe8b7ff6e7075c93efede0c6e9cbc64f3d52ce",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-08-23T13:57:59+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098651,
+                "version": "3.3.1",
+                "version_normalized": "3.3.1.0"
+            },
+            "3.3.10": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "ed398693bf41d6baa3b398b47f3d35f67e6d8c7a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/ed398693bf41d6baa3b398b47f3d35f67e6d8c7a"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "ed398693bf41d6baa3b398b47f3d35f67e6d8c7a",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-04-01T10:21:52+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1320881,
+                "version": "3.3.10",
+                "version_normalized": "3.3.10.0"
+            },
+            "3.3.11": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "fd142988e5e977d9b32670e9cbe48ff360f337b0",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/fd142988e5e977d9b32670e9cbe48ff360f337b0"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "fd142988e5e977d9b32670e9cbe48ff360f337b0",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-04-03T08:26:51+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1323577,
+                "version": "3.3.11",
+                "version_normalized": "3.3.11.0"
+            },
+            "3.3.12": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "079cad331680e0582ba4cc732754fcf8235949ce",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/079cad331680e0582ba4cc732754fcf8235949ce"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "079cad331680e0582ba4cc732754fcf8235949ce",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-04-07T16:18:59+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1332450,
+                "version": "3.3.12",
+                "version_normalized": "3.3.12.0"
+            },
+            "3.3.13": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "75c6279df99a11f986541ea62fbfb4253a71c401",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/75c6279df99a11f986541ea62fbfb4253a71c401"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "75c6279df99a11f986541ea62fbfb4253a71c401",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-04-11T19:31:41+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1338832,
+                "version": "3.3.13",
+                "version_normalized": "3.3.13.0"
+            },
+            "3.3.14": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "cd053b533fe5be211f9623772150a0b94b8c8575",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/cd053b533fe5be211f9623772150a0b94b8c8575"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "cd053b533fe5be211f9623772150a0b94b8c8575",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-06-18T16:54:10+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1453854,
+                "version": "3.3.14",
+                "version_normalized": "3.3.14.0"
+            },
+            "3.3.15": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "ed05adeb2cb4a7348df16007ae3b8a1e0ee15eaf",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/ed05adeb2cb4a7348df16007ae3b8a1e0ee15eaf"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "ed05adeb2cb4a7348df16007ae3b8a1e0ee15eaf",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-07-07T14:45:15+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1488499,
+                "version": "3.3.15",
+                "version_normalized": "3.3.15.0"
+            },
+            "3.3.16": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "940e4e188109d54592a721b916912fd12d2989c2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/940e4e188109d54592a721b916912fd12d2989c2"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "940e4e188109d54592a721b916912fd12d2989c2",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-07-27T16:08:00+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1522813,
+                "version": "3.3.16",
+                "version_normalized": "3.3.16.0"
+            },
+            "3.3.17": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "3877ae713f347ec38c85dc835ab61a2f2fac0f47",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/3877ae713f347ec38c85dc835ab61a2f2fac0f47"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "3877ae713f347ec38c85dc835ab61a2f2fac0f47",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-08-07T17:10:44+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1542134,
+                "version": "3.3.17",
+                "version_normalized": "3.3.17.0"
+            },
+            "3.3.18": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "f3f86bbba5da6d5f28f03db71497246b6e10b5e9",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/f3f86bbba5da6d5f28f03db71497246b6e10b5e9"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "f3f86bbba5da6d5f28f03db71497246b6e10b5e9",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-08-18T12:28:11+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1561813,
+                "version": "3.3.18",
+                "version_normalized": "3.3.18.0"
+            },
+            "3.3.19": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "013482e894ae1a9e5365489f5b49f0fddefdf2de",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/013482e894ae1a9e5365489f5b49f0fddefdf2de"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "013482e894ae1a9e5365489f5b49f0fddefdf2de",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-09-06T21:27:25+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1600600,
+                "version": "3.3.19",
+                "version_normalized": "3.3.19.0"
+            },
+            "3.3.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "a1412d1ed2110c62824b0733c4a1b2f39c9163b4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/a1412d1ed2110c62824b0733c4a1b2f39c9163b4"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "*",
+                    "neos/utility-arrays": "*",
+                    "neos/utility-files": "*",
+                    "neos/utility-lock": "*",
+                    "neos/utility-mediatypes": "*",
+                    "neos/utility-objecthandling": "*",
+                    "neos/utility-opcodecache": "*",
+                    "neos/utility-pdo": "*",
+                    "neos/utility-schema": "*",
+                    "neos/utility-unicode": "*",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "a1412d1ed2110c62824b0733c4a1b2f39c9163b4",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-08-24T08:39:38+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098652,
+                "version": "3.3.2",
+                "version_normalized": "3.3.2.0"
+            },
+            "3.3.20": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "37e7e7829fda4ba67ae8a15ed33cab3864774073",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/37e7e7829fda4ba67ae8a15ed33cab3864774073"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "37e7e7829fda4ba67ae8a15ed33cab3864774073",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-10-18T15:09:04+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1673279,
+                "version": "3.3.20",
+                "version_normalized": "3.3.20.0"
+            },
+            "3.3.21": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "5bfb3f2b6b6d011e32f383b53fbeaf25ef6bd559",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/5bfb3f2b6b6d011e32f383b53fbeaf25ef6bd559"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "5bfb3f2b6b6d011e32f383b53fbeaf25ef6bd559",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-11-09T18:31:40+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1715972,
+                "version": "3.3.21",
+                "version_normalized": "3.3.21.0"
+            },
+            "3.3.22": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "a355255072ec8a245f483578e6c699949724f2fe",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/a355255072ec8a245f483578e6c699949724f2fe"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "a355255072ec8a245f483578e6c699949724f2fe",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-12-14T16:15:44+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1789849,
+                "version": "3.3.22",
+                "version_normalized": "3.3.22.0"
+            },
+            "3.3.23": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "4d8ed89ef71b762cf16a97bbbdb0a6922d584f62",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/4d8ed89ef71b762cf16a97bbbdb0a6922d584f62"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "4d8ed89ef71b762cf16a97bbbdb0a6922d584f62",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2018-01-09T10:38:21+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1831862,
+                "version": "3.3.23",
+                "version_normalized": "3.3.23.0"
+            },
+            "3.3.24": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "a3608ea709441e4255b3f0d14ed517dce98d2293",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/a3608ea709441e4255b3f0d14ed517dce98d2293"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "a3608ea709441e4255b3f0d14ed517dce98d2293",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2018-02-06T08:35:58+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1894231,
+                "version": "3.3.24",
+                "version_normalized": "3.3.24.0"
+            },
+            "3.3.25": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "ba3b4cedfc40bd8afa4184573844e4659c402e14",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/ba3b4cedfc40bd8afa4184573844e4659c402e14"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^2.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "ba3b4cedfc40bd8afa4184573844e4659c402e14",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2018-03-20T13:17:47+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 2009682,
+                "version": "3.3.25",
+                "version_normalized": "3.3.25.0"
+            },
+            "3.3.26": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "da4ca54ed673e0db9c2ab0db09adc979889272a2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/da4ca54ed673e0db9c2ab0db09adc979889272a2"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^2.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "da4ca54ed673e0db9c2ab0db09adc979889272a2",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2018-05-16T11:48:09+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 2206052,
+                "version": "3.3.26",
+                "version_normalized": "3.3.26.0"
+            },
+            "3.3.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "23ff86bf76724d2a234c96fb841250f2add2aae3",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/23ff86bf76724d2a234c96fb841250f2add2aae3"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "*",
+                    "neos/utility-arrays": "*",
+                    "neos/utility-files": "*",
+                    "neos/utility-lock": "*",
+                    "neos/utility-mediatypes": "*",
+                    "neos/utility-objecthandling": "*",
+                    "neos/utility-opcodecache": "*",
+                    "neos/utility-pdo": "*",
+                    "neos/utility-schema": "*",
+                    "neos/utility-unicode": "*",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "23ff86bf76724d2a234c96fb841250f2add2aae3",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-08-29T20:15:43+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098653,
+                "version": "3.3.3",
+                "version_normalized": "3.3.3.0"
+            },
+            "3.3.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "ae15eb5359bf7412413d1df67bcc5ac401a0b355",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/ae15eb5359bf7412413d1df67bcc5ac401a0b355"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "*",
+                    "neos/utility-arrays": "*",
+                    "neos/utility-files": "*",
+                    "neos/utility-lock": "*",
+                    "neos/utility-mediatypes": "*",
+                    "neos/utility-objecthandling": "*",
+                    "neos/utility-opcodecache": "*",
+                    "neos/utility-pdo": "*",
+                    "neos/utility-schema": "*",
+                    "neos/utility-unicode": "*",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "ae15eb5359bf7412413d1df67bcc5ac401a0b355",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-09-29T16:16:49+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098654,
+                "version": "3.3.4",
+                "version_normalized": "3.3.4.0"
+            },
+            "3.3.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "141b54a6c1c0d533cb2c6606920db2577679343e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/141b54a6c1c0d533cb2c6606920db2577679343e"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "*",
+                    "neos/utility-arrays": "*",
+                    "neos/utility-files": "*",
+                    "neos/utility-lock": "*",
+                    "neos/utility-mediatypes": "*",
+                    "neos/utility-objecthandling": "*",
+                    "neos/utility-opcodecache": "*",
+                    "neos/utility-pdo": "*",
+                    "neos/utility-schema": "*",
+                    "neos/utility-unicode": "*",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "141b54a6c1c0d533cb2c6606920db2577679343e",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-11-01T12:16:14+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098655,
+                "version": "3.3.5",
+                "version_normalized": "3.3.5.0"
+            },
+            "3.3.6": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "3fbde3074fce5459bfed0fa8982d427b49d0c8ab",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/3fbde3074fce5459bfed0fa8982d427b49d0c8ab"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "*",
+                    "neos/utility-arrays": "*",
+                    "neos/utility-files": "*",
+                    "neos/utility-lock": "*",
+                    "neos/utility-mediatypes": "*",
+                    "neos/utility-objecthandling": "*",
+                    "neos/utility-opcodecache": "*",
+                    "neos/utility-pdo": "*",
+                    "neos/utility-schema": "*",
+                    "neos/utility-unicode": "*",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "3fbde3074fce5459bfed0fa8982d427b49d0c8ab",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2016-12-05T16:04:51+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1115900,
+                "version": "3.3.6",
+                "version_normalized": "3.3.6.0"
+            },
+            "3.3.7": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "1fdb8e01a80dbff8d9b7673d3b9aeca5322ee082",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/1fdb8e01a80dbff8d9b7673d3b9aeca5322ee082"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "1fdb8e01a80dbff8d9b7673d3b9aeca5322ee082",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-01-30T12:35:27+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1202988,
+                "version": "3.3.7",
+                "version_normalized": "3.3.7.0"
+            },
+            "3.3.8": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "f58d1300d89e2d653e7b097841188371baecaf56",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/f58d1300d89e2d653e7b097841188371baecaf56"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "f58d1300d89e2d653e7b097841188371baecaf56",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-02-14T15:37:51+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1232190,
+                "version": "3.3.8",
+                "version_normalized": "3.3.8.0"
+            },
+            "3.3.9": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "edee190e6fbf4d0471385f26cfb09ef0eee3d852",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/edee190e6fbf4d0471385f26cfb09ef0eee3d852"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^1.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "edee190e6fbf4d0471385f26cfb09ef0eee3d852",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2017-03-10T10:14:47+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1274949,
+                "version": "3.3.9",
+                "version_normalized": "3.3.9.0"
+            },
+            "3.3.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-0": {
+                        "TYPO3\\Flow": "Classes"
+                    },
+                    "psr-4": {
+                        "TYPO3\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "da4ca54ed673e0db9c2ab0db09adc979889272a2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/da4ca54ed673e0db9c2ab0db09adc979889272a2"
+                },
+                "homepage": "http://flow.typo3.org",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/error-messages": "~3.3.0",
+                    "neos/utility-arrays": "~3.3.0",
+                    "neos/utility-files": "~3.3.0",
+                    "neos/utility-lock": "~3.3.0",
+                    "neos/utility-mediatypes": "~3.3.0",
+                    "neos/utility-objecthandling": "~3.3.0",
+                    "neos/utility-opcodecache": "~3.3.0",
+                    "neos/utility-pdo": "~3.3.0",
+                    "neos/utility-schema": "~3.3.0",
+                    "neos/utility-unicode": "~3.3.0",
+                    "paragonie/random_compat": "^2.0",
+                    "php": ">=5.5.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3/eel": "~3.3.0",
+                    "typo3/fluid": "~3.3.0"
+                },
+                "source": {
+                    "reference": "da4ca54ed673e0db9c2ab0db09adc979889272a2",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence.",
+                    "typo3/party": "To make use of basic user handling"
+                },
+                "time": "2018-05-16T11:48:09+00:00",
+                "type": "typo3-flow-framework",
+                "uid": 1098664,
+                "version": "3.3.x-dev",
+                "version_normalized": "3.3.9999999.9999999-dev"
+            },
+            "4.0.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "79c5b78053c685b9b25929c2bb5fe725f0623ab6",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/79c5b78053c685b9b25929c2bb5fe725f0623ab6"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "4.0.0",
+                    "neos/utility-files": "4.0.0",
+                    "neos/utility-lock": "4.0.0",
+                    "neos/utility-mediatypes": "4.0.0",
+                    "neos/utility-objecthandling": "4.0.0",
+                    "neos/utility-opcodecache": "4.0.0",
+                    "neos/utility-pdo": "4.0.0",
+                    "neos/utility-schema": "4.0.0",
+                    "neos/utility-unicode": "4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "79c5b78053c685b9b25929c2bb5fe725f0623ab6",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-01-30T09:09:15+00:00",
+                "type": "neos-framework",
+                "uid": 1202213,
+                "version": "4.0.0",
+                "version_normalized": "4.0.0.0"
+            },
+            "4.0.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "3feb5d90f494449638565f683ffda57fdaf2cebd",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/3feb5d90f494449638565f683ffda57fdaf2cebd"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "4.0.0",
+                    "neos/utility-files": "4.0.0",
+                    "neos/utility-lock": "4.0.0",
+                    "neos/utility-mediatypes": "4.0.0",
+                    "neos/utility-objecthandling": "4.0.0",
+                    "neos/utility-opcodecache": "4.0.0",
+                    "neos/utility-pdo": "4.0.0",
+                    "neos/utility-schema": "4.0.0",
+                    "neos/utility-unicode": "4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "3feb5d90f494449638565f683ffda57fdaf2cebd",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-02-14T16:51:19+00:00",
+                "type": "neos-framework",
+                "uid": 1232335,
+                "version": "4.0.1",
+                "version_normalized": "4.0.1.0"
+            },
+            "4.0.10": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "872418a602267047f29d31fc85114e235868e9d2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/872418a602267047f29d31fc85114e235868e9d2"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "872418a602267047f29d31fc85114e235868e9d2",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-07-27T16:12:23+00:00",
+                "type": "neos-framework",
+                "uid": 1522928,
+                "version": "4.0.10",
+                "version_normalized": "4.0.10.0"
+            },
+            "4.0.11": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "8a30e5b071b40611a249c69546e859380f1efe4b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8a30e5b071b40611a249c69546e859380f1efe4b"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "8a30e5b071b40611a249c69546e859380f1efe4b",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-08-07T17:11:53+00:00",
+                "type": "neos-framework",
+                "uid": 1542242,
+                "version": "4.0.11",
+                "version_normalized": "4.0.11.0"
+            },
+            "4.0.12": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "a478681ae41743c4c524dbbefa831c8e7dbacb4a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/a478681ae41743c4c524dbbefa831c8e7dbacb4a"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "a478681ae41743c4c524dbbefa831c8e7dbacb4a",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-08-18T12:44:14+00:00",
+                "type": "neos-framework",
+                "uid": 1561971,
+                "version": "4.0.12",
+                "version_normalized": "4.0.12.0"
+            },
+            "4.0.13": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "c5650474c976a0e36ab8136c2c06c27b626bf020",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/c5650474c976a0e36ab8136c2c06c27b626bf020"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "c5650474c976a0e36ab8136c2c06c27b626bf020",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-09-06T21:32:36+00:00",
+                "type": "neos-framework",
+                "uid": 1604268,
+                "version": "4.0.13",
+                "version_normalized": "4.0.13.0"
+            },
+            "4.0.14": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "a9ead92b27699544a09b5c7949eccb48051e6b1b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/a9ead92b27699544a09b5c7949eccb48051e6b1b"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "a9ead92b27699544a09b5c7949eccb48051e6b1b",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-10-18T15:35:49+00:00",
+                "type": "neos-framework",
+                "uid": 1673489,
+                "version": "4.0.14",
+                "version_normalized": "4.0.14.0"
+            },
+            "4.0.15": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "dfc3285386178a29ab67b231b1b18e2a7add99fd",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/dfc3285386178a29ab67b231b1b18e2a7add99fd"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "dfc3285386178a29ab67b231b1b18e2a7add99fd",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-11-10T11:10:58+00:00",
+                "type": "neos-framework",
+                "uid": 1717275,
+                "version": "4.0.15",
+                "version_normalized": "4.0.15.0"
+            },
+            "4.0.16": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "dda2775da7792da5c3ec6f7ba41458f46aaf32bb",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/dda2775da7792da5c3ec6f7ba41458f46aaf32bb"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "dda2775da7792da5c3ec6f7ba41458f46aaf32bb",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-12-14T16:17:06+00:00",
+                "type": "neos-framework",
+                "uid": 1790072,
+                "version": "4.0.16",
+                "version_normalized": "4.0.16.0"
+            },
+            "4.0.17": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "dcc8af5171b07eefba5ae086697686262f718e61",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/dcc8af5171b07eefba5ae086697686262f718e61"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "dcc8af5171b07eefba5ae086697686262f718e61",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-01-09T10:51:50+00:00",
+                "type": "neos-framework",
+                "uid": 1832175,
+                "version": "4.0.17",
+                "version_normalized": "4.0.17.0"
+            },
+            "4.0.18": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "96b99fd616678a179b9c040b71876d8eba954205",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/96b99fd616678a179b9c040b71876d8eba954205"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "96b99fd616678a179b9c040b71876d8eba954205",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-02-06T09:35:11+00:00",
+                "type": "neos-framework",
+                "uid": 1894432,
+                "version": "4.0.18",
+                "version_normalized": "4.0.18.0"
+            },
+            "4.0.19": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "29c3bff95ce721f4e6c60b8d4bfa0ab948b79935",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/29c3bff95ce721f4e6c60b8d4bfa0ab948b79935"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "29c3bff95ce721f4e6c60b8d4bfa0ab948b79935",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-03-20T13:18:52+00:00",
+                "type": "neos-framework",
+                "uid": 2009908,
+                "version": "4.0.19",
+                "version_normalized": "4.0.19.0"
+            },
+            "4.0.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "07e85749a419b83b76d720fec8d5c342503ea5d8",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/07e85749a419b83b76d720fec8d5c342503ea5d8"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "4.0.0",
+                    "neos/utility-files": "4.0.0",
+                    "neos/utility-lock": "4.0.0",
+                    "neos/utility-mediatypes": "4.0.0",
+                    "neos/utility-objecthandling": "4.0.0",
+                    "neos/utility-opcodecache": "4.0.0",
+                    "neos/utility-pdo": "4.0.0",
+                    "neos/utility-schema": "4.0.0",
+                    "neos/utility-unicode": "4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "07e85749a419b83b76d720fec8d5c342503ea5d8",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-03-10T10:15:53+00:00",
+                "type": "neos-framework",
+                "uid": 1275104,
+                "version": "4.0.2",
+                "version_normalized": "4.0.2.0"
+            },
+            "4.0.20": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "1ce226746adfe432427fe30c23832b17a73a7a40",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/1ce226746adfe432427fe30c23832b17a73a7a40"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "1ce226746adfe432427fe30c23832b17a73a7a40",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T11:51:42+00:00",
+                "type": "neos-framework",
+                "uid": 2206193,
+                "version": "4.0.20",
+                "version_normalized": "4.0.20.0"
+            },
+            "4.0.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "8d0fbe586cce6c5f1ca5a9cf78fb8553874d2ef8",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8d0fbe586cce6c5f1ca5a9cf78fb8553874d2ef8"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "4.0.0",
+                    "neos/utility-files": "4.0.0",
+                    "neos/utility-lock": "4.0.0",
+                    "neos/utility-mediatypes": "4.0.0",
+                    "neos/utility-objecthandling": "4.0.0",
+                    "neos/utility-opcodecache": "4.0.0",
+                    "neos/utility-pdo": "4.0.0",
+                    "neos/utility-schema": "4.0.0",
+                    "neos/utility-unicode": "4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "8d0fbe586cce6c5f1ca5a9cf78fb8553874d2ef8",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-04-01T10:29:26+00:00",
+                "type": "neos-framework",
+                "uid": 1320966,
+                "version": "4.0.3",
+                "version_normalized": "4.0.3.0"
+            },
+            "4.0.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "a42067569d65ad049c4d86ec0aac7c1f0e6387b5",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/a42067569d65ad049c4d86ec0aac7c1f0e6387b5"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "a42067569d65ad049c4d86ec0aac7c1f0e6387b5",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-04-03T10:36:58+00:00",
+                "type": "neos-framework",
+                "uid": 1323762,
+                "version": "4.0.4",
+                "version_normalized": "4.0.4.0"
+            },
+            "4.0.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "ed9b345f68ca502fed2d11921062c5e2f677f82e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/ed9b345f68ca502fed2d11921062c5e2f677f82e"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "ed9b345f68ca502fed2d11921062c5e2f677f82e",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-04-07T16:22:05+00:00",
+                "type": "neos-framework",
+                "uid": 1332591,
+                "version": "4.0.5",
+                "version_normalized": "4.0.5.0"
+            },
+            "4.0.6": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "e5b357bcb3e8f86724dbda057f562b44a60abe2a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/e5b357bcb3e8f86724dbda057f562b44a60abe2a"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "e5b357bcb3e8f86724dbda057f562b44a60abe2a",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-04-12T04:45:49+00:00",
+                "type": "neos-framework",
+                "uid": 1339111,
+                "version": "4.0.6",
+                "version_normalized": "4.0.6.0"
+            },
+            "4.0.7": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "115bbad1405d4d52d2387a89283bc80c2b973086",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/115bbad1405d4d52d2387a89283bc80c2b973086"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "115bbad1405d4d52d2387a89283bc80c2b973086",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-06-20T08:28:05+00:00",
+                "type": "neos-framework",
+                "uid": 1453981,
+                "version": "4.0.7",
+                "version_normalized": "4.0.7.0"
+            },
+            "4.0.8": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "1d8a21c3898fc191f5986e96d6f5af5a02b93764",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/1d8a21c3898fc191f5986e96d6f5af5a02b93764"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "1d8a21c3898fc191f5986e96d6f5af5a02b93764",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-06-20T18:57:23+00:00",
+                "type": "neos-framework",
+                "uid": 1454940,
+                "version": "4.0.8",
+                "version_normalized": "4.0.8.0"
+            },
+            "4.0.9": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "c05e1279d03ed901619e1a2d3e51a5ebdaaf2428",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/c05e1279d03ed901619e1a2d3e51a5ebdaaf2428"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "c05e1279d03ed901619e1a2d3e51a5ebdaaf2428",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-07-07T14:46:24+00:00",
+                "type": "neos-framework",
+                "uid": 1488596,
+                "version": "4.0.9",
+                "version_normalized": "4.0.9.0"
+            },
+            "4.0.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "7a49cb592786e3bd06aa3a385f762d515d380c3c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/7a49cb592786e3bd06aa3a385f762d515d380c3c"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.0.0",
+                    "neos/error-messages": "~4.0.0",
+                    "neos/fluid-adaptor": "~4.0.0",
+                    "neos/utility-arrays": "~4.0.0",
+                    "neos/utility-files": "~4.0.0",
+                    "neos/utility-lock": "~4.0.0",
+                    "neos/utility-mediatypes": "~4.0.0",
+                    "neos/utility-objecthandling": "~4.0.0",
+                    "neos/utility-opcodecache": "~4.0.0",
+                    "neos/utility-pdo": "~4.0.0",
+                    "neos/utility-schema": "~4.0.0",
+                    "neos/utility-unicode": "~4.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "7a49cb592786e3bd06aa3a385f762d515d380c3c",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-04-09T13:33:09+00:00",
+                "type": "neos-framework",
+                "uid": 1198391,
+                "version": "4.0.x-dev",
+                "version_normalized": "4.0.9999999.9999999-dev"
+            },
+            "4.1.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "ac3d9ecfaeb50ecf4a1aa994a5c1677ac4a7a2c7",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/ac3d9ecfaeb50ecf4a1aa994a5c1677ac4a7a2c7"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "ac3d9ecfaeb50ecf4a1aa994a5c1677ac4a7a2c7",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-04-27T13:25:46+00:00",
+                "type": "neos-framework",
+                "uid": 1364909,
+                "version": "4.1.0",
+                "version_normalized": "4.1.0.0"
+            },
+            "4.1.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "4745b20effed6d7e85fd9bb77008a5309f5a8df9",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/4745b20effed6d7e85fd9bb77008a5309f5a8df9"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "4745b20effed6d7e85fd9bb77008a5309f5a8df9",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-06-20T08:28:24+00:00",
+                "type": "neos-framework",
+                "uid": 1454102,
+                "version": "4.1.1",
+                "version_normalized": "4.1.1.0"
+            },
+            "4.1.10": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "a75c655068f4159ac3920cf38a2db66793029856",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/a75c655068f4159ac3920cf38a2db66793029856"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "a75c655068f4159ac3920cf38a2db66793029856",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-12-14T16:20:27+00:00",
+                "type": "neos-framework",
+                "uid": 1790192,
+                "version": "4.1.10",
+                "version_normalized": "4.1.10.0"
+            },
+            "4.1.11": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "6001184013bad0c44ca0aa25dcb94b6a6b1741b6",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/6001184013bad0c44ca0aa25dcb94b6a6b1741b6"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "6001184013bad0c44ca0aa25dcb94b6a6b1741b6",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-01-09T10:53:09+00:00",
+                "type": "neos-framework",
+                "uid": 1832177,
+                "version": "4.1.11",
+                "version_normalized": "4.1.11.0"
+            },
+            "4.1.12": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "8ec5c219cbd18b00ccfbef968fcc02b58f4901a2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8ec5c219cbd18b00ccfbef968fcc02b58f4901a2"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "8ec5c219cbd18b00ccfbef968fcc02b58f4901a2",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-02-06T09:36:23+00:00",
+                "type": "neos-framework",
+                "uid": 1894436,
+                "version": "4.1.12",
+                "version_normalized": "4.1.12.0"
+            },
+            "4.1.13": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "4bd64a8779dd5c1c0b450d74d8a2ef826c41b813",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/4bd64a8779dd5c1c0b450d74d8a2ef826c41b813"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "4bd64a8779dd5c1c0b450d74d8a2ef826c41b813",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-03-20T13:20:18+00:00",
+                "type": "neos-framework",
+                "uid": 2009991,
+                "version": "4.1.13",
+                "version_normalized": "4.1.13.0"
+            },
+            "4.1.14": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "b44de94c189ee86089fa1ece529e8a9d07a3ba98",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/b44de94c189ee86089fa1ece529e8a9d07a3ba98"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "b44de94c189ee86089fa1ece529e8a9d07a3ba98",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T11:55:37+00:00",
+                "type": "neos-framework",
+                "uid": 2206295,
+                "version": "4.1.14",
+                "version_normalized": "4.1.14.0"
+            },
+            "4.1.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "9054cc0230113afd55525219f5a27ab7981d84ae",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/9054cc0230113afd55525219f5a27ab7981d84ae"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "9054cc0230113afd55525219f5a27ab7981d84ae",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-06-20T19:06:04+00:00",
+                "type": "neos-framework",
+                "uid": 1455021,
+                "version": "4.1.2",
+                "version_normalized": "4.1.2.0"
+            },
+            "4.1.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "a4a8d11f24f879e663ef400e18988b6d088fbba2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/a4a8d11f24f879e663ef400e18988b6d088fbba2"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "a4a8d11f24f879e663ef400e18988b6d088fbba2",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-07-07T14:49:00+00:00",
+                "type": "neos-framework",
+                "uid": 1488644,
+                "version": "4.1.3",
+                "version_normalized": "4.1.3.0"
+            },
+            "4.1.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "75b7d46968c66fa7dc2ee4718ec52b83af94e474",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/75b7d46968c66fa7dc2ee4718ec52b83af94e474"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "75b7d46968c66fa7dc2ee4718ec52b83af94e474",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-07-27T16:21:19+00:00",
+                "type": "neos-framework",
+                "uid": 1523032,
+                "version": "4.1.4",
+                "version_normalized": "4.1.4.0"
+            },
+            "4.1.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "234d248d972e073b3d33b256f2828b4b5884fd34",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/234d248d972e073b3d33b256f2828b4b5884fd34"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "234d248d972e073b3d33b256f2828b4b5884fd34",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-08-07T17:13:06+00:00",
+                "type": "neos-framework",
+                "uid": 1542337,
+                "version": "4.1.5",
+                "version_normalized": "4.1.5.0"
+            },
+            "4.1.6": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "edc57cfedcb9501a19552c518cb3656a8dd91a52",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/edc57cfedcb9501a19552c518cb3656a8dd91a52"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "edc57cfedcb9501a19552c518cb3656a8dd91a52",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-08-18T12:47:35+00:00",
+                "type": "neos-framework",
+                "uid": 1562117,
+                "version": "4.1.6",
+                "version_normalized": "4.1.6.0"
+            },
+            "4.1.7": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "9f223ac711c64252fafbbd93a63f7960b58ca3ee",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/9f223ac711c64252fafbbd93a63f7960b58ca3ee"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "9f223ac711c64252fafbbd93a63f7960b58ca3ee",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-09-06T21:35:29+00:00",
+                "type": "neos-framework",
+                "uid": 1600572,
+                "version": "4.1.7",
+                "version_normalized": "4.1.7.0"
+            },
+            "4.1.8": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "e726e0c7d158b6aa15a83974a2daeda9a3eb0403",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/e726e0c7d158b6aa15a83974a2daeda9a3eb0403"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "e726e0c7d158b6aa15a83974a2daeda9a3eb0403",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-10-18T15:38:45+00:00",
+                "type": "neos-framework",
+                "uid": 1673566,
+                "version": "4.1.8",
+                "version_normalized": "4.1.8.0"
+            },
+            "4.1.9": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "17fd995780f9f7e5d4353f0fbba320768f38989a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/17fd995780f9f7e5d4353f0fbba320768f38989a"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "17fd995780f9f7e5d4353f0fbba320768f38989a",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-11-10T11:41:43+00:00",
+                "type": "neos-framework",
+                "uid": 1717380,
+                "version": "4.1.9",
+                "version_normalized": "4.1.9.0"
+            },
+            "4.1.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "4bd64a8779dd5c1c0b450d74d8a2ef826c41b813",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/4bd64a8779dd5c1c0b450d74d8a2ef826c41b813"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.1.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.1.0",
+                    "neos/error-messages": "~4.1.0",
+                    "neos/fluid-adaptor": "~4.1.0",
+                    "neos/utility-arrays": "~4.1.0",
+                    "neos/utility-files": "~4.1.0",
+                    "neos/utility-lock": "~4.1.0",
+                    "neos/utility-mediatypes": "~4.1.0",
+                    "neos/utility-objecthandling": "~4.1.0",
+                    "neos/utility-opcodecache": "~4.1.0",
+                    "neos/utility-pdo": "~4.1.0",
+                    "neos/utility-schema": "~4.1.0",
+                    "neos/utility-unicode": "~4.1.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "4bd64a8779dd5c1c0b450d74d8a2ef826c41b813",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-03-20T13:20:18+00:00",
+                "type": "neos-framework",
+                "uid": 1325514,
+                "version": "4.1.x-dev",
+                "version_normalized": "4.1.9999999.9999999-dev"
+            },
+            "4.2.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "6db174c1ff96bedf7296a4b9d641bcd7ea80a354",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/6db174c1ff96bedf7296a4b9d641bcd7ea80a354"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.2.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.2.0",
+                    "neos/error-messages": "~4.2.0",
+                    "neos/fluid-adaptor": "~4.2.0",
+                    "neos/utility-arrays": "~4.2.0",
+                    "neos/utility-files": "~4.2.0",
+                    "neos/utility-lock": "~4.2.0",
+                    "neos/utility-mediatypes": "~4.2.0",
+                    "neos/utility-objecthandling": "~4.2.0",
+                    "neos/utility-opcodecache": "~4.2.0",
+                    "neos/utility-pdo": "~4.2.0",
+                    "neos/utility-schema": "~4.2.0",
+                    "neos/utility-unicode": "~4.2.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "6db174c1ff96bedf7296a4b9d641bcd7ea80a354",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-08-30T10:39:16+00:00",
+                "type": "neos-framework",
+                "uid": 1582490,
+                "version": "4.2.0",
+                "version_normalized": "4.2.0.0"
+            },
+            "4.2.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "8a777d205b63d9638464f9d619d28af2d9fd3619",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8a777d205b63d9638464f9d619d28af2d9fd3619"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.2.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.2.0",
+                    "neos/error-messages": "~4.2.0",
+                    "neos/fluid-adaptor": "~4.2.0",
+                    "neos/utility-arrays": "~4.2.0",
+                    "neos/utility-files": "~4.2.0",
+                    "neos/utility-lock": "~4.2.0",
+                    "neos/utility-mediatypes": "~4.2.0",
+                    "neos/utility-objecthandling": "~4.2.0",
+                    "neos/utility-opcodecache": "~4.2.0",
+                    "neos/utility-pdo": "~4.2.0",
+                    "neos/utility-schema": "~4.2.0",
+                    "neos/utility-unicode": "~4.2.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "8a777d205b63d9638464f9d619d28af2d9fd3619",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-08-31T11:34:06+00:00",
+                "type": "neos-framework",
+                "uid": 1585112,
+                "version": "4.2.1",
+                "version_normalized": "4.2.1.0"
+            },
+            "4.2.10": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "c3825eddc5e8b53daec34840212837d128632b84",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/c3825eddc5e8b53daec34840212837d128632b84"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.2.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.2.0",
+                    "neos/error-messages": "~4.2.0",
+                    "neos/fluid-adaptor": "~4.2.0",
+                    "neos/utility-arrays": "~4.2.0",
+                    "neos/utility-files": "~4.2.0",
+                    "neos/utility-lock": "~4.2.0",
+                    "neos/utility-mediatypes": "~4.2.0",
+                    "neos/utility-objecthandling": "~4.2.0",
+                    "neos/utility-opcodecache": "~4.2.0",
+                    "neos/utility-pdo": "~4.2.0",
+                    "neos/utility-schema": "~4.2.0",
+                    "neos/utility-unicode": "~4.2.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "c3825eddc5e8b53daec34840212837d128632b84",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T12:31:46+00:00",
+                "type": "neos-framework",
+                "uid": 2206347,
+                "version": "4.2.10",
+                "version_normalized": "4.2.10.0"
+            },
+            "4.2.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "eafbcda0d656da9276c1d2ef04dbeee1d041bf79",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/eafbcda0d656da9276c1d2ef04dbeee1d041bf79"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.2.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.2.0",
+                    "neos/error-messages": "~4.2.0",
+                    "neos/fluid-adaptor": "~4.2.0",
+                    "neos/utility-arrays": "~4.2.0",
+                    "neos/utility-files": "~4.2.0",
+                    "neos/utility-lock": "~4.2.0",
+                    "neos/utility-mediatypes": "~4.2.0",
+                    "neos/utility-objecthandling": "~4.2.0",
+                    "neos/utility-opcodecache": "~4.2.0",
+                    "neos/utility-pdo": "~4.2.0",
+                    "neos/utility-schema": "~4.2.0",
+                    "neos/utility-unicode": "~4.2.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "eafbcda0d656da9276c1d2ef04dbeee1d041bf79",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-09-01T15:50:18+00:00",
+                "type": "neos-framework",
+                "uid": 1587909,
+                "version": "4.2.2",
+                "version_normalized": "4.2.2.0"
+            },
+            "4.2.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "1350f25facea561f809527a3baf62c7b1e08ee32",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/1350f25facea561f809527a3baf62c7b1e08ee32"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.2.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.2.0",
+                    "neos/error-messages": "~4.2.0",
+                    "neos/fluid-adaptor": "~4.2.0",
+                    "neos/utility-arrays": "~4.2.0",
+                    "neos/utility-files": "~4.2.0",
+                    "neos/utility-lock": "~4.2.0",
+                    "neos/utility-mediatypes": "~4.2.0",
+                    "neos/utility-objecthandling": "~4.2.0",
+                    "neos/utility-opcodecache": "~4.2.0",
+                    "neos/utility-pdo": "~4.2.0",
+                    "neos/utility-schema": "~4.2.0",
+                    "neos/utility-unicode": "~4.2.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "1350f25facea561f809527a3baf62c7b1e08ee32",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-09-06T21:37:59+00:00",
+                "type": "neos-framework",
+                "uid": 1600500,
+                "version": "4.2.3",
+                "version_normalized": "4.2.3.0"
+            },
+            "4.2.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "771cf079d0aa1298d3b7cb47f9ba14d7bfbeef47",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/771cf079d0aa1298d3b7cb47f9ba14d7bfbeef47"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.2.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.2.0",
+                    "neos/error-messages": "~4.2.0",
+                    "neos/fluid-adaptor": "~4.2.0",
+                    "neos/utility-arrays": "~4.2.0",
+                    "neos/utility-files": "~4.2.0",
+                    "neos/utility-lock": "~4.2.0",
+                    "neos/utility-mediatypes": "~4.2.0",
+                    "neos/utility-objecthandling": "~4.2.0",
+                    "neos/utility-opcodecache": "~4.2.0",
+                    "neos/utility-pdo": "~4.2.0",
+                    "neos/utility-schema": "~4.2.0",
+                    "neos/utility-unicode": "~4.2.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "771cf079d0aa1298d3b7cb47f9ba14d7bfbeef47",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-10-18T15:40:16+00:00",
+                "type": "neos-framework",
+                "uid": 1673740,
+                "version": "4.2.4",
+                "version_normalized": "4.2.4.0"
+            },
+            "4.2.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "c94c92f0f008a5816be71501a1fdf22339b4eb26",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/c94c92f0f008a5816be71501a1fdf22339b4eb26"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.2.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.2.0",
+                    "neos/error-messages": "~4.2.0",
+                    "neos/fluid-adaptor": "~4.2.0",
+                    "neos/utility-arrays": "~4.2.0",
+                    "neos/utility-files": "~4.2.0",
+                    "neos/utility-lock": "~4.2.0",
+                    "neos/utility-mediatypes": "~4.2.0",
+                    "neos/utility-objecthandling": "~4.2.0",
+                    "neos/utility-opcodecache": "~4.2.0",
+                    "neos/utility-pdo": "~4.2.0",
+                    "neos/utility-schema": "~4.2.0",
+                    "neos/utility-unicode": "~4.2.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "c94c92f0f008a5816be71501a1fdf22339b4eb26",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-11-10T13:06:37+00:00",
+                "type": "neos-framework",
+                "uid": 1717648,
+                "version": "4.2.5",
+                "version_normalized": "4.2.5.0"
+            },
+            "4.2.6": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "6ec6c17df4f6dd7722ac1187d2739447cfe1c5e4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/6ec6c17df4f6dd7722ac1187d2739447cfe1c5e4"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.2.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.2.0",
+                    "neos/error-messages": "~4.2.0",
+                    "neos/fluid-adaptor": "~4.2.0",
+                    "neos/utility-arrays": "~4.2.0",
+                    "neos/utility-files": "~4.2.0",
+                    "neos/utility-lock": "~4.2.0",
+                    "neos/utility-mediatypes": "~4.2.0",
+                    "neos/utility-objecthandling": "~4.2.0",
+                    "neos/utility-opcodecache": "~4.2.0",
+                    "neos/utility-pdo": "~4.2.0",
+                    "neos/utility-schema": "~4.2.0",
+                    "neos/utility-unicode": "~4.2.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "6ec6c17df4f6dd7722ac1187d2739447cfe1c5e4",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-12-14T16:22:01+00:00",
+                "type": "neos-framework",
+                "uid": 1790307,
+                "version": "4.2.6",
+                "version_normalized": "4.2.6.0"
+            },
+            "4.2.7": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "5e1fb389e820b3aa5c136f9ba18ba221ecd81e59",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/5e1fb389e820b3aa5c136f9ba18ba221ecd81e59"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.2.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.2.0",
+                    "neos/error-messages": "~4.2.0",
+                    "neos/fluid-adaptor": "~4.2.0",
+                    "neos/utility-arrays": "~4.2.0",
+                    "neos/utility-files": "~4.2.0",
+                    "neos/utility-lock": "~4.2.0",
+                    "neos/utility-mediatypes": "~4.2.0",
+                    "neos/utility-objecthandling": "~4.2.0",
+                    "neos/utility-opcodecache": "~4.2.0",
+                    "neos/utility-pdo": "~4.2.0",
+                    "neos/utility-schema": "~4.2.0",
+                    "neos/utility-unicode": "~4.2.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "5e1fb389e820b3aa5c136f9ba18ba221ecd81e59",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-01-09T10:54:25+00:00",
+                "type": "neos-framework",
+                "uid": 1832243,
+                "version": "4.2.7",
+                "version_normalized": "4.2.7.0"
+            },
+            "4.2.8": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "25baefb3658ab1fba131e131c3a2fe3ef534d161",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/25baefb3658ab1fba131e131c3a2fe3ef534d161"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.2.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.2.0",
+                    "neos/error-messages": "~4.2.0",
+                    "neos/fluid-adaptor": "~4.2.0",
+                    "neos/utility-arrays": "~4.2.0",
+                    "neos/utility-files": "~4.2.0",
+                    "neos/utility-lock": "~4.2.0",
+                    "neos/utility-mediatypes": "~4.2.0",
+                    "neos/utility-objecthandling": "~4.2.0",
+                    "neos/utility-opcodecache": "~4.2.0",
+                    "neos/utility-pdo": "~4.2.0",
+                    "neos/utility-schema": "~4.2.0",
+                    "neos/utility-unicode": "~4.2.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "25baefb3658ab1fba131e131c3a2fe3ef534d161",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-02-06T09:37:30+00:00",
+                "type": "neos-framework",
+                "uid": 1894627,
+                "version": "4.2.8",
+                "version_normalized": "4.2.8.0"
+            },
+            "4.2.9": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "19810bb83fcf0aa14ac7514e331dadffb316285f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/19810bb83fcf0aa14ac7514e331dadffb316285f"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.2.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.2.0",
+                    "neos/error-messages": "~4.2.0",
+                    "neos/fluid-adaptor": "~4.2.0",
+                    "neos/utility-arrays": "~4.2.0",
+                    "neos/utility-files": "~4.2.0",
+                    "neos/utility-lock": "~4.2.0",
+                    "neos/utility-mediatypes": "~4.2.0",
+                    "neos/utility-objecthandling": "~4.2.0",
+                    "neos/utility-opcodecache": "~4.2.0",
+                    "neos/utility-pdo": "~4.2.0",
+                    "neos/utility-schema": "~4.2.0",
+                    "neos/utility-unicode": "~4.2.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "19810bb83fcf0aa14ac7514e331dadffb316285f",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-03-20T13:22:45+00:00",
+                "type": "neos-framework",
+                "uid": 2009998,
+                "version": "4.2.9",
+                "version_normalized": "4.2.9.0"
+            },
+            "4.2.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "19810bb83fcf0aa14ac7514e331dadffb316285f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/19810bb83fcf0aa14ac7514e331dadffb316285f"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.2.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.2.0",
+                    "neos/error-messages": "~4.2.0",
+                    "neos/fluid-adaptor": "~4.2.0",
+                    "neos/utility-arrays": "~4.2.0",
+                    "neos/utility-files": "~4.2.0",
+                    "neos/utility-lock": "~4.2.0",
+                    "neos/utility-mediatypes": "~4.2.0",
+                    "neos/utility-objecthandling": "~4.2.0",
+                    "neos/utility-opcodecache": "~4.2.0",
+                    "neos/utility-pdo": "~4.2.0",
+                    "neos/utility-schema": "~4.2.0",
+                    "neos/utility-unicode": "~4.2.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "19810bb83fcf0aa14ac7514e331dadffb316285f",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-03-20T13:22:45+00:00",
+                "type": "neos-framework",
+                "uid": 1561717,
+                "version": "4.2.x-dev",
+                "version_normalized": "4.2.9999999.9999999-dev"
+            },
+            "4.3.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "4340ec50f1dd473fec274714c38316f638afa904",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/4340ec50f1dd473fec274714c38316f638afa904"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.3.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.3.0",
+                    "neos/error-messages": "~4.3.0",
+                    "neos/fluid-adaptor": "~4.3.0",
+                    "neos/utility-arrays": "~4.3.0",
+                    "neos/utility-files": "~4.3.0",
+                    "neos/utility-lock": "~4.3.0",
+                    "neos/utility-mediatypes": "~4.3.0",
+                    "neos/utility-objecthandling": "~4.3.0",
+                    "neos/utility-opcodecache": "~4.3.0",
+                    "neos/utility-pdo": "~4.3.0",
+                    "neos/utility-schema": "~4.3.0",
+                    "neos/utility-unicode": "~4.3.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "4340ec50f1dd473fec274714c38316f638afa904",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-12-19T12:24:06+00:00",
+                "type": "neos-framework",
+                "uid": 1798376,
+                "version": "4.3.0",
+                "version_normalized": "4.3.0.0"
+            },
+            "4.3.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "2e8608ef51399beb5cfdc485979f9c9066ed2654",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/2e8608ef51399beb5cfdc485979f9c9066ed2654"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.3.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.3.0",
+                    "neos/error-messages": "~4.3.0",
+                    "neos/flow-log": "~4.3.0",
+                    "neos/fluid-adaptor": "~4.3.0",
+                    "neos/utility-arrays": "~4.3.0",
+                    "neos/utility-files": "~4.3.0",
+                    "neos/utility-lock": "~4.3.0",
+                    "neos/utility-mediatypes": "~4.3.0",
+                    "neos/utility-objecthandling": "~4.3.0",
+                    "neos/utility-opcodecache": "~4.3.0",
+                    "neos/utility-pdo": "~4.3.0",
+                    "neos/utility-schema": "~4.3.0",
+                    "neos/utility-unicode": "~4.3.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "2e8608ef51399beb5cfdc485979f9c9066ed2654",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-12-19T21:21:13+00:00",
+                "type": "neos-framework",
+                "uid": 1799624,
+                "version": "4.3.1",
+                "version_normalized": "4.3.1.0"
+            },
+            "4.3.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "aa3a6636c3f3db5e1e6a7dc8738f071eb1701e8e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/aa3a6636c3f3db5e1e6a7dc8738f071eb1701e8e"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.3.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.3.0",
+                    "neos/error-messages": "~4.3.0",
+                    "neos/flow-log": "~4.3.0",
+                    "neos/fluid-adaptor": "~4.3.0",
+                    "neos/utility-arrays": "~4.3.0",
+                    "neos/utility-files": "~4.3.0",
+                    "neos/utility-lock": "~4.3.0",
+                    "neos/utility-mediatypes": "~4.3.0",
+                    "neos/utility-objecthandling": "~4.3.0",
+                    "neos/utility-opcodecache": "~4.3.0",
+                    "neos/utility-pdo": "~4.3.0",
+                    "neos/utility-schema": "~4.3.0",
+                    "neos/utility-unicode": "~4.3.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "aa3a6636c3f3db5e1e6a7dc8738f071eb1701e8e",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-01-09T10:55:44+00:00",
+                "type": "neos-framework",
+                "uid": 1832265,
+                "version": "4.3.2",
+                "version_normalized": "4.3.2.0"
+            },
+            "4.3.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "8da76ba02e6b5ae72415e6f8c68fcc6e6298dc1c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8da76ba02e6b5ae72415e6f8c68fcc6e6298dc1c"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.3.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.3.0",
+                    "neos/error-messages": "~4.3.0",
+                    "neos/flow-log": "~4.3.0",
+                    "neos/fluid-adaptor": "~4.3.0",
+                    "neos/utility-arrays": "~4.3.0",
+                    "neos/utility-files": "~4.3.0",
+                    "neos/utility-lock": "~4.3.0",
+                    "neos/utility-mediatypes": "~4.3.0",
+                    "neos/utility-objecthandling": "~4.3.0",
+                    "neos/utility-opcodecache": "~4.3.0",
+                    "neos/utility-pdo": "~4.3.0",
+                    "neos/utility-schema": "~4.3.0",
+                    "neos/utility-unicode": "~4.3.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "8da76ba02e6b5ae72415e6f8c68fcc6e6298dc1c",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-02-06T09:57:39+00:00",
+                "type": "neos-framework",
+                "uid": 1894638,
+                "version": "4.3.3",
+                "version_normalized": "4.3.3.0"
+            },
+            "4.3.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "ddf5c2295be8dd46bad37646a5a40897a3b7a7a6",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/ddf5c2295be8dd46bad37646a5a40897a3b7a7a6"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.3.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.3.0",
+                    "neos/error-messages": "~4.3.0",
+                    "neos/flow-log": "~4.3.0",
+                    "neos/fluid-adaptor": "~4.3.0",
+                    "neos/utility-arrays": "~4.3.0",
+                    "neos/utility-files": "~4.3.0",
+                    "neos/utility-lock": "~4.3.0",
+                    "neos/utility-mediatypes": "~4.3.0",
+                    "neos/utility-objecthandling": "~4.3.0",
+                    "neos/utility-opcodecache": "~4.3.0",
+                    "neos/utility-pdo": "~4.3.0",
+                    "neos/utility-schema": "~4.3.0",
+                    "neos/utility-unicode": "~4.3.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "ddf5c2295be8dd46bad37646a5a40897a3b7a7a6",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-03-20T13:43:53+00:00",
+                "type": "neos-framework",
+                "uid": 2010224,
+                "version": "4.3.4",
+                "version_normalized": "4.3.4.0"
+            },
+            "4.3.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "8ac2dd7eb1ce0280a7ad7a5bf3c42adb19ee9ec7",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8ac2dd7eb1ce0280a7ad7a5bf3c42adb19ee9ec7"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.3.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.3.0",
+                    "neos/error-messages": "~4.3.0",
+                    "neos/flow-log": "~4.3.0",
+                    "neos/fluid-adaptor": "~4.3.0",
+                    "neos/utility-arrays": "~4.3.0",
+                    "neos/utility-files": "~4.3.0",
+                    "neos/utility-lock": "~4.3.0",
+                    "neos/utility-mediatypes": "~4.3.0",
+                    "neos/utility-objecthandling": "~4.3.0",
+                    "neos/utility-opcodecache": "~4.3.0",
+                    "neos/utility-pdo": "~4.3.0",
+                    "neos/utility-schema": "~4.3.0",
+                    "neos/utility-unicode": "~4.3.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "8ac2dd7eb1ce0280a7ad7a5bf3c42adb19ee9ec7",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T12:35:36+00:00",
+                "type": "neos-framework",
+                "uid": 2206486,
+                "version": "4.3.5",
+                "version_normalized": "4.3.5.0"
+            },
+            "4.3.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "ddf5c2295be8dd46bad37646a5a40897a3b7a7a6",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/ddf5c2295be8dd46bad37646a5a40897a3b7a7a6"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~4.3.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~4.3.0",
+                    "neos/error-messages": "~4.3.0",
+                    "neos/flow-log": "~4.3.0",
+                    "neos/fluid-adaptor": "~4.3.0",
+                    "neos/utility-arrays": "~4.3.0",
+                    "neos/utility-files": "~4.3.0",
+                    "neos/utility-lock": "~4.3.0",
+                    "neos/utility-mediatypes": "~4.3.0",
+                    "neos/utility-objecthandling": "~4.3.0",
+                    "neos/utility-opcodecache": "~4.3.0",
+                    "neos/utility-pdo": "~4.3.0",
+                    "neos/utility-schema": "~4.3.0",
+                    "neos/utility-unicode": "~4.3.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0"
+                },
+                "source": {
+                    "reference": "ddf5c2295be8dd46bad37646a5a40897a3b7a7a6",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-03-20T13:43:53+00:00",
+                "type": "neos-framework",
+                "uid": 1797358,
+                "version": "4.3.x-dev",
+                "version_normalized": "4.3.9999999.9999999-dev"
+            },
+            "5.0.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "7999f8edc6ffa3fec2047078805adf52684c3faf",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/7999f8edc6ffa3fec2047078805adf52684c3faf"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.6.0",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~5.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~5.0.0",
+                    "neos/error-messages": "~5.0.0",
+                    "neos/fluid-adaptor": "~5.0.0",
+                    "neos/utility-arrays": "~5.0.0",
+                    "neos/utility-files": "~5.0.0",
+                    "neos/utility-lock": "~5.0.0",
+                    "neos/utility-mediatypes": "~5.0.0",
+                    "neos/utility-objecthandling": "~5.0.0",
+                    "neos/utility-opcodecache": "~5.0.0",
+                    "neos/utility-pdo": "~5.0.0",
+                    "neos/utility-schema": "~5.0.0",
+                    "neos/utility-unicode": "~5.0.0",
+                    "php": "~7.1",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0"
+                },
+                "source": {
+                    "reference": "7999f8edc6ffa3fec2047078805adf52684c3faf",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-04-25T15:03:16+00:00",
+                "type": "neos-framework",
+                "uid": 2135117,
+                "version": "5.0.0",
+                "version_normalized": "5.0.0.0"
+            },
+            "5.0.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "556d2af9f38154714bf5239fa2978c9c69780228",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/556d2af9f38154714bf5239fa2978c9c69780228"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.6.0",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~5.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~5.0.0",
+                    "neos/error-messages": "~5.0.0",
+                    "neos/flow-log": "~5.0.0",
+                    "neos/fluid-adaptor": "~5.0.0",
+                    "neos/utility-arrays": "~5.0.0",
+                    "neos/utility-files": "~5.0.0",
+                    "neos/utility-lock": "~5.0.0",
+                    "neos/utility-mediatypes": "~5.0.0",
+                    "neos/utility-objecthandling": "~5.0.0",
+                    "neos/utility-opcodecache": "~5.0.0",
+                    "neos/utility-pdo": "~5.0.0",
+                    "neos/utility-schema": "~5.0.0",
+                    "neos/utility-unicode": "~5.0.0",
+                    "php": "~7.1",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0"
+                },
+                "source": {
+                    "reference": "556d2af9f38154714bf5239fa2978c9c69780228",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-04-25T20:36:36+00:00",
+                "type": "neos-framework",
+                "uid": 2136048,
+                "version": "5.0.1",
+                "version_normalized": "5.0.1.0"
+            },
+            "5.0.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "fe99fdda07840486b4fa9b47a07d518eb130be47",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/fe99fdda07840486b4fa9b47a07d518eb130be47"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.6.0",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~5.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~5.0.0",
+                    "neos/error-messages": "~5.0.0",
+                    "neos/flow-log": "~5.0.0",
+                    "neos/fluid-adaptor": "~5.0.0",
+                    "neos/utility-arrays": "~5.0.0",
+                    "neos/utility-files": "~5.0.0",
+                    "neos/utility-lock": "~5.0.0",
+                    "neos/utility-mediatypes": "~5.0.0",
+                    "neos/utility-objecthandling": "~5.0.0",
+                    "neos/utility-opcodecache": "~5.0.0",
+                    "neos/utility-pdo": "~5.0.0",
+                    "neos/utility-schema": "~5.0.0",
+                    "neos/utility-unicode": "~5.0.0",
+                    "php": "~7.1",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0"
+                },
+                "source": {
+                    "reference": "fe99fdda07840486b4fa9b47a07d518eb130be47",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-04-27T07:16:09+00:00",
+                "type": "neos-framework",
+                "uid": 2140988,
+                "version": "5.0.2",
+                "version_normalized": "5.0.2.0"
+            },
+            "5.0.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "62a1632530ac063e4e35f544557379b032d30661",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/62a1632530ac063e4e35f544557379b032d30661"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.6.0",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~5.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~5.0.0",
+                    "neos/error-messages": "~5.0.0",
+                    "neos/flow-log": "~5.0.0",
+                    "neos/fluid-adaptor": "~5.0.0",
+                    "neos/utility-arrays": "~5.0.0",
+                    "neos/utility-files": "~5.0.0",
+                    "neos/utility-lock": "~5.0.0",
+                    "neos/utility-mediatypes": "~5.0.0",
+                    "neos/utility-objecthandling": "~5.0.0",
+                    "neos/utility-opcodecache": "~5.0.0",
+                    "neos/utility-pdo": "~5.0.0",
+                    "neos/utility-schema": "~5.0.0",
+                    "neos/utility-unicode": "~5.0.0",
+                    "php": "~7.1",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0"
+                },
+                "source": {
+                    "reference": "62a1632530ac063e4e35f544557379b032d30661",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T12:44:12+00:00",
+                "type": "neos-framework",
+                "uid": 2206545,
+                "version": "5.0.3",
+                "version_normalized": "5.0.3.0"
+            },
+            "5.0.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "62a1632530ac063e4e35f544557379b032d30661",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/62a1632530ac063e4e35f544557379b032d30661"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.6.0",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~5.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~5.0.0",
+                    "neos/error-messages": "~5.0.0",
+                    "neos/flow-log": "~5.0.0",
+                    "neos/fluid-adaptor": "~5.0.0",
+                    "neos/utility-arrays": "~5.0.0",
+                    "neos/utility-files": "~5.0.0",
+                    "neos/utility-lock": "~5.0.0",
+                    "neos/utility-mediatypes": "~5.0.0",
+                    "neos/utility-objecthandling": "~5.0.0",
+                    "neos/utility-opcodecache": "~5.0.0",
+                    "neos/utility-pdo": "~5.0.0",
+                    "neos/utility-schema": "~5.0.0",
+                    "neos/utility-unicode": "~5.0.0",
+                    "php": "~7.1",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0"
+                },
+                "source": {
+                    "reference": "62a1632530ac063e4e35f544557379b032d30661",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T12:44:12+00:00",
+                "type": "neos-framework",
+                "uid": 2118362,
+                "version": "5.0.x-dev",
+                "version_normalized": "5.0.9999999.9999999-dev"
+            },
+            "dev-master": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Flow\\": "Classes",
+                        "Neos\\Flow\\Core\\Migrations\\": "Scripts/Migrations"
+                    }
+                },
+                "description": "Flow Application Framework",
+                "dist": {
+                    "reference": "8464912963f29ed82678df3a1552ccb68c1cb630",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow/zipball/8464912963f29ed82678df3a1552ccb68c1cb630"
+                },
+                "extra": {
+                    "applied-flow-migrations": [
+                        "Neos.Media-20161124233100"
+                    ],
+                    "neos": {
+                        "package-key": "Neos.Flow"
+                    }
+                },
+                "homepage": "http://flow.neos.io",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow",
+                "replace": {
+                    "typo3/flow": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.6.0",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/cache": "~5.0.0",
+                    "neos/composer-plugin": "^2.0.0",
+                    "neos/eel": "~5.0.0",
+                    "neos/error-messages": "~5.0.0",
+                    "neos/flow-log": "~5.0.0",
+                    "neos/fluid-adaptor": "~5.0.0",
+                    "neos/utility-arrays": "~5.0.0",
+                    "neos/utility-files": "~5.0.0",
+                    "neos/utility-lock": "~5.0.0",
+                    "neos/utility-mediatypes": "~5.0.0",
+                    "neos/utility-objecthandling": "~5.0.0",
+                    "neos/utility-opcodecache": "~5.0.0",
+                    "neos/utility-pdo": "~5.0.0",
+                    "neos/utility-schema": "~5.0.0",
+                    "neos/utility-unicode": "~5.0.0",
+                    "php": "~7.1",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0"
+                },
+                "source": {
+                    "reference": "8464912963f29ed82678df3a1552ccb68c1cb630",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T12:46:53+00:00",
+                "type": "neos-framework",
+                "uid": 1098656,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            }
+        },
+        "neos/flow-development-collection": {
+            "4.0.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "cc6a709dbf8119dd2ce873eb39d8078755dcbe65",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/cc6a709dbf8119dd2ce873eb39d8078755dcbe65"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version",
+                    "typo3/eel": "self.version",
+                    "typo3/flow": "self.version",
+                    "typo3/kickstart": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~4.8 || ~5.2.0"
+                },
+                "source": {
+                    "reference": "cc6a709dbf8119dd2ce873eb39d8078755dcbe65",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-01-30T09:09:15+00:00",
+                "type": "neos-package-collection",
+                "uid": 1202041,
+                "version": "4.0.0",
+                "version_normalized": "4.0.0.0"
+            },
+            "4.0.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "2d433f91e4b4766c45582c69853aea482d7a211e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/2d433f91e4b4766c45582c69853aea482d7a211e"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version",
+                    "typo3/eel": "self.version",
+                    "typo3/flow": "self.version",
+                    "typo3/kickstart": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~4.8 || ~5.2.0"
+                },
+                "source": {
+                    "reference": "2d433f91e4b4766c45582c69853aea482d7a211e",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-02-14T16:51:19+00:00",
+                "type": "neos-package-collection",
+                "uid": 1232158,
+                "version": "4.0.1",
+                "version_normalized": "4.0.1.0"
+            },
+            "4.0.10": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "d4e0af6d9c36c5d471ff6b839b749456dd821c68",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/d4e0af6d9c36c5d471ff6b839b749456dd821c68"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "d4e0af6d9c36c5d471ff6b839b749456dd821c68",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-07-27T16:12:23+00:00",
+                "type": "neos-package-collection",
+                "uid": 1522669,
+                "version": "4.0.10",
+                "version_normalized": "4.0.10.0"
+            },
+            "4.0.11": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "45d3d7a37fdabcbe4fe3db46392b8024ab06d5d0",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/45d3d7a37fdabcbe4fe3db46392b8024ab06d5d0"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "45d3d7a37fdabcbe4fe3db46392b8024ab06d5d0",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-08-07T17:11:53+00:00",
+                "type": "neos-package-collection",
+                "uid": 1542052,
+                "version": "4.0.11",
+                "version_normalized": "4.0.11.0"
+            },
+            "4.0.12": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "87499648131a7ae5765033e11d3153afb479cf8e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/87499648131a7ae5765033e11d3153afb479cf8e"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "87499648131a7ae5765033e11d3153afb479cf8e",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-08-18T12:44:14+00:00",
+                "type": "neos-package-collection",
+                "uid": 1561659,
+                "version": "4.0.12",
+                "version_normalized": "4.0.12.0"
+            },
+            "4.0.13": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "98abf7617a2c48a6a87e62868e800c10bdc6469e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/98abf7617a2c48a6a87e62868e800c10bdc6469e"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "98abf7617a2c48a6a87e62868e800c10bdc6469e",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-09-06T21:32:36+00:00",
+                "type": "neos-package-collection",
+                "uid": 1597127,
+                "version": "4.0.13",
+                "version_normalized": "4.0.13.0"
+            },
+            "4.0.14": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "55a557f62ecb9270744c24db694eeedaaede5f93",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/55a557f62ecb9270744c24db694eeedaaede5f93"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "55a557f62ecb9270744c24db694eeedaaede5f93",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-10-18T15:35:49+00:00",
+                "type": "neos-package-collection",
+                "uid": 1673079,
+                "version": "4.0.14",
+                "version_normalized": "4.0.14.0"
+            },
+            "4.0.15": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "53a241172448adc2e330dd2f2323bbb3a9e07881",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/53a241172448adc2e330dd2f2323bbb3a9e07881"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "53a241172448adc2e330dd2f2323bbb3a9e07881",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-11-10T11:10:58+00:00",
+                "type": "neos-package-collection",
+                "uid": 1717199,
+                "version": "4.0.15",
+                "version_normalized": "4.0.15.0"
+            },
+            "4.0.16": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "2c1081eac5cc19ca839d3354f42178cae242f487",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/2c1081eac5cc19ca839d3354f42178cae242f487"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "2c1081eac5cc19ca839d3354f42178cae242f487",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-12-14T16:17:06+00:00",
+                "type": "neos-package-collection",
+                "uid": 1789699,
+                "version": "4.0.16",
+                "version_normalized": "4.0.16.0"
+            },
+            "4.0.17": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "9e091947072c891a104effcfb266f1cbc27c60e0",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/9e091947072c891a104effcfb266f1cbc27c60e0"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "9e091947072c891a104effcfb266f1cbc27c60e0",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-01-09T10:51:50+00:00",
+                "type": "neos-package-collection",
+                "uid": 1831879,
+                "version": "4.0.17",
+                "version_normalized": "4.0.17.0"
+            },
+            "4.0.18": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "0978a1ac900d14d4e69185943deb4986d4dbeb7a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/0978a1ac900d14d4e69185943deb4986d4dbeb7a"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "0978a1ac900d14d4e69185943deb4986d4dbeb7a",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-02-06T09:35:11+00:00",
+                "type": "neos-package-collection",
+                "uid": 1894359,
+                "version": "4.0.18",
+                "version_normalized": "4.0.18.0"
+            },
+            "4.0.19": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "21c0bb3c5e6fff5774437d4b0f0497bade42c01f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/21c0bb3c5e6fff5774437d4b0f0497bade42c01f"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "21c0bb3c5e6fff5774437d4b0f0497bade42c01f",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-03-20T13:18:52+00:00",
+                "type": "neos-package-collection",
+                "uid": 2009551,
+                "version": "4.0.19",
+                "version_normalized": "4.0.19.0"
+            },
+            "4.0.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "a0718c68f34709d14a3a259ffbd767c6002caa29",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/a0718c68f34709d14a3a259ffbd767c6002caa29"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version",
+                    "typo3/eel": "self.version",
+                    "typo3/flow": "self.version",
+                    "typo3/kickstart": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~4.8 || ~5.2.0"
+                },
+                "source": {
+                    "reference": "a0718c68f34709d14a3a259ffbd767c6002caa29",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-03-10T10:15:53+00:00",
+                "type": "neos-package-collection",
+                "uid": 1274884,
+                "version": "4.0.2",
+                "version_normalized": "4.0.2.0"
+            },
+            "4.0.20": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "8820b006714fd24a22ab86c559a5482a1e4f1949",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/8820b006714fd24a22ab86c559a5482a1e4f1949"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "8820b006714fd24a22ab86c559a5482a1e4f1949",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T11:51:42+00:00",
+                "type": "neos-package-collection",
+                "uid": 2206027,
+                "version": "4.0.20",
+                "version_normalized": "4.0.20.0"
+            },
+            "4.0.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "f066c8cd2d3c0045d9c9714028887083aa090c77",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/f066c8cd2d3c0045d9c9714028887083aa090c77"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "f066c8cd2d3c0045d9c9714028887083aa090c77",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-04-01T10:29:26+00:00",
+                "type": "neos-package-collection",
+                "uid": 1320776,
+                "version": "4.0.3",
+                "version_normalized": "4.0.3.0"
+            },
+            "4.0.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "0420978834c057cf0cf6a8e4a9686f82a702f222",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/0420978834c057cf0cf6a8e4a9686f82a702f222"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "0420978834c057cf0cf6a8e4a9686f82a702f222",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-04-03T10:36:58+00:00",
+                "type": "neos-package-collection",
+                "uid": 1323693,
+                "version": "4.0.4",
+                "version_normalized": "4.0.4.0"
+            },
+            "4.0.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "8e96a7cce2cea2bc58c7ed72965024782c079d2b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/8e96a7cce2cea2bc58c7ed72965024782c079d2b"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "8e96a7cce2cea2bc58c7ed72965024782c079d2b",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-04-07T16:22:05+00:00",
+                "type": "neos-package-collection",
+                "uid": 1332341,
+                "version": "4.0.5",
+                "version_normalized": "4.0.5.0"
+            },
+            "4.0.6": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "77a7bcbc3cc30e864840d8abd2ac40cd12aa6c0b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/77a7bcbc3cc30e864840d8abd2ac40cd12aa6c0b"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "77a7bcbc3cc30e864840d8abd2ac40cd12aa6c0b",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-04-12T04:45:49+00:00",
+                "type": "neos-package-collection",
+                "uid": 1339072,
+                "version": "4.0.6",
+                "version_normalized": "4.0.6.0"
+            },
+            "4.0.7": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "ee3de23127502fea91a6b96b3e3c95c66741ea74",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/ee3de23127502fea91a6b96b3e3c95c66741ea74"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "ee3de23127502fea91a6b96b3e3c95c66741ea74",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-06-20T08:28:05+00:00",
+                "type": "neos-package-collection",
+                "uid": 1453687,
+                "version": "4.0.7",
+                "version_normalized": "4.0.7.0"
+            },
+            "4.0.8": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "72537e845d8dde10f7d9ff5a8b270c234ba1ab07",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/72537e845d8dde10f7d9ff5a8b270c234ba1ab07"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "72537e845d8dde10f7d9ff5a8b270c234ba1ab07",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-06-20T18:57:23+00:00",
+                "type": "neos-package-collection",
+                "uid": 1454798,
+                "version": "4.0.8",
+                "version_normalized": "4.0.8.0"
+            },
+            "4.0.9": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "159ced5ec73c29b72bdc562d3575f21f3ffa9f2b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/159ced5ec73c29b72bdc562d3575f21f3ffa9f2b"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "159ced5ec73c29b72bdc562d3575f21f3ffa9f2b",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-07-07T14:46:24+00:00",
+                "type": "neos-package-collection",
+                "uid": 1488326,
+                "version": "4.0.9",
+                "version_normalized": "4.0.9.0"
+            },
+            "4.0.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "8820b006714fd24a22ab86c559a5482a1e4f1949",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/8820b006714fd24a22ab86c559a5482a1e4f1949"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~5.4"
+                },
+                "source": {
+                    "reference": "8820b006714fd24a22ab86c559a5482a1e4f1949",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T11:51:42+00:00",
+                "type": "neos-package-collection",
+                "uid": 1136929,
+                "version": "4.0.x-dev",
+                "version_normalized": "4.0.9999999.9999999-dev"
+            },
+            "4.1.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "781272f1b2e145aafbf642a20eada12a2d8c6e0c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/781272f1b2e145aafbf642a20eada12a2d8c6e0c"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "781272f1b2e145aafbf642a20eada12a2d8c6e0c",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-04-27T13:25:46+00:00",
+                "type": "neos-package-collection",
+                "uid": 1364763,
+                "version": "4.1.0",
+                "version_normalized": "4.1.0.0"
+            },
+            "4.1.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "76804dc7a180c57c1c0a1e65b09192c0f73ad6eb",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/76804dc7a180c57c1c0a1e65b09192c0f73ad6eb"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "76804dc7a180c57c1c0a1e65b09192c0f73ad6eb",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-06-20T08:28:24+00:00",
+                "type": "neos-package-collection",
+                "uid": 1453691,
+                "version": "4.1.1",
+                "version_normalized": "4.1.1.0"
+            },
+            "4.1.10": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "e9c9983da90f99110a093713d2a0cde6be807d84",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/e9c9983da90f99110a093713d2a0cde6be807d84"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "e9c9983da90f99110a093713d2a0cde6be807d84",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-12-14T16:20:27+00:00",
+                "type": "neos-package-collection",
+                "uid": 1789714,
+                "version": "4.1.10",
+                "version_normalized": "4.1.10.0"
+            },
+            "4.1.11": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "3dae3fab09035d93b8c19abc65863b6bbba71c9b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/3dae3fab09035d93b8c19abc65863b6bbba71c9b"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "3dae3fab09035d93b8c19abc65863b6bbba71c9b",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-01-09T10:53:09+00:00",
+                "type": "neos-package-collection",
+                "uid": 1831883,
+                "version": "4.1.11",
+                "version_normalized": "4.1.11.0"
+            },
+            "4.1.12": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "1be7a0c28abaa55c0af166bb153a2f4e5a5d9506",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/1be7a0c28abaa55c0af166bb153a2f4e5a5d9506"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "1be7a0c28abaa55c0af166bb153a2f4e5a5d9506",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-02-06T09:36:23+00:00",
+                "type": "neos-package-collection",
+                "uid": 1894364,
+                "version": "4.1.12",
+                "version_normalized": "4.1.12.0"
+            },
+            "4.1.13": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "612422574cbb95a10b8a36936eec74eb439944de",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/612422574cbb95a10b8a36936eec74eb439944de"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "612422574cbb95a10b8a36936eec74eb439944de",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-03-20T13:20:18+00:00",
+                "type": "neos-package-collection",
+                "uid": 2009558,
+                "version": "4.1.13",
+                "version_normalized": "4.1.13.0"
+            },
+            "4.1.14": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "d0c2fbfe51206f769f00d4fb0d1ea4d0516fe07c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/d0c2fbfe51206f769f00d4fb0d1ea4d0516fe07c"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "d0c2fbfe51206f769f00d4fb0d1ea4d0516fe07c",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T11:55:37+00:00",
+                "type": "neos-package-collection",
+                "uid": 2206042,
+                "version": "4.1.14",
+                "version_normalized": "4.1.14.0"
+            },
+            "4.1.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "5585bf46b086bdc9b7ec24fc7c4826f602e1d328",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/5585bf46b086bdc9b7ec24fc7c4826f602e1d328"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "5585bf46b086bdc9b7ec24fc7c4826f602e1d328",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-06-20T19:06:04+00:00",
+                "type": "neos-package-collection",
+                "uid": 1454804,
+                "version": "4.1.2",
+                "version_normalized": "4.1.2.0"
+            },
+            "4.1.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "33477a984369570cf454322eb80499351f8ac94c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/33477a984369570cf454322eb80499351f8ac94c"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "33477a984369570cf454322eb80499351f8ac94c",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-07-07T14:49:00+00:00",
+                "type": "neos-package-collection",
+                "uid": 1488327,
+                "version": "4.1.3",
+                "version_normalized": "4.1.3.0"
+            },
+            "4.1.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "7f74317a8bed8e46312530239dfa49ac0f4fdbd8",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/7f74317a8bed8e46312530239dfa49ac0f4fdbd8"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "7f74317a8bed8e46312530239dfa49ac0f4fdbd8",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-07-27T16:21:19+00:00",
+                "type": "neos-package-collection",
+                "uid": 1522686,
+                "version": "4.1.4",
+                "version_normalized": "4.1.4.0"
+            },
+            "4.1.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "966b586e6a3b89b8399568b25ce14351032ba67d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/966b586e6a3b89b8399568b25ce14351032ba67d"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "966b586e6a3b89b8399568b25ce14351032ba67d",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-08-07T17:13:06+00:00",
+                "type": "neos-package-collection",
+                "uid": 1542055,
+                "version": "4.1.5",
+                "version_normalized": "4.1.5.0"
+            },
+            "4.1.6": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "379c8c8a7e692c9fdd90928594d51be5a95cce5f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/379c8c8a7e692c9fdd90928594d51be5a95cce5f"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "379c8c8a7e692c9fdd90928594d51be5a95cce5f",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-08-18T12:47:35+00:00",
+                "type": "neos-package-collection",
+                "uid": 1561670,
+                "version": "4.1.6",
+                "version_normalized": "4.1.6.0"
+            },
+            "4.1.7": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "3d37d2c52884ab38db851864441f948a4a98128e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/3d37d2c52884ab38db851864441f948a4a98128e"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "3d37d2c52884ab38db851864441f948a4a98128e",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-09-06T21:35:29+00:00",
+                "type": "neos-package-collection",
+                "uid": 1597142,
+                "version": "4.1.7",
+                "version_normalized": "4.1.7.0"
+            },
+            "4.1.8": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "707545e81c5e49115c9085fede8badfbe5fada47",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/707545e81c5e49115c9085fede8badfbe5fada47"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "707545e81c5e49115c9085fede8badfbe5fada47",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-10-18T15:38:45+00:00",
+                "type": "neos-package-collection",
+                "uid": 1673096,
+                "version": "4.1.8",
+                "version_normalized": "4.1.8.0"
+            },
+            "4.1.9": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "c4cbc8fac8c76b8b439414ebbd73e99164351d4e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/c4cbc8fac8c76b8b439414ebbd73e99164351d4e"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "c4cbc8fac8c76b8b439414ebbd73e99164351d4e",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-11-10T11:41:43+00:00",
+                "type": "neos-package-collection",
+                "uid": 1717238,
+                "version": "4.1.9",
+                "version_normalized": "4.1.9.0"
+            },
+            "4.1.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "d0c2fbfe51206f769f00d4fb0d1ea4d0516fe07c",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/d0c2fbfe51206f769f00d4fb0d1ea4d0516fe07c"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "d0c2fbfe51206f769f00d4fb0d1ea4d0516fe07c",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T11:55:37+00:00",
+                "type": "neos-package-collection",
+                "uid": 1325469,
+                "version": "4.1.x-dev",
+                "version_normalized": "4.1.9999999.9999999-dev"
+            },
+            "4.2.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "acfa0572b050d36ec2bf29cbf607adf193b68c9e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/acfa0572b050d36ec2bf29cbf607adf193b68c9e"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "acfa0572b050d36ec2bf29cbf607adf193b68c9e",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-08-30T10:39:16+00:00",
+                "type": "neos-package-collection",
+                "uid": 1582292,
+                "version": "4.2.0",
+                "version_normalized": "4.2.0.0"
+            },
+            "4.2.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "79c8a8becbbff3a610d7bce53fb24b1e382edefe",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/79c8a8becbbff3a610d7bce53fb24b1e382edefe"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "79c8a8becbbff3a610d7bce53fb24b1e382edefe",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-08-31T11:34:06+00:00",
+                "type": "neos-package-collection",
+                "uid": 1584842,
+                "version": "4.2.1",
+                "version_normalized": "4.2.1.0"
+            },
+            "4.2.10": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "3de10dee47c43b09aac1c56a32451af2c844e311",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/3de10dee47c43b09aac1c56a32451af2c844e311"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "3de10dee47c43b09aac1c56a32451af2c844e311",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T12:31:46+00:00",
+                "type": "neos-package-collection",
+                "uid": 2206161,
+                "version": "4.2.10",
+                "version_normalized": "4.2.10.0"
+            },
+            "4.2.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "766e93dfab1a59a8b8428f34ef41b477e6d1ef87",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/766e93dfab1a59a8b8428f34ef41b477e6d1ef87"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "766e93dfab1a59a8b8428f34ef41b477e6d1ef87",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-09-01T15:50:18+00:00",
+                "type": "neos-package-collection",
+                "uid": 1587792,
+                "version": "4.2.2",
+                "version_normalized": "4.2.2.0"
+            },
+            "4.2.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "345207f46ce6799f830f1a3e14301b91280c1664",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/345207f46ce6799f830f1a3e14301b91280c1664"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "345207f46ce6799f830f1a3e14301b91280c1664",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-09-06T21:37:59+00:00",
+                "type": "neos-package-collection",
+                "uid": 1597151,
+                "version": "4.2.3",
+                "version_normalized": "4.2.3.0"
+            },
+            "4.2.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "8cdcc454007ab4da4d077291742c3978edc84658",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/8cdcc454007ab4da4d077291742c3978edc84658"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "8cdcc454007ab4da4d077291742c3978edc84658",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-10-18T15:40:16+00:00",
+                "type": "neos-package-collection",
+                "uid": 1673116,
+                "version": "4.2.4",
+                "version_normalized": "4.2.4.0"
+            },
+            "4.2.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "88f7e467afffbd08211adede328faf986018acdd",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/88f7e467afffbd08211adede328faf986018acdd"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "88f7e467afffbd08211adede328faf986018acdd",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-11-10T13:06:37+00:00",
+                "type": "neos-package-collection",
+                "uid": 1717411,
+                "version": "4.2.5",
+                "version_normalized": "4.2.5.0"
+            },
+            "4.2.6": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "d683b1a8e3e7f686ae9c83aedff5de23d9d181f4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/d683b1a8e3e7f686ae9c83aedff5de23d9d181f4"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "d683b1a8e3e7f686ae9c83aedff5de23d9d181f4",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-12-14T16:22:01+00:00",
+                "type": "neos-package-collection",
+                "uid": 1789722,
+                "version": "4.2.6",
+                "version_normalized": "4.2.6.0"
+            },
+            "4.2.7": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "a878e78fa71abba34ed0238b15b0620c7f6c352d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/a878e78fa71abba34ed0238b15b0620c7f6c352d"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "a878e78fa71abba34ed0238b15b0620c7f6c352d",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-01-09T10:54:25+00:00",
+                "type": "neos-package-collection",
+                "uid": 1831892,
+                "version": "4.2.7",
+                "version_normalized": "4.2.7.0"
+            },
+            "4.2.8": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "d5a1640ecdde8f620fe5578407ff78900338f9d2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/d5a1640ecdde8f620fe5578407ff78900338f9d2"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "d5a1640ecdde8f620fe5578407ff78900338f9d2",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-02-06T09:37:30+00:00",
+                "type": "neos-package-collection",
+                "uid": 1894370,
+                "version": "4.2.8",
+                "version_normalized": "4.2.8.0"
+            },
+            "4.2.9": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "d767001fcd1f6a842829cf2c3a281d0c526e95fc",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/d767001fcd1f6a842829cf2c3a281d0c526e95fc"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "d767001fcd1f6a842829cf2c3a281d0c526e95fc",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-03-20T13:22:45+00:00",
+                "type": "neos-package-collection",
+                "uid": 2009674,
+                "version": "4.2.9",
+                "version_normalized": "4.2.9.0"
+            },
+            "4.2.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "3de10dee47c43b09aac1c56a32451af2c844e311",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/3de10dee47c43b09aac1c56a32451af2c844e311"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "3de10dee47c43b09aac1c56a32451af2c844e311",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T12:31:46+00:00",
+                "type": "neos-package-collection",
+                "uid": 1561587,
+                "version": "4.2.x-dev",
+                "version_normalized": "4.2.9999999.9999999-dev"
+            },
+            "4.3.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "37a8499f8b398a12367b09915998cce7066c41a9",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/37a8499f8b398a12367b09915998cce7066c41a9"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.5.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "37a8499f8b398a12367b09915998cce7066c41a9",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-12-19T12:24:06+00:00",
+                "type": "neos-package-collection",
+                "uid": 1797993,
+                "version": "4.3.0",
+                "version_normalized": "4.3.0.0"
+            },
+            "4.3.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "baeae0bee34673707d2d6f6c0ad34e840b5fdb9f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/baeae0bee34673707d2d6f6c0ad34e840b5fdb9f"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.5.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "baeae0bee34673707d2d6f6c0ad34e840b5fdb9f",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-12-19T21:21:13+00:00",
+                "type": "neos-package-collection",
+                "uid": 1799504,
+                "version": "4.3.1",
+                "version_normalized": "4.3.1.0"
+            },
+            "4.3.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "c46f4a6820ffe596dcdfd754cdaf7e804fe625b9",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/c46f4a6820ffe596dcdfd754cdaf7e804fe625b9"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.5.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "c46f4a6820ffe596dcdfd754cdaf7e804fe625b9",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-01-09T10:55:44+00:00",
+                "type": "neos-package-collection",
+                "uid": 1831898,
+                "version": "4.3.2",
+                "version_normalized": "4.3.2.0"
+            },
+            "4.3.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "6e210788d9a769e463fa6da5fa2238b37219450e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/6e210788d9a769e463fa6da5fa2238b37219450e"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.5.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "6e210788d9a769e463fa6da5fa2238b37219450e",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-02-06T09:57:39+00:00",
+                "type": "neos-package-collection",
+                "uid": 1894441,
+                "version": "4.3.3",
+                "version_normalized": "4.3.3.0"
+            },
+            "4.3.4": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "d4bfafba3e78510aa9b92ab10d0bbceb40cd1787",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/d4bfafba3e78510aa9b92ab10d0bbceb40cd1787"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.5.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "d4bfafba3e78510aa9b92ab10d0bbceb40cd1787",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-03-20T13:43:53+00:00",
+                "type": "neos-package-collection",
+                "uid": 2009898,
+                "version": "4.3.4",
+                "version_normalized": "4.3.4.0"
+            },
+            "4.3.5": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "fd249fbad6dc448d6ef35614a4fa8eff055eee67",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/fd249fbad6dc448d6ef35614a4fa8eff055eee67"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.5.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "fd249fbad6dc448d6ef35614a4fa8eff055eee67",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T12:35:36+00:00",
+                "type": "neos-package-collection",
+                "uid": 2206178,
+                "version": "4.3.5",
+                "version_normalized": "4.3.5.0"
+            },
+            "4.3.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "fd249fbad6dc448d6ef35614a4fa8eff055eee67",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/fd249fbad6dc448d6ef35614a4fa8eff055eee67"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.5.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "fd249fbad6dc448d6ef35614a4fa8eff055eee67",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T12:35:36+00:00",
+                "type": "neos-package-collection",
+                "uid": 1797294,
+                "version": "4.3.x-dev",
+                "version_normalized": "4.3.9999999.9999999-dev"
+            },
+            "5.0.0": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "beafb147c6ecceab2160686ef9136cb64d1af18d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/beafb147c6ecceab2160686ef9136cb64d1af18d"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version",
+                    "typo3/eel": "self.version",
+                    "typo3/flow": "self.version",
+                    "typo3/kickstart": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.6.0",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.1",
+                    "psr/cache": "~1.0",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "psr/simple-cache": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0",
+                    "typo3fluid/fluid": "~2.5.3"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.6.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "neos/flow": "*",
+                    "phpunit/phpunit": "~7.1"
+                },
+                "source": {
+                    "reference": "beafb147c6ecceab2160686ef9136cb64d1af18d",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-04-25T15:03:16+00:00",
+                "type": "neos-package-collection",
+                "uid": 2134824,
+                "version": "5.0.0",
+                "version_normalized": "5.0.0.0"
+            },
+            "5.0.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "010337354368265320774d2ef7ff9a8d0f623970",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/010337354368265320774d2ef7ff9a8d0f623970"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version",
+                    "typo3/eel": "self.version",
+                    "typo3/flow": "self.version",
+                    "typo3/kickstart": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.6.0",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.1",
+                    "psr/cache": "~1.0",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "psr/simple-cache": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0",
+                    "typo3fluid/fluid": "~2.5.3"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.6.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "neos/flow": "*",
+                    "phpunit/phpunit": "~7.1"
+                },
+                "source": {
+                    "reference": "010337354368265320774d2ef7ff9a8d0f623970",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-04-25T20:36:36+00:00",
+                "type": "neos-package-collection",
+                "uid": 2135878,
+                "version": "5.0.1",
+                "version_normalized": "5.0.1.0"
+            },
+            "5.0.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "466472e4f3707983b8562f46f3cefd0660582cbd",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/466472e4f3707983b8562f46f3cefd0660582cbd"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version",
+                    "typo3/eel": "self.version",
+                    "typo3/flow": "self.version",
+                    "typo3/kickstart": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.6.0",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.1",
+                    "psr/cache": "~1.0",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "psr/simple-cache": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0",
+                    "typo3fluid/fluid": "~2.5.3"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.6.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "neos/flow": "*",
+                    "phpunit/phpunit": "~7.1"
+                },
+                "source": {
+                    "reference": "466472e4f3707983b8562f46f3cefd0660582cbd",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-04-27T07:16:09+00:00",
+                "type": "neos-package-collection",
+                "uid": 2140764,
+                "version": "5.0.2",
+                "version_normalized": "5.0.2.0"
+            },
+            "5.0.3": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "3cdfc75b203fe513818e2ba523715a03d21d8800",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/3cdfc75b203fe513818e2ba523715a03d21d8800"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version",
+                    "typo3/eel": "self.version",
+                    "typo3/flow": "self.version",
+                    "typo3/kickstart": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.6.0",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.1",
+                    "psr/cache": "~1.0",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "psr/simple-cache": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0",
+                    "typo3fluid/fluid": "~2.5.3"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.6.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "neos/flow": "*",
+                    "phpunit/phpunit": "~7.1"
+                },
+                "source": {
+                    "reference": "3cdfc75b203fe513818e2ba523715a03d21d8800",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T12:44:12+00:00",
+                "type": "neos-package-collection",
+                "uid": 2206210,
+                "version": "5.0.3",
+                "version_normalized": "5.0.3.0"
+            },
+            "5.0.x-dev": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "3cdfc75b203fe513818e2ba523715a03d21d8800",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/3cdfc75b203fe513818e2ba523715a03d21d8800"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version",
+                    "typo3/eel": "self.version",
+                    "typo3/flow": "self.version",
+                    "typo3/kickstart": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.6.0",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.1",
+                    "psr/cache": "~1.0",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "psr/simple-cache": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0",
+                    "typo3fluid/fluid": "~2.5.3"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.6.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "neos/flow": "*",
+                    "phpunit/phpunit": "~7.1"
+                },
+                "source": {
+                    "reference": "3cdfc75b203fe513818e2ba523715a03d21d8800",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-16T12:44:12+00:00",
+                "type": "neos-package-collection",
+                "uid": 2116933,
+                "version": "5.0.x-dev",
+                "version_normalized": "5.0.9999999.9999999-dev"
+            },
+            "dev-dependabot/composer/doctrine/common-tw-2.8.1": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "4326bc05f97b67f0e6b6220d4129e94f26e65a83",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/4326bc05f97b67f0e6b6220d4129e94f26e65a83"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version",
+                    "typo3/eel": "self.version",
+                    "typo3/flow": "self.version",
+                    "typo3/kickstart": "self.version"
+                },
+                "require": {
+                    "doctrine/common": "^2.8.1",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.6.0",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.1",
+                    "psr/cache": "~1.0",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "psr/simple-cache": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0",
+                    "typo3fluid/fluid": "~2.5.3"
+                },
+                "require-dev": {
+                    "doctrine/common": "^2.8.1",
+                    "doctrine/orm": "~2.6.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "neos/flow": "*",
+                    "phpunit/phpunit": "~7.1"
+                },
+                "source": {
+                    "reference": "4326bc05f97b67f0e6b6220d4129e94f26e65a83",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-03T18:11:28+00:00",
+                "type": "neos-package-collection",
+                "uid": 2155164,
+                "version": "dev-dependabot/composer/doctrine/common-tw-2.8.1",
+                "version_normalized": "dev-dependabot/composer/doctrine/common-tw-2.8.1"
+            },
+            "dev-dependabot/composer/doctrine/migrations-approx-1.7.2": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "100d7bf51c2d42fe00ae0053f983b9f1b9e726c4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/100d7bf51c2d42fe00ae0053f983b9f1b9e726c4"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version",
+                    "typo3/eel": "self.version",
+                    "typo3/flow": "self.version",
+                    "typo3/kickstart": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.7.2",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.1",
+                    "psr/cache": "~1.0",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "psr/simple-cache": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0",
+                    "typo3fluid/fluid": "~2.5.3"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.6.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "neos/flow": "*",
+                    "phpunit/phpunit": "~7.1"
+                },
+                "source": {
+                    "reference": "100d7bf51c2d42fe00ae0053f983b9f1b9e726c4",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-14T09:26:08+00:00",
+                "type": "neos-package-collection",
+                "uid": 2198855,
+                "version": "dev-dependabot/composer/doctrine/migrations-approx-1.7.2",
+                "version_normalized": "dev-dependabot/composer/doctrine/migrations-approx-1.7.2"
+            },
+            "dev-dfeyer-patch-1": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "498ceb33deac8268c24f42eeb3a5c61233dc7b04",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/498ceb33deac8268c24f42eeb3a5c61233dc7b04"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.5.0",
+                    "doctrine/migrations": "~1.3.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~2.8",
+                    "symfony/dom-crawler": "~2.8.0",
+                    "symfony/yaml": "~2.8.0",
+                    "typo3fluid/fluid": "~2.1.3"
+                },
+                "require-dev": {
+                    "mikey179/vfsstream": "~1.6",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "498ceb33deac8268c24f42eeb3a5c61233dc7b04",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2017-10-04T12:29:52+00:00",
+                "type": "neos-package-collection",
+                "uid": 1646408,
+                "version": "dev-dfeyer-patch-1",
+                "version_normalized": "dev-dfeyer-patch-1"
+            },
+            "dev-event-sourced": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "de38230d8893498b8ae8ef283ad388b914da432f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/de38230d8893498b8ae8ef283ad388b914da432f"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version",
+                    "typo3/eel": "self.version",
+                    "typo3/flow": "self.version",
+                    "typo3/kickstart": "self.version"
+                },
+                "require": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/dbal": "~2.6.0",
+                    "doctrine/migrations": "~1.6.0",
+                    "doctrine/orm": "~2.5.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.1",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0",
+                    "typo3fluid/fluid": "~2.3.4"
+                },
+                "require-dev": {
+                    "doctrine/common": ">=2.4,<2.8-dev",
+                    "doctrine/orm": "~2.5.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "neos/flow": "*",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "de38230d8893498b8ae8ef283ad388b914da432f",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-02-23T12:53:06+00:00",
+                "type": "neos-package-collection",
+                "uid": 1942175,
+                "version": "dev-event-sourced",
+                "version_normalized": "dev-event-sourced"
+            },
+            "dev-master": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "Neos\\Cache\\": [
+                            "Neos.Cache/Classes"
+                        ],
+                        "Neos\\Eel\\": [
+                            "Neos.Eel/Classes"
+                        ],
+                        "Neos\\Error\\Messages\\": [
+                            "Neos.Error.Messages/Classes"
+                        ],
+                        "Neos\\Flow\\": [
+                            "Neos.Flow/Classes"
+                        ],
+                        "Neos\\Flow\\Core\\Migrations\\": [
+                            "Neos.Flow/Scripts/Migrations"
+                        ],
+                        "Neos\\Flow\\Log\\": [
+                            "Neos.Flow.Log/Classes"
+                        ],
+                        "Neos\\FluidAdaptor\\": [
+                            "Neos.FluidAdaptor/Classes/"
+                        ],
+                        "Neos\\Kickstarter\\": [
+                            "Neos.Kickstarter/Classes"
+                        ],
+                        "Neos\\Utility\\": [
+                            "Neos.Utility.Arrays/Classes",
+                            "Neos.Utility.Files/Classes",
+                            "Neos.Utility.MediaTypes/Classes",
+                            "Neos.Utility.ObjectHandling/Classes",
+                            "Neos.Utility.OpcodeCache/Classes",
+                            "Neos.Utility.Pdo/Classes",
+                            "Neos.Utility.Schema/Classes"
+                        ],
+                        "Neos\\Utility\\Lock\\": [
+                            "Neos.Utility.Lock/Classes"
+                        ],
+                        "Neos\\Utility\\Unicode\\": [
+                            "Neos.Utility.Unicode/Classes"
+                        ]
+                    }
+                },
+                "description": "Flow packages in a joined repository for pull requests.",
+                "dist": {
+                    "reference": "760ad4058675123545ffd089f7a9bb7b9fbe48a5",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/neos/flow-development-collection/zipball/760ad4058675123545ffd089f7a9bb7b9fbe48a5"
+                },
+                "extra": {
+                    "installer-name": "Framework",
+                    "neos": {
+                        "warning": "AUTOGENERATED FILE, ONLY MODIFY THE .composer.json IN THIS DIRECTORY AND RUN THE MERGE SCRIPT."
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "neos/flow-development-collection",
+                "replace": {
+                    "neos/cache": "self.version",
+                    "neos/eel": "self.version",
+                    "neos/error-messages": "self.version",
+                    "neos/flow": "self.version",
+                    "neos/flow-log": "self.version",
+                    "neos/fluid-adaptor": "self.version",
+                    "neos/kickstarter": "self.version",
+                    "neos/utility-arrays": "self.version",
+                    "neos/utility-files": "self.version",
+                    "neos/utility-lock": "self.version",
+                    "neos/utility-mediatypes": "self.version",
+                    "neos/utility-objecthandling": "self.version",
+                    "neos/utility-opcodecache": "self.version",
+                    "neos/utility-pdo": "self.version",
+                    "neos/utility-schema": "self.version",
+                    "neos/utility-unicode": "self.version",
+                    "typo3/eel": "self.version",
+                    "typo3/flow": "self.version",
+                    "typo3/kickstart": "self.version"
+                },
+                "require": {
+                    "doctrine/common": "^2.8.1",
+                    "doctrine/dbal": "~2.7.0",
+                    "doctrine/migrations": "~1.7.2",
+                    "doctrine/orm": "~2.6.0",
+                    "ext-json": ">=1.2.0",
+                    "ext-mbstring": "*",
+                    "ext-reflection": "*",
+                    "ext-spl": "*",
+                    "ext-zlib": "*",
+                    "neos/composer-plugin": "^2.0.0",
+                    "php": "~7.1",
+                    "psr/cache": "~1.0",
+                    "psr/container": "~1.0.0",
+                    "psr/http-message": "~1.0.0",
+                    "psr/log": "^1.0",
+                    "psr/simple-cache": "^1.0",
+                    "ramsey/uuid": "^3.0.0",
+                    "symfony/console": "~4.0.0",
+                    "symfony/dom-crawler": "~4.0.0",
+                    "symfony/yaml": "~4.0.0",
+                    "typo3fluid/fluid": "~2.5.3"
+                },
+                "require-dev": {
+                    "doctrine/common": "^2.8.1",
+                    "doctrine/orm": "~2.6.0",
+                    "mikey179/vfsstream": "~1.6",
+                    "neos/flow": "*",
+                    "phpunit/phpunit": "~7.1"
+                },
+                "source": {
+                    "reference": "760ad4058675123545ffd089f7a9bb7b9fbe48a5",
+                    "type": "git",
+                    "url": "https://github.com/neos/flow-development-collection.git"
+                },
+                "suggest": {
+                    "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
+                    "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
+                    "ext-memcache": "If you have a memcache server and want to use it for caching.",
+                    "ext-memcached": "Alternative, if you have a memcache server and want to use it for caching.",
+                    "ext-redis": "If you have a redis server and want to use it for caching.",
+                    "neos/party": "To make use of basic user handling",
+                    "php-uuid": "For fast generation of UUIDs used in the persistence."
+                },
+                "time": "2018-05-24T13:00:12+00:00",
+                "type": "neos-package-collection",
+                "uid": 494616,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            }
+        }
+    }
+}

--- a/spec/fixtures/php/packagist_responses/path_dep:path_dep.json
+++ b/spec/fixtures/php/packagist_responses/path_dep:path_dep.json
@@ -1,0 +1,1 @@
+{"error":{"code":404,"message":"Not Found"}}

--- a/spec/fixtures/php/packagist_responses/pear-pear.horde.org:horde_date.json
+++ b/spec/fixtures/php/packagist_responses/pear-pear.horde.org:horde_date.json
@@ -1,0 +1,1 @@
+{"error":{"code":404,"message":"Not Found"}}

--- a/spec/fixtures/php/packagist_responses/phpdocumentor:reflection-docblock.json
+++ b/spec/fixtures/php/packagist_responses/phpdocumentor:reflection-docblock.json
@@ -1,0 +1,2025 @@
+{
+    "packages": {
+        "phpdocumentor/reflection-docblock": {
+            "1.0.0": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor\\Reflection": "src/"
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "2b05ea32215fffe542e11795ea33ad82def10c58",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2b05ea32215fffe542e11795ea33ad82def10c58"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "dflydev/markdown": "1.0.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "2b05ea32215fffe542e11795ea33ad82def10c58",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2012-07-13T18:07:51+00:00",
+                "type": "library",
+                "uid": 15125,
+                "version": "1.0.0",
+                "version_normalized": "1.0.0.0"
+            },
+            "1.0.0-beta1": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor/Reflection": "src/phpDocumentor"
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "fea7abe168dfd01d96f61daa4bc27891814b94f3",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/fea7abe168dfd01d96f61daa4bc27891814b94f3"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "fea7abe168dfd01d96f61daa4bc27891814b94f3",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2012-04-06T18:15:46+00:00",
+                "type": "library",
+                "uid": 11554,
+                "version": "1.0.0-beta1",
+                "version_normalized": "1.0.0.0-beta1"
+            },
+            "1.0.0-beta2": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor\\Reflection": "src/phpDocumentor"
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "6a34cf123c10f9585d1d2453e7602c97db438979",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/6a34cf123c10f9585d1d2453e7602c97db438979"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "6a34cf123c10f9585d1d2453e7602c97db438979",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2012-04-06T18:39:59+00:00",
+                "type": "library",
+                "uid": 11555,
+                "version": "1.0.0-beta2",
+                "version_normalized": "1.0.0.0-beta2"
+            },
+            "1.0.0-beta3": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor\\Reflection": "src/"
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "3f8a4fca6dad3de99f76515c9a14222129f62b89",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/3f8a4fca6dad3de99f76515c9a14222129f62b89"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "3f8a4fca6dad3de99f76515c9a14222129f62b89",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2012-04-07T09:49:54+00:00",
+                "type": "library",
+                "uid": 11556,
+                "version": "1.0.0-beta3",
+                "version_normalized": "1.0.0.0-beta3"
+            },
+            "1.0.0-beta4": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor\\Reflection": "src/"
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "f0a2901e56721169a14915afb7afd52f7cc31f48",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/f0a2901e56721169a14915afb7afd52f7cc31f48"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "dflydev/markdown": "1.0.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "f0a2901e56721169a14915afb7afd52f7cc31f48",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2012-06-02T20:07:17+00:00",
+                "type": "library",
+                "uid": 13118,
+                "version": "1.0.0-beta4",
+                "version_normalized": "1.0.0.0-beta4"
+            },
+            "1.0.0-beta5": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor\\Reflection": "src/"
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "8f8cbd9ab6028e823c44444258788c386a457b0d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8f8cbd9ab6028e823c44444258788c386a457b0d"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "dflydev/markdown": "1.0.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "8f8cbd9ab6028e823c44444258788c386a457b0d",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2012-06-04T20:34:54+00:00",
+                "type": "library",
+                "uid": 13197,
+                "version": "1.0.0-beta5",
+                "version_normalized": "1.0.0.0-beta5"
+            },
+            "1.0.0-beta6": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor\\Reflection": "src/"
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "838fbfa43f3f4bb9081613514eb55535e9854cfd",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/838fbfa43f3f4bb9081613514eb55535e9854cfd"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "dflydev/markdown": "1.0.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "838fbfa43f3f4bb9081613514eb55535e9854cfd",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2012-06-21T21:03:48+00:00",
+                "type": "library",
+                "uid": 13897,
+                "version": "1.0.0-beta6",
+                "version_normalized": "1.0.0.0-beta6"
+            },
+            "1.0.0-beta7": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor\\Reflection": "src/"
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "cee3c0bc21d102762a81432d23f4bff9d5ef8658",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cee3c0bc21d102762a81432d23f4bff9d5ef8658"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "dflydev/markdown": "1.0.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "cee3c0bc21d102762a81432d23f4bff9d5ef8658",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2012-06-30T11:38:18+00:00",
+                "type": "library",
+                "uid": 14439,
+                "version": "1.0.0-beta7",
+                "version_normalized": "1.0.0.0-beta7"
+            },
+            "1.0.1": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor\\Reflection": "src/"
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "c999e7d32a64ad69b91d16f7904a1c2793323feb",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/c999e7d32a64ad69b91d16f7904a1c2793323feb"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "dflydev/markdown": "1.0.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "c999e7d32a64ad69b91d16f7904a1c2793323feb",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2012-07-26T15:09:50+00:00",
+                "type": "library",
+                "uid": 15748,
+                "version": "1.0.1",
+                "version_normalized": "1.0.1.0"
+            },
+            "1.0.2": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor\\Reflection": "src/"
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "60ba10fad1cf05066872b953a8b8d0cd204de9ee",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/60ba10fad1cf05066872b953a8b8d0cd204de9ee"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "dflydev/markdown": "1.0.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "60ba10fad1cf05066872b953a8b8d0cd204de9ee",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2012-09-10T14:50:44+00:00",
+                "type": "library",
+                "uid": 18814,
+                "version": "1.0.2",
+                "version_normalized": "1.0.2.0"
+            },
+            "1.0.3": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "6b707f71668d15d14564fc3766e108551037f10e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/6b707f71668d15d14564fc3766e108551037f10e"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "dflydev/markdown": "1.0.*",
+                    "php": ">=5.3.2"
+                },
+                "source": {
+                    "reference": "6b707f71668d15d14564fc3766e108551037f10e",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2012-11-03T21:14:43+00:00",
+                "type": "library",
+                "uid": 24106,
+                "version": "1.0.3",
+                "version_normalized": "1.0.3.0"
+            },
+            "2.0.0": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "66ae84e9d7c8ea85c979cb65977bd8e608baf0c5",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66ae84e9d7c8ea85c979cb65977bd8e608baf0c5"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "dflydev/markdown": "1.0.*",
+                    "php": ">=5.3.3"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*@stable"
+                },
+                "source": {
+                    "reference": "66ae84e9d7c8ea85c979cb65977bd8e608baf0c5",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2013-08-07T11:04:22+00:00",
+                "type": "library",
+                "uid": 75143,
+                "version": "2.0.0",
+                "version_normalized": "2.0.0.0"
+            },
+            "2.0.0a1": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "841897062442e2a0e8b3def1518caa25f6498dfd",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/841897062442e2a0e8b3def1518caa25f6498dfd"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "dflydev/markdown": "1.0.*",
+                    "php": ">=5.3.2"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "*@stable"
+                },
+                "source": {
+                    "reference": "841897062442e2a0e8b3def1518caa25f6498dfd",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2012-11-27T17:52:28+00:00",
+                "type": "library",
+                "uid": 34801,
+                "version": "2.0.0a1",
+                "version_normalized": "2.0.0.0-alpha1"
+            },
+            "2.0.0a2": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "5d93f42598d6a8332433856fb5656606a4c1e1e3",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/5d93f42598d6a8332433856fb5656606a4c1e1e3"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "dflydev/markdown": "1.0.*",
+                    "php": ">=5.3.3"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*@stable"
+                },
+                "source": {
+                    "reference": "5d93f42598d6a8332433856fb5656606a4c1e1e3",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2012-12-02T20:26:45+00:00",
+                "type": "library",
+                "uid": 34802,
+                "version": "2.0.0a2",
+                "version_normalized": "2.0.0.0-alpha2"
+            },
+            "2.0.0a3": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "47d3f86c53985b16d80f9a211d639505ccc3824a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/47d3f86c53985b16d80f9a211d639505ccc3824a"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "dflydev/markdown": "1.0.*",
+                    "php": ">=5.3.3"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*@stable"
+                },
+                "source": {
+                    "reference": "47d3f86c53985b16d80f9a211d639505ccc3824a",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2013-04-16T14:22:15+00:00",
+                "type": "library",
+                "uid": 49190,
+                "version": "2.0.0a3",
+                "version_normalized": "2.0.0.0-alpha3"
+            },
+            "2.0.1": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "cfb3ebea556b24df8f8f3745d61478293cb5a166",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cfb3ebea556b24df8f8f3745d61478293cb5a166"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*@stable"
+                },
+                "source": {
+                    "reference": "cfb3ebea556b24df8f8f3745d61478293cb5a166",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "suggest": {
+                    "dflydev/markdown": "1.0.*",
+                    "erusev/parsedown": "~0.7"
+                },
+                "time": "2013-12-05T08:16:55+00:00",
+                "type": "library",
+                "uid": 107309,
+                "version": "2.0.1",
+                "version_normalized": "2.0.1.0"
+            },
+            "2.0.2": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "0bca477a34baea39add016af90046f002a175619",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/0bca477a34baea39add016af90046f002a175619"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*@stable"
+                },
+                "source": {
+                    "reference": "0bca477a34baea39add016af90046f002a175619",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "suggest": {
+                    "dflydev/markdown": "1.0.*",
+                    "erusev/parsedown": "~0.7"
+                },
+                "time": "2014-03-28T09:21:30+00:00",
+                "type": "library",
+                "uid": 151063,
+                "version": "2.0.2",
+                "version_normalized": "2.0.2.0"
+            },
+            "2.0.3": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "38743b677965c48a637097b2746a281264ae2347",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/38743b677965c48a637097b2746a281264ae2347"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "3.7.*@stable"
+                },
+                "source": {
+                    "reference": "38743b677965c48a637097b2746a281264ae2347",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "suggest": {
+                    "dflydev/markdown": "1.0.*",
+                    "erusev/parsedown": "~0.7"
+                },
+                "time": "2014-08-09T10:27:07+00:00",
+                "type": "library",
+                "uid": 218937,
+                "version": "2.0.3",
+                "version_normalized": "2.0.3.0"
+            },
+            "2.0.4": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.0"
+                },
+                "source": {
+                    "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "suggest": {
+                    "dflydev/markdown": "~1.0",
+                    "erusev/parsedown": "~1.0"
+                },
+                "time": "2015-02-03T12:10:50+00:00",
+                "type": "library",
+                "uid": 320856,
+                "version": "2.0.4",
+                "version_normalized": "2.0.4.0"
+            },
+            "2.0.5": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.0"
+                },
+                "source": {
+                    "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "suggest": {
+                    "dflydev/markdown": "~1.0",
+                    "erusev/parsedown": "~1.0"
+                },
+                "time": "2016-01-25T08:17:30+00:00",
+                "type": "library",
+                "uid": 1412492,
+                "version": "2.0.5",
+                "version_normalized": "2.0.5.0"
+            },
+            "3.0.0": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "332c96dab8309293384505593ed7259c35a143e2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/332c96dab8309293384505593ed7259c35a143e2"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.5",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.1.5",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "332c96dab8309293384505593ed7259c35a143e2",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2016-01-28T12:45:51+00:00",
+                "type": "library",
+                "uid": 675244,
+                "version": "3.0.0",
+                "version_normalized": "3.0.0.0"
+            },
+            "3.0.1": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "52723f0fb83d053be05c3f6b58ec45e5851c0e99",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/52723f0fb83d053be05c3f6b58ec45e5851c0e99"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.5",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.1.5",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "52723f0fb83d053be05c3f6b58ec45e5851c0e99",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2016-02-26T20:44:16+00:00",
+                "type": "library",
+                "uid": 714967,
+                "version": "3.0.1",
+                "version_normalized": "3.0.1.0"
+            },
+            "3.0.2": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "45ada3e3fd09789fbfbd6d65b3f0901f0030dc61",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/45ada3e3fd09789fbfbd6d65b3f0901f0030dc61"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.5",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.1.5",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "45ada3e3fd09789fbfbd6d65b3f0901f0030dc61",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2016-06-06T06:44:13+00:00",
+                "type": "library",
+                "uid": 851262,
+                "version": "3.0.2",
+                "version_normalized": "3.0.2.0"
+            },
+            "3.0.3": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "ea48fd2c79b68fba8693ae67a21cae5b5ee4cfb8",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/ea48fd2c79b68fba8693ae67a21cae5b5ee4cfb8"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.5",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.1.5",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "ea48fd2c79b68fba8693ae67a21cae5b5ee4cfb8",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2016-06-10T07:04:47+00:00",
+                "type": "library",
+                "uid": 857123,
+                "version": "3.0.3",
+                "version_normalized": "3.0.3.0"
+            },
+            "3.1.0": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9270140b940ff02e58ec577c237274e92cd40cdd"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.5",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.2.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2016-06-10T09:48:41+00:00",
+                "type": "library",
+                "uid": 857356,
+                "version": "3.1.0",
+                "version_normalized": "3.1.0.0"
+            },
+            "3.1.1": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.5",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.2.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2016-09-30T07:12:33+00:00",
+                "type": "library",
+                "uid": 1015732,
+                "version": "3.1.1",
+                "version_normalized": "3.1.1.0"
+            },
+            "3.2.0": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "46f7e8bb075036c92695b15a1ddb6971c751e585",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/46f7e8bb075036c92695b15a1ddb6971c751e585"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.5",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.4.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "46f7e8bb075036c92695b15a1ddb6971c751e585",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2017-07-15T11:38:20+00:00",
+                "type": "library",
+                "uid": 1501144,
+                "version": "3.2.0",
+                "version_normalized": "3.2.0.0"
+            },
+            "3.2.1": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "183824db76118b9dddffc7e522b91fa175f75119",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/183824db76118b9dddffc7e522b91fa175f75119"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.5",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.3.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "183824db76118b9dddffc7e522b91fa175f75119",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2017-08-04T20:55:59+00:00",
+                "type": "library",
+                "uid": 1538638,
+                "version": "3.2.1",
+                "version_normalized": "3.2.1.0"
+            },
+            "3.2.2": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/4aada1f93c72c35e22fb1383b47fee43b8f1d157"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.5",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.3.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2017-08-08T06:39:58+00:00",
+                "type": "library",
+                "uid": 1542833,
+                "version": "3.2.2",
+                "version_normalized": "3.2.2.0"
+            },
+            "3.2.3": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "86e24012a3139b42a7b71155cfaa325389f00f1f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/86e24012a3139b42a7b71155cfaa325389f00f1f"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": "^7.0",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.4.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "86e24012a3139b42a7b71155cfaa325389f00f1f",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2017-08-29T19:37:41+00:00",
+                "type": "library",
+                "uid": 1583498,
+                "version": "3.2.3",
+                "version_normalized": "3.2.3.0"
+            },
+            "3.3.0": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "48eb1f629d55621f03ca72195fe04d05d463b807",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/48eb1f629d55621f03ca72195fe04d05d463b807"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": "^7.0",
+                    "phpdocumentor/reflection-common": "^1.0.0",
+                    "phpdocumentor/type-resolver": "^0.4.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "48eb1f629d55621f03ca72195fe04d05d463b807",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2017-09-11T18:06:56+00:00",
+                "type": "library",
+                "uid": 1605338,
+                "version": "3.3.0",
+                "version_normalized": "3.3.0.0"
+            },
+            "3.3.2": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": "^5.6 || ^7.0",
+                    "phpdocumentor/reflection-common": "^1.0.0",
+                    "phpdocumentor/type-resolver": "^0.4.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2017-11-10T14:09:06+00:00",
+                "type": "library",
+                "uid": 1738687,
+                "version": "3.3.2",
+                "version_normalized": "3.3.2.0"
+            },
+            "4.0.0": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "3c8d2425b563012ec50ffc8c59fe76247ac6e03e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/3c8d2425b563012ec50ffc8c59fe76247ac6e03e"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": "^7.0",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.4.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "3c8d2425b563012ec50ffc8c59fe76247ac6e03e",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2017-08-04T21:25:06+00:00",
+                "type": "library",
+                "uid": 1538650,
+                "version": "4.0.0",
+                "version_normalized": "4.0.0.0"
+            },
+            "4.0.1": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "a8d791f8c91ea5fb91580d48f2c7903849271ba7",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/a8d791f8c91ea5fb91580d48f2c7903849271ba7"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": "^7.0",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.4.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "a8d791f8c91ea5fb91580d48f2c7903849271ba7",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2017-08-08T06:43:50+00:00",
+                "type": "library",
+                "uid": 1542837,
+                "version": "4.0.1",
+                "version_normalized": "4.0.1.0"
+            },
+            "4.1.0": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "125c8b15c80827dbcd32facc9f85c8a603617d87",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/125c8b15c80827dbcd32facc9f85c8a603617d87"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": "^7.0",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.4.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "125c8b15c80827dbcd32facc9f85c8a603617d87",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2017-08-18T21:01:43+00:00",
+                "type": "library",
+                "uid": 1562780,
+                "version": "4.1.0",
+                "version_normalized": "4.1.0.0"
+            },
+            "4.1.1": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": "^7.0",
+                    "phpdocumentor/reflection-common": "^1.0@dev",
+                    "phpdocumentor/type-resolver": "^0.4.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2017-08-30T18:51:59+00:00",
+                "type": "library",
+                "uid": 1583501,
+                "version": "4.1.1",
+                "version_normalized": "4.1.1.0"
+            },
+            "4.2.0": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "4.x-dev"
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": "^7.0",
+                    "phpdocumentor/reflection-common": "^1.0.0",
+                    "phpdocumentor/type-resolver": "^0.4.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "doctrine/instantiator": "~1.0.5",
+                    "mockery/mockery": "^1.0",
+                    "phpunit/phpunit": "^6.4"
+                },
+                "source": {
+                    "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2017-11-27T17:38:31+00:00",
+                "type": "library",
+                "uid": 1750511,
+                "version": "4.2.0",
+                "version_normalized": "4.2.0.0"
+            },
+            "4.3.0": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "4.x-dev"
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": "^7.0",
+                    "phpdocumentor/reflection-common": "^1.0.0",
+                    "phpdocumentor/type-resolver": "^0.4.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "doctrine/instantiator": "~1.0.5",
+                    "mockery/mockery": "^1.0",
+                    "phpunit/phpunit": "^6.4"
+                },
+                "source": {
+                    "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2017-11-30T07:14:17+00:00",
+                "type": "library",
+                "uid": 1871351,
+                "version": "4.3.0",
+                "version_normalized": "4.3.0.0"
+            },
+            "5.0.0-alpha1": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": "src"
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "6946f85e19ea3342353e22b83b4e2e59414c1a2f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/6946f85e19ea3342353e22b83b4e2e59414c1a2f"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "4.x-dev"
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=7.1",
+                    "phpdocumentor/type-resolver": "^0",
+                    "webmozart/assert": "^1"
+                },
+                "require-dev": {
+                    "doctrine/instantiator": "^1",
+                    "mockery/mockery": "^1"
+                },
+                "source": {
+                    "reference": "6946f85e19ea3342353e22b83b4e2e59414c1a2f",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2018-01-31T20:23:19+00:00",
+                "type": "library",
+                "uid": 1882933,
+                "version": "5.0.0-alpha1",
+                "version_normalized": "5.0.0.0-alpha1"
+            },
+            "dev-_before-history-rewrite": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "9304b75a61d8aa9ce34d679408a8b41d46d24663",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9304b75a61d8aa9ce34d679408a8b41d46d24663"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "3.0.x-dev"
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.5",
+                    "phpdocumentor/reflection-common": "^0.1",
+                    "phpdocumentor/type-resolver": "^0.1.1",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "4.4"
+                },
+                "source": {
+                    "reference": "9304b75a61d8aa9ce34d679408a8b41d46d24663",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2015-06-22T06:12:13+00:00",
+                "type": "library",
+                "uid": 450330,
+                "version": "dev-_before-history-rewrite",
+                "version_normalized": "dev-_before-history-rewrite"
+            },
+            "dev-master": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": "src"
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "6537078c5e43d87931eebce7b2a07c50460a3fde",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/6537078c5e43d87931eebce7b2a07c50460a3fde"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "5.x-dev"
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=7.1",
+                    "phpdocumentor/type-resolver": "^0",
+                    "webmozart/assert": "^1"
+                },
+                "require-dev": {
+                    "doctrine/instantiator": "^1",
+                    "mockery/mockery": "^1"
+                },
+                "source": {
+                    "reference": "6537078c5e43d87931eebce7b2a07c50460a3fde",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2018-04-19T08:00:57+00:00",
+                "type": "library",
+                "uid": 11557,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            },
+            "dev-release/2.x": {
+                "authors": [
+                    {
+                        "email": "mike.vanriel@naenius.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-0": {
+                        "phpDocumentor": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "",
+                "dist": {
+                    "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.0"
+                },
+                "source": {
+                    "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "suggest": {
+                    "dflydev/markdown": "~1.0",
+                    "erusev/parsedown": "~1.0"
+                },
+                "time": "2016-01-25T08:17:30+00:00",
+                "type": "library",
+                "uid": 613204,
+                "version": "dev-release/2.x",
+                "version_normalized": "dev-release/2.x"
+            },
+            "dev-release/3.x": {
+                "authors": [
+                    {
+                        "email": "me@mikevanriel.com",
+                        "name": "Mike van Riel"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "phpDocumentor\\Reflection\\": [
+                            "src/"
+                        ]
+                    }
+                },
+                "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+                "dist": {
+                    "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "phpdocumentor/reflection-docblock",
+                "require": {
+                    "php": "^5.6 || ^7.0",
+                    "phpdocumentor/reflection-common": "^1.0.0",
+                    "phpdocumentor/type-resolver": "^0.4.0",
+                    "webmozart/assert": "^1.0"
+                },
+                "require-dev": {
+                    "mockery/mockery": "^0.9.4",
+                    "phpunit/phpunit": "^4.4"
+                },
+                "source": {
+                    "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                    "type": "git",
+                    "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git"
+                },
+                "time": "2017-11-10T14:09:06+00:00",
+                "type": "library",
+                "uid": 1542820,
+                "version": "dev-release/3.x",
+                "version_normalized": "dev-release/3.x"
+            }
+        }
+    }
+}

--- a/spec/fixtures/php/packagist_responses/symfony:polyfill-mbstring.json
+++ b/spec/fixtures/php/packagist_responses/symfony:polyfill-mbstring.json
@@ -1,0 +1,2750 @@
+{
+    "packages": {
+        "frosh/shopware-profiler": {
+            "1.1.5": {
+                "authors": [],
+                "description": "Profiling for Shopware",
+                "dist": {
+                    "reference": "24bef0c5cb51f26b1d03da45c8c7961b34089b02",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/FriendsOfShopware/FroshProfiler/zipball/24bef0c5cb51f26b1d03da45c8c7961b34089b02"
+                },
+                "extra": {
+                    "installer-name": "ShyimProfiler"
+                },
+                "homepage": "",
+                "keywords": [
+                    "plugin",
+                    "profiling",
+                    "shopware"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "frosh/shopware-profiler",
+                "replace": {
+                    "symfony/polyfill-mbstring": "~1.0"
+                },
+                "require": {
+                    "composer/installers": "~1.0",
+                    "jdorn/sql-formatter": "^1.2.17",
+                    "php": "^7.0",
+                    "roave/security-advisories": "dev-master",
+                    "symfony/stopwatch": "^3.3",
+                    "symfony/var-dumper": "^3.2"
+                },
+                "source": {
+                    "reference": "24bef0c5cb51f26b1d03da45c8c7961b34089b02",
+                    "type": "git",
+                    "url": "https://github.com/FriendsOfShopware/FroshProfiler.git"
+                },
+                "time": "2017-11-16T18:05:21+00:00",
+                "type": "shopware-plugin",
+                "uid": 1942879,
+                "version": "1.1.5",
+                "version_normalized": "1.1.5.0"
+            },
+            "1.1.6": {
+                "authors": [],
+                "description": "Profiling for Shopware",
+                "dist": {
+                    "reference": "ed5ddd7864c656a702dd678e206eee9daa0a7972",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/FriendsOfShopware/FroshProfiler/zipball/ed5ddd7864c656a702dd678e206eee9daa0a7972"
+                },
+                "extra": {
+                    "installer-name": "ShyimProfiler"
+                },
+                "homepage": "",
+                "keywords": [
+                    "plugin",
+                    "profiling",
+                    "shopware"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "frosh/shopware-profiler",
+                "replace": {
+                    "symfony/polyfill-mbstring": "~1.0"
+                },
+                "require": {
+                    "composer/installers": "~1.0",
+                    "jdorn/sql-formatter": "^1.2.17",
+                    "php": "^7.0",
+                    "roave/security-advisories": "dev-master",
+                    "symfony/stopwatch": "^3.3",
+                    "symfony/var-dumper": "^3.2"
+                },
+                "source": {
+                    "reference": "ed5ddd7864c656a702dd678e206eee9daa0a7972",
+                    "type": "git",
+                    "url": "https://github.com/FriendsOfShopware/FroshProfiler.git"
+                },
+                "time": "2018-01-25T18:08:54+00:00",
+                "type": "shopware-plugin",
+                "uid": 1942880,
+                "version": "1.1.6",
+                "version_normalized": "1.1.6.0"
+            },
+            "1.2.0": {
+                "authors": [],
+                "description": "Profiling for Shopware",
+                "dist": {
+                    "reference": "2797e2310c0ac74478ecd18a8032e1f388f44892",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/FriendsOfShopware/FroshProfiler/zipball/2797e2310c0ac74478ecd18a8032e1f388f44892"
+                },
+                "extra": {
+                    "installer-name": "FroshProfiler"
+                },
+                "homepage": "",
+                "keywords": [
+                    "plugin",
+                    "profiling",
+                    "shopware"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "frosh/shopware-profiler",
+                "replace": {
+                    "symfony/polyfill-mbstring": "~1.0"
+                },
+                "require": {
+                    "composer/installers": "~1.0",
+                    "jdorn/sql-formatter": "^1.2.17",
+                    "php": "^7.0",
+                    "roave/security-advisories": "dev-master",
+                    "symfony/stopwatch": "^3.3",
+                    "symfony/var-dumper": "^3.2"
+                },
+                "source": {
+                    "reference": "2797e2310c0ac74478ecd18a8032e1f388f44892",
+                    "type": "git",
+                    "url": "https://github.com/FriendsOfShopware/FroshProfiler.git"
+                },
+                "time": "2018-02-26T18:57:18+00:00",
+                "type": "shopware-plugin",
+                "uid": 1942895,
+                "version": "1.2.0",
+                "version_normalized": "1.2.0.0"
+            },
+            "1.2.1": {
+                "authors": [],
+                "description": "Profiling for Shopware",
+                "dist": {
+                    "reference": "d6a1267950a4f6d9b766db0770c6a66ef4d0ad67",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/FriendsOfShopware/FroshProfiler/zipball/d6a1267950a4f6d9b766db0770c6a66ef4d0ad67"
+                },
+                "extra": {
+                    "installer-name": "FroshProfiler"
+                },
+                "homepage": "",
+                "keywords": [
+                    "plugin",
+                    "profiling",
+                    "shopware"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "frosh/shopware-profiler",
+                "replace": {
+                    "symfony/polyfill-mbstring": "~1.0"
+                },
+                "require": {
+                    "composer/installers": "~1.0",
+                    "jdorn/sql-formatter": "^1.2.17",
+                    "php": "^7.0",
+                    "roave/security-advisories": "dev-master",
+                    "symfony/stopwatch": "^3.3",
+                    "symfony/var-dumper": "^3.2"
+                },
+                "source": {
+                    "reference": "d6a1267950a4f6d9b766db0770c6a66ef4d0ad67",
+                    "type": "git",
+                    "url": "https://github.com/FriendsOfShopware/FroshProfiler.git"
+                },
+                "time": "2018-03-20T20:16:45+00:00",
+                "type": "shopware-plugin",
+                "uid": 2011187,
+                "version": "1.2.1",
+                "version_normalized": "1.2.1.0"
+            },
+            "1.3.0": {
+                "authors": [],
+                "description": "Profiling for Shopware",
+                "dist": {
+                    "reference": "a1a293d904a68f10d0161d51d233f2df588c4b85",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/FriendsOfShopware/FroshProfiler/zipball/a1a293d904a68f10d0161d51d233f2df588c4b85"
+                },
+                "extra": {
+                    "installer-name": "FroshProfiler"
+                },
+                "homepage": "",
+                "keywords": [
+                    "plugin",
+                    "profiling",
+                    "shopware"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "frosh/shopware-profiler",
+                "replace": {
+                    "symfony/polyfill-mbstring": "~1.0"
+                },
+                "require": {
+                    "composer/installers": "~1.0",
+                    "jdorn/sql-formatter": "^1.2.17",
+                    "roave/security-advisories": "dev-master",
+                    "shyim/var-dumper": "dev-master",
+                    "symfony/stopwatch": "^3.3"
+                },
+                "source": {
+                    "reference": "a1a293d904a68f10d0161d51d233f2df588c4b85",
+                    "type": "git",
+                    "url": "https://github.com/FriendsOfShopware/FroshProfiler.git"
+                },
+                "time": "2018-04-21T09:55:24+00:00",
+                "type": "shopware-plugin",
+                "uid": 2117921,
+                "version": "1.3.0",
+                "version_normalized": "1.3.0.0"
+            },
+            "dev-master": {
+                "authors": [],
+                "description": "Profiling for Shopware",
+                "dist": {
+                    "reference": "bc6f6e8553df83fc5580c6c9baa0839174b71c86",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/FriendsOfShopware/FroshProfiler/zipball/bc6f6e8553df83fc5580c6c9baa0839174b71c86"
+                },
+                "extra": {
+                    "installer-name": "FroshProfiler"
+                },
+                "homepage": "",
+                "keywords": [
+                    "plugin",
+                    "profiling",
+                    "shopware"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "frosh/shopware-profiler",
+                "replace": {
+                    "symfony/polyfill-mbstring": "~1.0"
+                },
+                "require": {
+                    "composer/installers": "~1.0",
+                    "jdorn/sql-formatter": "^1.2.17",
+                    "shyim/var-dumper": "^1.0",
+                    "symfony/stopwatch": "^3.3"
+                },
+                "source": {
+                    "reference": "bc6f6e8553df83fc5580c6c9baa0839174b71c86",
+                    "type": "git",
+                    "url": "https://github.com/FriendsOfShopware/FroshProfiler.git"
+                },
+                "time": "2018-05-15T20:55:18+00:00",
+                "type": "shopware-plugin",
+                "uid": 1942883,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            }
+        },
+        "narrowspark/narrowspark": {
+            "dev-master": {
+                "authors": [],
+                "autoload": {
+                    "exclude-from-classmap": [
+                        "tests/"
+                    ],
+                    "psr-4": {
+                        "App\\": "app/"
+                    }
+                },
+                "conflict": {
+                    "narrowspark/framework": "*"
+                },
+                "description": "Narrowspark framework for creative people.",
+                "dist": {
+                    "reference": "82d10e98750cbc8be7906d98083352060ca91166",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/narrowspark/narrowspark/zipball/82d10e98750cbc8be7906d98083352060ca91166"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "MIT"
+                ],
+                "name": "narrowspark/narrowspark",
+                "replace": {
+                    "symfony/polyfill-mbstring": "*",
+                    "symfony/polyfill-php56": "*",
+                    "symfony/polyfill-php70": "*",
+                    "symfony/polyfill-php71": "*",
+                    "symfony/polyfill-php72": "*"
+                },
+                "require": {
+                    "ext-mbstring": "*",
+                    "narrowspark/configurators": "^0.1",
+                    "narrowspark/discovery": "dev-master",
+                    "php": "^7.2",
+                    "roave/security-advisories": "dev-master",
+                    "viserio/foundation": "dev-master"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.0"
+                },
+                "source": {
+                    "reference": "82d10e98750cbc8be7906d98083352060ca91166",
+                    "type": "git",
+                    "url": "https://github.com/narrowspark/narrowspark.git"
+                },
+                "time": "2018-05-04T06:16:18+00:00",
+                "type": "project",
+                "uid": 2163139,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            }
+        },
+        "notadd/wechat": {
+            "dev-master": {
+                "authors": [
+                    {
+                        "email": "notadd@ibenchu.com",
+                        "name": "Notadd"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "Notadd\\Wechat\\": "src/"
+                    }
+                },
+                "description": "Notadd's Wechat Module.",
+                "dist": {
+                    "reference": "e3f684cd225f3fadf21953c0289cb8426baad0e5",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/notadd/wechat/zipball/e3f684cd225f3fadf21953c0289cb8426baad0e5"
+                },
+                "homepage": "https://notadd.com",
+                "keywords": [
+                    "framework",
+                    "cms",
+                    "member",
+                    "notadd"
+                ],
+                "license": [
+                    "Apache-2.0"
+                ],
+                "name": "notadd/wechat",
+                "replace": {
+                    "guzzlehttp/guzzle": "*",
+                    "guzzlehttp/promises": "*",
+                    "guzzlehttp/psr7": "*",
+                    "monolog/monolog": "*",
+                    "psr/container": "*",
+                    "psr/http-message": "*",
+                    "psr/log": "*",
+                    "symfony/http-foundation": "*",
+                    "symfony/polyfill-mbstring": "*",
+                    "symfony/psr-http-message-bridge": "*"
+                },
+                "require": {
+                    "overtrue/wechat": "~3.1",
+                    "php": ">=7.0"
+                },
+                "require-dev": {
+                    "notadd/installers": "0.14.*",
+                    "notadd/testing": "0.4.*",
+                    "phpunit/phpunit": "~6.0"
+                },
+                "source": {
+                    "reference": "e3f684cd225f3fadf21953c0289cb8426baad0e5",
+                    "type": "git",
+                    "url": "https://github.com/notadd/wechat.git"
+                },
+                "time": "2017-11-13T04:23:05+00:00",
+                "type": "notadd-module",
+                "uid": 1108963,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            }
+        },
+        "nulldevelopmenthr/nemesis": {
+            "dev-master": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "": "src/",
+                        "MyVendor\\": "lib/src/MyVendor/",
+                        "Tests\\": "tests/",
+                        "Tests\\MyVendor\\": "lib/tests/MyVendor/",
+                        "spec\\": "spec/",
+                        "spec\\MyVendor\\": "lib/spec/MyVendor/",
+                        "tests\\": "tests/"
+                    }
+                },
+                "bin": [
+                    "bin/Nemesis"
+                ],
+                "description": "Nemesis",
+                "dist": {
+                    "reference": "30b4f9963d60005934989772df5a734c8827f2a4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/nulldevelopmenthr/nemesis/zipball/30b4f9963d60005934989772df5a734c8827f2a4"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "proprietary"
+                ],
+                "name": "nulldevelopmenthr/nemesis",
+                "replace": {
+                    "symfony/polyfill-mbstring": "*",
+                    "symfony/polyfill-php70": "*",
+                    "symfony/polyfill-php72": "*"
+                },
+                "require": {
+                    "friendsofphp/php-cs-fixer": "dev-long-line-fixers",
+                    "hanneskod/classtools": "^1.1",
+                    "league/tactician": "^1.0",
+                    "myclabs/php-enum": "^1.5",
+                    "nette/php-generator": "^3",
+                    "nikic/php-parser": "^3.0",
+                    "php": ">=7.1.0",
+                    "roave/better-reflection": "^2.0",
+                    "symfony/config": "^3.3",
+                    "symfony/dependency-injection": "^3.3",
+                    "symfony/finder": "~3",
+                    "symfony/yaml": "^3.3",
+                    "webmozart/assert": "^1.2"
+                },
+                "require-dev": {
+                    "behat/behat": "^3.3",
+                    "broadway/broadway": "^2.0",
+                    "broadway/read-model-elasticsearch": "^0.3.0",
+                    "ciaranmcnulty/phpspec-typehintedmethods": "^3.0",
+                    "codeclimate/php-test-reporter": "^0.4.4",
+                    "doctrine/orm": "^2.6",
+                    "infection/infection": "^0.7.0",
+                    "leanphp/phpspec-code-coverage": "^4.0",
+                    "mockery/mockery": "~1@dev",
+                    "phing/phing": "^2.16",
+                    "phpmd/phpmd": "~2.1",
+                    "phpspec/phpspec": "^4.2",
+                    "phpstan/phpstan": "^0.9.1",
+                    "phpunit/phpunit": "^6.5",
+                    "ramsey/uuid": "^3.1",
+                    "satooshi/php-coveralls": "^1",
+                    "slevomat/coding-standard": "^4.0",
+                    "squizlabs/php_codesniffer": "^3.0"
+                },
+                "source": {
+                    "reference": "30b4f9963d60005934989772df5a734c8827f2a4",
+                    "type": "git",
+                    "url": "https://github.com/nulldevelopmenthr/nemesis.git"
+                },
+                "time": "2018-01-12T12:15:50+00:00",
+                "type": "project",
+                "uid": 1501411,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            },
+            "dev-quality_check": {
+                "authors": [],
+                "autoload": {
+                    "psr-4": {
+                        "": "src/",
+                        "MyVendor\\": "lib/src/MyVendor/",
+                        "Tests\\": "tests/",
+                        "Tests\\MyVendor\\": "lib/tests/MyVendor/",
+                        "spec\\": "spec/",
+                        "spec\\MyVendor\\": "lib/spec/MyVendor/",
+                        "tests\\": "tests/"
+                    }
+                },
+                "bin": [
+                    "bin/Nemesis"
+                ],
+                "description": "Nemesis",
+                "dist": {
+                    "reference": "0e0ad6000a73581bdb8aa855faf9173a1899448e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/nulldevelopmenthr/nemesis/zipball/0e0ad6000a73581bdb8aa855faf9173a1899448e"
+                },
+                "homepage": "",
+                "keywords": [],
+                "license": [
+                    "proprietary"
+                ],
+                "name": "nulldevelopmenthr/nemesis",
+                "replace": {
+                    "symfony/polyfill-mbstring": "*",
+                    "symfony/polyfill-php70": "*",
+                    "symfony/polyfill-php72": "*"
+                },
+                "require": {
+                    "friendsofphp/php-cs-fixer": "dev-long-line-fixers",
+                    "hanneskod/classtools": "^1.1",
+                    "league/tactician": "^1.0",
+                    "myclabs/php-enum": "^1.5",
+                    "nette/php-generator": "^3",
+                    "nikic/php-parser": "^3.0",
+                    "php": ">=7.1.0",
+                    "roave/better-reflection": "^2.0",
+                    "symfony/config": "^3.3",
+                    "symfony/dependency-injection": "^3.3",
+                    "symfony/finder": "~3",
+                    "symfony/yaml": "^3.3",
+                    "webmozart/assert": "^1.2"
+                },
+                "require-dev": {
+                    "behat/behat": "^3.3",
+                    "broadway/broadway": "^2.0",
+                    "broadway/read-model-elasticsearch": "^0.3.0",
+                    "ciaranmcnulty/phpspec-typehintedmethods": "^3.0",
+                    "codeclimate/php-test-reporter": "^0.4.4",
+                    "doctrine/orm": "^2.6",
+                    "infection/infection": "^0.7.0",
+                    "leanphp/phpspec-code-coverage": "^4.0",
+                    "mockery/mockery": "~1@dev",
+                    "phing/phing": "^2.16",
+                    "phpmd/phpmd": "~2.1",
+                    "phpspec/phpspec": "^4.2",
+                    "phpstan/phpstan": "^0.9.1",
+                    "phpunit/phpunit": "^6.5",
+                    "ramsey/uuid": "^3.1",
+                    "satooshi/php-coveralls": "^1",
+                    "slevomat/coding-standard": "^4.0",
+                    "squizlabs/php_codesniffer": "^3.0"
+                },
+                "source": {
+                    "reference": "0e0ad6000a73581bdb8aa855faf9173a1899448e",
+                    "type": "git",
+                    "url": "https://github.com/nulldevelopmenthr/nemesis.git"
+                },
+                "time": "2018-01-12T12:16:56+00:00",
+                "type": "project",
+                "uid": 1828369,
+                "version": "dev-quality_check",
+                "version_normalized": "dev-quality_check"
+            }
+        },
+        "shyim/shopware-profiler": {
+            "1.1.5": {
+                "abandoned": "frosh/shopware-profiler",
+                "authors": [],
+                "description": "Profiling for Shopware",
+                "dist": {
+                    "reference": "24bef0c5cb51f26b1d03da45c8c7961b34089b02",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/shyim/shopware-profiler/zipball/24bef0c5cb51f26b1d03da45c8c7961b34089b02"
+                },
+                "extra": {
+                    "installer-name": "ShyimProfiler"
+                },
+                "homepage": "",
+                "keywords": [
+                    "plugin",
+                    "profiling",
+                    "shopware"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "shyim/shopware-profiler",
+                "replace": {
+                    "symfony/polyfill-mbstring": "~1.0"
+                },
+                "require": {
+                    "composer/installers": "~1.0",
+                    "jdorn/sql-formatter": "^1.2.17",
+                    "php": "^7.0",
+                    "roave/security-advisories": "dev-master",
+                    "symfony/stopwatch": "^3.3",
+                    "symfony/var-dumper": "^3.2"
+                },
+                "source": {
+                    "reference": "24bef0c5cb51f26b1d03da45c8c7961b34089b02",
+                    "type": "git",
+                    "url": "https://github.com/shyim/shopware-profiler.git"
+                },
+                "time": "2017-11-16T18:05:21+00:00",
+                "type": "shopware-plugin",
+                "uid": 1731447,
+                "version": "1.1.5",
+                "version_normalized": "1.1.5.0"
+            },
+            "1.1.6": {
+                "abandoned": "frosh/shopware-profiler",
+                "authors": [],
+                "description": "Profiling for Shopware",
+                "dist": {
+                    "reference": "ed5ddd7864c656a702dd678e206eee9daa0a7972",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/shyim/shopware-profiler/zipball/ed5ddd7864c656a702dd678e206eee9daa0a7972"
+                },
+                "extra": {
+                    "installer-name": "ShyimProfiler"
+                },
+                "homepage": "",
+                "keywords": [
+                    "plugin",
+                    "profiling",
+                    "shopware"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "shyim/shopware-profiler",
+                "replace": {
+                    "symfony/polyfill-mbstring": "~1.0"
+                },
+                "require": {
+                    "composer/installers": "~1.0",
+                    "jdorn/sql-formatter": "^1.2.17",
+                    "php": "^7.0",
+                    "roave/security-advisories": "dev-master",
+                    "symfony/stopwatch": "^3.3",
+                    "symfony/var-dumper": "^3.2"
+                },
+                "source": {
+                    "reference": "ed5ddd7864c656a702dd678e206eee9daa0a7972",
+                    "type": "git",
+                    "url": "https://github.com/shyim/shopware-profiler.git"
+                },
+                "time": "2018-01-25T18:08:54+00:00",
+                "type": "shopware-plugin",
+                "uid": 1868256,
+                "version": "1.1.6",
+                "version_normalized": "1.1.6.0"
+            },
+            "dev-feature/ajax": {
+                "abandoned": "frosh/shopware-profiler",
+                "authors": [],
+                "description": "Profiling for Shopware",
+                "dist": {
+                    "reference": "b54c238ad477032faa21f7a10d7ebed8590db64f",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/shyim/shopware-profiler/zipball/b54c238ad477032faa21f7a10d7ebed8590db64f"
+                },
+                "extra": {
+                    "installer-name": "ShyimProfiler"
+                },
+                "homepage": "",
+                "keywords": [
+                    "plugin",
+                    "profiling",
+                    "shopware"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "shyim/shopware-profiler",
+                "replace": {
+                    "symfony/polyfill-mbstring": "~1.0"
+                },
+                "require": {
+                    "composer/installers": "~1.0",
+                    "jdorn/sql-formatter": "^1.2.17",
+                    "php": "^7.0",
+                    "roave/security-advisories": "dev-master",
+                    "symfony/stopwatch": "^3.3",
+                    "symfony/var-dumper": "^3.2"
+                },
+                "source": {
+                    "reference": "b54c238ad477032faa21f7a10d7ebed8590db64f",
+                    "type": "git",
+                    "url": "https://github.com/shyim/shopware-profiler.git"
+                },
+                "time": "2018-02-05T18:32:15+00:00",
+                "type": "shopware-plugin",
+                "uid": 1893298,
+                "version": "dev-feature/ajax",
+                "version_normalized": "dev-feature/ajax"
+            },
+            "dev-frosh": {
+                "abandoned": "frosh/shopware-profiler",
+                "authors": [],
+                "description": "Profiling for Shopware",
+                "dist": {
+                    "reference": "2797e2310c0ac74478ecd18a8032e1f388f44892",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/shyim/shopware-profiler/zipball/2797e2310c0ac74478ecd18a8032e1f388f44892"
+                },
+                "extra": {
+                    "installer-name": "FroshProfiler"
+                },
+                "homepage": "",
+                "keywords": [
+                    "plugin",
+                    "profiling",
+                    "shopware"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "shyim/shopware-profiler",
+                "replace": {
+                    "symfony/polyfill-mbstring": "~1.0"
+                },
+                "require": {
+                    "composer/installers": "~1.0",
+                    "jdorn/sql-formatter": "^1.2.17",
+                    "php": "^7.0",
+                    "roave/security-advisories": "dev-master",
+                    "symfony/stopwatch": "^3.3",
+                    "symfony/var-dumper": "^3.2"
+                },
+                "source": {
+                    "reference": "2797e2310c0ac74478ecd18a8032e1f388f44892",
+                    "type": "git",
+                    "url": "https://github.com/shyim/shopware-profiler.git"
+                },
+                "time": "2018-02-26T18:57:18+00:00",
+                "type": "shopware-plugin",
+                "uid": 1942836,
+                "version": "dev-frosh",
+                "version_normalized": "dev-frosh"
+            },
+            "dev-master": {
+                "abandoned": "frosh/shopware-profiler",
+                "authors": [],
+                "description": "Profiling for Shopware",
+                "dist": {
+                    "reference": "2797e2310c0ac74478ecd18a8032e1f388f44892",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/shyim/shopware-profiler/zipball/2797e2310c0ac74478ecd18a8032e1f388f44892"
+                },
+                "extra": {
+                    "installer-name": "FroshProfiler"
+                },
+                "homepage": "",
+                "keywords": [
+                    "plugin",
+                    "profiling",
+                    "shopware"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "shyim/shopware-profiler",
+                "replace": {
+                    "symfony/polyfill-mbstring": "~1.0"
+                },
+                "require": {
+                    "composer/installers": "~1.0",
+                    "jdorn/sql-formatter": "^1.2.17",
+                    "php": "^7.0",
+                    "roave/security-advisories": "dev-master",
+                    "symfony/stopwatch": "^3.3",
+                    "symfony/var-dumper": "^3.2"
+                },
+                "source": {
+                    "reference": "2797e2310c0ac74478ecd18a8032e1f388f44892",
+                    "type": "git",
+                    "url": "https://github.com/shyim/shopware-profiler.git"
+                },
+                "time": "2018-02-26T18:57:18+00:00",
+                "type": "shopware-plugin",
+                "uid": 779517,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            }
+        },
+        "symfony/polyfill": {
+            "dev-master": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "classmap": [
+                        "src/Intl/Normalizer/Resources/stubs",
+                        "src/Php70/Resources/stubs",
+                        "src/Php54/Resources/stubs"
+                    ],
+                    "files": [
+                        "src/Apcu/bootstrap.php",
+                        "src/Ctype/bootstrap.php",
+                        "src/Php54/bootstrap.php",
+                        "src/Php55/bootstrap.php",
+                        "src/Php56/bootstrap.php",
+                        "src/Php70/bootstrap.php",
+                        "src/Php71/bootstrap.php",
+                        "src/Php72/bootstrap.php",
+                        "src/Php73/bootstrap.php",
+                        "src/Iconv/bootstrap.php",
+                        "src/Intl/Grapheme/bootstrap.php",
+                        "src/Intl/Icu/bootstrap.php",
+                        "src/Intl/Normalizer/bootstrap.php",
+                        "src/Mbstring/bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\": "src/"
+                    }
+                },
+                "description": "Symfony polyfills backporting features to lower PHP versions",
+                "dist": {
+                    "reference": "478d74d21e6e3fe5ecf268a584bda3a7b7655ef1",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill/zipball/478d74d21e6e3fe5ecf268a584bda3a7b7655ef1"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.8-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "compatibility",
+                    "compat",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill",
+                "replace": {
+                    "symfony/polyfill-apcu": "self.version",
+                    "symfony/polyfill-ctype": "self.version",
+                    "symfony/polyfill-iconv": "self.version",
+                    "symfony/polyfill-intl-grapheme": "self.version",
+                    "symfony/polyfill-intl-icu": "self.version",
+                    "symfony/polyfill-intl-normalizer": "self.version",
+                    "symfony/polyfill-mbstring": "self.version",
+                    "symfony/polyfill-php54": "self.version",
+                    "symfony/polyfill-php55": "self.version",
+                    "symfony/polyfill-php56": "self.version",
+                    "symfony/polyfill-php70": "self.version",
+                    "symfony/polyfill-php71": "self.version",
+                    "symfony/polyfill-php72": "self.version",
+                    "symfony/polyfill-php73": "self.version",
+                    "symfony/polyfill-util": "self.version",
+                    "symfony/polyfill-xml": "self.version"
+                },
+                "require": {
+                    "ircmaxell/password-compat": "~1.0",
+                    "paragonie/random_compat": "~1.0|~2.0",
+                    "php": ">=5.3.3",
+                    "symfony/intl": "~2.3|~3.0|~4.0"
+                },
+                "require-dev": {
+                    "symfony/phpunit-bridge": "~3.2"
+                },
+                "source": {
+                    "reference": "478d74d21e6e3fe5ecf268a584bda3a7b7655ef1",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill.git"
+                },
+                "time": "2018-05-17T19:25:54+00:00",
+                "type": "library",
+                "uid": 573980,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            },
+            "v1.0.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "classmap": [
+                        "src/Intl/Normalizer/Resources/stubs",
+                        "src/Php70/Resources/stubs",
+                        "src/Php54/Resources/stubs"
+                    ],
+                    "files": [
+                        "src/Php54/bootstrap.php",
+                        "src/Php55/bootstrap.php",
+                        "src/Php56/bootstrap.php",
+                        "src/Php70/bootstrap.php",
+                        "src/Iconv/bootstrap.php",
+                        "src/Intl/Grapheme/bootstrap.php",
+                        "src/Intl/Icu/bootstrap.php",
+                        "src/Intl/Normalizer/bootstrap.php",
+                        "src/Mbstring/bootstrap.php",
+                        "src/Xml/bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\": "src/"
+                    }
+                },
+                "description": "Symfony polyfills backporting features to lower PHP versions",
+                "dist": {
+                    "reference": "fef21adc706d3bb8f31d37c503ded2160c76c64a",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill/zipball/fef21adc706d3bb8f31d37c503ded2160c76c64a"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.0-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "compatibility",
+                    "compat",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill",
+                "replace": {
+                    "symfony/polyfill-iconv": "self.version",
+                    "symfony/polyfill-intl-grapheme": "self.version",
+                    "symfony/polyfill-intl-icu": "self.version",
+                    "symfony/polyfill-intl-normalizer": "self.version",
+                    "symfony/polyfill-mbstring": "self.version",
+                    "symfony/polyfill-php54": "self.version",
+                    "symfony/polyfill-php55": "self.version",
+                    "symfony/polyfill-php56": "self.version",
+                    "symfony/polyfill-php70": "self.version",
+                    "symfony/polyfill-util": "self.version",
+                    "symfony/polyfill-xml": "self.version"
+                },
+                "require": {
+                    "ircmaxell/password-compat": "~1.0",
+                    "paragonie/random_compat": "~1.0",
+                    "php": ">=5.3.3",
+                    "symfony/intl": "~2.3|~3.0"
+                },
+                "source": {
+                    "reference": "fef21adc706d3bb8f31d37c503ded2160c76c64a",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill.git"
+                },
+                "time": "2015-11-04T20:29:00+00:00",
+                "type": "library",
+                "uid": 573979,
+                "version": "v1.0.0",
+                "version_normalized": "1.0.0.0"
+            },
+            "v1.0.1": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "classmap": [
+                        "src/Intl/Normalizer/Resources/stubs",
+                        "src/Php70/Resources/stubs",
+                        "src/Php54/Resources/stubs"
+                    ],
+                    "files": [
+                        "src/Php54/bootstrap.php",
+                        "src/Php55/bootstrap.php",
+                        "src/Php56/bootstrap.php",
+                        "src/Php70/bootstrap.php",
+                        "src/Iconv/bootstrap.php",
+                        "src/Intl/Grapheme/bootstrap.php",
+                        "src/Intl/Icu/bootstrap.php",
+                        "src/Intl/Normalizer/bootstrap.php",
+                        "src/Mbstring/bootstrap.php",
+                        "src/Xml/bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\": "src/"
+                    }
+                },
+                "description": "Symfony polyfills backporting features to lower PHP versions",
+                "dist": {
+                    "reference": "dd9db1dc4013821a63f7afbd8340dd57939fe674",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill/zipball/dd9db1dc4013821a63f7afbd8340dd57939fe674"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.0-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "compatibility",
+                    "compat",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill",
+                "replace": {
+                    "symfony/polyfill-iconv": "self.version",
+                    "symfony/polyfill-intl-grapheme": "self.version",
+                    "symfony/polyfill-intl-icu": "self.version",
+                    "symfony/polyfill-intl-normalizer": "self.version",
+                    "symfony/polyfill-mbstring": "self.version",
+                    "symfony/polyfill-php54": "self.version",
+                    "symfony/polyfill-php55": "self.version",
+                    "symfony/polyfill-php56": "self.version",
+                    "symfony/polyfill-php70": "self.version",
+                    "symfony/polyfill-util": "self.version",
+                    "symfony/polyfill-xml": "self.version"
+                },
+                "require": {
+                    "ircmaxell/password-compat": "~1.0",
+                    "paragonie/random_compat": "~1.0",
+                    "php": ">=5.3.3",
+                    "symfony/intl": "~2.3|~3.0"
+                },
+                "source": {
+                    "reference": "dd9db1dc4013821a63f7afbd8340dd57939fe674",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill.git"
+                },
+                "time": "2015-12-18T15:10:25+00:00",
+                "type": "library",
+                "uid": 635243,
+                "version": "v1.0.1",
+                "version_normalized": "1.0.1.0"
+            },
+            "v1.1.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "classmap": [
+                        "src/Apcu/Resources/stubs",
+                        "src/Intl/Normalizer/Resources/stubs",
+                        "src/Php70/Resources/stubs",
+                        "src/Php54/Resources/stubs"
+                    ],
+                    "files": [
+                        "src/Apcu/bootstrap.php",
+                        "src/Php54/bootstrap.php",
+                        "src/Php55/bootstrap.php",
+                        "src/Php56/bootstrap.php",
+                        "src/Php70/bootstrap.php",
+                        "src/Iconv/bootstrap.php",
+                        "src/Intl/Grapheme/bootstrap.php",
+                        "src/Intl/Icu/bootstrap.php",
+                        "src/Intl/Normalizer/bootstrap.php",
+                        "src/Mbstring/bootstrap.php",
+                        "src/Xml/bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\": "src/"
+                    }
+                },
+                "description": "Symfony polyfills backporting features to lower PHP versions",
+                "dist": {
+                    "reference": "ceffa85c57f023a816f5c511ad35081e7c67d7cd",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill/zipball/ceffa85c57f023a816f5c511ad35081e7c67d7cd"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.1-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "compatibility",
+                    "compat",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill",
+                "replace": {
+                    "symfony/polyfill-apcu": "self.version",
+                    "symfony/polyfill-iconv": "self.version",
+                    "symfony/polyfill-intl-grapheme": "self.version",
+                    "symfony/polyfill-intl-icu": "self.version",
+                    "symfony/polyfill-intl-normalizer": "self.version",
+                    "symfony/polyfill-mbstring": "self.version",
+                    "symfony/polyfill-php54": "self.version",
+                    "symfony/polyfill-php55": "self.version",
+                    "symfony/polyfill-php56": "self.version",
+                    "symfony/polyfill-php70": "self.version",
+                    "symfony/polyfill-util": "self.version",
+                    "symfony/polyfill-xml": "self.version"
+                },
+                "require": {
+                    "ircmaxell/password-compat": "~1.0",
+                    "paragonie/random_compat": "~1.0",
+                    "php": ">=5.3.3",
+                    "symfony/intl": "~2.3|~3.0"
+                },
+                "source": {
+                    "reference": "ceffa85c57f023a816f5c511ad35081e7c67d7cd",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill.git"
+                },
+                "time": "2016-01-25T08:44:42+00:00",
+                "type": "library",
+                "uid": 670768,
+                "version": "v1.1.0",
+                "version_normalized": "1.1.0.0"
+            },
+            "v1.1.1": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "classmap": [
+                        "src/Intl/Normalizer/Resources/stubs",
+                        "src/Php70/Resources/stubs",
+                        "src/Php54/Resources/stubs"
+                    ],
+                    "files": [
+                        "src/Apcu/bootstrap.php",
+                        "src/Php54/bootstrap.php",
+                        "src/Php55/bootstrap.php",
+                        "src/Php56/bootstrap.php",
+                        "src/Php70/bootstrap.php",
+                        "src/Iconv/bootstrap.php",
+                        "src/Intl/Grapheme/bootstrap.php",
+                        "src/Intl/Icu/bootstrap.php",
+                        "src/Intl/Normalizer/bootstrap.php",
+                        "src/Mbstring/bootstrap.php",
+                        "src/Xml/bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\": "src/"
+                    }
+                },
+                "description": "Symfony polyfills backporting features to lower PHP versions",
+                "dist": {
+                    "reference": "3dc21aeff3e1f8cb708421ed02cf1a8901d7b535",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill/zipball/3dc21aeff3e1f8cb708421ed02cf1a8901d7b535"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.1-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "compatibility",
+                    "compat",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill",
+                "replace": {
+                    "symfony/polyfill-apcu": "self.version",
+                    "symfony/polyfill-iconv": "self.version",
+                    "symfony/polyfill-intl-grapheme": "self.version",
+                    "symfony/polyfill-intl-icu": "self.version",
+                    "symfony/polyfill-intl-normalizer": "self.version",
+                    "symfony/polyfill-mbstring": "self.version",
+                    "symfony/polyfill-php54": "self.version",
+                    "symfony/polyfill-php55": "self.version",
+                    "symfony/polyfill-php56": "self.version",
+                    "symfony/polyfill-php70": "self.version",
+                    "symfony/polyfill-util": "self.version",
+                    "symfony/polyfill-xml": "self.version"
+                },
+                "require": {
+                    "ircmaxell/password-compat": "~1.0",
+                    "paragonie/random_compat": "~1.0",
+                    "php": ">=5.3.3",
+                    "symfony/intl": "~2.3|~3.0"
+                },
+                "source": {
+                    "reference": "3dc21aeff3e1f8cb708421ed02cf1a8901d7b535",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill.git"
+                },
+                "time": "2016-03-03T16:58:13+00:00",
+                "type": "library",
+                "uid": 730456,
+                "version": "v1.1.1",
+                "version_normalized": "1.1.1.0"
+            },
+            "v1.2.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "classmap": [
+                        "src/Intl/Normalizer/Resources/stubs",
+                        "src/Php70/Resources/stubs",
+                        "src/Php54/Resources/stubs"
+                    ],
+                    "files": [
+                        "src/Apcu/bootstrap.php",
+                        "src/Php54/bootstrap.php",
+                        "src/Php55/bootstrap.php",
+                        "src/Php56/bootstrap.php",
+                        "src/Php70/bootstrap.php",
+                        "src/Iconv/bootstrap.php",
+                        "src/Intl/Grapheme/bootstrap.php",
+                        "src/Intl/Icu/bootstrap.php",
+                        "src/Intl/Normalizer/bootstrap.php",
+                        "src/Mbstring/bootstrap.php",
+                        "src/Xml/bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\": "src/"
+                    }
+                },
+                "description": "Symfony polyfills backporting features to lower PHP versions",
+                "dist": {
+                    "reference": "ee2c9c2576fdd4a42b024260a1906a9888770c34",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill/zipball/ee2c9c2576fdd4a42b024260a1906a9888770c34"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.2-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "compatibility",
+                    "compat",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill",
+                "replace": {
+                    "symfony/polyfill-apcu": "self.version",
+                    "symfony/polyfill-iconv": "self.version",
+                    "symfony/polyfill-intl-grapheme": "self.version",
+                    "symfony/polyfill-intl-icu": "self.version",
+                    "symfony/polyfill-intl-normalizer": "self.version",
+                    "symfony/polyfill-mbstring": "self.version",
+                    "symfony/polyfill-php54": "self.version",
+                    "symfony/polyfill-php55": "self.version",
+                    "symfony/polyfill-php56": "self.version",
+                    "symfony/polyfill-php70": "self.version",
+                    "symfony/polyfill-util": "self.version",
+                    "symfony/polyfill-xml": "self.version"
+                },
+                "require": {
+                    "ircmaxell/password-compat": "~1.0",
+                    "paragonie/random_compat": "~1.0|~2.0",
+                    "php": ">=5.3.3",
+                    "symfony/intl": "~2.3|~3.0"
+                },
+                "source": {
+                    "reference": "ee2c9c2576fdd4a42b024260a1906a9888770c34",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill.git"
+                },
+                "time": "2016-05-18T14:27:53+00:00",
+                "type": "library",
+                "uid": 826272,
+                "version": "v1.2.0",
+                "version_normalized": "1.2.0.0"
+            },
+            "v1.3.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "classmap": [
+                        "src/Intl/Normalizer/Resources/stubs",
+                        "src/Php70/Resources/stubs",
+                        "src/Php54/Resources/stubs"
+                    ],
+                    "files": [
+                        "src/Apcu/bootstrap.php",
+                        "src/Php54/bootstrap.php",
+                        "src/Php55/bootstrap.php",
+                        "src/Php56/bootstrap.php",
+                        "src/Php70/bootstrap.php",
+                        "src/Php71/bootstrap.php",
+                        "src/Iconv/bootstrap.php",
+                        "src/Intl/Grapheme/bootstrap.php",
+                        "src/Intl/Icu/bootstrap.php",
+                        "src/Intl/Normalizer/bootstrap.php",
+                        "src/Mbstring/bootstrap.php",
+                        "src/Xml/bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\": "src/"
+                    }
+                },
+                "description": "Symfony polyfills backporting features to lower PHP versions",
+                "dist": {
+                    "reference": "385d033a8e1d8778446d699ecbd886480716eba7",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill/zipball/385d033a8e1d8778446d699ecbd886480716eba7"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.3-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "compatibility",
+                    "compat",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill",
+                "replace": {
+                    "symfony/polyfill-apcu": "self.version",
+                    "symfony/polyfill-iconv": "self.version",
+                    "symfony/polyfill-intl-grapheme": "self.version",
+                    "symfony/polyfill-intl-icu": "self.version",
+                    "symfony/polyfill-intl-normalizer": "self.version",
+                    "symfony/polyfill-mbstring": "self.version",
+                    "symfony/polyfill-php54": "self.version",
+                    "symfony/polyfill-php55": "self.version",
+                    "symfony/polyfill-php56": "self.version",
+                    "symfony/polyfill-php70": "self.version",
+                    "symfony/polyfill-php71": "self.version",
+                    "symfony/polyfill-util": "self.version",
+                    "symfony/polyfill-xml": "self.version"
+                },
+                "require": {
+                    "ircmaxell/password-compat": "~1.0",
+                    "paragonie/random_compat": "~1.0|~2.0",
+                    "php": ">=5.3.3",
+                    "symfony/intl": "~2.3|~3.0"
+                },
+                "source": {
+                    "reference": "385d033a8e1d8778446d699ecbd886480716eba7",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill.git"
+                },
+                "time": "2016-11-14T01:15:23+00:00",
+                "type": "library",
+                "uid": 1079312,
+                "version": "v1.3.0",
+                "version_normalized": "1.3.0.0"
+            },
+            "v1.3.1": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "classmap": [
+                        "src/Intl/Normalizer/Resources/stubs",
+                        "src/Php70/Resources/stubs",
+                        "src/Php54/Resources/stubs"
+                    ],
+                    "files": [
+                        "src/Apcu/bootstrap.php",
+                        "src/Php54/bootstrap.php",
+                        "src/Php55/bootstrap.php",
+                        "src/Php56/bootstrap.php",
+                        "src/Php70/bootstrap.php",
+                        "src/Php71/bootstrap.php",
+                        "src/Iconv/bootstrap.php",
+                        "src/Intl/Grapheme/bootstrap.php",
+                        "src/Intl/Icu/bootstrap.php",
+                        "src/Intl/Normalizer/bootstrap.php",
+                        "src/Mbstring/bootstrap.php",
+                        "src/Xml/bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\": "src/"
+                    }
+                },
+                "description": "Symfony polyfills backporting features to lower PHP versions",
+                "dist": {
+                    "reference": "59052c86fa8c36097b640fc6e5c7461f46ac71d3",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill/zipball/59052c86fa8c36097b640fc6e5c7461f46ac71d3"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.3-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "compatibility",
+                    "compat",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill",
+                "replace": {
+                    "symfony/polyfill-apcu": "self.version",
+                    "symfony/polyfill-iconv": "self.version",
+                    "symfony/polyfill-intl-grapheme": "self.version",
+                    "symfony/polyfill-intl-icu": "self.version",
+                    "symfony/polyfill-intl-normalizer": "self.version",
+                    "symfony/polyfill-mbstring": "self.version",
+                    "symfony/polyfill-php54": "self.version",
+                    "symfony/polyfill-php55": "self.version",
+                    "symfony/polyfill-php56": "self.version",
+                    "symfony/polyfill-php70": "self.version",
+                    "symfony/polyfill-php71": "self.version",
+                    "symfony/polyfill-util": "self.version",
+                    "symfony/polyfill-xml": "self.version"
+                },
+                "require": {
+                    "ircmaxell/password-compat": "~1.0",
+                    "paragonie/random_compat": "~1.0|~2.0",
+                    "php": ">=5.3.3",
+                    "symfony/intl": "~2.3|~3.0|~4.0"
+                },
+                "require-dev": {
+                    "symfony/phpunit-bridge": "~3.2"
+                },
+                "source": {
+                    "reference": "59052c86fa8c36097b640fc6e5c7461f46ac71d3",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill.git"
+                },
+                "time": "2017-06-09T14:08:27+00:00",
+                "type": "library",
+                "uid": 1436913,
+                "version": "v1.3.1",
+                "version_normalized": "1.3.1.0"
+            },
+            "v1.4.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "classmap": [
+                        "src/Intl/Normalizer/Resources/stubs",
+                        "src/Php70/Resources/stubs",
+                        "src/Php54/Resources/stubs"
+                    ],
+                    "files": [
+                        "src/Apcu/bootstrap.php",
+                        "src/Php54/bootstrap.php",
+                        "src/Php55/bootstrap.php",
+                        "src/Php56/bootstrap.php",
+                        "src/Php70/bootstrap.php",
+                        "src/Php71/bootstrap.php",
+                        "src/Php72/bootstrap.php",
+                        "src/Iconv/bootstrap.php",
+                        "src/Intl/Grapheme/bootstrap.php",
+                        "src/Intl/Icu/bootstrap.php",
+                        "src/Intl/Normalizer/bootstrap.php",
+                        "src/Mbstring/bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\": "src/"
+                    }
+                },
+                "description": "Symfony polyfills backporting features to lower PHP versions",
+                "dist": {
+                    "reference": "a80c6de45ebd2a041415ba17879ff7309ead51f6",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill/zipball/a80c6de45ebd2a041415ba17879ff7309ead51f6"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.4-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "compatibility",
+                    "compat",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill",
+                "replace": {
+                    "symfony/polyfill-apcu": "self.version",
+                    "symfony/polyfill-iconv": "self.version",
+                    "symfony/polyfill-intl-grapheme": "self.version",
+                    "symfony/polyfill-intl-icu": "self.version",
+                    "symfony/polyfill-intl-normalizer": "self.version",
+                    "symfony/polyfill-mbstring": "self.version",
+                    "symfony/polyfill-php54": "self.version",
+                    "symfony/polyfill-php55": "self.version",
+                    "symfony/polyfill-php56": "self.version",
+                    "symfony/polyfill-php70": "self.version",
+                    "symfony/polyfill-php71": "self.version",
+                    "symfony/polyfill-php72": "self.version",
+                    "symfony/polyfill-util": "self.version",
+                    "symfony/polyfill-xml": "self.version"
+                },
+                "require": {
+                    "ircmaxell/password-compat": "~1.0",
+                    "paragonie/random_compat": "~1.0|~2.0",
+                    "php": ">=5.3.3",
+                    "symfony/intl": "~2.3|~3.0|~4.0"
+                },
+                "require-dev": {
+                    "symfony/phpunit-bridge": "~3.2"
+                },
+                "source": {
+                    "reference": "a80c6de45ebd2a041415ba17879ff7309ead51f6",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill.git"
+                },
+                "time": "2017-06-09T14:32:47+00:00",
+                "type": "library",
+                "uid": 1437002,
+                "version": "v1.4.0",
+                "version_normalized": "1.4.0.0"
+            },
+            "v1.5.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "classmap": [
+                        "src/Intl/Normalizer/Resources/stubs",
+                        "src/Php70/Resources/stubs",
+                        "src/Php54/Resources/stubs"
+                    ],
+                    "files": [
+                        "src/Apcu/bootstrap.php",
+                        "src/Php54/bootstrap.php",
+                        "src/Php55/bootstrap.php",
+                        "src/Php56/bootstrap.php",
+                        "src/Php70/bootstrap.php",
+                        "src/Php71/bootstrap.php",
+                        "src/Php72/bootstrap.php",
+                        "src/Iconv/bootstrap.php",
+                        "src/Intl/Grapheme/bootstrap.php",
+                        "src/Intl/Icu/bootstrap.php",
+                        "src/Intl/Normalizer/bootstrap.php",
+                        "src/Mbstring/bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\": "src/"
+                    }
+                },
+                "description": "Symfony polyfills backporting features to lower PHP versions",
+                "dist": {
+                    "reference": "157dfe598da2181908ff2345cad1807b2c23f5f9",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill/zipball/157dfe598da2181908ff2345cad1807b2c23f5f9"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.5-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "compatibility",
+                    "compat",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill",
+                "replace": {
+                    "symfony/polyfill-apcu": "self.version",
+                    "symfony/polyfill-iconv": "self.version",
+                    "symfony/polyfill-intl-grapheme": "self.version",
+                    "symfony/polyfill-intl-icu": "self.version",
+                    "symfony/polyfill-intl-normalizer": "self.version",
+                    "symfony/polyfill-mbstring": "self.version",
+                    "symfony/polyfill-php54": "self.version",
+                    "symfony/polyfill-php55": "self.version",
+                    "symfony/polyfill-php56": "self.version",
+                    "symfony/polyfill-php70": "self.version",
+                    "symfony/polyfill-php71": "self.version",
+                    "symfony/polyfill-php72": "self.version",
+                    "symfony/polyfill-util": "self.version",
+                    "symfony/polyfill-xml": "self.version"
+                },
+                "require": {
+                    "ircmaxell/password-compat": "~1.0",
+                    "paragonie/random_compat": "~1.0|~2.0",
+                    "php": ">=5.3.3",
+                    "symfony/intl": "~2.3|~3.0|~4.0"
+                },
+                "require-dev": {
+                    "symfony/phpunit-bridge": "~3.2"
+                },
+                "source": {
+                    "reference": "157dfe598da2181908ff2345cad1807b2c23f5f9",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill.git"
+                },
+                "time": "2017-08-16T07:33:06+00:00",
+                "type": "library",
+                "uid": 1557063,
+                "version": "v1.5.0",
+                "version_normalized": "1.5.0.0"
+            },
+            "v1.6.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "classmap": [
+                        "src/Intl/Normalizer/Resources/stubs",
+                        "src/Php70/Resources/stubs",
+                        "src/Php54/Resources/stubs"
+                    ],
+                    "files": [
+                        "src/Apcu/bootstrap.php",
+                        "src/Php54/bootstrap.php",
+                        "src/Php55/bootstrap.php",
+                        "src/Php56/bootstrap.php",
+                        "src/Php70/bootstrap.php",
+                        "src/Php71/bootstrap.php",
+                        "src/Php72/bootstrap.php",
+                        "src/Iconv/bootstrap.php",
+                        "src/Intl/Grapheme/bootstrap.php",
+                        "src/Intl/Icu/bootstrap.php",
+                        "src/Intl/Normalizer/bootstrap.php",
+                        "src/Mbstring/bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\": "src/"
+                    }
+                },
+                "description": "Symfony polyfills backporting features to lower PHP versions",
+                "dist": {
+                    "reference": "5b34ccc9f409387e81ab3e38f37b12e42772a0cf",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill/zipball/5b34ccc9f409387e81ab3e38f37b12e42772a0cf"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.6-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "compatibility",
+                    "compat",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill",
+                "replace": {
+                    "symfony/polyfill-apcu": "self.version",
+                    "symfony/polyfill-iconv": "self.version",
+                    "symfony/polyfill-intl-grapheme": "self.version",
+                    "symfony/polyfill-intl-icu": "self.version",
+                    "symfony/polyfill-intl-normalizer": "self.version",
+                    "symfony/polyfill-mbstring": "self.version",
+                    "symfony/polyfill-php54": "self.version",
+                    "symfony/polyfill-php55": "self.version",
+                    "symfony/polyfill-php56": "self.version",
+                    "symfony/polyfill-php70": "self.version",
+                    "symfony/polyfill-php71": "self.version",
+                    "symfony/polyfill-php72": "self.version",
+                    "symfony/polyfill-util": "self.version",
+                    "symfony/polyfill-xml": "self.version"
+                },
+                "require": {
+                    "ircmaxell/password-compat": "~1.0",
+                    "paragonie/random_compat": "~1.0|~2.0",
+                    "php": ">=5.3.3",
+                    "symfony/intl": "~2.3|~3.0|~4.0"
+                },
+                "require-dev": {
+                    "symfony/phpunit-bridge": "~3.2"
+                },
+                "source": {
+                    "reference": "5b34ccc9f409387e81ab3e38f37b12e42772a0cf",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill.git"
+                },
+                "time": "2017-10-11T12:05:26+00:00",
+                "type": "library",
+                "uid": 1669330,
+                "version": "v1.6.0",
+                "version_normalized": "1.6.0.0"
+            },
+            "v1.7.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "classmap": [
+                        "src/Intl/Normalizer/Resources/stubs",
+                        "src/Php70/Resources/stubs",
+                        "src/Php54/Resources/stubs"
+                    ],
+                    "files": [
+                        "src/Apcu/bootstrap.php",
+                        "src/Php54/bootstrap.php",
+                        "src/Php55/bootstrap.php",
+                        "src/Php56/bootstrap.php",
+                        "src/Php70/bootstrap.php",
+                        "src/Php71/bootstrap.php",
+                        "src/Php72/bootstrap.php",
+                        "src/Iconv/bootstrap.php",
+                        "src/Intl/Grapheme/bootstrap.php",
+                        "src/Intl/Icu/bootstrap.php",
+                        "src/Intl/Normalizer/bootstrap.php",
+                        "src/Mbstring/bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\": "src/"
+                    }
+                },
+                "description": "Symfony polyfills backporting features to lower PHP versions",
+                "dist": {
+                    "reference": "86e27771f290e6af6d95c1c256f6d6d15ac9e22e",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill/zipball/86e27771f290e6af6d95c1c256f6d6d15ac9e22e"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.7-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "compatibility",
+                    "compat",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill",
+                "replace": {
+                    "symfony/polyfill-apcu": "self.version",
+                    "symfony/polyfill-iconv": "self.version",
+                    "symfony/polyfill-intl-grapheme": "self.version",
+                    "symfony/polyfill-intl-icu": "self.version",
+                    "symfony/polyfill-intl-normalizer": "self.version",
+                    "symfony/polyfill-mbstring": "self.version",
+                    "symfony/polyfill-php54": "self.version",
+                    "symfony/polyfill-php55": "self.version",
+                    "symfony/polyfill-php56": "self.version",
+                    "symfony/polyfill-php70": "self.version",
+                    "symfony/polyfill-php71": "self.version",
+                    "symfony/polyfill-php72": "self.version",
+                    "symfony/polyfill-util": "self.version",
+                    "symfony/polyfill-xml": "self.version"
+                },
+                "require": {
+                    "ircmaxell/password-compat": "~1.0",
+                    "paragonie/random_compat": "~1.0|~2.0",
+                    "php": ">=5.3.3",
+                    "symfony/intl": "~2.3|~3.0|~4.0"
+                },
+                "require-dev": {
+                    "symfony/phpunit-bridge": "~3.2"
+                },
+                "source": {
+                    "reference": "86e27771f290e6af6d95c1c256f6d6d15ac9e22e",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill.git"
+                },
+                "time": "2018-01-31T19:39:15+00:00",
+                "type": "library",
+                "uid": 1882783,
+                "version": "v1.7.0",
+                "version_normalized": "1.7.0.0"
+            },
+            "v1.8.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "classmap": [
+                        "src/Intl/Normalizer/Resources/stubs",
+                        "src/Php70/Resources/stubs",
+                        "src/Php54/Resources/stubs"
+                    ],
+                    "files": [
+                        "src/Apcu/bootstrap.php",
+                        "src/Ctype/bootstrap.php",
+                        "src/Php54/bootstrap.php",
+                        "src/Php55/bootstrap.php",
+                        "src/Php56/bootstrap.php",
+                        "src/Php70/bootstrap.php",
+                        "src/Php71/bootstrap.php",
+                        "src/Php72/bootstrap.php",
+                        "src/Php73/bootstrap.php",
+                        "src/Iconv/bootstrap.php",
+                        "src/Intl/Grapheme/bootstrap.php",
+                        "src/Intl/Icu/bootstrap.php",
+                        "src/Intl/Normalizer/bootstrap.php",
+                        "src/Mbstring/bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\": "src/"
+                    }
+                },
+                "description": "Symfony polyfills backporting features to lower PHP versions",
+                "dist": {
+                    "reference": "6f13be2ff1681db53292eee1719dcee57e983207",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill/zipball/6f13be2ff1681db53292eee1719dcee57e983207"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.8-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "compatibility",
+                    "compat",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill",
+                "replace": {
+                    "symfony/polyfill-apcu": "self.version",
+                    "symfony/polyfill-ctype": "self.version",
+                    "symfony/polyfill-iconv": "self.version",
+                    "symfony/polyfill-intl-grapheme": "self.version",
+                    "symfony/polyfill-intl-icu": "self.version",
+                    "symfony/polyfill-intl-normalizer": "self.version",
+                    "symfony/polyfill-mbstring": "self.version",
+                    "symfony/polyfill-php54": "self.version",
+                    "symfony/polyfill-php55": "self.version",
+                    "symfony/polyfill-php56": "self.version",
+                    "symfony/polyfill-php70": "self.version",
+                    "symfony/polyfill-php71": "self.version",
+                    "symfony/polyfill-php72": "self.version",
+                    "symfony/polyfill-php73": "self.version",
+                    "symfony/polyfill-util": "self.version",
+                    "symfony/polyfill-xml": "self.version"
+                },
+                "require": {
+                    "ircmaxell/password-compat": "~1.0",
+                    "paragonie/random_compat": "~1.0|~2.0",
+                    "php": ">=5.3.3",
+                    "symfony/intl": "~2.3|~3.0|~4.0"
+                },
+                "require-dev": {
+                    "symfony/phpunit-bridge": "~3.2"
+                },
+                "source": {
+                    "reference": "6f13be2ff1681db53292eee1719dcee57e983207",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill.git"
+                },
+                "time": "2018-05-01T05:47:21+00:00",
+                "type": "library",
+                "uid": 2152743,
+                "version": "v1.8.0",
+                "version_normalized": "1.8.0.0"
+            }
+        },
+        "symfony/polyfill-mbstring": {
+            "dev-master": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "files": [
+                        "bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\Mbstring\\": ""
+                    }
+                },
+                "description": "Symfony polyfill for the Mbstring extension",
+                "dist": {
+                    "reference": "3296adf6a6454a050679cde90f95350ad604b171",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/3296adf6a6454a050679cde90f95350ad604b171"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.8-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "mbstring",
+                    "compatibility",
+                    "portable",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill-mbstring",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "source": {
+                    "reference": "3296adf6a6454a050679cde90f95350ad604b171",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill-mbstring.git"
+                },
+                "suggest": {
+                    "ext-mbstring": "For best performance"
+                },
+                "time": "2018-04-26T10:06:28+00:00",
+                "type": "library",
+                "uid": 562035,
+                "version": "dev-master",
+                "version_normalized": "9999999-dev"
+            },
+            "v1.0.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "files": [
+                        "bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\Mbstring\\": ""
+                    }
+                },
+                "description": "Symfony polyfill for the Mbstring extension",
+                "dist": {
+                    "reference": "0b6a8940385311a24e060ec1fe35680e17c74497",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0b6a8940385311a24e060ec1fe35680e17c74497"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.0-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "mbstring",
+                    "compatibility",
+                    "portable",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill-mbstring",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "source": {
+                    "reference": "0b6a8940385311a24e060ec1fe35680e17c74497",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill-mbstring.git"
+                },
+                "time": "2015-11-04T20:28:58+00:00",
+                "type": "library",
+                "uid": 573973,
+                "version": "v1.0.0",
+                "version_normalized": "1.0.0.0"
+            },
+            "v1.0.1": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "files": [
+                        "bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\Mbstring\\": ""
+                    }
+                },
+                "description": "Symfony polyfill for the Mbstring extension",
+                "dist": {
+                    "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/49ff736bd5d41f45240cec77b44967d76e0c3d25"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.0-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "mbstring",
+                    "compatibility",
+                    "portable",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill-mbstring",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "source": {
+                    "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill-mbstring.git"
+                },
+                "suggest": {
+                    "ext-mbstring": "For best performance"
+                },
+                "time": "2015-11-20T09:19:13+00:00",
+                "type": "library",
+                "uid": 635252,
+                "version": "v1.0.1",
+                "version_normalized": "1.0.1.0"
+            },
+            "v1.1.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "files": [
+                        "bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\Mbstring\\": ""
+                    }
+                },
+                "description": "Symfony polyfill for the Mbstring extension",
+                "dist": {
+                    "reference": "1289d16209491b584839022f29257ad859b8532d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/1289d16209491b584839022f29257ad859b8532d"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.1-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "mbstring",
+                    "compatibility",
+                    "portable",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill-mbstring",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "source": {
+                    "reference": "1289d16209491b584839022f29257ad859b8532d",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill-mbstring.git"
+                },
+                "suggest": {
+                    "ext-mbstring": "For best performance"
+                },
+                "time": "2016-01-20T09:13:37+00:00",
+                "type": "library",
+                "uid": 670779,
+                "version": "v1.1.0",
+                "version_normalized": "1.1.0.0"
+            },
+            "v1.1.1": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "files": [
+                        "bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\Mbstring\\": ""
+                    }
+                },
+                "description": "Symfony polyfill for the Mbstring extension",
+                "dist": {
+                    "reference": "1289d16209491b584839022f29257ad859b8532d",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/1289d16209491b584839022f29257ad859b8532d"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.1-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "mbstring",
+                    "compatibility",
+                    "portable",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill-mbstring",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "source": {
+                    "reference": "1289d16209491b584839022f29257ad859b8532d",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill-mbstring.git"
+                },
+                "suggest": {
+                    "ext-mbstring": "For best performance"
+                },
+                "time": "2016-01-20T09:13:37+00:00",
+                "type": "library",
+                "uid": 730515,
+                "version": "v1.1.1",
+                "version_normalized": "1.1.1.0"
+            },
+            "v1.2.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "files": [
+                        "bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\Mbstring\\": ""
+                    }
+                },
+                "description": "Symfony polyfill for the Mbstring extension",
+                "dist": {
+                    "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.2-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "mbstring",
+                    "compatibility",
+                    "portable",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill-mbstring",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "source": {
+                    "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill-mbstring.git"
+                },
+                "suggest": {
+                    "ext-mbstring": "For best performance"
+                },
+                "time": "2016-05-18T14:26:46+00:00",
+                "type": "library",
+                "uid": 826286,
+                "version": "v1.2.0",
+                "version_normalized": "1.2.0.0"
+            },
+            "v1.3.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "files": [
+                        "bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\Mbstring\\": ""
+                    }
+                },
+                "description": "Symfony polyfill for the Mbstring extension",
+                "dist": {
+                    "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.3-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "mbstring",
+                    "compatibility",
+                    "portable",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill-mbstring",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "source": {
+                    "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill-mbstring.git"
+                },
+                "suggest": {
+                    "ext-mbstring": "For best performance"
+                },
+                "time": "2016-11-14T01:06:16+00:00",
+                "type": "library",
+                "uid": 1079316,
+                "version": "v1.3.0",
+                "version_normalized": "1.3.0.0"
+            },
+            "v1.3.1": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "files": [
+                        "bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\Mbstring\\": ""
+                    }
+                },
+                "description": "Symfony polyfill for the Mbstring extension",
+                "dist": {
+                    "reference": "dee1c8b1e040d7dec299e4133c8105538cb2e5c7",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dee1c8b1e040d7dec299e4133c8105538cb2e5c7"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.3-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "mbstring",
+                    "compatibility",
+                    "portable",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill-mbstring",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "source": {
+                    "reference": "dee1c8b1e040d7dec299e4133c8105538cb2e5c7",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill-mbstring.git"
+                },
+                "suggest": {
+                    "ext-mbstring": "For best performance"
+                },
+                "time": "2017-05-29T17:37:41+00:00",
+                "type": "library",
+                "uid": 1436918,
+                "version": "v1.3.1",
+                "version_normalized": "1.3.1.0"
+            },
+            "v1.4.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "files": [
+                        "bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\Mbstring\\": ""
+                    }
+                },
+                "description": "Symfony polyfill for the Mbstring extension",
+                "dist": {
+                    "reference": "f29dca382a6485c3cbe6379f0c61230167681937",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f29dca382a6485c3cbe6379f0c61230167681937"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.4-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "mbstring",
+                    "compatibility",
+                    "portable",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill-mbstring",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "source": {
+                    "reference": "f29dca382a6485c3cbe6379f0c61230167681937",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill-mbstring.git"
+                },
+                "suggest": {
+                    "ext-mbstring": "For best performance"
+                },
+                "time": "2017-06-09T14:24:12+00:00",
+                "type": "library",
+                "uid": 1437011,
+                "version": "v1.4.0",
+                "version_normalized": "1.4.0.0"
+            },
+            "v1.5.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "files": [
+                        "bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\Mbstring\\": ""
+                    }
+                },
+                "description": "Symfony polyfill for the Mbstring extension",
+                "dist": {
+                    "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7c8fae0ac1d216eb54349e6a8baa57d515fe8803"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.5-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "mbstring",
+                    "compatibility",
+                    "portable",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill-mbstring",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "source": {
+                    "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill-mbstring.git"
+                },
+                "suggest": {
+                    "ext-mbstring": "For best performance"
+                },
+                "time": "2017-06-14T15:44:48+00:00",
+                "type": "library",
+                "uid": 1557074,
+                "version": "v1.5.0",
+                "version_normalized": "1.5.0.0"
+            },
+            "v1.6.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "files": [
+                        "bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\Mbstring\\": ""
+                    }
+                },
+                "description": "Symfony polyfill for the Mbstring extension",
+                "dist": {
+                    "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.6-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "mbstring",
+                    "compatibility",
+                    "portable",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill-mbstring",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "source": {
+                    "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill-mbstring.git"
+                },
+                "suggest": {
+                    "ext-mbstring": "For best performance"
+                },
+                "time": "2017-10-11T12:05:26+00:00",
+                "type": "library",
+                "uid": 1669338,
+                "version": "v1.6.0",
+                "version_normalized": "1.6.0.0"
+            },
+            "v1.7.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "files": [
+                        "bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\Mbstring\\": ""
+                    }
+                },
+                "description": "Symfony polyfill for the Mbstring extension",
+                "dist": {
+                    "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/78be803ce01e55d3491c1397cf1c64beb9c1b63b"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.7-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "mbstring",
+                    "compatibility",
+                    "portable",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill-mbstring",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "source": {
+                    "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill-mbstring.git"
+                },
+                "suggest": {
+                    "ext-mbstring": "For best performance"
+                },
+                "time": "2018-01-30T19:27:44+00:00",
+                "type": "library",
+                "uid": 1882800,
+                "version": "v1.7.0",
+                "version_normalized": "1.7.0.0"
+            },
+            "v1.8.0": {
+                "authors": [
+                    {
+                        "email": "p@tchwork.com",
+                        "name": "Nicolas Grekas"
+                    },
+                    {
+                        "homepage": "https://symfony.com/contributors",
+                        "name": "Symfony Community"
+                    }
+                ],
+                "autoload": {
+                    "files": [
+                        "bootstrap.php"
+                    ],
+                    "psr-4": {
+                        "Symfony\\Polyfill\\Mbstring\\": ""
+                    }
+                },
+                "description": "Symfony polyfill for the Mbstring extension",
+                "dist": {
+                    "reference": "3296adf6a6454a050679cde90f95350ad604b171",
+                    "shasum": "",
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/3296adf6a6454a050679cde90f95350ad604b171"
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "1.8-dev"
+                    }
+                },
+                "homepage": "https://symfony.com",
+                "keywords": [
+                    "mbstring",
+                    "compatibility",
+                    "portable",
+                    "polyfill",
+                    "shim"
+                ],
+                "license": [
+                    "MIT"
+                ],
+                "name": "symfony/polyfill-mbstring",
+                "require": {
+                    "php": ">=5.3.3"
+                },
+                "source": {
+                    "reference": "3296adf6a6454a050679cde90f95350ad604b171",
+                    "type": "git",
+                    "url": "https://github.com/symfony/polyfill-mbstring.git"
+                },
+                "suggest": {
+                    "ext-mbstring": "For best performance"
+                },
+                "time": "2018-04-26T10:06:28+00:00",
+                "type": "library",
+                "uid": 2152762,
+                "version": "v1.8.0",
+                "version_normalized": "1.8.0.0"
+            }
+        }
+    }
+}

--- a/spec/fixtures/php/packagist_responses/wpackagist-plugin:acf-to-rest-api.json
+++ b/spec/fixtures/php/packagist_responses/wpackagist-plugin:acf-to-rest-api.json
@@ -1,0 +1,1 @@
+{"error":{"code":404,"message":"Not Found"}}

--- a/spec/fixtures/php/wpackagist_response.json
+++ b/spec/fixtures/php/wpackagist_response.json
@@ -1,0 +1,39 @@
+{
+    "packages": [],
+    "provider-includes": {
+        "p/providers-2011$%hash%.json": {
+            "sha256": "5a7cd3329908dfe6268759a3266fc46c3413c4f511d7849400e233d9ba008586"
+        },
+        "p/providers-2012$%hash%.json": {
+            "sha256": "14d9a1585f9d81abae3189d5c9eee6f3c4a10fef22a463391bc018051aab6be9"
+        },
+        "p/providers-2013$%hash%.json": {
+            "sha256": "b33c91c8c07c913eb030ffda4a77a9e1507b677db0d6bbb947d1600af96e69a7"
+        },
+        "p/providers-2014$%hash%.json": {
+            "sha256": "319ad153ff8003f6db9ac6367dacb04c18d552c61edbaf473f926b6dee55ca69"
+        },
+        "p/providers-2015$%hash%.json": {
+            "sha256": "f729a478639cb9d2238eff2707a0456bd6f1e30bd7bf018ed0fd49e94dca6cca"
+        },
+        "p/providers-2016$%hash%.json": {
+            "sha256": "532996e51771e0eff1e1a3d596d9d088607caa4d408c7446bc1880433563323b"
+        },
+        "p/providers-2017$%hash%.json": {
+            "sha256": "aa5b9edbb163eef3c2f092d92a2653549b8a8571b5d773594e036cc3c2e24cc7"
+        },
+        "p/providers-2018-03$%hash%.json": {
+            "sha256": "9b058277cd1ccd643c795abd3dd2122f8acab14e28acc298baccc065e78e3214"
+        },
+        "p/providers-2018-06$%hash%.json": {
+            "sha256": "8b5f31ccf212f027a5033e2ab0bb48bf8d137cd665a1f2481bf353f20edd07af"
+        },
+        "p/providers-old$%hash%.json": {
+            "sha256": "033ebeaca9efa1e2f471e1e7d646c8daec48b9f07488b2ee18e9b56569e2a20e"
+        },
+        "p/providers-this-week$%hash%.json": {
+            "sha256": "5012b9d3e6fddd6aef9378c03e850def0434a925d26df21c4a1b7e189d5b713b"
+        }
+    },
+    "providers-url": "/p/%package%$%hash%.json"
+}


### PR DESCRIPTION
Previously, the PHP UpdateChecker knew nothing about versions the user had chosen to ignore. It always suggested updating to the latest resolvable version, and a separate process (in the Dependabot webapp) would ignore the generated update if the user had asked it to ignore that range.

This PR makes the PHP UpdateChecker aware of ignored versions. It will now only generate an update if one is possible that isn't being ignored, and will consider those ignores when determining the latest resolvable version that the user might want. As a result, if you're ignoring v2 of a dependency, Dependabot will still be able to generate updates for you if they're available on the v1 branch.

The same functionality is already being used in our Java and Python updaters, and is working well.