### PR TITLE
Respect platform requirements if they are set

### DIFF
--- a/helpers/php/src/ExceptionIO.php
+++ b/helpers/php/src/ExceptionIO.php
@@ -8,13 +8,18 @@ use Composer\IO\NullIO;
 
 class ExceptionIO extends NullIO
 {
+    private $raise_next_error = false;
+
     public function writeError($messages, $newline = true, $verbosity = self::NORMAL): void
     {
         if (is_array($messages)) {
             return;
         }
+        if ($this->raise_next_error) {
+            throw new \RuntimeException('Your requirements could not be resolved to an installable set of packages.' . $messages);
+        }
         if (strpos($messages, 'Your requirements could not be resolved') !== false) {
-            throw new \RuntimeException('Requirements could not be resolved');
+            $this->raise_next_error = true;
         }
     }
 }

--- a/helpers/php/src/UpdateChecker.php
+++ b/helpers/php/src/UpdateChecker.php
@@ -66,8 +66,15 @@ class UpdateChecker
             ->setWhitelistTransitiveDependencies(true)
             ->setExecuteOperations(false)
             ->setDumpAutoloader(false)
-            ->setRunScripts(false)
-            ->setIgnorePlatformRequirements(true);
+            ->setRunScripts(false);
+
+        /*
+         * If a platform is set we assume people know what they are doing and we respect the setting.
+         * If no platform is set we ignore it so that the php we run as doesn't interfere
+         */
+        if ($config->get('platform') === []) {
+            $install->setIgnorePlatformRequirements(true);
+        }
 
         $install->run();
 

--- a/helpers/php/src/Updater.php
+++ b/helpers/php/src/Updater.php
@@ -74,8 +74,15 @@ class Updater
             ->setWhitelistTransitiveDependencies(true)
             ->setExecuteOperations(false)
             ->setDumpAutoloader(false)
-            ->setRunScripts(false)
-            ->setIgnorePlatformRequirements(true);
+            ->setRunScripts(false);
+
+        /*
+         * If a platform is set we assume people know what they are doing and we respect the setting.
+         * If no platform is set we ignore it so that the php we run as doesn't interfere
+         */
+        if ($config->get('platform') === []) {
+            $install->setIgnorePlatformRequirements(true);
+        }
 
         $install->run();
 

--- a/lib/dependabot/update_checkers/php/composer/version_resolver.rb
+++ b/lib/dependabot/update_checkers/php/composer/version_resolver.rb
@@ -107,6 +107,7 @@ module Dependabot
           # rubocop:disable Metrics/PerceivedComplexity
           # rubocop:disable Metrics/AbcSize
           # rubocop:disable Metrics/CyclomaticComplexity
+          # rubocop:disable Metrics/MethodLength
           def handle_composer_errors(error)
             if error.message.start_with?("Failed to execute git clone")
               dependency_url =
@@ -120,7 +121,10 @@ module Dependabot
               raise Dependabot::GitDependenciesNotReachable, dependency_url
             elsif error.message.start_with?("Could not parse version")
               raise Dependabot::DependencyFileNotResolvable, error.message
-            elsif error.message == "Requirements could not be resolved"
+            elsif error.message.include?("requested PHP extension") ||
+                  error.message.include?("package requires php")
+              raise Dependabot::DependencyFileNotResolvable, error.message
+            elsif error.message.include?("requirements could not be resolved")
               # We should raise a Dependabot::DependencyFileNotResolvable error
               # here, but can't confidently distinguish between cases where we
               # can't install and cases where we can't update. For now, we
@@ -141,6 +145,7 @@ module Dependabot
           # rubocop:enable Metrics/PerceivedComplexity
           # rubocop:enable Metrics/AbcSize
           # rubocop:enable Metrics/CyclomaticComplexity
+          # rubocop:enable Metrics/MethodLength
 
           def php_helper_path
             project_root = File.join(File.dirname(__FILE__), "../../../../..")

--- a/spec/dependabot/file_updaters/php/composer_spec.rb
+++ b/spec/dependabot/file_updaters/php/composer_spec.rb
@@ -185,6 +185,37 @@ RSpec.describe Dependabot::FileUpdaters::Php::Composer do
 
       it { is_expected.to include "\"prefer-stable\":false" }
 
+      context "when an old version of PHP is specified" do
+        context "as a platform requirement" do
+          let(:manifest_fixture_name) { "old_php_platform" }
+          let(:dependency) do
+            Dependabot::Dependency.new(
+              name: "illuminate/support",
+              version: "5.4.36",
+              requirements: [{
+                file: "composer.json",
+                requirement: "^5.2.0",
+                groups: ["runtime"],
+                source: nil
+              }],
+              previous_version: "5.2.7",
+              previous_requirements: [{
+                file: "composer.json",
+                requirement: "^5.2.0",
+                groups: ["runtime"],
+                source: nil
+              }],
+              package_manager: "composer"
+            )
+          end
+
+          it "has details of the updated item" do
+            expect(updated_lockfile_content).
+              to include("\"version\":\"v5.4.36\"")
+          end
+        end
+      end
+
       context "that requires an environment variable" do
         let(:manifest_fixture_name) { "env_variable" }
 

--- a/spec/dependabot/update_checkers/php/composer_spec.rb
+++ b/spec/dependabot/update_checkers/php/composer_spec.rb
@@ -338,6 +338,40 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer do
         end
         it { is_expected.to be >= Gem::Version.new("4.3.0") }
       end
+
+      context "when an old version of PHP is specified" do
+        let(:composer_file_content) do
+          fixture("php", "composer_files", "old_php_specified")
+        end
+
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "illuminate/support",
+            version: "v5.2.7",
+            requirements: [
+              {
+                file: "composer.json",
+                requirement: "^5.2.0",
+                groups: ["runtime"],
+                source: nil
+              }
+            ],
+            package_manager: "composer"
+          )
+        end
+
+        # 5.5.0 series requires PHP 7
+        it { is_expected.to be >= Gem::Version.new("5.4.36") }
+        it { is_expected.to be < Gem::Version.new("5.5.0") }
+
+        context "as a platform requirement" do
+          let(:composer_file_content) do
+            fixture("php", "composer_files", "old_php_platform")
+          end
+          it { is_expected.to be >= Gem::Version.new("5.4.36") }
+          it { is_expected.to be < Gem::Version.new("5.5.0") }
+        end
+      end
     end
 
     context "with a dev dependency" do

--- a/spec/dependabot/update_checkers/php/composer_spec.rb
+++ b/spec/dependabot/update_checkers/php/composer_spec.rb
@@ -340,10 +340,7 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer do
       end
 
       context "when an old version of PHP is specified" do
-        let(:composer_file_content) do
-          fixture("php", "composer_files", "old_php_specified")
-        end
-
+        let(:manifest_fixture_name) { "old_php_specified" }
         let(:dependency_name) { "illuminate/support" }
         let(:dependency_version) { "5.2.7" }
         let(:requirements) do
@@ -360,9 +357,7 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer do
         it { is_expected.to be < Gem::Version.new("5.5.0") }
 
         context "as a platform requirement" do
-          let(:composer_file_content) do
-            fixture("php", "composer_files", "old_php_platform")
-          end
+          let(:manifest_fixture_name) { "old_php_platform" }
           it { is_expected.to be >= Gem::Version.new("5.4.36") }
           it { is_expected.to be < Gem::Version.new("5.5.0") }
         end

--- a/spec/dependabot/update_checkers/php/composer_spec.rb
+++ b/spec/dependabot/update_checkers/php/composer_spec.rb
@@ -344,20 +344,15 @@ RSpec.describe Dependabot::UpdateCheckers::Php::Composer do
           fixture("php", "composer_files", "old_php_specified")
         end
 
-        let(:dependency) do
-          Dependabot::Dependency.new(
-            name: "illuminate/support",
-            version: "v5.2.7",
-            requirements: [
-              {
-                file: "composer.json",
-                requirement: "^5.2.0",
-                groups: ["runtime"],
-                source: nil
-              }
-            ],
-            package_manager: "composer"
-          )
+        let(:dependency_name) { "illuminate/support" }
+        let(:dependency_version) { "5.2.7" }
+        let(:requirements) do
+          [{
+            file: "composer.json",
+            requirement: "^5.2.0",
+            groups: ["runtime"],
+            source: nil
+          }]
         end
 
         # 5.5.0 series requires PHP 7

--- a/spec/fixtures/php/composer_files/bad_php
+++ b/spec/fixtures/php/composer_files/bad_php
@@ -1,13 +1,12 @@
 {
     "require": {
-        "php": "^5.6.0",
+        "php": "5.6.4",
         "erusev/parsedown": "^1.6.0",
         "illuminate/support": "^5.2.0"
     },
     "config": {
         "platform": {
-            "php": "5.6.4",
-            "ext-mbstring": "1.0.0"
+            "ext-xdebug": "1.0.0"
         }
     }
 }

--- a/spec/fixtures/php/composer_files/missing_extension
+++ b/spec/fixtures/php/composer_files/missing_extension
@@ -1,13 +1,12 @@
 {
     "require": {
-        "php": "^5.6.0",
+        "ext-xdebug": "*",
         "erusev/parsedown": "^1.6.0",
         "illuminate/support": "^5.2.0"
     },
     "config": {
         "platform": {
-            "php": "5.6.4",
-            "ext-mbstring": "1.0.0"
+            "php": "5.6.4"
         }
     }
 }

--- a/spec/fixtures/php/composer_files/old_php_platform
+++ b/spec/fixtures/php/composer_files/old_php_platform
@@ -1,0 +1,11 @@
+{
+    "require": {
+        "erusev/parsedown": "^1.6.0",
+        "illuminate/support": "^5.2.0"
+    },
+    "config": {
+        "platform": {
+            "php": "5.6.4"
+        }
+    }
+}

--- a/spec/fixtures/php/lockfiles/old_php_platform
+++ b/spec/fixtures/php/lockfiles/old_php_platform
@@ -1,0 +1,280 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "08fa269dea2df753587e037e5bb3a9f2",
+    "packages": [
+        {
+            "name": "doctrine/inflector",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/90b2128806bfde671b6952ab8bea493942c1fdae",
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Inflector\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "inflection",
+                "pluralize",
+                "singularize",
+                "string"
+            ],
+            "time": "2015-11-06T14:35:42+00:00"
+        },
+        {
+            "name": "erusev/parsedown",
+            "version": "1.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/erusev/parsedown.git",
+                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/fbe3fe878f4fe69048bb8a52783a09802004f548",
+                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Parsedown": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
+                }
+            ],
+            "description": "Parser for Markdown.",
+            "homepage": "http://parsedown.org",
+            "keywords": [
+                "markdown",
+                "parser"
+            ],
+            "time": "2017-11-14T20:44:03+00:00"
+        },
+        {
+            "name": "illuminate/contracts",
+            "version": "v5.4.36",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/contracts.git",
+                "reference": "67f642e018f3e95fb0b2ebffc206c3200391b1ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/67f642e018f3e95fb0b2ebffc206c3200391b1ab",
+                "reference": "67f642e018f3e95fb0b2ebffc206c3200391b1ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Contracts\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Contracts package.",
+            "homepage": "https://laravel.com",
+            "time": "2017-08-26T23:56:53+00:00"
+        },
+        {
+            "name": "illuminate/support",
+            "version": "v5.4.36",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/support.git",
+                "reference": "feab1d1495fd6d38970bd6c83586ba2ace8f299a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/feab1d1495fd6d38970bd6c83586ba2ace8f299a",
+                "reference": "feab1d1495fd6d38970bd6c83586ba2ace8f299a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "~1.1",
+                "ext-mbstring": "*",
+                "illuminate/contracts": "5.4.*",
+                "paragonie/random_compat": "~1.4|~2.0",
+                "php": ">=5.6.4"
+            },
+            "replace": {
+                "tightenco/collect": "self.version"
+            },
+            "suggest": {
+                "illuminate/filesystem": "Required to use the composer class (5.2.*).",
+                "symfony/process": "Required to use the composer class (~3.2).",
+                "symfony/var-dumper": "Required to use the dd function (~3.2)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                },
+                "files": [
+                    "helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Support package.",
+            "homepage": "https://laravel.com",
+            "time": "2017-08-15T13:25:41+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2017-09-27T21:40:39+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.6.4"
+    }
+}


### PR DESCRIPTION
Fixes #394

When a user sets the platform requirements we should respect them. Else
proposed new versions might not run on their target platform.

If no platform is set we ignore it all so that the current platform
isn't taken into account.

Todo:
- [ ] Add some test (once I figure out how)
  * Just took them from https://github.com/dependabot/dependabot-core/pull/209