### PR TITLE
Failing spec for Elixir UpdateChecker

### DIFF
--- a/spec/dependabot/update_checkers/elixir/hex/version_resolver_spec.rb
+++ b/spec/dependabot/update_checkers/elixir/hex/version_resolver_spec.rb
@@ -116,5 +116,28 @@ RSpec.describe Dependabot::UpdateCheckers::Elixir::Hex::VersionResolver do
         expect(resolver.latest_resolvable_version).to be_nil
       end
     end
+
+    context "without a lockfile" do
+      it "respects the resolvability of the mix.exs" do
+        expect(latest_resolvable_version).
+          to be > Gem::Version.new("1.3.5")
+        expect(latest_resolvable_version).
+          to be < Gem::Version.new("1.4.0")
+      end
+
+      context "with a mix.exs that has caused trouble in the past" do
+        let(:files) { [mixfile] }
+        let(:mixfile_fixture_name) { "coxir" }
+        let(:dependency_name) { "kcl" }
+        let(:version) { nil }
+        let(:dependency_requirements) do
+          [{ file: "mix.exs", requirement: "~> 1.1", groups: [], source: nil }]
+        end
+
+        it "resolves without issue" do
+          expect(latest_resolvable_version).to be >= Gem::Version.new("1.1.0")
+        end
+      end
+    end
   end
 end

--- a/spec/fixtures/elixir/mixfiles/coxir
+++ b/spec/fixtures/elixir/mixfiles/coxir
@@ -1,0 +1,58 @@
+defmodule Coxir.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coxir,
+      version: "0.8.0",
+      elixir: "~> 1.5",
+      build_embedded: Mix.env == :prod,
+      start_permanent: Mix.env == :prod,
+      deps: deps(),
+
+      name: "coxir",
+      docs: docs(),
+      package: package(),
+      description: "An Elixir wrapper for Discord.",
+      source_url: "https://github.com/satom99/coxir"
+    ]
+  end
+
+  def application do
+    [
+      mod: {Coxir, []}
+    ]
+  end
+
+  defp deps do
+    [
+      {:kcl, "~> 1.1"},
+      {:jason, "~> 1.1"},
+      {:porcelain, "~> 2.0"},
+      {:websockex, "~> 0.4.1"},
+      {:httpoison, "~> 0.13.0"},
+      {:gen_stage, "~> 0.14.0"},
+      {:ex_doc, "~> 0.18.1", only: :dev}
+    ]
+  end
+
+  defp package do
+    [
+      licenses: ["Apache-2.0"],
+      maintainers: ["Santiago Tortosa"],
+      links: %{"GitHub" => "https://github.com/satom99/coxir"}
+    ]
+  end
+
+  defp docs do
+    [
+      main: "overview",
+      extras: [
+        "docs/Overview.md"
+      ],
+      groups_for_extras: [
+        "Introduction": ~r/docs\/.?/
+      ]
+    ]
+  end
+end


### PR DESCRIPTION
Can I get your eye on `spec/dependabot/update_checkers/elixir/hex/version_resolver_spec.rb:137` please @stevedomin?

Would also be hugely grateful if you could take a look at the deprecation warnings when running `bundle exec rspec spec/dependabot/file_parsers/elixir/hex_spec.rb`.