### PR TITLE
Use source api endpoint in gitlab client for using self host gitlab

### DIFF
--- a/lib/dependabot/file_fetchers/base.rb
+++ b/lib/dependabot/file_fetchers/base.rb
@@ -209,12 +209,12 @@ module Dependabot
         access_token =
           credentials.
           select { |cred| cred["type"] == "git_source" }.
-          find { |cred| cred["host"] == "gitlab.com" }&.
+          find { |cred| cred["host"] == source.hostname }&.
           fetch("password")
 
         @gitlab_client ||=
           Gitlab.client(
-            endpoint: "https://gitlab.com/api/v4",
+            endpoint: source.api_endpoint,
             private_token: access_token || ""
           )
       end

--- a/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/lib/dependabot/pull_request_creator/gitlab.rb
@@ -54,7 +54,7 @@ module Dependabot
 
         @gitlab_client_for_source ||=
           ::Gitlab.client(
-            endpoint: "https://gitlab.com/api/v4",
+            endpoint: source.api_endpoint,
             private_token: access_token || ""
           )
       end

--- a/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/lib/dependabot/pull_request_creator/message_builder.rb
@@ -597,7 +597,7 @@ module Dependabot
 
         @gitlab_client_for_source ||=
           ::Gitlab.client(
-            endpoint: "https://gitlab.com/api/v4",
+            endpoint: source.api_endpoint,
             private_token: access_token || ""
           )
       end


### PR DESCRIPTION
Hello @greysteil,

As we already discussed, we are very interested by your project. 
But we use gitlab selfhosted, so we were waiting for the implementation of gitlab.
I discovered your project dependabot\dependabot-script and we tried to use it. 
We got a lot of snafu but we got it at the end. 
But to be able to make it work, we add to make some little changes. Here they are. Maybe it can be of some help.
You will maybe see that we didn't leave from master. There is a very good reason for that ! :smile: 
We working on php/composer projects and we add a fatal yesterday due to this very recent commit on master : https://github.com/dependabot/dependabot-core/commit/319b92a99ecb0ff94a73dc1598b35a6bf3577215
Since we are on gitlab, we got no username to use for these credentials.
Maybe we can try to find a way to make it work.