### PR TITLE
Add poetry support

### DIFF
--- a/helpers/python/lib/hasher.py
+++ b/helpers/python/lib/hasher.py
@@ -1,6 +1,7 @@
 import hashin
 import json
 import pipfile
+from poetry.poetry import Poetry
 
 def get_dependency_hash(dependency_name, dependency_version, algorithm):
     hashes = hashin.get_package_hashes(
@@ -15,3 +16,8 @@ def get_pipfile_hash(directory):
     p = pipfile.load(directory + '/Pipfile')
 
     return json.dumps({ "result": p.hash })
+
+def get_pyproject_hash(directory):
+    p = Poetry.create(directory)
+
+    return json.dumps({ "result": p.locker._get_content_hash() })

--- a/helpers/python/requirements.txt
+++ b/helpers/python/requirements.txt
@@ -3,3 +3,4 @@ pip-tools==2.0.2
 hashin==0.13.3
 pipenv==2018.7.1
 pipfile==0.0.2
+poetry==0.11.4

--- a/helpers/python/run.py
+++ b/helpers/python/run.py
@@ -14,3 +14,5 @@ if __name__ == "__main__":
         print(hasher.get_dependency_hash(*args["args"]))
     elif args["function"] == "get_pipfile_hash":
         print(hasher.get_pipfile_hash(*args["args"]))
+    elif args["function"] == "get_pyproject_hash":
+        print(hasher.get_pyproject_hash(*args["args"]))

--- a/lib/dependabot/file_parsers/python/pip/pipfile_files_parser.rb
+++ b/lib/dependabot/file_parsers/python/pip/pipfile_files_parser.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "toml-rb"
+
+require "dependabot/dependency"
+require "dependabot/file_parsers/base/dependency_set"
+require "dependabot/file_parsers/python/pip"
+require "dependabot/errors"
+
+module Dependabot
+  module FileParsers
+    module Python
+      class Pip
+        class PipfileFilesParser
+          DEPENDENCY_GROUP_KEYS = [
+            {
+              pipfile: "packages",
+              lockfile: "default"
+            },
+            {
+              pipfile: "dev-packages",
+              lockfile: "develop"
+            }
+          ].freeze
+
+          def initialize(dependency_files:)
+            @dependency_files = dependency_files
+          end
+
+          def dependency_set
+            dependency_set = Dependabot::FileParsers::Base::DependencySet.new
+
+            dependency_set += pipfile_dependencies
+            dependency_set += pipfile_lock_dependencies
+
+            dependency_set
+          end
+
+          private
+
+          attr_reader :dependency_files
+
+          def pipfile_dependencies
+            dependencies = Dependabot::FileParsers::Base::DependencySet.new
+
+            DEPENDENCY_GROUP_KEYS.each do |keys|
+              next unless parsed_pipfile[keys[:pipfile]]
+
+              parsed_pipfile[keys[:pipfile]].map do |dep_name, req|
+                next unless req.is_a?(String) || req["version"]
+                next unless dependency_version(dep_name, keys[:lockfile])
+
+                dependencies <<
+                  Dependency.new(
+                    name: normalised_name(dep_name),
+                    version: dependency_version(dep_name, keys[:lockfile]),
+                    requirements: [{
+                      requirement: req.is_a?(String) ? req : req["version"],
+                      file: pipfile.name,
+                      source: nil,
+                      groups: [keys[:lockfile]]
+                    }],
+                    package_manager: "pip"
+                  )
+              end
+            end
+
+            dependencies
+          end
+
+          # Create a DependencySet where each element has no requirement. Any
+          # requirements will be added when combining the DependencySet with
+          # other DependencySets.
+          def pipfile_lock_dependencies
+            dependencies = Dependabot::FileParsers::Base::DependencySet.new
+
+            DEPENDENCY_GROUP_KEYS.map { |h| h.fetch(:lockfile) }.each do |key|
+              next unless parsed_pipfile_lock[key]
+
+              parsed_pipfile_lock[key].each do |dep_name, details|
+                next unless details["version"]
+
+                dependencies <<
+                  Dependency.new(
+                    name: dep_name,
+                    version: details["version"]&.gsub(/^===?/, ""),
+                    requirements: [],
+                    package_manager: "pip"
+                  )
+              end
+            end
+
+            dependencies
+          end
+
+          def dependency_version(dep_name, group)
+            parsed_pipfile_lock.
+              dig(group, normalised_name(dep_name), "version")&.
+              gsub(/^===?/, "")
+          end
+
+          # See https://www.python.org/dev/peps/pep-0503/#normalized-names
+          def normalised_name(name)
+            name.downcase.tr("_", "-").tr(".", "-")
+          end
+
+          def parsed_pipfile
+            @parsed_pipfile ||= TomlRB.parse(pipfile.content)
+          rescue TomlRB::ParseError
+            raise Dependabot::DependencyFileNotParseable, pipfile.path
+          end
+
+          def parsed_pipfile_lock
+            @parsed_pipfile_lock ||= JSON.parse(pipfile_lock.content)
+          rescue JSON::ParseError
+            raise Dependabot::DependencyFileNotParseable, pipfile_lock.path
+          end
+
+          def pipfile
+            @pipfile ||= dependency_files.find { |f| f.name == "Pipfile" }
+          end
+
+          def pipfile_lock
+            @pipfile_lock ||=
+              dependency_files.find { |f| f.name == "Pipfile.lock" }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dependabot/file_parsers/python/pip/poetry_files_parser.rb
+++ b/lib/dependabot/file_parsers/python/pip/poetry_files_parser.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "toml-rb"
+
+require "dependabot/dependency"
+require "dependabot/file_parsers/base/dependency_set"
+require "dependabot/file_parsers/python/pip"
+require "dependabot/errors"
+
+module Dependabot
+  module FileParsers
+    module Python
+      class Pip
+        class PoetryFilesParser
+          POETRY_DEPENDENCY_TYPES =
+            %w(dependencies dev-dependencies).freeze
+
+          def initialize(dependency_files:)
+            @dependency_files = dependency_files
+          end
+
+          def dependency_set
+            dependency_set = Dependabot::FileParsers::Base::DependencySet.new
+
+            dependency_set += pyproject_dependencies
+            dependency_set += pyproject_lock_dependencies if pyproject_lock
+
+            dependency_set
+          end
+
+          private
+
+          attr_reader :dependency_files
+
+          def pyproject_dependencies
+            dependencies = Dependabot::FileParsers::Base::DependencySet.new
+
+            POETRY_DEPENDENCY_TYPES.each do |type|
+              deps_hash = parsed_pyproject.dig("tool", "poetry", type) || {}
+
+              deps_hash.each do |name, req|
+                next if normalised_name(name) == "python"
+
+                dependencies <<
+                  Dependency.new(
+                    name: normalised_name(name),
+                    version: version_from_lockfile(name),
+                    requirements: [{
+                      requirement: req.is_a?(String) ? req : req["version"],
+                      file: pyproject.name,
+                      source: nil,
+                      groups: [type]
+                    }],
+                    package_manager: "pip"
+                  )
+              end
+            end
+
+            dependencies
+          end
+
+          # Create a DependencySet where each element has no requirement. Any
+          # requirements will be added when combining the DependencySet with
+          # other DependencySets.
+          def pyproject_lock_dependencies
+            dependencies = Dependabot::FileParsers::Base::DependencySet.new
+
+            parsed_pyproject_lock.fetch("package", []).each do |details|
+              dependencies <<
+                Dependency.new(
+                  name: details.fetch("name"),
+                  version: details.fetch("version"),
+                  requirements: [],
+                  package_manager: "pip"
+                )
+            end
+
+            dependencies
+          end
+
+          def version_from_lockfile(dep_name)
+            return unless pyproject_lock
+
+            parsed_pyproject_lock.fetch("package", []).
+              find { |p| p.fetch("name") == normalised_name(dep_name) }&.
+              fetch("verison", nil)
+          end
+
+          # See https://www.python.org/dev/peps/pep-0503/#normalized-names
+          def normalised_name(name)
+            name.downcase.tr("_", "-").tr(".", "-")
+          end
+
+          def parsed_pyproject
+            @parsed_pyproject ||= TomlRB.parse(pyproject.content)
+          rescue TomlRB::ParseError
+            raise Dependabot::DependencyFileNotParseable, pyproject.path
+          end
+
+          def parsed_pyproject_lock
+            @parsed_pyproject_lock ||= TomlRB.parse(pyproject_lock.content)
+          rescue TomlRB::ParseError
+            raise Dependabot::DependencyFileNotParseable, pyproject_lock.path
+          end
+
+          def pyproject
+            @pyproject ||=
+              dependency_files.find { |f| f.name == "pyproject.toml" }
+          end
+
+          def pyproject_lock
+            @pyproject_lock ||=
+              dependency_files.find { |f| f.name == "pyproject.lock" }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dependabot/file_updaters/python/pip/poetry_file_updater.rb
+++ b/lib/dependabot/file_updaters/python/pip/poetry_file_updater.rb
@@ -136,7 +136,7 @@ module Dependabot
             SharedHelpers.in_a_temporary_directory do
               write_temporary_dependency_files(pyproject_content)
 
-              run_poetry_command("poetry lock")
+              run_poetry_command("pyenv exec poetry lock")
 
               File.read("pyproject.lock")
             end

--- a/lib/dependabot/file_updaters/python/pip/poetry_file_updater.rb
+++ b/lib/dependabot/file_updaters/python/pip/poetry_file_updater.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require "toml-rb"
+
+require "dependabot/file_updaters/python/pip"
+require "dependabot/shared_helpers"
+
+module Dependabot
+  module FileUpdaters
+    module Python
+      class Pip
+        class PoetryFileUpdater
+          require_relative "pyproject_preparer"
+
+          attr_reader :dependencies, :dependency_files, :credentials
+
+          def initialize(dependencies:, dependency_files:, credentials:)
+            @dependencies = dependencies
+            @dependency_files = dependency_files
+            @credentials = credentials
+          end
+
+          def updated_dependency_files
+            return @updated_dependency_files if @update_already_attempted
+
+            @update_already_attempted = true
+            @updated_dependency_files ||= fetch_updated_dependency_files
+          end
+
+          private
+
+          def dependency
+            # For now, we'll only ever be updating a single dependency
+            dependencies.first
+          end
+
+          def fetch_updated_dependency_files
+            updated_files = []
+
+            if file_changed?(pyproject)
+              updated_files <<
+                updated_file(
+                  file: pyproject,
+                  content: updated_pyproject_content
+                )
+            end
+
+            if lockfile && lockfile.content == updated_lockfile_content
+              raise "Expected pyproject.lock to change!"
+            end
+
+            updated_files <<
+              updated_file(file: lockfile, content: updated_lockfile_content)
+
+            updated_files
+          end
+
+          def updated_pyproject_content
+            dependencies.
+              select { |dep| requirement_changed?(pyproject, dep) }.
+              reduce(pyproject.content.dup) do |content, dep|
+                updated_requirement =
+                  dep.requirements.find { |r| r[:file] == pyproject.name }.
+                  fetch(:requirement)
+
+                old_req =
+                  dep.previous_requirements.
+                  find { |r| r[:file] == pyproject.name }.
+                  fetch(:requirement)
+
+                updated_content =
+                  content.gsub(declaration_regex(dep)) do |line|
+                    line.gsub(old_req, updated_requirement)
+                  end
+
+                raise "Content did not change!" if content == updated_content
+                updated_content
+              end
+          end
+
+          def updated_lockfile_content
+            @updated_lockfile_content ||=
+              begin
+                original_hash = parsed_lockfile["metadata"]["content-hash"]
+                updated_hash = pyproject_hash_for(updated_pyproject_content)
+
+                new_lockfile = updated_lockfile_content_for(prepared_pyproject)
+                new_lockfile.gsub(original_hash, updated_hash)
+              end
+          end
+
+          def prepared_pyproject
+            content = updated_pyproject_content
+            content = freeze_other_dependencies(content)
+            content = freeze_dependencies_being_updated(content)
+            content = add_private_sources(content)
+            content
+          end
+
+          def freeze_other_dependencies(pyproject_content)
+            PyprojectPreparer.
+              new(pyproject_content: pyproject_content).
+              freeze_top_level_dependencies_except(dependencies, lockfile)
+          end
+
+          def freeze_dependencies_being_updated(pyproject_content)
+            pyproject_object = TomlRB.parse(pyproject_content)
+            poetry_object = pyproject_object.fetch("tool").fetch("poetry")
+
+            dependencies.each do |dep|
+              %w(dependencies dev-dependencies).each do |type|
+                names = poetry_object[type]&.keys || []
+                pkg_name = names.find { |nm| normalise(nm) == dep.name }
+                next unless pkg_name
+
+                if poetry_object[type][pkg_name].is_a?(Hash)
+                  poetry_object[type][pkg_name]["version"] = dep.version
+                else
+                  poetry_object[type][pkg_name] = dep.version
+                end
+              end
+            end
+
+            TomlRB.dump(pyproject_object)
+          end
+
+          def add_private_sources(pyproject_content)
+            PyprojectPreparer.
+              new(pyproject_content: pyproject_content).
+              replace_sources(credentials)
+          end
+
+          def updated_lockfile_content_for(pyproject_content)
+            SharedHelpers.in_a_temporary_directory do
+              write_temporary_dependency_files(pyproject_content)
+
+              run_poetry_command("poetry lock")
+
+              File.read("pyproject.lock")
+            end
+          end
+
+          def run_poetry_command(cmd)
+            raw_response = nil
+            IO.popen(cmd, err: %i(child out)) { |p| raw_response = p.read }
+
+            # Raise an error with the output from the shell session if Pipenv
+            # returns a non-zero status
+            return if $CHILD_STATUS.success?
+            raise SharedHelpers::HelperSubprocessFailed.new(raw_response, cmd)
+          end
+
+          def write_temporary_dependency_files(pyproject_content)
+            dependency_files.each do |file|
+              path = file.name
+              FileUtils.mkdir_p(Pathname.new(path).dirname)
+              File.write(path, file.content)
+            end
+
+            # Overwrite the pyproject with updated content
+            File.write("pyproject.toml", pyproject_content)
+          end
+
+          def pyproject_hash_for(pyproject_content)
+            SharedHelpers.in_a_temporary_directory do |dir|
+              File.write(File.join(dir, "Pipfile"), pyproject_content)
+              SharedHelpers.run_helper_subprocess(
+                command:  "pyenv exec python #{python_helper_path}",
+                function: "get_pipfile_hash",
+                args: [dir]
+              )
+            end
+          end
+
+          def declaration_regex(dep)
+            escaped_name = Regexp.escape(dep.name).gsub("\\-", "[-_.]")
+            /(?:^|["'])#{escaped_name}["']?\s*=.*$/i
+          end
+
+          def file_changed?(file)
+            dependencies.any? { |dep| requirement_changed?(file, dep) }
+          end
+
+          def requirement_changed?(file, dependency)
+            changed_requirements =
+              dependency.requirements - dependency.previous_requirements
+
+            changed_requirements.any? { |f| f[:file] == file.name }
+          end
+
+          def updated_file(file:, content:)
+            updated_file = file.dup
+            updated_file.content = content
+            updated_file
+          end
+
+          def python_helper_path
+            project_root = File.join(File.dirname(__FILE__), "../../../../..")
+            File.join(project_root, "helpers/python/run.py")
+          end
+
+          # See https://www.python.org/dev/peps/pep-0503/#normalized-names
+          def normalise(name)
+            name.downcase.tr("_", "-").tr(".", "-")
+          end
+
+          def parsed_lockfile
+            @parsed_lockfile ||= TomlRB.parse(lockfile.content)
+          end
+
+          def pyproject
+            @pyproject ||=
+              dependency_files.find { |f| f.name == "pyproject.toml" }
+          end
+
+          def lockfile
+            @lockfile ||=
+              dependency_files.find { |f| f.name == "pyproject.lock" }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dependabot/file_updaters/python/pip/pyproject_preparer.rb
+++ b/lib/dependabot/file_updaters/python/pip/pyproject_preparer.rb
@@ -43,9 +43,9 @@ module Dependabot
                 next unless locked_version
 
                 if poetry_object[dep_name].is_a?(Hash)
-                  poetry_object[dep_name]["version"] = locked_version
+                  poetry_object[key][dep_name]["version"] = locked_version
                 else
-                  poetry_object[dep_name] = locked_version
+                  poetry_object[key][dep_name] = locked_version
                 end
               end
             end

--- a/lib/dependabot/file_updaters/python/pip/pyproject_preparer.rb
+++ b/lib/dependabot/file_updaters/python/pip/pyproject_preparer.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "toml-rb"
+
+require "dependabot/file_parsers/python/pip"
+require "dependabot/file_updaters/python/pip"
+
+module Dependabot
+  module FileUpdaters
+    module Python
+      class Pip
+        class PyprojectPreparer
+          def initialize(pyproject_content:)
+            @pyproject_content = pyproject_content
+          end
+
+          def replace_sources(credentials)
+            pyproject_object = TomlRB.parse(pyproject_content)
+            poetry_object = pyproject_object.fetch("tool").fetch("poetry")
+
+            poetry_object["source"] = pyproject_sources +
+                                      config_variable_sources(credentials)
+
+            TomlRB.dump(pyproject_object)
+          end
+
+          def freeze_top_level_dependencies_except(dependencies, lockfile)
+            return pyproject_content unless lockfile
+            pyproject_object = TomlRB.parse(pyproject_content)
+            poetry_object = pyproject_object.fetch("tool").fetch("poetry")
+            parsed_lockfile = TomlRB.parse(lockfile.content)
+            excluded_names = dependencies.map(&:name) + ["python"]
+
+            %w(dependencies dev-dependencies).each do |key|
+              next unless poetry_object[key]
+
+              poetry_object.fetch(key).each do |dep_name, _|
+                next if excluded_names.include?(normalise(dep_name))
+                locked_version =
+                  parsed_lockfile.fetch("package").
+                  find { |d| d["name"] == normalise(dep_name) }&.
+                  fetch("version")
+                next unless locked_version
+
+                if poetry_object[dep_name].is_a?(Hash)
+                  poetry_object[dep_name]["version"] = locked_version
+                else
+                  poetry_object[dep_name] = locked_version
+                end
+              end
+            end
+
+            TomlRB.dump(pyproject_object)
+          end
+
+          private
+
+          attr_reader :pyproject_content
+
+          # See https://www.python.org/dev/peps/pep-0503/#normalized-names
+          def normalise(name)
+            name.downcase.tr("_", "-").tr(".", "-")
+          end
+
+          def pyproject_sources
+            @pyproject_sources ||=
+              TomlRB.parse(pyproject_content).fetch("source", []).
+              map { |h| h.dup.merge("url" => h["url"].gsub(%r{/*$}, "") + "/") }
+          end
+
+          def config_variable_sources(credentials)
+            @config_variable_sources ||=
+              credentials.
+              select { |cred| cred["type"] == "python_index" }.
+              map { |cred| { "url" => cred["index-url"] } }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dependabot/update_checkers/python/pip/poetry_version_resolver.rb
+++ b/lib/dependabot/update_checkers/python/pip/poetry_version_resolver.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require "excon"
+require "toml-rb"
+
+require "dependabot/file_parsers/python/pip"
+require "dependabot/file_updaters/python/pip/pyproject_preparer"
+require "dependabot/update_checkers/python/pip"
+require "dependabot/shared_helpers"
+require "dependabot/utils/python/version"
+require "dependabot/errors"
+
+module Dependabot
+  module UpdateCheckers
+    module Python
+      class Pip
+        # This class does version resolution for pyproject.toml files.
+        class PoetryVersionResolver
+          VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-_]+)*/
+
+          attr_reader :dependency, :dependency_files, :credentials
+
+          def initialize(dependency:, dependency_files:, credentials:,
+                         unlock_requirement:, latest_allowable_version:)
+            @dependency               = dependency
+            @dependency_files         = dependency_files
+            @credentials              = credentials
+            @latest_allowable_version = latest_allowable_version
+            @unlock_requirement       = unlock_requirement
+
+            check_private_sources_are_reachable
+          end
+
+          def latest_resolvable_version
+            return @latest_resolvable_version if @resolution_already_attempted
+
+            @resolution_already_attempted = true
+            @latest_resolvable_version ||= fetch_latest_resolvable_version
+          end
+
+          private
+
+          attr_reader :latest_allowable_version
+
+          def unlock_requirement?
+            @unlock_requirement
+          end
+
+          def fetch_latest_resolvable_version
+            @latest_resolvable_version_string ||=
+              SharedHelpers.in_a_temporary_directory do
+                write_temporary_dependency_files
+
+                # Shell out to Poetry, which handles everything for us.
+                # Calling `lock` avoids doing an install.
+                run_poetry_command("poetry lock")
+
+                updated_lockfile = TomlRB.parse(File.read("pyproject.lock"))
+
+                fetch_version_from_parsed_lockfile(updated_lockfile)
+              end
+            return unless @latest_resolvable_version_string
+            Utils::Python::Version.new(@latest_resolvable_version_string)
+          end
+
+          def fetch_version_from_parsed_lockfile(updated_lockfile)
+            updated_lockfile.fetch("package", []).
+              find { |d| d["name"] == dependency.name }.
+              fetch("version")
+          end
+
+          def write_temporary_dependency_files(update_pyproject: true)
+            dependency_files.each do |file|
+              path = file.name
+              FileUtils.mkdir_p(Pathname.new(path).dirname)
+              File.write(path, file.content)
+            end
+
+            # Overwrite the pyproject with updated content
+            File.write("pyproject.toml", pyproject_content) if update_pyproject
+          end
+
+          def pyproject_content
+            content = pyproject.content
+            content = freeze_other_dependencies(content)
+            content = unlock_target_dependency(content) if unlock_requirement?
+            content
+          end
+
+          def freeze_other_dependencies(pyproject_content)
+            FileUpdaters::Python::Pip::PyprojectPreparer.
+              new(pyproject_content: pyproject_content).
+              freeze_top_level_dependencies_except([dependency], pyproject_lock)
+          end
+
+          def unlock_target_dependency(pyproject_content)
+            pyproject_object = TomlRB.parse(pyproject_content)
+            poetry_object = pyproject_object.dig("tool", "poetry")
+
+            %w(dependencies dev-dependencies).each do |type|
+              names = poetry_object[type]&.keys || []
+              pkg_name = names.find { |nm| normalise(nm) == dependency.name }
+              next unless pkg_name
+
+              if poetry_object.dig(type, pkg_name).is_a?(Hash)
+                poetry_object[type][pkg_name]["version"] =
+                  updated_version_requirement_string
+              else
+                poetry_object[type][pkg_name] =
+                  updated_version_requirement_string
+              end
+            end
+
+            TomlRB.dump(pyproject_object)
+          end
+
+          def check_private_sources_are_reachable
+            sources_to_check =
+              pyproject_sources +
+              config_variable_sources
+
+            sources_to_check.
+              map { |details| details["url"] }.
+              reject { |url| MAIN_PYPI_INDEXES.include?(url) }.
+              each do |url|
+                sanitized_url = url.gsub(%r{(?<=//).*(?=@)}, "redacted")
+
+                response = Excon.get(
+                  url + dependency.name + "/",
+                  idempotent: true,
+                  **SharedHelpers.excon_defaults
+                )
+
+                if response.status == 401 || response.status == 403
+                  raise PrivateSourceAuthenticationFailure, sanitized_url
+                end
+              rescue Excon::Error::Timeout, Excon::Error::Socket
+                raise PrivateSourceTimedOut, sanitized_url
+              end
+          end
+
+          def updated_version_requirement_string
+            lower_bound_req = updated_version_req_lower_bound
+
+            # Add the latest_allowable_version as an upper bound. This means
+            # ignore conditions are considered when checking for the latest
+            # resolvable version.
+            #
+            # NOTE: This isn't perfect. If v2.x is ignored and v3 is out but
+            # unresolvable then the `latest_allowable_version` will be v3, and
+            # we won't be ignoring v2.x releases like we should be.
+            return lower_bound_req if latest_allowable_version.nil?
+            unless Utils::Python::Version.correct?(latest_allowable_version)
+              return lower_bound_req
+            end
+
+            lower_bound_req + ", <= #{latest_allowable_version}"
+          end
+
+          def updated_version_req_lower_bound
+            if dependency.version
+              ">= #{dependency.version}"
+            else
+              version_for_requirement =
+                dependency.requirements.map { |r| r[:requirement] }.compact.
+                reject { |req_string| req_string.start_with?("<") }.
+                select { |req_string| req_string.match?(VERSION_REGEX) }.
+                map { |req_string| req_string.match(VERSION_REGEX) }.
+                select { |version| Gem::Version.correct?(version) }.
+                max_by { |version| Gem::Version.new(version) }
+
+              ">= #{version_for_requirement || 0}"
+            end
+          end
+
+          def pyproject
+            dependency_files.find { |f| f.name == "pyproject.toml" }
+          end
+
+          def pyproject_lock
+            dependency_files.find { |f| f.name == "pyproject.lock" }
+          end
+
+          def run_poetry_command(command)
+            raw_response = nil
+            IO.popen(command, err: %i(child out)) do |process|
+              raw_response = process.read
+            end
+
+            # Raise an error with the output from the shell session if Pipenv
+            # returns a non-zero status
+            return if $CHILD_STATUS.success?
+            raise SharedHelpers::HelperSubprocessFailed.new(
+              raw_response,
+              command
+            )
+          end
+
+          # See https://www.python.org/dev/peps/pep-0503/#normalized-names
+          def normalise(name)
+            name.downcase.tr("_", "-").tr(".", "-")
+          end
+
+          def config_variable_sources
+            @config_variable_sources ||=
+              credentials.
+              select { |cred| cred["type"] == "python_index" }.
+              map { |h| { "url" => h["index-url"].gsub(%r{/*$}, "") + "/" } }
+          end
+
+          def pyproject_sources
+            sources =
+              TomlRB.parse(pyproject.content).dig("tool", "poetry", "source") ||
+              []
+
+            @pyproject_sources ||=
+              sources.
+              map { |h| h.dup.merge("url" => h["url"].gsub(%r{/*$}, "") + "/") }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dependabot/update_checkers/python/pip/poetry_version_resolver.rb
+++ b/lib/dependabot/update_checkers/python/pip/poetry_version_resolver.rb
@@ -53,7 +53,7 @@ module Dependabot
 
                 # Shell out to Poetry, which handles everything for us.
                 # Calling `lock` avoids doing an install.
-                run_poetry_command("poetry lock")
+                run_poetry_command("pyenv exec poetry lock")
 
                 updated_lockfile = TomlRB.parse(File.read("pyproject.lock"))
 

--- a/spec/dependabot/file_fetchers/python/pip_spec.rb
+++ b/spec/dependabot/file_fetchers/python/pip_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe Dependabot::FileFetchers::Python::Pip do
       it { is_expected.to eq(false) }
     end
 
+    context "with a pyproject.toml" do
+      let(:filenames) { %w(pyproject.toml) }
+      it { is_expected.to eq(true) }
+    end
+
     context "with no requirements" do
       let(:filenames) { %w(requirements-dev.md) }
       it { is_expected.to eq(false) }
@@ -182,6 +187,27 @@ RSpec.describe Dependabot::FileFetchers::Python::Pip do
         expect(file_fetcher_instance.files.count).to eq(2)
         expect(file_fetcher_instance.files.map(&:name)).
           to match_array(%w(Pipfile Pipfile.lock))
+      end
+    end
+
+    context "with only a pyproject.toml" do
+      let(:repo_contents) do
+        fixture("github", "contents_python_only_pyproject.json")
+      end
+      before do
+        stub_request(:get, url + "pyproject.toml?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "setup_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+      end
+
+      it "fetches the pyproject.toml" do
+        expect(file_fetcher_instance.files.count).to eq(1)
+        expect(file_fetcher_instance.files.map(&:name)).
+          to match_array(%w(pyproject.toml))
       end
     end
 

--- a/spec/dependabot/file_parsers/python/pip/poetry_files_parser_spec.rb
+++ b/spec/dependabot/file_parsers/python/pip/poetry_files_parser_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency_file"
+require "dependabot/file_parsers/python/pip/poetry_files_parser"
+
+RSpec.describe Dependabot::FileParsers::Python::Pip::PoetryFilesParser do
+  let(:parser) { described_class.new(dependency_files: files) }
+
+  let(:files) { [pyproject] }
+  let(:pyproject) do
+    Dependabot::DependencyFile.new(
+      name: "pyproject.toml",
+      content: pyproject_body
+    )
+  end
+  let(:pyproject_body) do
+    fixture("python", "pyproject_files", pyproject_fixture_name)
+  end
+  let(:pyproject_fixture_name) { "pyproject.toml" }
+
+  describe "parse" do
+    subject(:dependencies) { parser.dependency_set.dependencies }
+
+    context "without a lockfile" do
+      its(:length) { is_expected.to eq(15) }
+
+      it "doesn't include the Python requirement" do
+        expect(dependencies.map(&:name)).to_not include("python")
+      end
+
+      context "with a string declaration" do
+        subject(:dependency) { dependencies.first }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("geopy")
+          expect(dependency.version).to be_nil
+          expect(dependency.requirements).to eq(
+            [{
+              requirement: "^1.13",
+              file: "pyproject.toml",
+              groups: ["dependencies"],
+              source: nil
+            }]
+          )
+        end
+      end
+    end
+
+    context "with a lockfile" do
+      let(:files) { [pyproject, pyproject_lock] }
+      let(:pyproject_lock) do
+        Dependabot::DependencyFile.new(
+          name: "pyproject.lock",
+          content: pyproject_lock_body
+        )
+      end
+      let(:pyproject_lock_body) do
+        fixture("python", "pyproject_locks", pyproject_lock_fixture_name)
+      end
+      let(:pyproject_lock_fixture_name) { "pyproject.lock" }
+
+      its(:length) { is_expected.to eq(36) }
+
+      it "doesn't include the Python requirement" do
+        expect(dependencies.map(&:name)).to_not include("python")
+      end
+
+      context "with a manifest declaration" do
+        subject(:dependency) { dependencies.find { |f| f.name == "geopy" } }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("geopy")
+          expect(dependency.version).to eq("1.14.0")
+          expect(dependency.requirements).to eq(
+            [{
+              requirement: "^1.13",
+              file: "pyproject.toml",
+              groups: ["dependencies"],
+              source: nil
+            }]
+          )
+        end
+
+        context "that has a name that needs normalising" do
+          subject(:dependency) { dependencies.find { |f| f.name == "pillow" } }
+
+          it "has the right details" do
+            expect(dependency).to be_a(Dependabot::Dependency)
+            expect(dependency.name).to eq("pillow")
+            expect(dependency.version).to eq("5.1.0")
+            expect(dependency.requirements).to eq(
+              [{
+                requirement: "^5.1",
+                file: "pyproject.toml",
+                groups: ["dependencies"],
+                source: nil
+              }]
+            )
+          end
+        end
+      end
+
+      context "without a manifest declaration" do
+        subject(:dependency) { dependencies.find { |f| f.name == "appdirs" } }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("appdirs")
+          expect(dependency.version).to eq("1.4.3")
+          expect(dependency.requirements).to eq([])
+        end
+      end
+    end
+  end
+end

--- a/spec/dependabot/file_parsers/python/pip_spec.rb
+++ b/spec/dependabot/file_parsers/python/pip_spec.rb
@@ -1087,5 +1087,46 @@ RSpec.describe Dependabot::FileParsers::Python::Pip do
         end
       end
     end
+
+    context "with a pyproject.toml and pyproject.lock" do
+      let(:files) { [pyproject, pyproject_lock] }
+      let(:pyproject) do
+        Dependabot::DependencyFile.new(
+          name: "pyproject.toml",
+          content: fixture("python", "pyproject_files", "pyproject.toml")
+        )
+      end
+      let(:pyproject_lock) do
+        Dependabot::DependencyFile.new(
+          name: "pyproject.lock",
+          content: fixture("python", "pyproject_locks", "pyproject.lock")
+        )
+      end
+
+      its(:length) { is_expected.to eq(36) }
+
+      describe "top level dependencies" do
+        subject(:dependencies) { parser.parse.select(&:top_level?) }
+        its(:length) { is_expected.to eq(15) }
+
+        describe "the first dependency" do
+          subject(:dependency) { dependencies.first }
+
+          it "has the right details" do
+            expect(dependency).to be_a(Dependabot::Dependency)
+            expect(dependency.name).to eq("geopy")
+            expect(dependency.version).to eq("1.14.0")
+            expect(dependency.requirements).to eq(
+              [{
+                requirement: "^1.13",
+                file: "pyproject.toml",
+                groups: ["dependencies"],
+                source: nil
+              }]
+            )
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/dependabot/file_updaters/python/pip/poetry_file_updater_spec.rb
+++ b/spec/dependabot/file_updaters/python/pip/poetry_file_updater_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "toml-rb"
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/file_updaters/python/pip/poetry_file_updater"
+require "dependabot/shared_helpers"
+
+RSpec.describe Dependabot::FileUpdaters::Python::Pip::PoetryFileUpdater do
+  let(:updater) do
+    described_class.new(
+      dependency_files: dependency_files,
+      dependencies: [dependency],
+      credentials: credentials
+    )
+  end
+  let(:dependency_files) { [pyproject, lockfile] }
+  let(:pyproject) do
+    Dependabot::DependencyFile.new(
+      name: "pyproject.toml",
+      content: fixture("python", "pyproject_files", pyproject_fixture_name)
+    )
+  end
+  let(:lockfile) do
+    Dependabot::DependencyFile.new(
+      name: "pyproject.lock",
+      content: fixture("python", "pyproject_locks", lockfile_fixture_name)
+    )
+  end
+  let(:pyproject_fixture_name) { "version_not_specified.toml" }
+  let(:lockfile_fixture_name) { "version_not_specified.lock" }
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: dependency_name,
+      version: "2.19.1",
+      previous_version: "2.18.0",
+      package_manager: "pip",
+      requirements: [{
+        requirement: "*",
+        file: "pyproject.toml",
+        source: nil,
+        groups: ["dependencies"]
+      }],
+      previous_requirements: [{
+        requirement: "*",
+        file: "pyproject.toml",
+        source: nil,
+        groups: ["dependencies"]
+      }]
+    )
+  end
+  let(:dependency_name) { "requests" }
+  let(:credentials) do
+    [{
+      "type" => "git_source",
+      "host" => "github.com",
+      "username" => "x-access-token",
+      "password" => "token"
+    }]
+  end
+
+  describe "#updated_dependency_files" do
+    subject(:updated_files) { updater.updated_dependency_files }
+
+    it "updates the lockfile successfully (and doesn't affect other deps)" do
+      expect(updated_files.map(&:name)).to eq(%w(pyproject.lock))
+
+      updated_lockfile = updated_files.find { |f| f.name == "pyproject.lock" }
+
+      lockfile_obj = TomlRB.parse(updated_lockfile.content)
+      requests = lockfile_obj["package"].find { |d| d["name"] == "requests" }
+      pytest = lockfile_obj["package"].find { |d| d["name"] == "pytest" }
+
+      expect(requests["version"]).to eq("2.19.1")
+      expect(pytest["version"]).to eq("3.5.0")
+
+      # TODO!
+      # expect(lockfile_obj["metadata"]["content-hash"]).
+      #   to start_with("82505f37a0da79b1e0f8d5c715d5435ef9318adf4df0e7372bde")
+    end
+  end
+end

--- a/spec/dependabot/file_updaters/python/pip/poetry_file_updater_spec.rb
+++ b/spec/dependabot/file_updaters/python/pip/poetry_file_updater_spec.rb
@@ -76,9 +76,8 @@ RSpec.describe Dependabot::FileUpdaters::Python::Pip::PoetryFileUpdater do
       expect(requests["version"]).to eq("2.19.1")
       expect(pytest["version"]).to eq("3.5.0")
 
-      # TODO!
-      # expect(lockfile_obj["metadata"]["content-hash"]).
-      #   to start_with("82505f37a0da79b1e0f8d5c715d5435ef9318adf4df0e7372bde")
+      expect(lockfile_obj["metadata"]["content-hash"]).
+        to start_with("82505f37a0da79b1e0f8d5c715d5435ef9318adf4df0e7372bde")
     end
   end
 end

--- a/spec/dependabot/file_updaters/python/pip/pyproject_preparer_spec.rb
+++ b/spec/dependabot/file_updaters/python/pip/pyproject_preparer_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/file_updaters/python/pip/pyproject_preparer"
+
+RSpec.describe Dependabot::FileUpdaters::Python::Pip::PyprojectPreparer do
+  let(:preparer) { described_class.new(pyproject_content: pyproject_content) }
+  let(:pyproject_content) do
+    fixture("python", "pyproject_files", "pyproject.toml")
+  end
+
+  describe "#replace_sources" do
+    subject(:replace_sources) { preparer.replace_sources(credentials) }
+
+    context "with no credentials" do
+      let(:credentials) { [] }
+      it { is_expected.to_not include("tool.poetry.source") }
+    end
+
+    context "with a python_index credential" do
+      let(:credentials) do
+        [{
+          "type" => "python_index",
+          "index-url" => "https://username:password@pypi.posrip.com/pypi/"
+        }]
+      end
+
+      it { is_expected.to include("tool.poetry.source") }
+      it { is_expected.to include('url = "https://username:password@pypi') }
+    end
+  end
+
+  describe "#freeze_top_level_dependencies_except" do
+    subject(:freeze_top_level_dependencies_except) do
+      preparer.freeze_top_level_dependencies_except(dependencies, lockfile)
+    end
+
+    let(:lockfile) do
+      Dependabot::DependencyFile.new(
+        name: "pyproject.lock",
+        content: pyproject_lock_body
+      )
+    end
+    let(:pyproject_lock_body) do
+      fixture("python", "pyproject_locks", pyproject_lock_fixture_name)
+    end
+    let(:pyproject_lock_fixture_name) { "pyproject.lock" }
+
+    context "with no dependencies to except" do
+      let(:dependencies) { [] }
+      it { is_expected.to include("geopy = \"1.14.0\"\n") }
+      it { is_expected.to include("hypothesis = \"3.57.0\"\n") }
+      it { is_expected.to include("python = \"^3.6\"\n") }
+    end
+
+    context "with a dependency to except" do
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "geopy",
+            version: "1.14.0",
+            package_manager: "pip",
+            requirements: []
+          )
+        ]
+      end
+
+      it { is_expected.to include("geopy = \"^1.13\"\n") }
+    end
+  end
+end

--- a/spec/dependabot/file_updaters/python/pip_spec.rb
+++ b/spec/dependabot/file_updaters/python/pip_spec.rb
@@ -103,6 +103,52 @@ RSpec.describe Dependabot::FileUpdaters::Python::Pip do
       end
     end
 
+    context "with a pyproject.toml and pyproject.lock" do
+      let(:dependency_files) { [pyproject, lockfile] }
+      let(:pyproject) do
+        Dependabot::DependencyFile.new(
+          name: "pyproject.toml",
+          content:
+            fixture("python", "pyproject_files", "version_not_specified.toml")
+        )
+      end
+      let(:lockfile) do
+        Dependabot::DependencyFile.new(
+          name: "pyproject.lock",
+          content:
+            fixture("python", "pyproject_locks", "version_not_specified.lock")
+        )
+      end
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "requests",
+          version: "2.18.4",
+          previous_version: "2.18.0",
+          package_manager: "pip",
+          requirements: [{
+            requirement: "*",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["default"]
+          }],
+          previous_requirements: [{
+            requirement: "*",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["default"]
+          }]
+        )
+      end
+
+      it "delegates to PoetryFileUpdater" do
+        expect(described_class::PoetryFileUpdater).
+          to receive(:new).and_call_original
+        expect { updated_files }.to_not(change { Dir.entries(tmp_path) })
+        updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+      end
+    end
+
     context "with a pip-compile file" do
       let(:dependency_files) { [manifest_file, generated_file] }
       let(:manifest_file) do

--- a/spec/dependabot/update_checkers/python/pip/poetry_version_resolver_spec.rb
+++ b/spec/dependabot/update_checkers/python/pip/poetry_version_resolver_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/update_checkers/python/pip/poetry_version_resolver"
+
+namespace = Dependabot::UpdateCheckers::Python::Pip
+RSpec.describe namespace::PoetryVersionResolver do
+  let(:resolver) do
+    described_class.new(
+      dependency: dependency,
+      dependency_files: dependency_files,
+      credentials: credentials,
+      unlock_requirement: unlock_requirement,
+      latest_allowable_version: latest_version
+    )
+  end
+  let(:credentials) do
+    [{
+      "type" => "git_source",
+      "host" => "github.com",
+      "username" => "x-access-token",
+      "password" => "token"
+    }]
+  end
+  let(:unlock_requirement) { true }
+  let(:dependency_files) { [pyproject, pyproject_lock] }
+  let(:latest_version) { Gem::Version.new("2.18.4") }
+  let(:pyproject) do
+    Dependabot::DependencyFile.new(
+      name: "pyproject.toml",
+      content: fixture("python", "pyproject_files", pyproject_fixture_name)
+    )
+  end
+  let(:pyproject_fixture_name) { "exact_version.toml" }
+  let(:pyproject_lock) do
+    Dependabot::DependencyFile.new(
+      name: "pyproject.toml",
+      content: fixture("python", "lockfiles", lockfile_fixture_name)
+    )
+  end
+  let(:lockfile_fixture_name) { "exact_version.lock" }
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: dependency_name,
+      version: dependency_version,
+      requirements: dependency_requirements,
+      package_manager: "pip"
+    )
+  end
+  let(:dependency_name) { "requests" }
+  let(:dependency_version) { "2.18.0" }
+  let(:dependency_requirements) do
+    [{
+      file: "pyproject.toml",
+      requirement: "2.18.0",
+      groups: ["dependencies"],
+      source: nil
+    }]
+  end
+
+  describe "#latest_resolvable_version" do
+    subject { resolver.latest_resolvable_version }
+
+    context "with a lockfile" do
+      let(:dependency_files) { [pyproject, pyproject_lock] }
+      let(:dependency_version) { "2.18.0" }
+      it { is_expected.to eq(Gem::Version.new("2.18.4")) }
+
+      context "when not unlocking the requirement" do
+        let(:unlock_requirement) { false }
+        it { is_expected.to eq(Gem::Version.new("2.18.0")) }
+      end
+    end
+
+    context "without a lockfile (but with a latest version)" do
+      let(:dependency_files) { [pyproject] }
+      let(:dependency_version) { nil }
+      it { is_expected.to eq(Gem::Version.new("2.18.4")) }
+    end
+
+    context "when the latest version isn't allowed" do
+      let(:latest_version) { Gem::Version.new("2.18.3") }
+      it { is_expected.to eq(Gem::Version.new("2.18.3")) }
+    end
+
+    context "when the latest version is nil" do
+      let(:latest_version) { nil }
+      it { is_expected.to be >= Gem::Version.new("2.19.0") }
+    end
+
+    context "with a subdependency" do
+      let(:dependency_name) { "idna" }
+      let(:dependency_version) { "2.5" }
+      let(:dependency_requirements) { [] }
+      let(:latest_version) { Gem::Version.new("2.7") }
+
+      # Resolution blocked by requests
+      it { is_expected.to eq(Gem::Version.new("2.5")) }
+    end
+
+    context "with a conflict at the latest version" do
+      let(:pyproject_fixture_name) { "conflict_at_latest.toml" }
+      let(:lockfile_fixture_name) { "conflict_at_latest.lock" }
+      let(:dependency_version) { "2.6.0" }
+      let(:dependency_requirements) do
+        [{
+          file: "pyproject.toml",
+          requirement: "2.6.0",
+          groups: ["dependencies"],
+          source: nil
+        }]
+      end
+
+      # Conflict with chardet is introduced in v2.16.0
+      it { is_expected.to eq(Gem::Version.new("2.15.1")) }
+    end
+  end
+end

--- a/spec/dependabot/update_checkers/python/pip_spec.rb
+++ b/spec/dependabot/update_checkers/python/pip_spec.rb
@@ -39,6 +39,13 @@ RSpec.describe Dependabot::UpdateCheckers::Python::Pip do
     )
   end
   let(:pipfile_fixture_name) { "exact_version" }
+  let(:pyproject) do
+    Dependabot::DependencyFile.new(
+      name: "pyproject.toml",
+      content: fixture("python", "pyproject_files", pyproject_fixture_name)
+    )
+  end
+  let(:pyproject_fixture_name) { "exact_version.toml" }
   let(:requirements_file) do
     Dependabot::DependencyFile.new(
       name: "requirements.txt",
@@ -357,6 +364,30 @@ RSpec.describe Dependabot::UpdateCheckers::Python::Pip do
         dummy_resolver =
           instance_double(described_class::PipfileVersionResolver)
         allow(described_class::PipfileVersionResolver).to receive(:new).
+          and_return(dummy_resolver)
+        expect(dummy_resolver).
+          to receive(:latest_resolvable_version).
+          and_return(Gem::Version.new("2.5.0"))
+        expect(checker.latest_resolvable_version).
+          to eq(Gem::Version.new("2.5.0"))
+      end
+    end
+
+    context "with a pyproject.toml" do
+      let(:dependency_files) { [pyproject] }
+      let(:dependency_requirements) do
+        [{
+          file: "pyproject.toml",
+          requirement: "2.18.0",
+          groups: [],
+          source: nil
+        }]
+      end
+
+      it "delegates to PoetryVersionResolver" do
+        dummy_resolver =
+          instance_double(described_class::PoetryVersionResolver)
+        allow(described_class::PoetryVersionResolver).to receive(:new).
           and_return(dummy_resolver)
         expect(dummy_resolver).
           to receive(:latest_resolvable_version).

--- a/spec/fixtures/github/contents_python_only_pyproject.json
+++ b/spec/fixtures/github/contents_python_only_pyproject.json
@@ -1,0 +1,242 @@
+[
+  {
+    "name": ".coveragerc",
+    "path": ".coveragerc",
+    "sha": "73ec6b729bfbb906d63ce7f63af65e5e50e0c97f",
+    "size": 176,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/.coveragerc?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/.coveragerc",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/73ec6b729bfbb906d63ce7f63af65e5e50e0c97f",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/.coveragerc",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/.coveragerc?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/73ec6b729bfbb906d63ce7f63af65e5e50e0c97f",
+      "html": "https://github.com/sdispater/pendulum/blob/master/.coveragerc"
+    }
+  },
+  {
+    "name": ".gitignore",
+    "path": ".gitignore",
+    "sha": "f1152e6f31ab32173b895e1dfe19ae4fa68ac4ef",
+    "size": 335,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/.gitignore?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/.gitignore",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/f1152e6f31ab32173b895e1dfe19ae4fa68ac4ef",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/.gitignore",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/.gitignore?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/f1152e6f31ab32173b895e1dfe19ae4fa68ac4ef",
+      "html": "https://github.com/sdispater/pendulum/blob/master/.gitignore"
+    }
+  },
+  {
+    "name": ".travis.yml",
+    "path": ".travis.yml",
+    "sha": "6078c0f77b8e920b479ec0bde20a161895d760a1",
+    "size": 1831,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/.travis.yml?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/.travis.yml",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/6078c0f77b8e920b479ec0bde20a161895d760a1",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/.travis.yml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/.travis.yml?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/6078c0f77b8e920b479ec0bde20a161895d760a1",
+      "html": "https://github.com/sdispater/pendulum/blob/master/.travis.yml"
+    }
+  },
+  {
+    "name": "CHANGELOG.md",
+    "path": "CHANGELOG.md",
+    "sha": "c4bccb2d630f660a2d3d904e3c69a10622b2bbdf",
+    "size": 2721,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/CHANGELOG.md?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/CHANGELOG.md",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/c4bccb2d630f660a2d3d904e3c69a10622b2bbdf",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/CHANGELOG.md",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/CHANGELOG.md?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/c4bccb2d630f660a2d3d904e3c69a10622b2bbdf",
+      "html": "https://github.com/sdispater/pendulum/blob/master/CHANGELOG.md"
+    }
+  },
+  {
+    "name": "LICENSE",
+    "path": "LICENSE",
+    "sha": "701df228d97e9bf3f2b10c5634107daff2f7bd3d",
+    "size": 1062,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/LICENSE?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/LICENSE",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/701df228d97e9bf3f2b10c5634107daff2f7bd3d",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/LICENSE",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/LICENSE?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/701df228d97e9bf3f2b10c5634107daff2f7bd3d",
+      "html": "https://github.com/sdispater/pendulum/blob/master/LICENSE"
+    }
+  },
+  {
+    "name": "Makefile",
+    "path": "Makefile",
+    "sha": "a3a3ef448f0e9dbe0ed0849d19d74cbc2e93607f",
+    "size": 1568,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/Makefile?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/Makefile",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/a3a3ef448f0e9dbe0ed0849d19d74cbc2e93607f",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/Makefile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/Makefile?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/a3a3ef448f0e9dbe0ed0849d19d74cbc2e93607f",
+      "html": "https://github.com/sdispater/pendulum/blob/master/Makefile"
+    }
+  },
+  {
+    "name": "README.rst",
+    "path": "README.rst",
+    "sha": "70f59df8e74705a3392b6b87804e882a50c6dda6",
+    "size": 7409,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/README.rst?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/README.rst",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/70f59df8e74705a3392b6b87804e882a50c6dda6",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/README.rst",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/README.rst?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/70f59df8e74705a3392b6b87804e882a50c6dda6",
+      "html": "https://github.com/sdispater/pendulum/blob/master/README.rst"
+    }
+  },
+  {
+    "name": "appveyor.yml",
+    "path": "appveyor.yml",
+    "sha": "55cba3cc7d675f63a233f03cbe03b9265f9c7af7",
+    "size": 856,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/appveyor.yml?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/appveyor.yml",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/55cba3cc7d675f63a233f03cbe03b9265f9c7af7",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/appveyor.yml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/appveyor.yml?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/55cba3cc7d675f63a233f03cbe03b9265f9c7af7",
+      "html": "https://github.com/sdispater/pendulum/blob/master/appveyor.yml"
+    }
+  },
+  {
+    "name": "build-wheels.sh",
+    "path": "build-wheels.sh",
+    "sha": "83a4d1e7b3a75152e42685750c44d631fe7ffbb6",
+    "size": 1415,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/build-wheels.sh?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/build-wheels.sh",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/83a4d1e7b3a75152e42685750c44d631fe7ffbb6",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/build-wheels.sh",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/build-wheels.sh?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/83a4d1e7b3a75152e42685750c44d631fe7ffbb6",
+      "html": "https://github.com/sdispater/pendulum/blob/master/build-wheels.sh"
+    }
+  },
+  {
+    "name": "build.py",
+    "path": "build.py",
+    "sha": "097d14faa10f114e281e65d3d2d3da45ad4dc516",
+    "size": 2116,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/build.py?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/build.py",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/097d14faa10f114e281e65d3d2d3da45ad4dc516",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/build.py",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/build.py?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/097d14faa10f114e281e65d3d2d3da45ad4dc516",
+      "html": "https://github.com/sdispater/pendulum/blob/master/build.py"
+    }
+  },
+  {
+    "name": "clock",
+    "path": "clock",
+    "sha": "c4c0f180b92bdbab1c27e3a210de5219e8d5b007",
+    "size": 7917,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/clock?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/clock",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/c4c0f180b92bdbab1c27e3a210de5219e8d5b007",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/clock",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/clock?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/c4c0f180b92bdbab1c27e3a210de5219e8d5b007",
+      "html": "https://github.com/sdispater/pendulum/blob/master/clock"
+    }
+  },
+  {
+    "name": "codecov.yml",
+    "path": "codecov.yml",
+    "sha": "3cbba2876f8581b69de8fa55746e3700bd415f6d",
+    "size": 85,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/codecov.yml?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/codecov.yml",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/3cbba2876f8581b69de8fa55746e3700bd415f6d",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/codecov.yml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/codecov.yml?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/3cbba2876f8581b69de8fa55746e3700bd415f6d",
+      "html": "https://github.com/sdispater/pendulum/blob/master/codecov.yml"
+    }
+  },
+  {
+    "name": "pyproject.toml",
+    "path": "pyproject.toml",
+    "sha": "e003114331b9777c5ff4bf3915ae98f08a972a41",
+    "size": 709,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/pyproject.toml?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/pyproject.toml",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/e003114331b9777c5ff4bf3915ae98f08a972a41",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/pyproject.toml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/pyproject.toml?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/e003114331b9777c5ff4bf3915ae98f08a972a41",
+      "html": "https://github.com/sdispater/pendulum/blob/master/pyproject.toml"
+    }
+  },
+  {
+    "name": "tests",
+    "path": "tests",
+    "sha": "f09909434d110482e86b36bdb68182b3dc951095",
+    "size": 0,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/tests?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/tree/master/tests",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/trees/f09909434d110482e86b36bdb68182b3dc951095",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/tests?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/trees/f09909434d110482e86b36bdb68182b3dc951095",
+      "html": "https://github.com/sdispater/pendulum/tree/master/tests"
+    }
+  },
+  {
+    "name": "tox.ini",
+    "path": "tox.ini",
+    "sha": "072640ccb4e1a591c32af70dbb3245e29ca482ac",
+    "size": 325,
+    "url": "https://api.github.com/repos/sdispater/pendulum/contents/tox.ini?ref=master",
+    "html_url": "https://github.com/sdispater/pendulum/blob/master/tox.ini",
+    "git_url": "https://api.github.com/repos/sdispater/pendulum/git/blobs/072640ccb4e1a591c32af70dbb3245e29ca482ac",
+    "download_url": "https://raw.githubusercontent.com/sdispater/pendulum/master/tox.ini",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/sdispater/pendulum/contents/tox.ini?ref=master",
+      "git": "https://api.github.com/repos/sdispater/pendulum/git/blobs/072640ccb4e1a591c32af70dbb3245e29ca482ac",
+      "html": "https://github.com/sdispater/pendulum/blob/master/tox.ini"
+    }
+  }
+]

--- a/spec/fixtures/python/pyproject_files/conflict_at_latest.toml
+++ b/spec/fixtures/python/pyproject_files/conflict_at_latest.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "Python Projects"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+description = "Various small python projects."
+
+[tool.poetry.dependencies]
+python = "^3.6"
+requests = "2.6.0"
+chardet = "3.0.0"
+
+[tool.poetry.dev-dependencies]
+pytest = "3.4.0"

--- a/spec/fixtures/python/pyproject_files/exact_version.toml
+++ b/spec/fixtures/python/pyproject_files/exact_version.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "Python Projects"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+description = "Various small python projects."
+
+[tool.poetry.dependencies]
+python = "^3.6"
+requests = "2.18.0"

--- a/spec/fixtures/python/pyproject_files/pyproject.toml
+++ b/spec/fixtures/python/pyproject_files/pyproject.toml
@@ -1,0 +1,28 @@
+[tool.poetry]
+name = "Python Projects"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+description = "Various small python projects."
+
+[tool.poetry.dependencies]
+python = "^3.6"
+geopy = "^1.13"
+Pillow = "^5.1"
+requests = "^2.18"
+
+[tool.poetry.dev-dependencies]
+black = "^18.5"
+flake8 = "^3.5"
+flake8-comprehensions = "^1.4"
+httmock = "^1.2"
+hypothesis = "^3.56"
+mypy = "^0.600"
+pytest = "^3.5"
+pytest-cov = "^2.5"
+pytest-mock = "^1.9"
+pytest-sugar = "^0.9"
+pytest-random-order = "^0.7"
+tox = "^3.0"

--- a/spec/fixtures/python/pyproject_files/version_not_specified.toml
+++ b/spec/fixtures/python/pyproject_files/version_not_specified.toml
@@ -1,0 +1,13 @@
+[tool.poetry]
+name = "Python Projects"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+description = "Various small python projects."
+
+[tool.poetry.dependencies]
+python = "^3.6"
+requests = "*"
+pytest = "*"

--- a/spec/fixtures/python/pyproject_locks/conflict_at_latest.lock
+++ b/spec/fixtures/python/pyproject_locks/conflict_at_latest.lock
@@ -1,0 +1,100 @@
+[[package]]
+category = "dev"
+description = "Classes Without Boilerplate"
+name = "attrs"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "18.1.0"
+
+[[package]]
+category = "main"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "3.0.0"
+
+[[package]]
+category = "dev"
+description = "Cross-platform colored terminal text."
+name = "colorama"
+optional = false
+platform = "UNKNOWN"
+python-versions = "*"
+version = "0.3.9"
+
+[package.requirements]
+platform = "win32"
+
+[[package]]
+category = "dev"
+description = "plugin and hook calling mechanisms for python"
+name = "pluggy"
+optional = false
+platform = "unix"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.6.0"
+
+[[package]]
+category = "dev"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+name = "py"
+optional = false
+platform = "unix"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.5.4"
+
+[[package]]
+category = "dev"
+description = "pytest: simple powerful testing with Python"
+name = "pytest"
+optional = false
+platform = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.4.0"
+
+[package.dependencies]
+attrs = ">=17.2.0"
+pluggy = ">=0.5,<0.7"
+py = ">=1.5.0"
+setuptools = "*"
+six = ">=1.10.0"
+
+[package.dependencies.colorama]
+platform = "win32"
+version = "*"
+
+[[package]]
+category = "main"
+description = "Python HTTP for Humans."
+name = "requests"
+optional = false
+platform = "UNKNOWN"
+python-versions = "*"
+version = "2.6.0"
+
+[[package]]
+category = "dev"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "1.11.0"
+
+[metadata]
+content-hash = "eae25082e355381411c3f71fde8ff26a0d09429d27f4ad6272faea571a2311b5"
+platform = "*"
+python-versions = "^3.6"
+
+[metadata.hashes]
+attrs = ["4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265", "e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"]
+chardet = ["171dfc754d56c16b82cf77ac3eee1d42db9bc2f26c2c61c6573426d2a108d9e3", "bedd581d3daea4180b3cb555940dcbc89916e7922b070d2a9a37e660791e90a2"]
+colorama = ["463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda", "48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"]
+pluggy = ["7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff", "d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c", "e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"]
+py = ["3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7", "e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"]
+pytest = ["6074ea3b9c999bd6d0df5fa9d12dd95ccd23550df2a582f5f5b848331d2e82ca", "95fa025cd6deb5d937e04e368a00552332b58cae23f63b76c8c540ff1733ab6d"]
+requests = ["1cdbed1f0e236f35ef54e919982c7a338e4fea3786310933d3a7887a04b74d75", "fdb9af60d47ca57a80df0a213336019a34ff6192d8fff361c349f2c8398fe460"]
+six = ["70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9", "832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"]

--- a/spec/fixtures/python/pyproject_locks/exact_version.lock
+++ b/spec/fixtures/python/pyproject_locks/exact_version.lock
@@ -1,0 +1,62 @@
+[[package]]
+category = "main"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "2018.4.16"
+
+[[package]]
+category = "main"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "3.0.4"
+
+[[package]]
+category = "main"
+description = "Internationalized Domain Names in Applications (IDNA)"
+name = "idna"
+optional = false
+platform = "UNKNOWN"
+python-versions = "*"
+version = "2.5"
+
+[[package]]
+category = "main"
+description = "Python HTTP for Humans."
+name = "requests"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "2.18.0"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<3.1.0"
+idna = ">=2.5,<2.6"
+urllib3 = ">=1.21.1,<1.22"
+
+[[package]]
+category = "main"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "1.21.1"
+
+[metadata]
+content-hash = "a8d5762e953227a34625a209e9cc67a1c6fb2d7a971845829cf2f9cf61a5bd7c"
+platform = "*"
+python-versions = "^3.6"
+
+[metadata.hashes]
+certifi = ["13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7", "9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"]
+chardet = ["84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae", "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"]
+idna = ["3cb5ce08046c4e3a560fc02f138d0ac63e00f8ce5901a56b32ec8b7994082aab", "cc19709fd6d0cbfed39ea875d29ba6d4e22c0cebc510a76d6302a28385e8bb70"]
+requests = ["5e88d64aa56ac0fda54e77fb9762ebc65879e171b746d5479a33c4082519d6c6", "cd0189f962787284bff715fddaad478eb4d9c15aa167bd64e52ea0f661e7ea5c"]
+urllib3 = ["8ed6d5c1ff9d6ba84677310060d6a3a78ca3072ce0684cb3c645023009c114b1", "b14486978518ca0901a76ba973d7821047409d7f726f22156b24e83fd71382a5"]

--- a/spec/fixtures/python/pyproject_locks/pyproject.lock
+++ b/spec/fixtures/python/pyproject_locks/pyproject.lock
@@ -1,0 +1,424 @@
+[[package]]
+name = "appdirs"
+version = "1.4.3"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[[package]]
+name = "atomicwrites"
+version = "1.1.5"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "UNKNOWN"
+
+[[package]]
+name = "attrs"
+version = "18.1.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[[package]]
+name = "black"
+version = "18.6b1"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+platform = "*"
+
+[package.dependencies]
+click = ">=6.5"
+attrs = ">=17.4.0"
+appdirs = "*"
+[[package]]
+name = "certifi"
+version = "2018.4.16"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[[package]]
+name = "chardet"
+version = "3.0.4"
+description = "Universal encoding detector for Python 2 and 3"
+category = "main"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[[package]]
+name = "click"
+version = "6.7"
+description = "A simple wrapper around optparse for powerful command line utilities."
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[[package]]
+name = "colorama"
+version = "0.3.9"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "UNKNOWN"
+
+[package.requirements]
+platform = "win32"
+[[package]]
+name = "coverage"
+version = "4.5.1"
+description = "Code coverage measurement for Python"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4"
+platform = "*"
+
+[[package]]
+name = "flake8"
+version = "3.5.0"
+description = "the modular source code checker: pep8, pyflakes and co"
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[package.dependencies]
+enum34 = "*"
+configparser = "*"
+pyflakes = ">=1.5.0,<1.7.0"
+pycodestyle = ">=2.0.0,<2.4.0"
+mccabe = ">=0.6.0,<0.7.0"
+[[package]]
+name = "flake8-comprehensions"
+version = "1.4.1"
+description = "A flake8 plugin to help you write better list/set/dict comprehensions."
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[package.dependencies]
+flake8 = "<3.2.0 || >3.2.0"
+[[package]]
+name = "geographiclib"
+version = "1.49"
+description = "The geodesic routines from GeographicLib"
+category = "main"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[[package]]
+name = "geopy"
+version = "1.14.0"
+description = "Python Geocoding Toolbox"
+category = "main"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[package.dependencies]
+geographiclib = ">=1.49,<2"
+[[package]]
+name = "httmock"
+version = "1.2.6"
+description = "A mocking library for requests."
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "UNKNOWN"
+
+[package.dependencies]
+requests = ">=1.0.0"
+[[package]]
+name = "hypothesis"
+version = "3.57.0"
+description = "A library for property based testing"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+platform = "*"
+
+[package.dependencies]
+attrs = ">=16.0.0"
+coverage = "*"
+enum34 = "*"
+[[package]]
+name = "idna"
+version = "2.6"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[[package]]
+name = "more-itertools"
+version = "4.2.0"
+description = "More routines for operating on iterables, beyond itertools"
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[package.dependencies]
+six = ">=1.0.0,<2.0.0"
+[[package]]
+name = "mypy"
+version = "0.600"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[package.dependencies]
+typing = ">=3.5.3"
+typed-ast = ">=1.1.0,<1.2.0"
+[[package]]
+name = "pillow"
+version = "5.1.0"
+description = "Python Imaging Library (Fork)"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+platform = "*"
+
+[[package]]
+name = "pluggy"
+version = "0.6.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+platform = "unix"
+
+[[package]]
+name = "py"
+version = "1.5.3"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+platform = "unix"
+
+[[package]]
+name = "pycodestyle"
+version = "2.3.1"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[[package]]
+name = "pyflakes"
+version = "1.6.0"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[[package]]
+name = "pytest"
+version = "3.6.1"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+platform = "unix"
+
+[package.dependencies]
+colorama = "*"
+funcsigs = "*"
+pluggy = ">=0.5,<0.7"
+atomicwrites = ">=1.0"
+more-itertools = ">=4.0.0"
+attrs = ">=17.4.0"
+setuptools = "*"
+six = ">=1.10.0"
+py = ">=1.5.0"
+[[package]]
+name = "pytest-cov"
+version = "2.5.1"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[package.dependencies]
+coverage = ">=3.7.1"
+pytest = ">=2.6.0"
+[[package]]
+name = "pytest-mock"
+version = "1.10.0"
+description = "Thin-wrapper around the mock package for easier use with py.test"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+platform = "any"
+
+[package.dependencies]
+mock = "*"
+pytest = ">=2.7"
+[[package]]
+name = "pytest-random-order"
+version = "0.7.0"
+description = "Randomise the order in which pytest tests are run with some control over the randomness"
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[package.dependencies]
+pytest = ">=2.9.2"
+[[package]]
+name = "pytest-sugar"
+version = "0.9.1"
+description = "py.test is a plugin for py.test that changes the default look and feel of py.test (e.g. progressbar, show tests that fail instantly)."
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "any"
+
+[package.dependencies]
+pytest = ">=2.9"
+termcolor = ">=1.1.0"
+[[package]]
+name = "requests"
+version = "2.18.4"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<3.1.0"
+idna = ">=2.5,<2.7"
+urllib3 = ">=1.21.1,<1.23"
+[[package]]
+name = "six"
+version = "1.11.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+description = "ANSII Color formatting for output in terminal."
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "UNKNOWN"
+
+[[package]]
+name = "tox"
+version = "3.0.0"
+description = "virtualenv-based automation of test activities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+platform = "unix"
+
+[package.dependencies]
+virtualenv = ">=1.11.2"
+six = "*"
+pluggy = ">=0.3.0,<1.0"
+py = ">=1.4.17"
+[[package]]
+name = "typed-ast"
+version = "1.1.0"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = "*"
+platform = "POSIX"
+
+[[package]]
+name = "urllib3"
+version = "1.22"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = "*"
+platform = "*"
+
+[[package]]
+name = "virtualenv"
+version = "16.0.0"
+description = "Virtual Python Environment builder"
+category = "dev"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*"
+platform = "*"
+
+[metadata]
+python-versions = "^3.6"
+platform = "*"
+content-hash = "ee304fb3aa8d4516585e9fa28f655f28afecea1cdaf9474b2b4fb25510aad40d"
+
+[metadata.hashes]
+appdirs = [ "d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e", "9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",]
+atomicwrites = [ "a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6", "240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",]
+attrs = [ "4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265", "e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b",]
+black = [ "80dbe2103e937de543942b7946fe71adc387506fe1922018e2b97555513a35fc", "0c07b68fc6fc4df8b09873e81893d7b77d52794fa3431d8843b590bc33956105",]
+certifi = [ "9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0", "13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",]
+chardet = [ "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691", "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",]
+click = [ "29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d", "f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b",]
+colorama = [ "463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda", "48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1",]
+coverage = [ "7608a3dd5d73cb06c531b8925e0ef8d3de31fed2544a7de6c63960a1e73ea4bc", "3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694", "f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80", "0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed", "337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249", "3eb42bf89a6be7deb64116dd1cc4b08171734d721e7a7e57ad64cc4ef29ed2f1", "be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9", "69bf008a06b76619d3c3f3b1983f5145c75a305a0fea513aca094cae5c40a8f5", "2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508", "9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f", "701cd6093d63e6b8ad7009d8a92425428bc4d6e7ab8d75efbb665c806c1d79ba", "5a13ea7911ff5e1796b6d5e4fbbf6952381a611209b736d48e675c2756f3f74e", "c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd", "03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba", "28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162", "de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d", "8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558", "7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c", "6bc583dc18d5979dc0f6cec26a8603129de0304d5ae1f17e57a12834e7235062", "198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640", "7aa36d2b844a3e4a4b356708d79fd2c260281a7390d678a10b91ca595ddc9e99", "3d72c20bd105022d29b14a7d628462ebdc61de2f303322c0212a054352f3b287", "4635a184d0bbe537aa185a34193898eee409332a8ccb27eea36f262566585000", "e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6", "76ecd006d1d8f739430ec50cc872889af1f9c1b6b8f48e29941814b09b0fd3cc", "7d3f553904b0c5c016d1dad058a7554c7ac4c91a789fca496e7d8347ad040653", "3c79a6f7b95751cdebcd9037e4d06f8d5a9b60e4ed0cd231342aa8ad7124882a", "56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1", "ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91", "1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2", "b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d", "104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a", "9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4", "15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd", "e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77", "f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e",]
+flake8 = [ "c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37", "7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0",]
+flake8-comprehensions = [ "e4ccf1627f75f192eb7fde640f5edb81c98d04b1390df9d4145ffd7710bb1ef2", "b83891fec0e680b07aa1fd92e53eb6993be29a0f3673a09badbe8da307c445e0",]
+geographiclib = [ "635da648fce80a57b81b28875d103dacf7deb12a3f5f7387ba7d39c51e096533",]
+geopy = [ "2947f914c89d665e86b19466cce3600f0d0574a54a17c7ba609058a0ef0b5f24", "9df0d61b431c51bcc47e64d16f9517dacfed10875f0dfc36cd8cb87c52fa9547",]
+httmock = [ "4696306d1ff835c3ca865fdef2684d7e130b4120cc00126f862ba4797b1602ac",]
+hypothesis = [ "ceb4d9b582184b041adc5647121fbafe3fcf49b7fbd218195d903c3fc6bc7916",]
+idna = [ "8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4", "2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",]
+mccabe = [ "ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42", "dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f",]
+more-itertools = [ "a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0", "6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3", "2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",]
+mypy = [ "01cf289838f266ae7c6550c813181ee77d21eac9459dbf067e7a95a0a2db9721", "bc251cb31bc236d9fe4bcc442c994c45fff2541f7161ee52dc949741fe9ca3dd",]
+pillow = [ "f0d4433adce6075efd24fc0285135248b0b50f5a58129c7e552030e04fe45c7f", "81762cf5fca9a82b53b7b2d0e6b420e0f3b06167b97678c81d00470daa622d58", "b48401752496757e95304a46213c3155bc911ac884bed2e9b275ce1c1df3e293", "040144ba422216aecf7577484865ade90e1a475f867301c48bf9fbd7579efd76", "b6cf18f9e653a8077522bb3aa753a776b117e3e0cc872c25811cfdf1459491c2", "4d32c8e3623a61d6e29ccd024066cd1ba556555abfb4cd714155020e00107e3f", "438a3faf5f702c8d0f80b9f9f9b8382cfa048ca6a0d64ef71b86b563b0ee0359", "1cb38df69362af35c14d4a50123b63c7ff18ec9a6d4d5da629a6f19d05e16ba8", "4d8077fd649ac40a5c4165f2c22fa2a4ad18c668e271ecb2f9d849d1017a9313", "bb8adab1877e9213385cbb1adc297ed8337e01872c42a30cfaa66ff8c422779c", "f1f3bd92f8e12dc22884935a73c9f94c4d9bd0d34410c456540713d6b7832b8c", "6eca36905444c4b91fe61f1b9933a47a30480738a1dd26501ff67d94fc2bc112", "f7634d534662bbb08976db801ba27a112aee23e597eeaf09267b4575341e45bf", "eeb247f4f4d962942b3b555530b0c63b77473c7bfe475e51c6b75b7344b49ce3", "ea0091cd4100519cedfeea2c659f52291f535ac6725e2368bcf59e874f270efa", "e87cc1acbebf263f308a8494272c2d42016aa33c32bf14d209c81e1f65e11868", "3b4560c3891b05022c464b09121bd507c477505a4e19d703e1027a3a7c68d896", "7673e7473a13107059377c96c563aa36f73184c29d2926882e0a0210b779a1e7", "fe6931db24716a0845bd8c8915bd096b77c2a7043e6fc59ae9ca364fe816f08b", "f5f302db65e2e0ae96e26670818157640d3ca83a3054c290eff3631598dcf819", "9b66e968da9c4393f5795285528bc862c7b97b91251f31a08004a3c626d18114", "62ec7ae98357fcd46002c110bb7cad15fce532776f0cbe7ca1d44c49b837d49d", "d0dc1313dff48af64517cbbd85e046d6b477fbe5e9d69712801f024dcb08c62b", "00633bc2ec40313f4daf351855e506d296ec3c553f21b66720d0f1225ca84c6f", "16246261ff22368e5e32ad74d5ef40403ab6895171a7fc6d34f6c17cfc0f1943", "e52e8f675ba0b2b417fa98579e7286a41a8e23871f17f4793772f5aa884fea79", "6c7cab6a05351cf61e469937c49dbf3cdf5ffb3eeac71f8d22dc9be3507598d8", "e39142332541ed2884c257495504858b22c078a5d781059b07aba4c3a80d7551", "8554bbeb4218d9cfb1917c69e6f2d2ad0be9b18a775d2162547edf992e1f5f1f", "2400e122f7b21d9801798207e424cbe1f716cee7314cd0c8963fdb6fc564b5fb", "a00edb2dec0035e98ac3ec768086f0b06dfabb4ad308592ede364ef573692f55", "fdd374c02e8bb2d6468a85be50ea66e1c4ef9e809974c30d8576728473a6ed03", "df5863a21f91de5ecdf7d32a32f406dd9867ebb35d41033b8bd9607a21887599", "472a124c640bde4d5468f6991c9fa7e30b723d84ac4195a77c6ab6aea30f2b9c", "cee9bc75bff455d317b6947081df0824a8f118de2786dc3d74a3503fd631f4ef", "2ee6364b270b56a49e8b8a51488e847ab130adc1220c171bed6818c0d4742455", "03514478db61b034fc5d38b9bf060f994e5916776e93f02e59732a8270069c61", "74e2ebfd19c16c28ad43b8a28ff73b904ed382ea4875188838541751986e8c9a", "e6dd55d5d94b9e36929325dd0c9ab85bfde84a5fc35947c334c32af1af668944", "f42a87cbf50e905f49f053c0b1fb86c911c730624022bf44c8857244fc4cdaca", "d5bf527ed83617edd1855a5c923eeeaf68bcb9ac0ceb28e3f19b575b3a424984", "41374a6afb3f44794410dab54a0d7175e6209a5a02d407119c81083f1a4c1841", "c8a4b39ba380b57a31a4b5449a9d257b1302d8bc4799767e645dcee25725efe1",]
+pluggy = [ "d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c", "e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5", "7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",]
+py = [ "983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a", "29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881",]
+pycodestyle = [ "6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9", "682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",]
+pyflakes = [ "08bd6a50edf8cffa9fa09a463063c425ecaaf10d1eb0335a7e8b1401aef89e6f", "8d616a382f243dbf19b54743f280b80198be0bca3a5396f1d2e1fca6223e8805",]
+pytest = [ "26838b2bc58620e01675485491504c3aa7ee0faf335c37fcd5f8731ca4319591", "32c49a69566aa7c333188149ad48b58ac11a426d5352ea3d8f6ce843f88199cb",]
+pytest-cov = [ "890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec", "03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d",]
+pytest-mock = [ "53801e621223d34724926a5c98bd90e8e417ce35264365d39d6c896388dcc928", "d89a8209d722b8307b5e351496830d5cc5e192336003a485443ae9adeb7dd4c0",]
+pytest-random-order = [ "44cd0e1ae035d91b927f61a4c23c7949d295e57958d168f2e950b1d322089def",]
+pytest-sugar = [ "ab8cc42faf121344a4e9b13f39a51257f26f410e416c52ea11078cdd00d98a2c",]
+requests = [ "6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b", "9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e",]
+six = [ "832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb", "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",]
+termcolor = [ "1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b",]
+tox = [ "9ee7de958a43806402a38c0d2aa07fa8553f4d2c20a15b140e9f771c2afeade0", "96efa09710a3daeeb845561ebbe1497641d9cef2ee0aea30db6969058b2bda2f",]
+typed-ast = [ "0948004fa228ae071054f5208840a1e88747a357ec1101c17217bfe99b299d58", "25d8feefe27eb0303b73545416b13d108c6067b846b543738a25ff304824ed9a", "c05b41bc1deade9f90ddc5d988fe506208019ebba9f2578c622516fd201f5863", "519425deca5c2b2bdac49f77b2c5625781abbaf9a809d727d3a5596b30bb4ded", "6de012d2b166fe7a4cdf505eee3aaa12192f7ba365beeefaca4ec10e31241a85", "79b91ebe5a28d349b6d0d323023350133e927b4de5b651a8aa2db69c761420c6", "a8034021801bc0440f2e027c354b4eafd95891b573e12ff0418dec385c76785c", "f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6", "c9b060bd1e5a26ab6e8267fd46fc9e02b54eb15fffb16d112d4c7b1c12987559", "2e214b72168ea0275efd6c884b114ab42e316de3ffa125b267e732ed2abda892", "bc978ac17468fe868ee589c795d06777f75496b1ed576d308002c8a5756fb9ea", "edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87", "668d0cec391d9aed1c6a388b0d5b97cd22e6073eaa5fbaa6d2946603b4871efe", "29464a177d56e4e055b5f7b629935af7f49c196be47528cc94e0a7bf83fbc2b9", "8550177fa5d4c1f09b5e5f524411c44633c80ec69b24e0e98906dd761941ca46", "3e0d5e48e3a23e9a4d1a9f698e32a542a4a288c871d33ed8df1b092a40f3a0f9", "68ba70684990f59497680ff90d18e756a47bf4863c604098f10de9716b2c0bdd", "57fe287f0cdd9ceaf69e7b71a2e94a24b5d268b35df251a88fef5cc241bf73aa",]
+urllib3 = [ "06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b", "cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f",]
+virtualenv = [ "2ce32cd126117ce2c539f0134eb89de91a8413a29baac49cbab3eb50e2026669", "ca07b4c0b54e14a91af9f34d0919790b016923d157afda5efdde55c96718f752",]

--- a/spec/fixtures/python/pyproject_locks/version_not_specified.lock
+++ b/spec/fixtures/python/pyproject_locks/version_not_specified.lock
@@ -1,0 +1,150 @@
+[[package]]
+category = "main"
+description = "Classes Without Boilerplate"
+name = "attrs"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "18.1.0"
+
+[[package]]
+category = "main"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "2018.4.16"
+
+[[package]]
+category = "main"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "3.0.4"
+
+[[package]]
+category = "main"
+description = "Cross-platform colored terminal text."
+name = "colorama"
+optional = false
+platform = "UNKNOWN"
+python-versions = "*"
+version = "0.3.9"
+
+[package.requirements]
+platform = "win32"
+
+[[package]]
+category = "main"
+description = "Internationalized Domain Names in Applications (IDNA)"
+name = "idna"
+optional = false
+platform = "UNKNOWN"
+python-versions = "*"
+version = "2.5"
+
+[[package]]
+category = "main"
+description = "More routines for operating on iterables, beyond itertools"
+name = "more-itertools"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "4.3.0"
+
+[package.dependencies]
+six = ">=1.0.0,<2.0.0"
+
+[[package]]
+category = "main"
+description = "plugin and hook calling mechanisms for python"
+name = "pluggy"
+optional = false
+platform = "unix"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.6.0"
+
+[[package]]
+category = "main"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+name = "py"
+optional = false
+platform = "unix"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.5.4"
+
+[[package]]
+category = "main"
+description = "pytest: simple powerful testing with Python"
+name = "pytest"
+optional = false
+platform = "unix"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.5.0"
+
+[package.dependencies]
+attrs = ">=17.4.0"
+more-itertools = ">=4.0.0"
+pluggy = ">=0.5,<0.7"
+py = ">=1.5.0"
+setuptools = "*"
+six = ">=1.10.0"
+
+[package.dependencies.colorama]
+platform = "win32"
+version = "*"
+
+[[package]]
+category = "main"
+description = "Python HTTP for Humans."
+name = "requests"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "2.18.0"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<3.1.0"
+idna = ">=2.5,<2.6"
+urllib3 = ">=1.21.1,<1.22"
+
+[[package]]
+category = "main"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "1.11.0"
+
+[[package]]
+category = "main"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "1.21.1"
+
+[metadata]
+content-hash = "82505f37a0da79b1e0f8d5c715d5435ef9318adf4df0e7372bded484f7cdb27a"
+platform = "*"
+python-versions = "^3.6"
+
+[metadata.hashes]
+attrs = ["4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265", "e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"]
+certifi = ["13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7", "9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"]
+chardet = ["84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae", "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"]
+colorama = ["463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda", "48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"]
+idna = ["3cb5ce08046c4e3a560fc02f138d0ac63e00f8ce5901a56b32ec8b7994082aab", "cc19709fd6d0cbfed39ea875d29ba6d4e22c0cebc510a76d6302a28385e8bb70"]
+more-itertools = ["c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092", "c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e", "fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"]
+pluggy = ["7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff", "d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c", "e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"]
+py = ["3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7", "e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"]
+pytest = ["6266f87ab64692112e5477eba395cfedda53b1933ccd29478e671e73b420c19c", "fae491d1874f199537fd5872b5e1f0e74a009b979df9d53d1553fd03da1703e1"]
+requests = ["5e88d64aa56ac0fda54e77fb9762ebc65879e171b746d5479a33c4082519d6c6", "cd0189f962787284bff715fddaad478eb4d9c15aa167bd64e52ea0f661e7ea5c"]
+six = ["70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9", "832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"]
+urllib3 = ["8ed6d5c1ff9d6ba84677310060d6a3a78ca3072ce0684cb3c645023009c114b1", "b14486978518ca0901a76ba973d7821047409d7f726f22156b24e83fd71382a5"]


### PR DESCRIPTION
Support for [Poetry](https://github.com/sdispater/poetry), a Python dependency management tool that has a build in resolver.

~~Note: currently the `content-hash` generated will be wrong. Needs some Python code to get it right (or some painstaking matching of Ruby and Python JSON generation).~~ Fixed!

Closes https://github.com/dependabot/feedback/issues/57.