### PR TITLE
Update semantic-release commit messages to be compliant with @commitlint/config-conventional

### DIFF
--- a/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/lib/dependabot/pull_request_creator/message_builder.rb
@@ -121,7 +121,7 @@ module Dependabot
       def pr_name_prefix
         pr_name = ""
         if using_semantic_commit_messages?
-          scope = dependencies.any?(&:production?) ? "deps" : "devDeps"
+          scope = dependencies.any?(&:production?) ? "deps" : "deps-dev"
           pr_name += "build(#{scope}): "
           pr_name += "[security] " if includes_security_fixes?
           pr_name + (library? ? "update " : "bump ")

--- a/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
           end
 
-          it { is_expected.to start_with("build(devDeps): bump") }
+          it { is_expected.to start_with("build(deps-dev): bump") }
         end
       end
 


### PR DESCRIPTION
Implements the fix in https://github.com/dependabot/dependabot-core/issues/560, by changing the semantic-release commit message scope for development dependencies from `"devDeps"` scope to `"deps-dev"`.