### PR TITLE
Add support for gems.rb and gems.locked setup

### DIFF
--- a/lib/dependabot/file_fetchers/ruby/bundler.rb
+++ b/lib/dependabot/file_fetchers/ruby/bundler.rb
@@ -39,9 +39,7 @@ module Dependabot
         def fetch_files
           fetched_files = []
           fetched_files << gemfile if gemfile
-          fetched_files << gems_rb if gems_rb
           fetched_files << lockfile if lockfile
-          fetched_files << gems_locked if gems_locked
           fetched_files += gemspecs
           fetched_files << ruby_version_file if ruby_version_file
           fetched_files += child_gemfiles
@@ -58,7 +56,7 @@ module Dependabot
         end
 
         def check_required_files_present
-          return if gemfile || gemspecs.any? || gems_rb
+          return if gemfile || gemspecs.any?
 
           path = Pathname.new(File.join(directory, "Gemfile")).
                  cleanpath.to_path
@@ -66,19 +64,13 @@ module Dependabot
         end
 
         def gemfile
-          @gemfile ||= fetch_file_if_present("Gemfile")
+          @gemfile ||= fetch_file_if_present("Gemfile") ||
+                       fetch_file_if_present("gems.rb")
         end
 
         def lockfile
-          @lockfile ||= fetch_file_if_present("Gemfile.lock")
-        end
-
-        def gems_rb
-          @gems_rb ||= fetch_file_if_present("gems.rb")
-        end
-
-        def gems_locked
-          @gems_locked ||= fetch_file_if_present("gems.locked")
+          @lockfile ||= fetch_file_if_present("Gemfile.lock") ||
+                        fetch_file_if_present("gems.locked")
         end
 
         def gemspecs

--- a/lib/dependabot/file_parsers/ruby/bundler/file_preparer.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler/file_preparer.rb
@@ -38,7 +38,8 @@ module Dependabot
           attr_reader :dependency_files
 
           def gemfile
-            dependency_files.find { |f| f.name == "Gemfile" }
+            dependency_files.find { |f| f.name == "Gemfile" } ||
+              dependency_files.find { |f| f.name == "gems.rb" }
           end
 
           def evaled_gemfiles
@@ -46,11 +47,14 @@ module Dependabot
               reject { |f| f.name.end_with?(".gemspec") }.
               reject { |f| f.name.end_with?(".lock") }.
               reject { |f| f.name.end_with?(".ruby-version") }.
-              reject { |f| f.name == "Gemfile" }
+              reject { |f| f.name == "Gemfile" }.
+              reject { |f| f.name == "gems.rb" }.
+              reject { |f| f.name == "gems.locked" }
           end
 
           def lockfile
-            dependency_files.find { |f| f.name == "Gemfile.lock" }
+            dependency_files.find { |f| f.name == "Gemfile.lock" } ||
+              dependency_files.find { |f| f.name == "gems.locked" }
           end
 
           def gemspecs
@@ -62,7 +66,9 @@ module Dependabot
           end
 
           def imported_ruby_files
-            dependency_files.select { |f| f.name.end_with?(".rb") }
+            dependency_files.
+              select { |f| f.name.end_with?(".rb") }.
+              reject { |f| f.name == "gems.rb" }
           end
 
           def sanitize_gemspec_content(gemspec_content)

--- a/lib/dependabot/file_updaters/ruby/bundler/gemfile_updater.rb
+++ b/lib/dependabot/file_updaters/ruby/bundler/gemfile_updater.rb
@@ -73,19 +73,21 @@ module Dependabot
           def remove_git_source?(dependency)
             old_gemfile_req =
               dependency.previous_requirements.
-              find { |f| f[:file] == "Gemfile" }
+              find { |f| %w(Gemfile gems.rb).include?(f[:file]) }
 
             return false unless old_gemfile_req&.dig(:source, :type) == "git"
 
             new_gemfile_req =
-              dependency.requirements.find { |f| f[:file] == "Gemfile" }
+              dependency.requirements.
+              find { |f| %w(Gemfile gems.rb).include?(f[:file]) }
 
             new_gemfile_req[:source].nil?
           end
 
           def update_git_pin?(dependency)
             new_gemfile_req =
-              dependency.requirements.find { |f| f[:file] == "Gemfile" }
+              dependency.requirements.
+              find { |f| %w(Gemfile gems.rb).include?(f[:file]) }
             return false unless new_gemfile_req&.dig(:source, :type) == "git"
 
             # If the new requirement is a git dependency with a ref then there's

--- a/lib/dependabot/update_checkers/ruby/bundler/file_preparer.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler/file_preparer.rb
@@ -106,7 +106,8 @@ module Dependabot
           end
 
           def gemfile
-            dependency_files.find { |f| f.name == "Gemfile" }
+            dependency_files.find { |f| f.name == "Gemfile" } ||
+              dependency_files.find { |f| f.name == "gems.rb" }
           end
 
           def evaled_gemfiles
@@ -114,11 +115,14 @@ module Dependabot
               reject { |f| f.name.end_with?(".gemspec") }.
               reject { |f| f.name.end_with?(".lock") }.
               reject { |f| f.name.end_with?(".ruby-version") }.
-              reject { |f| f.name == "Gemfile" }
+              reject { |f| f.name == "Gemfile" }.
+              reject { |f| f.name == "gems.rb" }.
+              reject { |f| f.name == "gems.locked" }
           end
 
           def lockfile
-            dependency_files.find { |f| f.name == "Gemfile.lock" }
+            dependency_files.find { |f| f.name == "Gemfile.lock" } ||
+              dependency_files.find { |f| f.name == "gems.locked" }
           end
 
           def top_level_gemspecs
@@ -135,7 +139,9 @@ module Dependabot
           end
 
           def imported_ruby_files
-            dependency_files.select { |f| f.name.end_with?(".rb") }
+            dependency_files.
+              select { |f| f.name.end_with?(".rb") }.
+              reject { |f| f.name == "gems.rb" }
           end
 
           def gemfile_content_for_update_check(file)

--- a/lib/dependabot/update_checkers/ruby/bundler/force_updater.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler/force_updater.rb
@@ -118,7 +118,7 @@ module Dependabot
           def build_definition(other_updates:)
             gems_to_unlock = other_updates.map(&:name) + [dependency.name]
             definition = ::Bundler::Definition.build(
-              "Gemfile",
+              gemfile.name,
               lockfile&.name,
               gems: gems_to_unlock + subdependencies,
               lock_shared_dependencies: true
@@ -147,7 +147,7 @@ module Dependabot
             all_deps =  ::Bundler::LockfileParser.new(lockfile.content).
                         specs.map(&:name).map(&:to_s)
             top_level = ::Bundler::Definition.
-                        build("Gemfile", lockfile.name, {}).
+                        build(gemfile.name, lockfile.name, {}).
                         dependencies.map(&:name).map(&:to_s)
 
             all_deps - top_level
@@ -217,11 +217,13 @@ module Dependabot
           end
 
           def gemfile
-            dependency_files.find { |f| f.name == "Gemfile" }
+            dependency_files.find { |f| f.name == "Gemfile" } ||
+              dependency_files.find { |f| f.name == "gems.rb" }
           end
 
           def lockfile
-            dependency_files.find { |f| f.name == "Gemfile.lock" }
+            dependency_files.find { |f| f.name == "Gemfile.lock" } ||
+              dependency_files.find { |f| f.name == "gems.locked" }
           end
 
           def library?

--- a/lib/dependabot/update_checkers/ruby/bundler/latest_version_finder.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler/latest_version_finder.rb
@@ -144,7 +144,7 @@ module Dependabot
 
             @dependency_source ||=
               in_a_temporary_bundler_context do
-                definition = ::Bundler::Definition.build("Gemfile", nil, {})
+                definition = ::Bundler::Definition.build(gemfile.name, nil, {})
 
                 specified_source =
                   definition.dependencies.
@@ -159,7 +159,8 @@ module Dependabot
           end
 
           def gemfile
-            dependency_files.find { |f| f.name == "Gemfile" }
+            dependency_files.find { |f| f.name == "Gemfile" } ||
+              dependency_files.find { |f| f.name == "gems.rb" }
           end
         end
       end

--- a/lib/dependabot/update_checkers/ruby/bundler/shared_bundler_helpers.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler/shared_bundler_helpers.rb
@@ -165,7 +165,7 @@ module Dependabot
 
           def inaccessible_git_dependencies
             in_a_temporary_bundler_context(error_handling: false) do
-              ::Bundler::Definition.build("Gemfile", nil, {}).dependencies.
+              ::Bundler::Definition.build(gemfile.name, nil, {}).dependencies.
                 reject do |spec|
                   next true unless spec.source.is_a?(::Bundler::Source::Git)
 
@@ -192,7 +192,7 @@ module Dependabot
 
           def jfrog_source
             in_a_temporary_bundler_context(error_handling: false) do
-              ::Bundler::Definition.build("Gemfile", nil, {}).
+              ::Bundler::Definition.build(gemfile.name, nil, {}).
                 send(:sources).
                 rubygems_remotes.
                 find { |uri| uri.host.include?("jfrog") }&.
@@ -218,6 +218,11 @@ module Dependabot
 
           def git_source_credentials
             credentials.select { |cred| cred["type"] == "git_source" }
+          end
+
+          def gemfile
+            dependency_files.find { |f| f.name == "Gemfile" } ||
+              dependency_files.find { |f| f.name == "gems.rb" }
           end
         end
       end

--- a/lib/dependabot/update_checkers/ruby/bundler/version_resolver.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler/version_resolver.rb
@@ -210,7 +210,7 @@ module Dependabot
             # dependencies getting unlocked (which would happen if they were
             # also subdependencies of the dependency being unlocked)
             ::Bundler::Definition.build(
-              "Gemfile",
+              gemfile.name,
               lockfile&.name,
               gems: dependencies_to_unlock,
               lock_shared_dependencies: true
@@ -234,11 +234,13 @@ module Dependabot
           end
 
           def gemfile
-            dependency_files.find { |f| f.name == "Gemfile" }
+            dependency_files.find { |f| f.name == "Gemfile" } ||
+              dependency_files.find { |f| f.name == "gems.rb" }
           end
 
           def lockfile
-            dependency_files.find { |f| f.name == "Gemfile.lock" }
+            dependency_files.find { |f| f.name == "Gemfile.lock" } ||
+              dependency_files.find { |f| f.name == "gems.locked" }
           end
         end
       end

--- a/spec/dependabot/file_fetchers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_fetchers/ruby/bundler_spec.rb
@@ -144,6 +144,40 @@ RSpec.describe Dependabot::FileFetchers::Ruby::Bundler do
     end
   end
 
+  context "with a gems.rb rather than a Gemfile" do
+    before do
+      stub_request(:get, url + "?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "contents_ruby_bundler_2.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, url + "gems.rb?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "gemfile_content.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, url + "gems.locked?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "gemfile_lock_content.json"),
+          headers: { "content-type" => "application/json" }
+        )
+    end
+
+    it "fetches the ruby-version file" do
+      expect(file_fetcher_instance.files.count).to eq(2)
+      expect(file_fetcher_instance.files.map(&:name)).
+        to eq(%w(gems.rb gems.locked))
+    end
+  end
+
   context "with a file included with require_relative" do
     let(:directory) { "/Library/Homebrew/test" }
     let(:url) do

--- a/spec/dependabot/file_parsers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/bundler_spec.rb
@@ -124,6 +124,39 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
       end
     end
 
+    context "from a gems.rb and gems.locked" do
+      let(:gemfile) do
+        Dependabot::DependencyFile.new(name: "gems.rb", content: gemfile_body)
+      end
+      let(:lockfile) do
+        Dependabot::DependencyFile.new(
+          name: "gems.locked",
+          content: lockfile_body
+        )
+      end
+      let(:gemfile_fixture_name) { "version_specified" }
+
+      its(:length) { is_expected.to eq(2) }
+
+      describe "the first dependency" do
+        subject { dependencies.first }
+        let(:expected_requirements) do
+          [{
+            requirement: "~> 1.4.0",
+            file: "gems.rb",
+            source: nil,
+            groups: [:default]
+          }]
+        end
+
+        it { is_expected.to be_a(Dependabot::Dependency) }
+        it { is_expected.to be_production }
+        its(:name) { is_expected.to eq("business") }
+        its(:requirements) { is_expected.to eq(expected_requirements) }
+        its(:version) { is_expected.to eq("1.4.0") }
+      end
+    end
+
     context "with a git dependency" do
       let(:gemfile_fixture_name) { "git_source" }
       let(:lockfile_fixture_name) { "git_source.lock" }

--- a/spec/dependabot/file_updaters/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_updaters/ruby/bundler_spec.rb
@@ -128,6 +128,56 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
           expect(updated_gemfile.content).
             to include("\"statesman\", \"~> 1.2.0\"")
         end
+
+        context "for a gems.rb setup" do
+          subject(:updated_gemfile) do
+            updated_files.find { |f| f.name == "gems.rb" }
+          end
+
+          let(:gemfile) do
+            Dependabot::DependencyFile.new(
+              name: "gems.rb",
+              content: gemfile_body,
+              directory: directory
+            )
+          end
+          let(:lockfile) do
+            Dependabot::DependencyFile.new(
+              name: "gems.locked",
+              content: lockfile_body,
+              directory: directory
+            )
+          end
+          let(:requirements) do
+            [{
+              file: "gems.rb",
+              requirement: "~> 1.5.0",
+              groups: [],
+              source: nil
+            }]
+          end
+          let(:previous_requirements) do
+            [{
+              file: "gems.rb",
+              requirement: "~> 1.4.0",
+              groups: [],
+              source: nil
+            }]
+          end
+
+          it "delegates to GemfileUpdater" do
+            expect(described_class::GemfileUpdater).
+              to receive(:new).
+              with(dependencies: dependencies, gemfile: gemfile).
+              and_call_original.
+              twice
+
+            expect(updated_gemfile.content).
+              to include("\"business\", \"~> 1.5.0\"")
+            expect(updated_gemfile.content).
+              to include("\"statesman\", \"~> 1.2.0\"")
+          end
+        end
       end
 
       context "when updating a sub-dependency" do
@@ -162,36 +212,30 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
           fixture("ruby", "gemfiles", "version_not_specified")
         end
         let(:requirements) do
-          [
-            {
-              file: "Gemfile",
-              requirement: ">= 0",
-              groups: [],
-              source: nil
-            },
-            {
-              file: "backend/Gemfile",
-              requirement: ">= 0",
-              groups: [],
-              source: nil
-            }
-          ]
+          [{
+            file: "Gemfile",
+            requirement: ">= 0",
+            groups: [],
+            source: nil
+          }, {
+            file: "backend/Gemfile",
+            requirement: ">= 0",
+            groups: [],
+            source: nil
+          }]
         end
         let(:previous_requirements) do
-          [
-            {
-              file: "Gemfile",
-              requirement: ">= 0",
-              groups: [],
-              source: nil
-            },
-            {
-              file: "backend/Gemfile",
-              requirement: ">= 0",
-              groups: [],
-              source: nil
-            }
-          ]
+          [{
+            file: "Gemfile",
+            requirement: ">= 0",
+            groups: [],
+            source: nil
+          }, {
+            file: "backend/Gemfile",
+            requirement: ">= 0",
+            groups: [],
+            source: nil
+          }]
         end
         it { is_expected.to be_nil }
       end
@@ -201,36 +245,30 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
           fixture("ruby", "gemfiles", "version_specified")
         end
         let(:requirements) do
-          [
-            {
-              file: "Gemfile",
-              requirement: "~> 1.5.0",
-              groups: [],
-              source: nil
-            },
-            {
-              file: "backend/Gemfile",
-              requirement: "~> 1.5.0",
-              groups: [],
-              source: nil
-            }
-          ]
+          [{
+            file: "Gemfile",
+            requirement: "~> 1.5.0",
+            groups: [],
+            source: nil
+          }, {
+            file: "backend/Gemfile",
+            requirement: "~> 1.5.0",
+            groups: [],
+            source: nil
+          }]
         end
         let(:previous_requirements) do
-          [
-            {
-              file: "Gemfile",
-              requirement: "~> 1.4.0",
-              groups: [],
-              source: nil
-            },
-            {
-              file: "backend/Gemfile",
-              requirement: "~> 1.4.0",
-              groups: [],
-              source: nil
-            }
-          ]
+          [{
+            file: "Gemfile",
+            requirement: "~> 1.4.0",
+            groups: [],
+            source: nil
+          }, {
+            file: "backend/Gemfile",
+            requirement: "~> 1.4.0",
+            groups: [],
+            source: nil
+          }]
         end
         its(:content) { is_expected.to include "\"business\", \"~> 1.5.0\"" }
         its(:content) { is_expected.to include "\"statesman\", \"~> 1.2.0\"" }
@@ -350,6 +388,45 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
 
         it "doesn't add in a RUBY VERSION" do
           expect(file.content).to_not include("RUBY VERSION")
+        end
+
+        context "for a gems.rb setup" do
+          subject(:file) { updated_files.find { |f| f.name == "gems.locked" } }
+
+          let(:gemfile) do
+            Dependabot::DependencyFile.new(
+              name: "gems.rb",
+              content: gemfile_body,
+              directory: directory
+            )
+          end
+          let(:lockfile) do
+            Dependabot::DependencyFile.new(
+              name: "gems.locked",
+              content: lockfile_body,
+              directory: directory
+            )
+          end
+          let(:requirements) do
+            [{
+              file: "gems.rb",
+              requirement: "~> 1.5.0",
+              groups: [],
+              source: nil
+            }]
+          end
+          let(:previous_requirements) do
+            [{
+              file: "gems.rb",
+              requirement: "~> 1.4.0",
+              groups: [],
+              source: nil
+            }]
+          end
+
+          it "locks the updated gem to the latest version" do
+            expect(file.content).to include("business (1.5.0)")
+          end
         end
       end
 
@@ -849,36 +926,30 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
         let(:child_gemfile_body) { fixture("ruby", "gemfiles", "Gemfile") }
         let(:lockfile_fixture_name) { "path_source.lock" }
         let(:requirements) do
-          [
-            {
-              file: "Gemfile",
-              requirement: "~> 1.5.0",
-              groups: [],
-              source: nil
-            },
-            {
-              file: "backend/Gemfile",
-              requirement: "~> 1.5.0",
-              groups: [],
-              source: nil
-            }
-          ]
+          [{
+            file: "Gemfile",
+            requirement: "~> 1.5.0",
+            groups: [],
+            source: nil
+          }, {
+            file: "backend/Gemfile",
+            requirement: "~> 1.5.0",
+            groups: [],
+            source: nil
+          }]
         end
         let(:previous_requirements) do
-          [
-            {
-              file: "Gemfile",
-              requirement: "~> 1.4.0",
-              groups: [],
-              source: nil
-            },
-            {
-              file: "backend/Gemfile",
-              requirement: "~> 1.4.0",
-              groups: [],
-              source: nil
-            }
-          ]
+          [{
+            file: "Gemfile",
+            requirement: "~> 1.4.0",
+            groups: [],
+            source: nil
+          }, {
+            file: "backend/Gemfile",
+            requirement: "~> 1.4.0",
+            groups: [],
+            source: nil
+          }]
         end
 
         it "updates the gem just fine" do
@@ -959,34 +1030,28 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
               name: "business",
               version: "1.8.0",
               previous_version: "1.4.0",
-              requirements: [
-                {
-                  file: "example.gemspec",
-                  requirement: requirement,
-                  groups: [],
-                  source: nil
-                },
-                {
-                  file: "Gemfile",
-                  requirement: requirement,
-                  groups: [],
-                  source: nil
-                }
-              ],
-              previous_requirements: [
-                {
-                  file: "example.gemspec",
-                  requirement: "~> 1.0",
-                  groups: [],
-                  source: nil
-                },
-                {
-                  file: "Gemfile",
-                  requirement: "~> 1.4.0",
-                  groups: [],
-                  source: nil
-                }
-              ],
+              requirements: [{
+                file: "example.gemspec",
+                requirement: requirement,
+                groups: [],
+                source: nil
+              }, {
+                file: "Gemfile",
+                requirement: requirement,
+                groups: [],
+                source: nil
+              }],
+              previous_requirements: [{
+                file: "example.gemspec",
+                requirement: "~> 1.0",
+                groups: [],
+                source: nil
+              }, {
+                file: "Gemfile",
+                requirement: "~> 1.4.0",
+                groups: [],
+                source: nil
+              }],
               package_manager: "bundler"
             )
           end
@@ -1196,36 +1261,30 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
         let(:gemspec_body) { fixture("ruby", "gemspecs", "small_example") }
         let(:dependency_name) { "business" }
         let(:requirements) do
-          [
-            {
-              file: "example.gemspec",
-              requirement: ">= 1.0, < 6.0",
-              groups: [],
-              source: nil
-            },
-            {
-              file: "Gemfile",
-              requirement: "~> 5.1.0",
-              groups: [],
-              source: nil
-            }
-          ]
+          [{
+            file: "example.gemspec",
+            requirement: ">= 1.0, < 6.0",
+            groups: [],
+            source: nil
+          }, {
+            file: "Gemfile",
+            requirement: "~> 5.1.0",
+            groups: [],
+            source: nil
+          }]
         end
         let(:previous_requirements) do
-          [
-            {
-              file: "example.gemspec",
-              requirement: "~> 1.0",
-              groups: [],
-              source: nil
-            },
-            {
-              file: "Gemfile",
-              requirement: "~> 1.4.0",
-              groups: [],
-              source: nil
-            }
-          ]
+          [{
+            file: "example.gemspec",
+            requirement: "~> 1.0",
+            groups: [],
+            source: nil
+          }, {
+            file: "Gemfile",
+            requirement: "~> 1.4.0",
+            groups: [],
+            source: nil
+          }]
         end
 
         its(:length) { is_expected.to eq(2) }

--- a/spec/fixtures/github/contents_ruby_bundler_2.json
+++ b/spec/fixtures/github/contents_ruby_bundler_2.json
@@ -1,0 +1,450 @@
+[
+  {
+    "name": ".codeclimate.yml",
+    "path": ".codeclimate.yml",
+    "sha": "6393602fac96cfe31d64f89476014124b4a13b85",
+    "size": 416,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.codeclimate.yml?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.codeclimate.yml",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/6393602fac96cfe31d64f89476014124b4a13b85",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.codeclimate.yml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.codeclimate.yml?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/6393602fac96cfe31d64f89476014124b4a13b85",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.codeclimate.yml"
+    }
+  },
+  {
+    "name": ".coveragerc",
+    "path": ".coveragerc",
+    "sha": "be7fdc86067d0924f3e1e92c1a3ed92d9486fcbb",
+    "size": 646,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.coveragerc?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.coveragerc",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/be7fdc86067d0924f3e1e92c1a3ed92d9486fcbb",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.coveragerc",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.coveragerc?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/be7fdc86067d0924f3e1e92c1a3ed92d9486fcbb",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.coveragerc"
+    }
+  },
+  {
+    "name": ".csslintrc",
+    "path": ".csslintrc",
+    "sha": "aacba956e5bbede1c195ce554fcad3e200b24ff8",
+    "size": 107,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.csslintrc?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.csslintrc",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/aacba956e5bbede1c195ce554fcad3e200b24ff8",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.csslintrc",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.csslintrc?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/aacba956e5bbede1c195ce554fcad3e200b24ff8",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.csslintrc"
+    }
+  },
+  {
+    "name": ".env.example",
+    "path": ".env.example",
+    "sha": "d9f599b33ecd834ea88979dcc3daf4fcafacf4e7",
+    "size": 2617,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.env.example?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.env.example",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/d9f599b33ecd834ea88979dcc3daf4fcafacf4e7",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.env.example",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.env.example?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/d9f599b33ecd834ea88979dcc3daf4fcafacf4e7",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.env.example"
+    }
+  },
+  {
+    "name": ".eslintignore",
+    "path": ".eslintignore",
+    "sha": "96212a3593bac8c93f624b77185a8d11018efd96",
+    "size": 16,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.eslintignore?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.eslintignore",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/96212a3593bac8c93f624b77185a8d11018efd96",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.eslintignore",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.eslintignore?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/96212a3593bac8c93f624b77185a8d11018efd96",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.eslintignore"
+    }
+  },
+  {
+    "name": ".eslintrc.yml",
+    "path": ".eslintrc.yml",
+    "sha": "a6a0ce9c44238e06ff55ca335a66a4e16810da38",
+    "size": 6056,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.eslintrc.yml?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.eslintrc.yml",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/a6a0ce9c44238e06ff55ca335a66a4e16810da38",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.eslintrc.yml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.eslintrc.yml?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/a6a0ce9c44238e06ff55ca335a66a4e16810da38",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.eslintrc.yml"
+    }
+  },
+  {
+    "name": ".gitignore",
+    "path": ".gitignore",
+    "sha": "93923ac3a463bd17d0aefca2de9d2810f243d747",
+    "size": 1073,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.gitignore?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.gitignore",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/93923ac3a463bd17d0aefca2de9d2810f243d747",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.gitignore",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.gitignore?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/93923ac3a463bd17d0aefca2de9d2810f243d747",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.gitignore"
+    }
+  },
+  {
+    "name": ".ruby-version",
+    "path": ".ruby-version",
+    "sha": "87ce492908ab2362771f27134bab4a075348a8f3",
+    "size": 6,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.ruby-version?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.ruby-version",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/87ce492908ab2362771f27134bab4a075348a8f3",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.ruby-version",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.ruby-version?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/87ce492908ab2362771f27134bab4a075348a8f3",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.ruby-version"
+    }
+  },
+  {
+    "name": "LICENSE.md",
+    "path": "LICENSE.md",
+    "sha": "8dada3edaf50dbc082c9a125058f25def75e625a",
+    "size": 11357,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/LICENSE.md?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/LICENSE.md",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/8dada3edaf50dbc082c9a125058f25def75e625a",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/LICENSE.md",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/LICENSE.md?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/8dada3edaf50dbc082c9a125058f25def75e625a",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/LICENSE.md"
+    }
+  },
+  {
+    "name": "Procfile",
+    "path": "Procfile",
+    "sha": "72e4ef1be7c64eb0f874344bc8a6cf859bd39e00",
+    "size": 26,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/Procfile?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/Procfile",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/72e4ef1be7c64eb0f874344bc8a6cf859bd39e00",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/Procfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/Procfile?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/72e4ef1be7c64eb0f874344bc8a6cf859bd39e00",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/Procfile"
+    }
+  },
+  {
+    "name": "README.md",
+    "path": "README.md",
+    "sha": "01aae7d562fe164d2cee644e8ef5fba82d2b8e81",
+    "size": 1589,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/README.md?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/README.md",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/01aae7d562fe164d2cee644e8ef5fba82d2b8e81",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/README.md",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/README.md?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/01aae7d562fe164d2cee644e8ef5fba82d2b8e81",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/README.md"
+    }
+  },
+  {
+    "name": "Vagrantfile.example",
+    "path": "Vagrantfile.example",
+    "sha": "54be29ea9e1e2ecdbfa642656cded8b3cb85c910",
+    "size": 4329,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/Vagrantfile.example?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/Vagrantfile.example",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/54be29ea9e1e2ecdbfa642656cded8b3cb85c910",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/Vagrantfile.example",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/Vagrantfile.example?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/54be29ea9e1e2ecdbfa642656cded8b3cb85c910",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/Vagrantfile.example"
+    }
+  },
+  {
+    "name": "app",
+    "path": "app",
+    "sha": "f9e84e24364972f3aa4f92b869a622db1f260fa1",
+    "size": 0,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/app?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/app",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/f9e84e24364972f3aa4f92b869a622db1f260fa1",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/app?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/f9e84e24364972f3aa4f92b869a622db1f260fa1",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/app"
+    }
+  },
+  {
+    "name": "build_scripts",
+    "path": "build_scripts",
+    "sha": "be8e80f054e47f0c9a6fc9cfe5061346c6f8b2d0",
+    "size": 0,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/build_scripts?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/build_scripts",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/be8e80f054e47f0c9a6fc9cfe5061346c6f8b2d0",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/build_scripts?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/be8e80f054e47f0c9a6fc9cfe5061346c6f8b2d0",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/build_scripts"
+    }
+  },
+  {
+    "name": "celery_worker.py",
+    "path": "celery_worker.py",
+    "sha": "c84c73c1f1c1aa42550a08ae4f32dc955ced5f18",
+    "size": 279,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/celery_worker.py?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/celery_worker.py",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/c84c73c1f1c1aa42550a08ae4f32dc955ced5f18",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/celery_worker.py",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/celery_worker.py?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/c84c73c1f1c1aa42550a08ae4f32dc955ced5f18",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/celery_worker.py"
+    }
+  },
+  {
+    "name": "config.py",
+    "path": "config.py",
+    "sha": "2886556fc4844e708472a99a85b42b4f5b51d509",
+    "size": 8250,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/config.py?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/config.py",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/2886556fc4844e708472a99a85b42b4f5b51d509",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/config.py",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/config.py?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/2886556fc4844e708472a99a85b42b4f5b51d509",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/config.py"
+    }
+  },
+  {
+    "name": "crontab",
+    "path": "crontab",
+    "sha": "1e2c1da613e8272df6ece759565524c93bc76780",
+    "size": 300,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/crontab?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/crontab",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/1e2c1da613e8272df6ece759565524c93bc76780",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/crontab",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/crontab?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/1e2c1da613e8272df6ece759565524c93bc76780",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/crontab"
+    }
+  },
+  {
+    "name": "data",
+    "path": "data",
+    "sha": "7bceca86ff0e88cb53c8828d441f5e0725776395",
+    "size": 0,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/data?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/data",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/7bceca86ff0e88cb53c8828d441f5e0725776395",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/data?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/7bceca86ff0e88cb53c8828d441f5e0725776395",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/data"
+    }
+  },
+  {
+    "name": "gunicorn_config.py",
+    "path": "gunicorn_config.py",
+    "sha": "7b1a455133c2e78611550e45e8d2072d5c5c4ad7",
+    "size": 2504,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/gunicorn_config.py?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/gunicorn_config.py",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/7b1a455133c2e78611550e45e8d2072d5c5c4ad7",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/gunicorn_config.py",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/gunicorn_config.py?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/7b1a455133c2e78611550e45e8d2072d5c5c4ad7",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/gunicorn_config.py"
+    }
+  },
+  {
+    "name": "jobs.py",
+    "path": "jobs.py",
+    "sha": "79f2957e2c94e44786f6ca3dfc7384aaceb80c0a",
+    "size": 6213,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/jobs.py?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/jobs.py",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/79f2957e2c94e44786f6ca3dfc7384aaceb80c0a",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/jobs.py",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/jobs.py?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/79f2957e2c94e44786f6ca3dfc7384aaceb80c0a",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/jobs.py"
+    }
+  },
+  {
+    "name": "magic",
+    "path": "magic",
+    "sha": "6342094c1d4b1af948867ffba67cf0b866e5613c",
+    "size": 659195,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/magic?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/magic",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/6342094c1d4b1af948867ffba67cf0b866e5613c",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/magic",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/magic?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/6342094c1d4b1af948867ffba67cf0b866e5613c",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/magic"
+    }
+  },
+  {
+    "name": "manage.py",
+    "path": "manage.py",
+    "sha": "a0b80d4c7b5fd7e50d6dcb5bcbdcd995b8da27f0",
+    "size": 15323,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/manage.py?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/manage.py",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/a0b80d4c7b5fd7e50d6dcb5bcbdcd995b8da27f0",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/manage.py",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/manage.py?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/a0b80d4c7b5fd7e50d6dcb5bcbdcd995b8da27f0",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/manage.py"
+    }
+  },
+  {
+    "name": "migrations",
+    "path": "migrations",
+    "sha": "da206a9809330d01f4800718bca2a20c05038b44",
+    "size": 0,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/migrations?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/migrations",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/da206a9809330d01f4800718bca2a20c05038b44",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/migrations?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/da206a9809330d01f4800718bca2a20c05038b44",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/migrations"
+    }
+  },
+  {
+    "name": "gems.rb",
+    "path": "gems.rb",
+    "sha": "88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+    "size": 2433,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/gems.rb?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/gems.rb",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/gems.rb",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/gems.rb?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/gems.rb"
+    }
+  },
+  {
+    "name": "gems.locked",
+    "path": "gems.locked",
+    "sha": "d429264c8c2f0f306a422900c2f41123e07c31b4",
+    "size": 2433,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/gems.locked?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/gems.locked",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/d429264c8c2f0f306a422900c2f41123e07c31b4",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/gems.locked",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/gems.locked?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/d429264c8c2f0f306a422900c2f41123e07c31b4",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/gems.locked"
+    }
+  },
+  {
+    "name": "tests",
+    "path": "tests",
+    "sha": "88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+    "size": 0,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/tests?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/tests",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/tests?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/tests"
+    }
+  },
+  {
+    "name": "todo.txt",
+    "path": "todo.txt",
+    "sha": "3e369beef1c9e64f0c10735d35aa8ad755daddc6",
+    "size": 1147,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/todo.txt?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/todo.txt",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/3e369beef1c9e64f0c10735d35aa8ad755daddc6",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/todo.txt",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/todo.txt?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/3e369beef1c9e64f0c10735d35aa8ad755daddc6",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/todo.txt"
+    }
+  },
+  {
+    "name": "update_definitions.sh",
+    "path": "update_definitions.sh",
+    "sha": "fbde266ea5ebd519b94d18f8f78ab825b02766df",
+    "size": 7877,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/update_definitions.sh?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/update_definitions.sh",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/fbde266ea5ebd519b94d18f8f78ab825b02766df",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/update_definitions.sh",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/update_definitions.sh?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/fbde266ea5ebd519b94d18f8f78ab825b02766df",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/update_definitions.sh"
+    }
+  }
+]


### PR DESCRIPTION
That. Optional setup under Bundler 1.17.0, so time we supported it.