### PR TITLE
Add version and private keys to helper package.json files

### DIFF
--- a/helpers/npm/package.json
+++ b/helpers/npm/package.json
@@ -1,5 +1,7 @@
 {
   "name": "dependabot-core",
+  "version": "0.0.0",
+  "private": true,
   "dependencies": {
     "npm": "6.4.1",
     "npm5": "file:./npm5",

--- a/helpers/yarn/package.json
+++ b/helpers/yarn/package.json
@@ -1,5 +1,7 @@
 {
   "name": "dependabot-core",
+  "version": "0.0.0",
+  "private": true,
   "dependencies": {
     "@dependabot/yarn-lib": "^1.9.4",
     "semver": "^5.5.1"


### PR DESCRIPTION
I am using yarn workspaces to manage dependencies of helpers.
Without a version parameter, `yarn install` ignores the dependencies of this package.json when using workspaces. 

https://yarnpkg.com/lang/en/docs/workspaces/

Additionally, add private property to avoid accidentally publishing this package.