### PR TITLE
go: fix go.sum updating by writing a dummy main.go

### DIFF
--- a/lib/dependabot/file_updaters/go/modules/go_mod_updater.rb
+++ b/lib/dependabot/file_updaters/go/modules/go_mod_updater.rb
@@ -49,6 +49,7 @@ module Dependabot
                 SharedHelpers.with_git_configured(credentials: credentials) do
                   File.write("go.mod", updated_go_mod_content)
                   File.write("go.sum", go_sum.content)
+                  File.write("main.go", dummy_main_go)
 
                   `GO111MODULE=on go get`
                   unless $CHILD_STATUS.success?
@@ -61,6 +62,16 @@ module Dependabot
           end
 
           private
+
+          def dummy_main_go
+            lines = ["package main", "import ("]
+            dependencies.each do |dep|
+              lines << "_ \"#{dep.name}\""
+            end
+            lines << ")"
+            lines << "func main() {}"
+            lines.join("\n")
+          end
 
           attr_reader :dependencies, :go_mod, :go_sum, :credentials
         end

--- a/spec/dependabot/file_updaters/go/modules/go_mod_updater_spec.rb
+++ b/spec/dependabot/file_updaters/go/modules/go_mod_updater_spec.rb
@@ -88,12 +88,16 @@ RSpec.describe Dependabot::FileUpdaters::Go::Modules::GoModUpdater do
 
           it "adds new entries to the go.sum" do
             is_expected.
+              to include(%(rsc.io/quote v1.5.2 h1:))
+            is_expected.
               to include(%(rsc.io/quote v1.5.2/go.mod h1:))
           end
 
           # This happens via `go mod tidy`, which we currently can't run, as we
           # need to the whole source repo
           pending "removes old entries from the go.sum" do
+            is_expected.
+              to include(%(rsc.io/quote v1.4.0 h1:))
             is_expected.
               to_not include(%(rsc.io/quote v1.4.0/go.mod h1:))
           end


### PR DESCRIPTION
`go get` rewrites the `go.sum`, but only includes the `go.mod` entry if there module is not imported.