### PR TITLE
Stop downloading node_modules when checking yarn peer deps

### DIFF
--- a/lib/dependabot/update_checkers/java_script/npm_and_yarn/version_resolver.rb
+++ b/lib/dependabot/update_checkers/java_script/npm_and_yarn/version_resolver.rb
@@ -213,8 +213,7 @@ module Dependabot
                     Dir.pwd,
                     dependency.name,
                     version,
-                    requirements_for_path(dependency.requirements, path),
-                    top_level_dependencies.map(&:to_h)
+                    requirements_for_path(dependency.requirements, path)
                   ]
                 )
               end


### PR DESCRIPTION
Also don't need to pass down the top levels deps now that we fetch all manifests.