### PR TITLE
Add failing spec for Elixir resolution in an umbrella app

### DIFF
--- a/spec/dependabot/update_checkers/elixir/hex_spec.rb
+++ b/spec/dependabot/update_checkers/elixir/hex_spec.rb
@@ -412,6 +412,37 @@ RSpec.describe Dependabot::UpdateCheckers::Elixir::Hex do
       end
 
       it { is_expected.to be >= Gem::Version.new("1.4.3") }
+
+      context "when upgrading is blocked" do
+        let(:lockfile_body) do
+          fixture("elixir", "lockfiles", "umbrella_blocked")
+        end
+        let(:sub_mixfile1) do
+          Dependabot::DependencyFile.new(
+            name: "apps/dependabot_business/mix.exs",
+            content: fixture("elixir", "mixfiles", "dependabot_business_exact")
+          )
+        end
+        let(:sub_mixfile2) do
+          Dependabot::DependencyFile.new(
+            name: "apps/dependabot_web/mix.exs",
+            content: fixture("elixir", "mixfiles", "dependabot_web_exact")
+          )
+        end
+
+        let(:dependency_name) { "phoenix" }
+        let(:version) { "1.2.1" }
+        let(:dependency_requirements) do
+          [{
+            file: "apps/dependabot_web/mix.exs",
+            requirement: "== 1.2.1",
+            groups: [],
+            source: nil
+          }]
+        end
+
+        it { is_expected.to be >= Gem::Version.new("1.2.2") }
+      end
     end
   end
 

--- a/spec/fixtures/elixir/lockfiles/umbrella_blocked
+++ b/spec/fixtures/elixir/lockfiles/umbrella_blocked
@@ -1,0 +1,9 @@
+%{
+  "distillery": {:hex, :distillery, "1.5.5", "c6132d5c0152bdce6850fb6c942d58f1971b169b6965d908dc4e8767cfa51a95", [:mix], [], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
+  "phoenix": {:hex, :phoenix, "1.2.1", "6dc592249ab73c67575769765b66ad164ad25d83defa3492dc6ae269bd2a68ab", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.1", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.1.1", "6668d787e602981f24f17a5fbb69cc98f8ab085114ebfac6cc36e10a90c8e93c", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.3.0", "6e2b01afc5db3fd011ca4a16efd9cb424528c157c30a44a0186bcc92c7b2e8f3", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm"},
+}

--- a/spec/fixtures/elixir/mixfiles/dependabot_business_exact
+++ b/spec/fixtures/elixir/mixfiles/dependabot_business_exact
@@ -1,0 +1,30 @@
+defmodule DependabotBusiness.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :dependabot_business,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.6",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:plug, "== 1.3.0"},
+      {:jason, "~> 1.0"}
+    ]
+  end
+end

--- a/spec/fixtures/elixir/mixfiles/dependabot_web_exact
+++ b/spec/fixtures/elixir/mixfiles/dependabot_web_exact
@@ -1,0 +1,30 @@
+defmodule DependabotWeb.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :dependabot_web,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.6",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:phoenix, "== 1.2.1"},
+      {:dependabot_business, in_umbrella: true}
+    ]
+  end
+end


### PR DESCRIPTION
Elixir version resolution fails (and errors) for umbrella applications where resolution of the latest version is blocked.
- This *doesn't* happen for non-umbrella apps
- This *doesn't* happen for cases where resolution of the latest version isn't blocked