### PR TITLE
.NET: Don't fetch ProjectReference paths

### DIFF
--- a/lib/dependabot/file_fetchers/dotnet/nuget.rb
+++ b/lib/dependabot/file_fetchers/dotnet/nuget.rb
@@ -133,9 +133,7 @@ module Dependabot
         end
 
         def fetch_imported_property_files(file:, previously_fetched_files:)
-          paths =
-            ImportPathsFinder.new(project_file: file).import_paths +
-            ImportPathsFinder.new(project_file: file).project_reference_paths
+          paths = ImportPathsFinder.new(project_file: file).import_paths
 
           paths.flat_map do |path|
             next if previously_fetched_files.map(&:name).include?(path)

--- a/lib/dependabot/file_fetchers/dotnet/nuget/import_paths_finder.rb
+++ b/lib/dependabot/file_fetchers/dotnet/nuget/import_paths_finder.rb
@@ -24,16 +24,6 @@ module Dependabot
             end
           end
 
-          def project_reference_paths
-            doc = Nokogiri::XML(project_file.content)
-            doc.remove_namespaces!
-            doc.xpath("/Project/ItemGroup/ProjectReference").map do |node|
-              path = node.attribute("Include").value.strip.tr("\\", "/")
-              path = File.join(current_dir, path) unless current_dir.nil?
-              Pathname.new(path).cleanpath.to_path
-            end
-          end
-
           private
 
           attr_reader :project_file

--- a/spec/dependabot/file_fetchers/dotnet/nuget/import_paths_finder_spec.rb
+++ b/spec/dependabot/file_fetchers/dotnet/nuget/import_paths_finder_spec.rb
@@ -31,19 +31,4 @@ RSpec.describe Dependabot::FileFetchers::Dotnet::Nuget::ImportPathsFinder do
       end
     end
   end
-
-  describe "#project_reference_paths" do
-    subject(:project_reference_paths) { finder.project_reference_paths }
-
-    context "when the file does not reference any other projects" do
-      let(:fixture_name) { "basic.csproj" }
-      it { is_expected.to eq([]) }
-    end
-
-    context "when the file does reference another project" do
-      let(:fixture_name) { "project_reference.csproj" }
-      let(:csproj_name) { "nested/my.csproj" }
-      it { is_expected.to eq(["ref/another.csproj"]) }
-    end
-  end
 end


### PR DESCRIPTION
Follow-up from the discussion on https://github.com/stryker-mutator/stryker-net/pull/82.

Idea here is that `ProjectReference` declarations shouldn't be pulled in automatically. If a user wants Dependabot to operate on all of the projects in a `.NET` repo then those would be expected to be explicitly referenced in the `.sln` file.

@simondel mentioned that when using Visual Studio to look at a `.csproj` you will only see packages related to that project, without any additional dependencies that are pulled in by projects pulled in with `ProjectReference`. Given that, I *think* this makes sense to me.

@deinok, @RohanNagar, @simondel - would love your thoughts, as you know the space much better.