### PR TITLE
WIP: Add support for npm-shrinkwrap.json

### DIFF
--- a/helpers/npm/lib/updater.js
+++ b/helpers/npm/lib/updater.js
@@ -6,6 +6,7 @@
  *  - name of the dependency to be updated
  *  - new dependency version
  *  - previous requirements for this dependency
+ *  - the name of the lockfile (package-lock.json or npm-shrinkwrap.json)
  *
  * Outputs:
  *  - updated package.json and package-lock.json files
@@ -25,14 +26,15 @@ async function updateDependencyFiles(
   directory,
   depName,
   desiredVersion,
-  requirements
+  requirements,
+  lockfile_name
 ) {
   const readFile = fileName =>
     fs.readFileSync(path.join(directory, fileName)).toString();
 
   await runAsync(npm6, npm6.load, [{ loglevel: "silent" }]);
   await runAsync(npm5, npm5.load, [{ loglevel: "silent" }]);
-  const oldLockfile = JSON.parse(readFile("package-lock.json"));
+  const oldLockfile = JSON.parse(readFile(lockfile_name));
   const installer = installer_for_lockfile(oldLockfile);
 
   const dryRun = true;
@@ -60,9 +62,9 @@ async function updateDependencyFiles(
     unmute();
   }
 
-  const updatedLockfile = readFile("package-lock.json");
+  const updatedLockfile = readFile(lockfile_name);
 
-  return { "package-lock.json": updatedLockfile };
+  return { [lockfile_name]: updatedLockfile };
 }
 
 function install_args(depName, desiredVersion, requirements, oldLockfile) {

--- a/helpers/npm/test/updater.test.js
+++ b/helpers/npm/test/updater.test.js
@@ -30,9 +30,13 @@ describe("updater", () => {
   it("generates an updated package-lock.json", async () => {
     await copyDependencies("original", tempDir);
 
-    const result = await updateDependencyFiles(tempDir, "left-pad", "1.1.3", [
-      { file: "package.json", groups: ["dependencies"] }
-    ]);
+    const result = await updateDependencyFiles(
+      tempDir,
+      "left-pad",
+      "1.1.3",
+      [{ file: "package.json", groups: ["dependencies"] }],
+      "package-lock.json"
+    );
     expect(result).toEqual({
       "package-lock.json": helpers.loadFixture(
         "updater/updated/package-lock.json"

--- a/lib/dependabot/file_fetchers/java_script/npm_and_yarn.rb
+++ b/lib/dependabot/file_fetchers/java_script/npm_and_yarn.rb
@@ -26,6 +26,7 @@ module Dependabot
           fetched_files << npmrc if npmrc
           fetched_files << package_lock if package_lock && !ignore_package_lock?
           fetched_files << yarn_lock if yarn_lock
+          fetched_files << shrinkwrap if shrinkwrap
           fetched_files << lerna_json if lerna_json
           fetched_files += workspace_package_jsons
           fetched_files += lerna_packages
@@ -44,6 +45,10 @@ module Dependabot
 
         def yarn_lock
           @yarn_lock ||= fetch_file_if_present("yarn.lock")
+        end
+
+        def shrinkwrap
+          @shrinkwrap ||= fetch_file_if_present("npm-shrinkwrap.json")
         end
 
         def npmrc
@@ -147,12 +152,14 @@ module Dependabot
             package_json_path = File.join(workspace, "package.json")
             npm_lock_path = File.join(workspace, "package-lock.json")
             yarn_lock_path = File.join(workspace, "yarn.lock")
+            shrinkwrap_path = File.join(workspace, "npm-shrinkwrap.json")
 
             begin
               dependency_files << fetch_file_from_host(package_json_path)
               dependency_files += [
                 fetch_file_if_present(npm_lock_path),
-                fetch_file_if_present(yarn_lock_path)
+                fetch_file_if_present(yarn_lock_path),
+                fetch_file_if_present(shrinkwrap_path)
               ].compact
             rescue Dependabot::DependencyFileNotFound
               nil

--- a/spec/dependabot/file_parsers/java_script/npm_and_yarn_spec.rb
+++ b/spec/dependabot/file_parsers/java_script/npm_and_yarn_spec.rb
@@ -498,6 +498,41 @@ RSpec.describe Dependabot::FileParsers::JavaScript::NpmAndYarn do
         end
       end
 
+      context "with an npm-shrinkwrap.json" do
+        let(:lockfile) do
+          Dependabot::DependencyFile.new(
+            name: "npm-shrinkwrap.json",
+            content: lockfile_body
+          )
+        end
+        let(:lockfile_body) do
+          fixture("javascript", "shrinkwraps", shrinkwrap_fixture_name)
+        end
+        let(:shrinkwrap_fixture_name) { "npm-shrinkwrap.json" }
+
+        its(:length) { is_expected.to eq(2) }
+
+        context "with a version specified" do
+          describe "the first dependency" do
+            subject { top_level_dependencies.first }
+
+            it { is_expected.to be_a(Dependabot::Dependency) }
+            its(:name) { is_expected.to eq("fetch-factory") }
+            its(:version) { is_expected.to eq("0.0.1") }
+            its(:requirements) do
+              is_expected.to eq(
+                [{
+                  requirement: "^0.0.1",
+                  file: "package.json",
+                  groups: ["dependencies"],
+                  source: nil
+                }]
+              )
+            end
+          end
+        end
+      end
+
       context "with a yarn.lock" do
         let(:lockfile) do
           Dependabot::DependencyFile.new(

--- a/spec/dependabot/file_updaters/java_script/npm_and_yarn_spec.rb
+++ b/spec/dependabot/file_updaters/java_script/npm_and_yarn_spec.rb
@@ -130,6 +130,20 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn do
         expect(parsed_shrinkwrap["dependencies"]["fetch-factory"]["version"]).
           to eq("0.0.2")
       end
+
+      context "and a package-json.lock" do
+        let(:files) { [package_json, shrinkwrap, package_lock] }
+
+        it "updates the shrinkwrap and the package-lock.json" do
+          parsed_shrinkwrap = JSON.parse(updated_shrinkwrap.content)
+          expect(parsed_shrinkwrap["dependencies"]["fetch-factory"]["version"]).
+            to eq("0.0.2")
+
+          parsed_npm_lock = JSON.parse(updated_npm_lock.content)
+          expect(parsed_npm_lock["dependencies"]["fetch-factory"]["version"]).
+            to eq("0.0.2")
+        end
+      end
     end
 
     context "with a git dependency" do

--- a/spec/dependabot/file_updaters/java_script/npm_and_yarn_spec.rb
+++ b/spec/dependabot/file_updaters/java_script/npm_and_yarn_spec.rb
@@ -104,9 +104,31 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn do
       let(:files) { [package_json] }
       its(:length) { is_expected.to eq(1) }
 
-      context "whe nothing has changed" do
+      context "when nothing has changed" do
         let(:requirements) { previous_requirements }
         specify { expect { updated_files }.to raise_error(/No files/) }
+      end
+    end
+
+    context "with a shrinkwrap" do
+      let(:files) { [package_json, shrinkwrap] }
+      let(:shrinkwrap) do
+        Dependabot::DependencyFile.new(
+          name: "npm-shrinkwrap.json",
+          content: shrinkwrap_body
+        )
+      end
+      let(:shrinkwrap_body) do
+        fixture("javascript", "shrinkwraps", "npm-shrinkwrap.json")
+      end
+      let(:updated_shrinkwrap) do
+        updated_files.find { |f| f.name == "npm-shrinkwrap.json" }
+      end
+
+      it "updates the shrinkwrap" do
+        parsed_shrinkwrap = JSON.parse(updated_shrinkwrap.content)
+        expect(parsed_shrinkwrap["dependencies"]["fetch-factory"]["version"]).
+          to eq("0.0.2")
       end
     end
 

--- a/spec/fixtures/github/contents_js_shrinkwrap.json
+++ b/spec/fixtures/github/contents_js_shrinkwrap.json
@@ -1,0 +1,450 @@
+[
+  {
+    "name": ".codeclimate.yml",
+    "path": ".codeclimate.yml",
+    "sha": "6393602fac96cfe31d64f89476014124b4a13b85",
+    "size": 416,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.codeclimate.yml?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.codeclimate.yml",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/6393602fac96cfe31d64f89476014124b4a13b85",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.codeclimate.yml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.codeclimate.yml?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/6393602fac96cfe31d64f89476014124b4a13b85",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.codeclimate.yml"
+    }
+  },
+  {
+    "name": ".coveragerc",
+    "path": ".coveragerc",
+    "sha": "be7fdc86067d0924f3e1e92c1a3ed92d9486fcbb",
+    "size": 646,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.coveragerc?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.coveragerc",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/be7fdc86067d0924f3e1e92c1a3ed92d9486fcbb",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.coveragerc",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.coveragerc?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/be7fdc86067d0924f3e1e92c1a3ed92d9486fcbb",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.coveragerc"
+    }
+  },
+  {
+    "name": ".csslintrc",
+    "path": ".csslintrc",
+    "sha": "aacba956e5bbede1c195ce554fcad3e200b24ff8",
+    "size": 107,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.csslintrc?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.csslintrc",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/aacba956e5bbede1c195ce554fcad3e200b24ff8",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.csslintrc",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.csslintrc?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/aacba956e5bbede1c195ce554fcad3e200b24ff8",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.csslintrc"
+    }
+  },
+  {
+    "name": ".env.example",
+    "path": ".env.example",
+    "sha": "d9f599b33ecd834ea88979dcc3daf4fcafacf4e7",
+    "size": 2617,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.env.example?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.env.example",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/d9f599b33ecd834ea88979dcc3daf4fcafacf4e7",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.env.example",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.env.example?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/d9f599b33ecd834ea88979dcc3daf4fcafacf4e7",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.env.example"
+    }
+  },
+  {
+    "name": ".eslintignore",
+    "path": ".eslintignore",
+    "sha": "96212a3593bac8c93f624b77185a8d11018efd96",
+    "size": 16,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.eslintignore?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.eslintignore",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/96212a3593bac8c93f624b77185a8d11018efd96",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.eslintignore",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.eslintignore?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/96212a3593bac8c93f624b77185a8d11018efd96",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.eslintignore"
+    }
+  },
+  {
+    "name": ".eslintrc.yml",
+    "path": ".eslintrc.yml",
+    "sha": "a6a0ce9c44238e06ff55ca335a66a4e16810da38",
+    "size": 6056,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.eslintrc.yml?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.eslintrc.yml",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/a6a0ce9c44238e06ff55ca335a66a4e16810da38",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.eslintrc.yml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.eslintrc.yml?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/a6a0ce9c44238e06ff55ca335a66a4e16810da38",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.eslintrc.yml"
+    }
+  },
+  {
+    "name": ".gitignore",
+    "path": ".gitignore",
+    "sha": "93923ac3a463bd17d0aefca2de9d2810f243d747",
+    "size": 1073,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.gitignore?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.gitignore",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/93923ac3a463bd17d0aefca2de9d2810f243d747",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.gitignore",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.gitignore?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/93923ac3a463bd17d0aefca2de9d2810f243d747",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.gitignore"
+    }
+  },
+  {
+    "name": ".python-version",
+    "path": ".python-version",
+    "sha": "87ce492908ab2362771f27134bab4a075348a8f3",
+    "size": 6,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.python-version?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.python-version",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/87ce492908ab2362771f27134bab4a075348a8f3",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.python-version",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.python-version?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/87ce492908ab2362771f27134bab4a075348a8f3",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.python-version"
+    }
+  },
+  {
+    "name": "LICENSE.md",
+    "path": "LICENSE.md",
+    "sha": "8dada3edaf50dbc082c9a125058f25def75e625a",
+    "size": 11357,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/LICENSE.md?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/LICENSE.md",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/8dada3edaf50dbc082c9a125058f25def75e625a",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/LICENSE.md",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/LICENSE.md?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/8dada3edaf50dbc082c9a125058f25def75e625a",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/LICENSE.md"
+    }
+  },
+  {
+    "name": "Procfile",
+    "path": "Procfile",
+    "sha": "72e4ef1be7c64eb0f874344bc8a6cf859bd39e00",
+    "size": 26,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/Procfile?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/Procfile",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/72e4ef1be7c64eb0f874344bc8a6cf859bd39e00",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/Procfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/Procfile?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/72e4ef1be7c64eb0f874344bc8a6cf859bd39e00",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/Procfile"
+    }
+  },
+  {
+    "name": "README.md",
+    "path": "README.md",
+    "sha": "01aae7d562fe164d2cee644e8ef5fba82d2b8e81",
+    "size": 1589,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/README.md?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/README.md",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/01aae7d562fe164d2cee644e8ef5fba82d2b8e81",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/README.md",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/README.md?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/01aae7d562fe164d2cee644e8ef5fba82d2b8e81",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/README.md"
+    }
+  },
+  {
+    "name": "Vagrantfile.example",
+    "path": "Vagrantfile.example",
+    "sha": "54be29ea9e1e2ecdbfa642656cded8b3cb85c910",
+    "size": 4329,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/Vagrantfile.example?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/Vagrantfile.example",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/54be29ea9e1e2ecdbfa642656cded8b3cb85c910",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/Vagrantfile.example",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/Vagrantfile.example?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/54be29ea9e1e2ecdbfa642656cded8b3cb85c910",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/Vagrantfile.example"
+    }
+  },
+  {
+    "name": "app",
+    "path": "app",
+    "sha": "f9e84e24364972f3aa4f92b869a622db1f260fa1",
+    "size": 0,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/app?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/app",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/f9e84e24364972f3aa4f92b869a622db1f260fa1",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/app?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/f9e84e24364972f3aa4f92b869a622db1f260fa1",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/app"
+    }
+  },
+  {
+    "name": "build_scripts",
+    "path": "build_scripts",
+    "sha": "be8e80f054e47f0c9a6fc9cfe5061346c6f8b2d0",
+    "size": 0,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/build_scripts?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/build_scripts",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/be8e80f054e47f0c9a6fc9cfe5061346c6f8b2d0",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/build_scripts?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/be8e80f054e47f0c9a6fc9cfe5061346c6f8b2d0",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/build_scripts"
+    }
+  },
+  {
+    "name": "celery_worker.py",
+    "path": "celery_worker.py",
+    "sha": "c84c73c1f1c1aa42550a08ae4f32dc955ced5f18",
+    "size": 279,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/celery_worker.py?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/celery_worker.py",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/c84c73c1f1c1aa42550a08ae4f32dc955ced5f18",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/celery_worker.py",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/celery_worker.py?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/c84c73c1f1c1aa42550a08ae4f32dc955ced5f18",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/celery_worker.py"
+    }
+  },
+  {
+    "name": "config.py",
+    "path": "config.py",
+    "sha": "2886556fc4844e708472a99a85b42b4f5b51d509",
+    "size": 8250,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/config.py?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/config.py",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/2886556fc4844e708472a99a85b42b4f5b51d509",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/config.py",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/config.py?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/2886556fc4844e708472a99a85b42b4f5b51d509",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/config.py"
+    }
+  },
+  {
+    "name": "crontab",
+    "path": "crontab",
+    "sha": "1e2c1da613e8272df6ece759565524c93bc76780",
+    "size": 300,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/crontab?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/crontab",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/1e2c1da613e8272df6ece759565524c93bc76780",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/crontab",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/crontab?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/1e2c1da613e8272df6ece759565524c93bc76780",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/crontab"
+    }
+  },
+  {
+    "name": "data",
+    "path": "data",
+    "sha": "7bceca86ff0e88cb53c8828d441f5e0725776395",
+    "size": 0,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/data?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/data",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/7bceca86ff0e88cb53c8828d441f5e0725776395",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/data?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/7bceca86ff0e88cb53c8828d441f5e0725776395",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/data"
+    }
+  },
+  {
+    "name": "gunicorn_config.py",
+    "path": "gunicorn_config.py",
+    "sha": "7b1a455133c2e78611550e45e8d2072d5c5c4ad7",
+    "size": 2504,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/gunicorn_config.py?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/gunicorn_config.py",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/7b1a455133c2e78611550e45e8d2072d5c5c4ad7",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/gunicorn_config.py",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/gunicorn_config.py?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/7b1a455133c2e78611550e45e8d2072d5c5c4ad7",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/gunicorn_config.py"
+    }
+  },
+  {
+    "name": "jobs.py",
+    "path": "jobs.py",
+    "sha": "79f2957e2c94e44786f6ca3dfc7384aaceb80c0a",
+    "size": 6213,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/jobs.py?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/jobs.py",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/79f2957e2c94e44786f6ca3dfc7384aaceb80c0a",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/jobs.py",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/jobs.py?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/79f2957e2c94e44786f6ca3dfc7384aaceb80c0a",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/jobs.py"
+    }
+  },
+  {
+    "name": "magic",
+    "path": "magic",
+    "sha": "6342094c1d4b1af948867ffba67cf0b866e5613c",
+    "size": 659195,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/magic?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/magic",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/6342094c1d4b1af948867ffba67cf0b866e5613c",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/magic",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/magic?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/6342094c1d4b1af948867ffba67cf0b866e5613c",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/magic"
+    }
+  },
+  {
+    "name": "manage.py",
+    "path": "manage.py",
+    "sha": "a0b80d4c7b5fd7e50d6dcb5bcbdcd995b8da27f0",
+    "size": 15323,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/manage.py?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/manage.py",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/a0b80d4c7b5fd7e50d6dcb5bcbdcd995b8da27f0",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/manage.py",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/manage.py?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/a0b80d4c7b5fd7e50d6dcb5bcbdcd995b8da27f0",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/manage.py"
+    }
+  },
+  {
+    "name": "migrations",
+    "path": "migrations",
+    "sha": "da206a9809330d01f4800718bca2a20c05038b44",
+    "size": 0,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/migrations?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/migrations",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/da206a9809330d01f4800718bca2a20c05038b44",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/migrations?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/da206a9809330d01f4800718bca2a20c05038b44",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/migrations"
+    }
+  },
+  {
+    "name": "npm-shrinkwrap.json",
+    "path": "npm-shrinkwrap.json",
+    "sha": "88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+    "size": 2433,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/npm-shrinkwrap.json?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/npm-shrinkwrap.json",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/npm-shrinkwrap.json",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/npm-shrinkwrap.json?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/npm-shrinkwrap.json"
+    }
+  },
+  {
+    "name": "package.json",
+    "path": "package.json",
+    "sha": "d429264c8c2f0f306a422900c2f41123e07c31b4",
+    "size": 2433,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/package.json?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/package.json",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/d429264c8c2f0f306a422900c2f41123e07c31b4",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/package.json",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/package.json?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/d429264c8c2f0f306a422900c2f41123e07c31b4",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/package.json"
+    }
+  },
+  {
+    "name": "tests",
+    "path": "tests",
+    "sha": "88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+    "size": 0,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/tests?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/tests",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/tests?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/tests"
+    }
+  },
+  {
+    "name": "todo.txt",
+    "path": "todo.txt",
+    "sha": "3e369beef1c9e64f0c10735d35aa8ad755daddc6",
+    "size": 1147,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/todo.txt?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/todo.txt",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/3e369beef1c9e64f0c10735d35aa8ad755daddc6",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/todo.txt",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/todo.txt?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/3e369beef1c9e64f0c10735d35aa8ad755daddc6",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/todo.txt"
+    }
+  },
+  {
+    "name": "update_definitions.sh",
+    "path": "update_definitions.sh",
+    "sha": "fbde266ea5ebd519b94d18f8f78ab825b02766df",
+    "size": 7877,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/update_definitions.sh?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/update_definitions.sh",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/fbde266ea5ebd519b94d18f8f78ab825b02766df",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/update_definitions.sh",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/update_definitions.sh?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/fbde266ea5ebd519b94d18f8f78ab825b02766df",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/update_definitions.sh"
+    }
+  }
+]

--- a/spec/fixtures/javascript/shrinkwraps/npm-shrinkwrap.json
+++ b/spec/fixtures/javascript/shrinkwraps/npm-shrinkwrap.json
@@ -1,0 +1,75 @@
+{
+    "name": "test",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "encoding": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+            "requires": {
+                "iconv-lite": "0.4.19"
+            }
+        },
+        "es6-promise": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+            "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+        },
+        "etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "dev": true
+        },
+        "fetch-factory": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.1.tgz",
+            "integrity": "sha1-4AdgWb2zHjFHx1s7jAQTO6jH4HE=",
+            "requires": {
+                "es6-promise": "3.3.1",
+                "isomorphic-fetch": "2.2.1",
+                "lodash": "3.10.1"
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "isomorphic-fetch": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+            "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+            "requires": {
+                "node-fetch": "1.7.3",
+                "whatwg-fetch": "2.0.3"
+            }
+        },
+        "lodash": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+            "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "node-fetch": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+            "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+            "requires": {
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
+            }
+        },
+        "whatwg-fetch": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+            "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        }
+    }
+}


### PR DESCRIPTION
File format for `npm-shrinkwrap.json` is identical to `package-lock.json`, so it should be relatively straightforward to update.

TODO:
- [x] File fetcher
- [x] File parser
- [x] File updater
- [x] Add test that file updater doesn't explode if both a `package-lock.json` and a `npm-shrinkwrap.json` are provided.