### PR TITLE
Be GitLab API agnostic

### DIFF
--- a/lib/dependabot/pull_request_creator/labeler.rb
+++ b/lib/dependabot/pull_request_creator/labeler.rb
@@ -314,7 +314,7 @@ module Dependabot
 
         @gitlab_client_for_source ||=
           ::Gitlab.client(
-            endpoint: "https://gitlab.com/api/v4",
+            endpoint: source.api_endpoint,
             private_token: access_token || ""
           )
       end


### PR DESCRIPTION
Hello there! :wave:

We're using [gitlab-update-script.rb](https://github.com/dependabot/dependabot-script/blob/master/gitlab-update-script.rb) for our private GitLab instance and found out issues when the script was trying to check the labels endpoint.

Our configuration:
```
source = Dependabot::Source.new(
  provider: "gitlab",
  api_endpoint: "https://git.example.com/api/v4",
  hostname: "git.example.com",
  repo: repo_name,
  directory: directory,
  branch: "master"
)
```

Error message:
```
Gitlab::Error::Unauthorized (Server responded with code 401, message: 401 Unauthorized. Request URI: https://gitlab.com/api/v4/projects/dev%2Ffoobar%2Dapp/labels)
```

Here I changed the hardcoded line to `source.api_endpoint`