### PR TITLE
Elixir error detail

### DIFF
--- a/spec/dependabot/update_checkers/elixir/hex/version_resolver_spec.rb
+++ b/spec/dependabot/update_checkers/elixir/hex/version_resolver_spec.rb
@@ -87,7 +87,9 @@ RSpec.describe Dependabot::UpdateCheckers::Elixir::Hex::VersionResolver do
 
       it "raises a Dependabot::DependencyFileNotResolvable error" do
         expect { resolver.latest_resolvable_version }.
-          to raise_error(Dependabot::DependencyFileNotResolvable)
+          to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
+            expect(error.message).to include('Failed to use "plug"')
+          end
       end
     end
 


### PR DESCRIPTION
Currently, when Dependabot is give an unresolvable dependency file, it raises a `Dependabot::DependencyFileNotResolvable` error with the following message:

```
** (Mix) Hex dependency resolution failed, change the version requirements of your dependencies or unlock them (by using mix deps.update or mix deps.unlock). If you are unable to resolve the conflicts you can try overriding with {:dependency, "~> 1.0", override: true}
```

Ideally, that message would include the details which have just been printed above it (at least they are when doing an install manually):

```
Resolving Hex dependencies...

Failed to use "plug" (version 0.9.0) because
  phoenix (versions 1.2.1 and 1.2.2) requires ~> 1.1
  mix.exs specifies ~> 0.9.0


Failed to use "plug" (version 0.9.0) because
  phoenix (versions 1.2.3 and 1.2.4) requires ~> 1.4 or ~> 1.3.3 or ~> 1.2.4 or ~> 1.1.8 or ~> 1.0.5
  mix.exs specifies ~> 0.9.0


Failed to use "plug" (version 0.9.0) because
  phoenix (version 1.2.5) requires ~> 1.3.3 or ~> 1.2.4 or ~> 1.1.8 or ~> 1.0.5
  mix.exs specifies ~> 0.9.0

** (Mix) Hex dependency resolution failed, change the version requirements of your dependencies or unlock them (by using mix deps.update or mix deps.unlock). If you are unable to resolve the conflicts you can try overriding with {:dependency, "~> 1.0", override: true}
```

This PR adds a failing test for those details being captured.