### PR TITLE
Add failing test for Python install

### DIFF
--- a/spec/dependabot/update_checkers/python/pip/pipfile_version_resolver_spec.rb
+++ b/spec/dependabot/update_checkers/python/pip/pipfile_version_resolver_spec.rb
@@ -167,6 +167,23 @@ RSpec.describe namespace::PipfileVersionResolver do
         end
       end
 
+      context "that is implicit" do
+        let(:pipfile_fixture_name) { "required_python_implicit" }
+        let(:dependency_name) { "pytest" }
+        let(:dependency_version) { "3.4.0" }
+        let(:dependency_requirements) do
+          [{
+            file: "Pipfile",
+            requirement: "==3.4.0",
+            groups: ["develop"],
+            source: nil
+          }]
+        end
+        let(:latest_version) { Gem::Version.new("3.8.1") }
+
+        it { is_expected.to eq(Gem::Version.new("3.8.1")) }
+      end
+
       context "for a resolution that has caused trouble in the past" do
         let(:dependency_files) { [pipfile] }
         let(:pipfile_fixture_name) { "problematic_resolution" }

--- a/spec/fixtures/python/pipfiles/required_python_implicit
+++ b/spec/fixtures/python/pipfiles/required_python_implicit
@@ -1,0 +1,9 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pytest = "==3.4.0"
+
+[packages]
+BeautifulSoup = "==3.2.1"


### PR DESCRIPTION
This was failing before Pipenv 2018.10.9. It now passes. 🎉 