### PR TITLE
[WIP] JS: Implement full unlock for resolving JS peer dependencies

### DIFF
--- a/lib/dependabot/file_parsers/java_script/npm_and_yarn.rb
+++ b/lib/dependabot/file_parsers/java_script/npm_and_yarn.rb
@@ -18,6 +18,7 @@ module Dependabot
           %w(dependencies devDependencies optionalDependencies).freeze
         CENTRAL_REGISTRIES = %w(
           https://registry.npmjs.org
+          http://registry.npmjs.org
           https://registry.yarnpkg.com
         ).freeze
         GIT_URL_REGEX = %r{

--- a/spec/fixtures/javascript/npm_responses/react-modal.json
+++ b/spec/fixtures/javascript/npm_responses/react-modal.json
@@ -1,0 +1,10278 @@
+{
+    "_id": "react-modal",
+    "_rev": "163-8d62bb265d10426c56e417448b6f605f",
+    "bugs": {
+        "url": "https://github.com/reactjs/react-modal/issues"
+    },
+    "description": "Accessible modal dialog component for React.JS",
+    "dist-tags": {
+        "latest": "3.6.1",
+        "next": "3.0.0-rc2"
+    },
+    "homepage": "https://github.com/reactjs/react-modal",
+    "keywords": [
+        "react",
+        "react-component",
+        "modal",
+        "dialog"
+    ],
+    "license": "MIT",
+    "maintainers": [
+        {
+            "email": "dias.h.bruno@gmail.com",
+            "name": "diasbruno"
+        }
+    ],
+    "name": "react-modal",
+    "readme": "# react-modal\n\nAccessible modal dialog component for React.JS\n\n[![Build Status](https://travis-ci.org/reactjs/react-modal.svg?branch=v1)](https://travis-ci.org/reactjs/react-modal)\n[![Coverage Status](https://coveralls.io/repos/github/reactjs/react-modal/badge.svg?branch=master)](https://coveralls.io/github/reactjs/react-modal?branch=master)\n![gzip size](http://img.badgesize.io/https://unpkg.com/react-modal/dist/react-modal.min.js?compression=gzip)\n[![Join the chat at https://gitter.im/react-modal/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/react-modal/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)\n\n## Table of Contents\n\n* [Installation](#installation)\n* [API documentation](#api-documentation)\n* [Examples](#examples)\n* [Demos](#demos)\n\n## Installation\n\nTo install, you can use [npm](https://npmjs.org/) or [yarn](https://yarnpkg.com):\n\n\n    $ npm install react-modal\n    $ yarn add react-modal\n\n\n## API documentation\n\nThe primary documentation for react-modal is the\n[reference book](https://reactjs.github.io/react-modal), which describes the API\nand gives examples of its usage.\n\n## Examples\n\nHere is a simple example of react-modal being used in an app with some custom\nstyles and focusable input elements within the modal content:\n\n```jsx\nimport React from 'react';\nimport ReactDOM from 'react-dom';\nimport Modal from 'react-modal';\n\nconst customStyles = {\n  content : {\n    top                   : '50%',\n    left                  : '50%',\n    right                 : 'auto',\n    bottom                : 'auto',\n    marginRight           : '-50%',\n    transform             : 'translate(-50%, -50%)'\n  }\n};\n\n// Make sure to bind modal to your appElement (http://reactcommunity.org/react-modal/accessibility/)\nModal.setAppElement('#yourAppElement')\n\nclass App extends React.Component {\n  constructor() {\n    super();\n\n    this.state = {\n      modalIsOpen: false\n    };\n\n    this.openModal = this.openModal.bind(this);\n    this.afterOpenModal = this.afterOpenModal.bind(this);\n    this.closeModal = this.closeModal.bind(this);\n  }\n\n  openModal() {\n    this.setState({modalIsOpen: true});\n  }\n\n  afterOpenModal() {\n    // references are now sync'd and can be accessed.\n    this.subtitle.style.color = '#f00';\n  }\n\n  closeModal() {\n    this.setState({modalIsOpen: false});\n  }\n\n  render() {\n    return (\n      <div>\n        <button onClick={this.openModal}>Open Modal</button>\n        <Modal\n          isOpen={this.state.modalIsOpen}\n          onAfterOpen={this.afterOpenModal}\n          onRequestClose={this.closeModal}\n          style={customStyles}\n          contentLabel=\"Example Modal\"\n        >\n\n          <h2 ref={subtitle => this.subtitle = subtitle}>Hello</h2>\n          <button onClick={this.closeModal}>close</button>\n          <div>I am a modal</div>\n          <form>\n            <input />\n            <button>tab navigation</button>\n            <button>stays</button>\n            <button>inside</button>\n            <button>the modal</button>\n          </form>\n        </Modal>\n      </div>\n    );\n  }\n}\n\nReactDOM.render(<App />, appElement);\n```\n\nYou can find more examples in the `examples` directory, which you can run in a\nlocal development server using `npm start` or `yarn run start`.\n\n## Demos\n\nThere are several demos hosted on [CodePen](https://codepen.io) which\ndemonstrate various features of react-modal:\n\n* [Minimal example](https://codepen.io/claydiffrient/pen/KNxgav)\n* [Using setAppElement](https://codepen.io/claydiffrient/pen/ENegGJ)\n* [Using onRequestClose](https://codepen.io/claydiffrient/pen/KNjVBx)\n* [Using shouldCloseOnOverlayClick](https://codepen.io/claydiffrient/pen/woLzwo)\n* [Using inline styles](https://codepen.io/claydiffrient/pen/ZBmyKz)\n* [Using CSS classes for styling](https://codepen.io/claydiffrient/pen/KNjVrG)\n* [Customizing the default styles](https://codepen.io/claydiffrient/pen/pNXgqQ)\n",
+    "readmeFilename": "README.md",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/reactjs/react-modal.git"
+    },
+    "time": {
+        "0.0.0": "2014-09-24T22:22:56.400Z",
+        "0.0.1": "2014-09-24T22:24:35.867Z",
+        "0.0.2": "2014-09-25T02:34:40.986Z",
+        "0.0.3": "2014-10-31T19:26:45.497Z",
+        "0.0.4": "2014-11-11T16:08:30.402Z",
+        "0.0.5": "2014-11-13T18:56:08.363Z",
+        "0.0.6": "2014-12-03T21:28:04.776Z",
+        "0.0.7": "2015-01-03T06:47:18.030Z",
+        "0.1.0": "2015-02-26T17:14:29.418Z",
+        "0.1.1": "2015-03-31T15:56:52.977Z",
+        "0.2.0": "2015-05-09T05:16:27.202Z",
+        "0.3.0": "2015-07-15T06:16:42.932Z",
+        "0.5.0": "2015-09-22T19:18:24.247Z",
+        "0.6.0": "2015-10-21T21:40:00.621Z",
+        "0.6.1": "2015-10-23T18:04:04.855Z",
+        "1.0.0": "2016-04-09T05:04:26.840Z",
+        "1.1.0": "2016-04-12T13:03:15.360Z",
+        "1.1.1": "2016-04-15T05:30:55.678Z",
+        "1.1.2": "2016-04-19T02:36:11.520Z",
+        "1.2.0": "2016-04-21T22:02:11.878Z",
+        "1.2.1": "2016-04-23T19:09:55.249Z",
+        "1.3.0": "2016-05-17T16:04:59.473Z",
+        "1.4.0": "2016-06-30T19:12:14.730Z",
+        "1.5.0": "2016-10-08T02:19:00.389Z",
+        "1.5.1": "2016-10-08T04:11:48.038Z",
+        "1.5.2": "2016-10-08T14:29:20.516Z",
+        "1.6.0": "2016-12-06T15:09:33.610Z",
+        "1.6.1": "2016-12-06T17:16:17.529Z",
+        "1.6.2": "2016-12-11T17:33:30.043Z",
+        "1.6.3": "2016-12-12T14:03:49.798Z",
+        "1.6.4": "2016-12-15T05:49:08.479Z",
+        "1.6.5": "2016-12-31T17:14:39.846Z",
+        "1.7.0": "2017-03-02T03:54:18.193Z",
+        "1.7.1": "2017-03-02T14:49:39.634Z",
+        "1.7.10": "2017-06-08T19:43:49.446Z",
+        "1.7.11": "2017-06-08T19:48:03.646Z",
+        "1.7.12": "2017-06-10T01:27:57.581Z",
+        "1.7.13": "2017-06-12T13:26:41.895Z",
+        "1.7.2": "2017-03-09T04:01:32.569Z",
+        "1.7.3": "2017-03-14T01:23:53.519Z",
+        "1.7.4": "2017-04-13T13:38:48.991Z",
+        "1.7.5": "2017-04-13T14:22:03.448Z",
+        "1.7.6": "2017-04-13T14:42:43.397Z",
+        "1.7.7": "2017-04-18T19:39:15.088Z",
+        "1.7.8": "2017-06-08T04:46:04.364Z",
+        "1.7.9": "2017-06-08T15:59:47.986Z",
+        "1.8.1": "2017-06-12T15:37:20.129Z",
+        "1.9.1": "2017-06-12T19:27:43.738Z",
+        "1.9.2": "2017-06-13T00:05:26.013Z",
+        "1.9.3": "2017-06-13T12:21:35.119Z",
+        "1.9.4": "2017-06-13T13:12:41.428Z",
+        "1.9.5": "2017-06-15T01:57:35.367Z",
+        "1.9.6": "2017-06-15T03:57:52.574Z",
+        "1.9.7": "2017-06-15T16:28:46.887Z",
+        "2.0.0": "2017-06-15T21:16:48.100Z",
+        "2.0.1": "2017-06-16T14:31:05.128Z",
+        "2.0.2": "2017-06-16T16:10:13.868Z",
+        "2.0.6": "2017-06-20T14:23:39.589Z",
+        "2.0.7": "2017-06-25T20:46:52.202Z",
+        "2.1.0": "2017-06-27T01:12:07.428Z",
+        "2.2.0": "2017-06-28T21:56:29.124Z",
+        "2.2.1": "2017-06-30T12:22:55.365Z",
+        "2.2.2": "2017-07-11T17:20:37.709Z",
+        "2.2.3": "2017-08-10T22:27:57.466Z",
+        "2.2.4": "2017-08-14T12:41:46.660Z",
+        "2.3.1": "2017-09-05T19:18:48.868Z",
+        "2.3.2": "2017-09-06T19:10:33.631Z",
+        "2.3.3": "2017-10-04T05:00:07.577Z",
+        "2.4.1": "2017-10-06T15:10:03.666Z",
+        "3.0.0": "2017-10-06T16:29:27.123Z",
+        "3.0.0-alpha": "2017-10-04T07:00:48.359Z",
+        "3.0.0-rc1": "2017-10-04T13:36:19.482Z",
+        "3.0.0-rc2": "2017-10-04T16:31:55.178Z",
+        "3.0.2": "2017-10-14T15:04:54.766Z",
+        "3.0.3": "2017-10-14T20:38:53.578Z",
+        "3.0.4": "2017-10-18T22:55:42.200Z",
+        "3.1.0": "2017-10-25T17:26:25.101Z",
+        "3.1.10": "2017-12-19T20:42:38.787Z",
+        "3.1.11": "2018-01-16T14:45:30.742Z",
+        "3.1.12": "2018-02-05T11:35:32.434Z",
+        "3.1.13": "2018-02-09T13:28:47.997Z",
+        "3.1.2": "2017-11-06T22:56:28.771Z",
+        "3.1.3": "2017-11-22T19:38:13.632Z",
+        "3.1.4": "2017-11-24T17:27:48.332Z",
+        "3.1.5": "2017-11-27T22:57:44.858Z",
+        "3.1.6": "2017-11-30T13:25:13.556Z",
+        "3.1.7": "2017-12-04T17:23:11.916Z",
+        "3.1.8": "2017-12-12T23:45:53.319Z",
+        "3.1.9": "2017-12-19T20:36:59.953Z",
+        "3.2.1": "2018-02-15T12:08:06.565Z",
+        "3.3.1": "2018-02-21T12:54:59.910Z",
+        "3.3.2": "2018-03-13T01:16:49.745Z",
+        "3.4.1": "2018-04-17T12:50:15.555Z",
+        "3.4.2": "2018-04-19T12:17:23.496Z",
+        "3.4.3": "2018-04-24T02:07:28.972Z",
+        "3.4.4": "2018-04-24T02:08:50.174Z",
+        "3.4.5": "2018-06-01T14:12:02.577Z",
+        "3.5.1": "2018-07-04T13:23:17.701Z",
+        "3.6.1": "2018-09-25T16:46:40.435Z",
+        "created": "2014-09-24T22:22:56.400Z",
+        "modified": "2018-09-25T16:46:45.103Z"
+    },
+    "users": {
+        "18731256026": true,
+        "abuelwafa": true,
+        "bart1208": true,
+        "cfleschhut": true,
+        "chinawolf_wyp": true,
+        "crouman": true,
+        "fearnbuster": true,
+        "fsgdez": true,
+        "hasssan": true,
+        "hexcola": true,
+        "hugovila": true,
+        "isenricho": true,
+        "jamesulph": true,
+        "jk6": true,
+        "junya": true,
+        "karzanosman984": true,
+        "kaufmo": true,
+        "kvangrae": true,
+        "kvrao": true,
+        "loasnir": true,
+        "matiasherranz": true,
+        "migkjy": true,
+        "nahleen": true,
+        "nauhil": true,
+        "orenschwartz": true,
+        "pasichnyk": true,
+        "pixel67": true,
+        "ptitdam2001": true,
+        "rodriguesmarcos": true,
+        "rossjs": true,
+        "ryanlittle": true,
+        "saikrishnaseri": true,
+        "scotchulous": true,
+        "serge-nikitin": true,
+        "shanewholloway": true,
+        "shantanu.saini": true,
+        "shyling": true,
+        "snghrym": true,
+        "stipsan": true,
+        "susuaung": true,
+        "swak": true,
+        "vjenks": true,
+        "vtocco": true,
+        "wayn": true,
+        "yologith": true
+    },
+    "versions": {
+        "0.0.0": {
+            "_from": ".",
+            "_id": "react-modal@0.0.0",
+            "_npmUser": {
+                "email": "rpflorence@gmail.com",
+                "name": "ryanflorence"
+            },
+            "_npmVersion": "2.0.0-beta.0",
+            "_shasum": "6523d18aad08b4f3676cc7c7315ca1412309e67e",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {},
+            "description": "A complete routing library for React.js",
+            "devDependencies": {
+                "browserify": "4.2.3",
+                "browserify-shim": "3.6.0",
+                "envify": "1.2.0",
+                "expect": "0.1.1",
+                "karma": "0.12.16",
+                "karma-browserify": "^0.2.1",
+                "karma-chrome-launcher": "0.1.4",
+                "karma-cli": "0.0.4",
+                "karma-firefox-launcher": "0.1.3",
+                "karma-mocha": "0.1.3",
+                "mocha": "1.20.1",
+                "react": ">=0.11.0",
+                "react-tap-event-plugin": "git://github.com/appsforartists/react-tap-event-plugin",
+                "reactify": "^0.14.0",
+                "rf-release": "0.3.1",
+                "uglify-js": "2.4.15"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "6523d18aad08b4f3676cc7c7315ca1412309e67e",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.0.0.tgz"
+            },
+            "gitHead": "298607644d5878b5063eaba4152448ea45a246ec",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./modules/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": ">=0.11.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "test": "script/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.0.0"
+        },
+        "0.0.1": {
+            "_from": ".",
+            "_id": "react-modal@0.0.1",
+            "_npmUser": {
+                "email": "rpflorence@gmail.com",
+                "name": "ryanflorence"
+            },
+            "_npmVersion": "2.0.0-beta.0",
+            "_shasum": "f893e609eec8b3e9bedc586bb978236e72323f79",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {},
+            "description": "A complete routing library for React.js",
+            "devDependencies": {
+                "browserify": "4.2.3",
+                "browserify-shim": "3.6.0",
+                "envify": "1.2.0",
+                "expect": "0.1.1",
+                "karma": "0.12.16",
+                "karma-browserify": "^0.2.1",
+                "karma-chrome-launcher": "0.1.4",
+                "karma-cli": "0.0.4",
+                "karma-firefox-launcher": "0.1.3",
+                "karma-mocha": "0.1.3",
+                "mocha": "1.20.1",
+                "react": ">=0.11.0",
+                "react-tap-event-plugin": "git://github.com/appsforartists/react-tap-event-plugin",
+                "reactify": "^0.14.0",
+                "rf-release": "0.3.1",
+                "uglify-js": "2.4.15"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "f893e609eec8b3e9bedc586bb978236e72323f79",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.0.1.tgz"
+            },
+            "gitHead": "af7edb83788beda981e270535a813967adbde8b9",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./modules/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": ">=0.11.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "test": "script/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.0.1"
+        },
+        "0.0.2": {
+            "_from": ".",
+            "_id": "react-modal@0.0.2",
+            "_npmUser": {
+                "email": "rpflorence@gmail.com",
+                "name": "ryanflorence"
+            },
+            "_npmVersion": "2.0.0-beta.0",
+            "_shasum": "4889f4731a59961d4512ac4a77de0a6efb89ebcd",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {},
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "4.2.3",
+                "browserify-shim": "3.6.0",
+                "envify": "1.2.0",
+                "expect": "0.1.1",
+                "karma": "0.12.16",
+                "karma-browserify": "^0.2.1",
+                "karma-chrome-launcher": "0.1.4",
+                "karma-cli": "0.0.4",
+                "karma-firefox-launcher": "0.1.3",
+                "karma-mocha": "0.1.3",
+                "mocha": "1.20.1",
+                "react": ">=0.11.0",
+                "react-tap-event-plugin": "git://github.com/appsforartists/react-tap-event-plugin",
+                "reactify": "^0.14.0",
+                "rf-release": "0.3.1",
+                "uglify-js": "2.4.15"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "4889f4731a59961d4512ac4a77de0a6efb89ebcd",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.0.2.tgz"
+            },
+            "gitHead": "26012856a5100ab55c6fc8e49c199a7cfecdf9ff",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./modules/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": ">=0.11.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "test": "script/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.0.2"
+        },
+        "0.0.3": {
+            "_from": ".",
+            "_id": "react-modal@0.0.3",
+            "_npmUser": {
+                "email": "rpflorence@gmail.com",
+                "name": "ryanflorence"
+            },
+            "_npmVersion": "2.0.0-beta.0",
+            "_shasum": "06360272581cac5e1bed4042c2f4e26e938571ac",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {},
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "4.2.3",
+                "browserify-shim": "3.6.0",
+                "envify": "1.2.0",
+                "expect": "0.1.1",
+                "karma": "0.12.16",
+                "karma-browserify": "^0.2.1",
+                "karma-chrome-launcher": "0.1.4",
+                "karma-cli": "0.0.4",
+                "karma-firefox-launcher": "0.1.3",
+                "karma-mocha": "0.1.3",
+                "mocha": "1.20.1",
+                "react": ">=0.11.0",
+                "react-tap-event-plugin": "git://github.com/appsforartists/react-tap-event-plugin",
+                "reactify": "^0.14.0",
+                "rf-release": "0.3.1",
+                "uglify-js": "2.4.15"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "06360272581cac5e1bed4042c2f4e26e938571ac",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.0.3.tgz"
+            },
+            "gitHead": "54975386b17e80a67d12592b703d9a5403a27193",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": ">=0.11.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "test": "script/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.0.3"
+        },
+        "0.0.4": {
+            "_from": ".",
+            "_id": "react-modal@0.0.4",
+            "_npmUser": {
+                "email": "rpflorence@gmail.com",
+                "name": "ryanflorence"
+            },
+            "_npmVersion": "2.0.0-beta.0",
+            "_shasum": "2973950ea9359e15da36b2fe436b7afb17e5dd66",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {},
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "4.2.3",
+                "browserify-shim": "3.6.0",
+                "envify": "1.2.0",
+                "expect": "0.1.1",
+                "jsx-loader": "0.11.2",
+                "karma": "0.12.16",
+                "karma-browserify": "^0.2.1",
+                "karma-chrome-launcher": "0.1.4",
+                "karma-cli": "0.0.4",
+                "karma-firefox-launcher": "0.1.3",
+                "karma-mocha": "0.1.3",
+                "mocha": "1.20.1",
+                "react": ">=0.11.0",
+                "reactify": "^0.14.0",
+                "rf-release": "0.3.1",
+                "uglify-js": "2.4.15",
+                "webpack-dev-server": "1.6.5"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "2973950ea9359e15da36b2fe436b7afb17e5dd66",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.0.4.tgz"
+            },
+            "gitHead": "c04e0838dcb4cd1a6d69f0e441509036f745b4d1",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": ">=0.11.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.0.4"
+        },
+        "0.0.5": {
+            "_from": ".",
+            "_id": "react-modal@0.0.5",
+            "_npmUser": {
+                "email": "rpflorence@gmail.com",
+                "name": "ryanflorence"
+            },
+            "_npmVersion": "2.0.0-beta.0",
+            "_shasum": "5900d2f51673a79473e7440408b9fb2a247478ac",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {},
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "4.2.3",
+                "browserify-shim": "3.6.0",
+                "envify": "1.2.0",
+                "expect": "0.1.1",
+                "jsx-loader": "0.11.2",
+                "karma": "0.12.16",
+                "karma-browserify": "^0.2.1",
+                "karma-chrome-launcher": "0.1.4",
+                "karma-cli": "0.0.4",
+                "karma-firefox-launcher": "0.1.3",
+                "karma-mocha": "0.1.3",
+                "mocha": "1.20.1",
+                "react": ">=0.11.0",
+                "reactify": "^0.14.0",
+                "rf-release": "0.3.1",
+                "uglify-js": "2.4.15",
+                "webpack-dev-server": "1.6.5"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "5900d2f51673a79473e7440408b9fb2a247478ac",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.0.5.tgz"
+            },
+            "gitHead": "fb05715b1f628591bffed29ae51d55db0f56dd80",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": ">=0.11.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.0.5"
+        },
+        "0.0.6": {
+            "_from": ".",
+            "_id": "react-modal@0.0.6",
+            "_nodeVersion": "0.10.33",
+            "_npmUser": {
+                "email": "mzabriskie@gmail.com",
+                "name": "mzabriskie"
+            },
+            "_npmVersion": "2.1.6",
+            "_shasum": "cea15ecae654213956cf918b409f5f735ad23259",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {},
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "4.2.3",
+                "browserify-shim": "3.6.0",
+                "envify": "1.2.0",
+                "expect": "0.1.1",
+                "jsx-loader": "0.11.2",
+                "karma": "0.12.16",
+                "karma-browserify": "^0.2.1",
+                "karma-chrome-launcher": "0.1.4",
+                "karma-cli": "0.0.4",
+                "karma-firefox-launcher": "0.1.3",
+                "karma-mocha": "0.1.3",
+                "mocha": "1.20.1",
+                "react": ">=0.11.0",
+                "reactify": "^0.14.0",
+                "rf-release": "0.3.1",
+                "uglify-js": "2.4.15",
+                "webpack-dev-server": "1.6.5"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "cea15ecae654213956cf918b409f5f735ad23259",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.0.6.tgz"
+            },
+            "gitHead": "734acb5b309780b10bc6bd4fb850dd214e5fd948",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": ">=0.11.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.0.6"
+        },
+        "0.0.7": {
+            "_from": ".",
+            "_id": "react-modal@0.0.7",
+            "_nodeVersion": "0.10.33",
+            "_npmUser": {
+                "email": "mzabriskie@gmail.com",
+                "name": "mzabriskie"
+            },
+            "_npmVersion": "2.1.6",
+            "_shasum": "2208d63ce94ba6533ee76545924c8909ee7fe523",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {},
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "4.2.3",
+                "browserify-shim": "3.6.0",
+                "envify": "1.2.0",
+                "expect": "0.1.1",
+                "jsx-loader": "0.11.2",
+                "karma": "0.12.16",
+                "karma-browserify": "^0.2.1",
+                "karma-chrome-launcher": "0.1.4",
+                "karma-cli": "0.0.4",
+                "karma-firefox-launcher": "0.1.3",
+                "karma-mocha": "0.1.3",
+                "mocha": "1.20.1",
+                "react": ">=0.12.0",
+                "reactify": "^0.14.0",
+                "rf-release": "0.3.1",
+                "uglify-js": "2.4.15",
+                "webpack-dev-server": "1.6.5"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "2208d63ce94ba6533ee76545924c8909ee7fe523",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.0.7.tgz"
+            },
+            "gitHead": "6fd8456b92ea70135d8c8261c198288f476b87e3",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": ">=0.12.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.0.7"
+        },
+        "0.1.0": {
+            "_from": ".",
+            "_id": "react-modal@0.1.0",
+            "_nodeVersion": "0.10.22",
+            "_npmUser": {
+                "email": "rpflorence@gmail.com",
+                "name": "ryanflorence"
+            },
+            "_npmVersion": "2.1.10",
+            "_shasum": "afdefc3482853c6bb4dbe927c9b5043a95288ffa",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {},
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "4.2.3",
+                "browserify-shim": "3.6.0",
+                "envify": "1.2.0",
+                "expect": "0.1.1",
+                "jsx-loader": "0.11.2",
+                "karma": "0.12.16",
+                "karma-browserify": "^0.2.1",
+                "karma-chrome-launcher": "0.1.4",
+                "karma-cli": "0.0.4",
+                "karma-firefox-launcher": "0.1.3",
+                "karma-mocha": "0.1.3",
+                "mocha": "1.20.1",
+                "react": ">=0.12.0",
+                "reactify": "^0.14.0",
+                "rf-release": "0.3.1",
+                "uglify-js": "2.4.15",
+                "webpack-dev-server": "1.6.5"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "afdefc3482853c6bb4dbe927c9b5043a95288ffa",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.1.0.tgz"
+            },
+            "gitHead": "d053cf8173664fb7a635f57c31a079e30f73b4e6",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": ">=0.12.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.1.0"
+        },
+        "0.1.1": {
+            "_from": ".",
+            "_id": "react-modal@0.1.1",
+            "_nodeVersion": "0.10.33",
+            "_npmUser": {
+                "email": "mzabriskie@gmail.com",
+                "name": "mzabriskie"
+            },
+            "_npmVersion": "2.7.0",
+            "_shasum": "dbf0e214b445191b7c4dee4a023f536e5116fc74",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {},
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "4.2.3",
+                "browserify-shim": "3.6.0",
+                "envify": "1.2.0",
+                "expect": "0.1.1",
+                "jsx-loader": "0.11.2",
+                "karma": "0.12.16",
+                "karma-browserify": "^0.2.1",
+                "karma-chrome-launcher": "0.1.4",
+                "karma-cli": "0.0.4",
+                "karma-firefox-launcher": "0.1.3",
+                "karma-mocha": "0.1.3",
+                "mocha": "1.20.1",
+                "react": ">=0.12.0",
+                "reactify": "^0.14.0",
+                "rf-release": "0.3.1",
+                "uglify-js": "2.4.15",
+                "webpack-dev-server": "1.6.5"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "dbf0e214b445191b7c4dee4a023f536e5116fc74",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.1.1.tgz"
+            },
+            "gitHead": "0b2028e6158654750cc3148444ec7d961adb8f91",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": ">=0.12.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.1.1"
+        },
+        "0.2.0": {
+            "_from": ".",
+            "_id": "react-modal@0.2.0",
+            "_nodeVersion": "0.10.33",
+            "_npmUser": {
+                "email": "mzabriskie@gmail.com",
+                "name": "mzabriskie"
+            },
+            "_npmVersion": "2.7.0",
+            "_shasum": "f34f566c087ce32745ae410f0eed66775a713c5f",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "4.2.3",
+                "browserify-shim": "3.6.0",
+                "envify": "1.2.0",
+                "expect": "0.1.1",
+                "jsx-loader": "0.11.2",
+                "karma": "0.12.16",
+                "karma-browserify": "^0.2.1",
+                "karma-chrome-launcher": "0.1.4",
+                "karma-cli": "0.0.4",
+                "karma-firefox-launcher": "0.1.3",
+                "karma-mocha": "0.1.3",
+                "mocha": "1.20.1",
+                "react": ">=0.12.0",
+                "reactify": "^0.14.0",
+                "rf-release": "0.3.1",
+                "uglify-js": "2.4.15",
+                "webpack-dev-server": "1.6.5"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "f34f566c087ce32745ae410f0eed66775a713c5f",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.2.0.tgz"
+            },
+            "gitHead": "48eed0077bebe2695e54857a1d9a9027f9e2f8d7",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "classnames": "^1.2.0",
+                "react": ">=0.12.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.2.0"
+        },
+        "0.3.0": {
+            "_from": ".",
+            "_id": "react-modal@0.3.0",
+            "_nodeVersion": "0.10.33",
+            "_npmUser": {
+                "email": "mzabriskie@gmail.com",
+                "name": "mzabriskie"
+            },
+            "_npmVersion": "2.7.0",
+            "_shasum": "28635230b18c7df28190b9794da04693f57d6dbe",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "classnames": "^2.1.3",
+                "element-class": "^0.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "10.2.6",
+                "browserify-shim": "3.8.9",
+                "envify": "3.4.0",
+                "expect": "1.6.0",
+                "jsx-loader": "0.13.2",
+                "karma": "0.12.37",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "mocha": "2.2.5",
+                "react": ">=0.13.3",
+                "reactify": "^1.1.1",
+                "rf-release": "0.4.0",
+                "uglify-js": "2.4.23",
+                "webpack-dev-server": "1.10.1"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "28635230b18c7df28190b9794da04693f57d6dbe",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.3.0.tgz"
+            },
+            "gitHead": "ec39e07219835f9b492d4f9e9baf44b2a1e1551c",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": ">=0.13.3"
+            },
+            "repository": {
+                "type": "git",
+                "url": "https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.3.0"
+        },
+        "0.5.0": {
+            "_from": ".",
+            "_id": "react-modal@0.5.0",
+            "_nodeVersion": "0.10.33",
+            "_npmUser": {
+                "email": "mzabriskie@gmail.com",
+                "name": "mzabriskie"
+            },
+            "_npmVersion": "2.13.4",
+            "_shasum": "cb803aa2272aa49c3c803c8e7cfa334aa9124e95",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "11.1.0",
+                "browserify-shim": "3.8.10",
+                "envify": "3.4.0",
+                "expect": "1.10.0",
+                "jsx-loader": "0.13.2",
+                "karma": "0.13.10",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": ">=0.13.3",
+                "reactify": "^1.1.1",
+                "rf-release": "0.4.0",
+                "uglify-js": "2.4.24",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "cb803aa2272aa49c3c803c8e7cfa334aa9124e95",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.5.0.tgz"
+            },
+            "gitHead": "ae68cc1673fe87acb83a7786a85ea9fd2c3422c8",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": ">=0.13.3 || ^0.14.0-beta3"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.5.0"
+        },
+        "0.6.0": {
+            "_from": ".",
+            "_id": "react-modal@0.6.0",
+            "_nodeVersion": "3.3.1",
+            "_npmUser": {
+                "email": "mzabriskie@gmail.com",
+                "name": "mzabriskie"
+            },
+            "_npmVersion": "2.14.3",
+            "_shasum": "df43d53eb19c3d51fa280a772c21fca5a97a0dd2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "deprecated": "ReactDOM is bundled in v0.6.0",
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "11.1.0",
+                "browserify-shim": "3.8.10",
+                "envify": "3.4.0",
+                "expect": "1.10.0",
+                "jsx-loader": "0.13.2",
+                "karma": "0.13.10",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^0.14.0",
+                "react-addons-test-utils": "^0.14.0",
+                "react-dom": "^0.14.0",
+                "reactify": "^1.1.1",
+                "rf-release": "0.4.0",
+                "uglify-js": "2.4.24",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "df43d53eb19c3d51fa280a772c21fca5a97a0dd2",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.6.0.tgz"
+            },
+            "gitHead": "1ff6a02c689e9fdc03616c4ab82ec53317f14c69",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.6.0"
+        },
+        "0.6.1": {
+            "_from": ".",
+            "_id": "react-modal@0.6.1",
+            "_nodeVersion": "3.3.1",
+            "_npmUser": {
+                "email": "mzabriskie@gmail.com",
+                "name": "mzabriskie"
+            },
+            "_npmVersion": "2.14.3",
+            "_shasum": "286444d80f3ae8a0aceba970371c9c73aa812849",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React",
+                "react-dom": "global:ReactDOM"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "11.1.0",
+                "browserify-shim": "3.8.10",
+                "envify": "3.4.0",
+                "expect": "1.10.0",
+                "jsx-loader": "0.13.2",
+                "karma": "0.13.10",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^0.14.0",
+                "react-addons-test-utils": "^0.14.0",
+                "react-dom": "^0.14.0",
+                "reactify": "^1.1.1",
+                "rf-release": "0.4.0",
+                "uglify-js": "2.4.24",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "286444d80f3ae8a0aceba970371c9c73aa812849",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-0.6.1.tgz"
+            },
+            "gitHead": "1a0a069a7f91aa660433bdfa410636d4e3d81fcf",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "0.6.1"
+        },
+        "1.0.0": {
+            "_from": ".",
+            "_id": "react-modal@1.0.0",
+            "_nodeVersion": "5.7.1",
+            "_npmOperationalInternal": {
+                "host": "packages-16-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.0.0.tgz_1460178264550_0.5645000243093818"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.6.0",
+            "_shasum": "feeaacf5bfae9716b734ecc63bb3235065a8555e",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React",
+                "react-dom": "global:ReactDOM"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "11.1.0",
+                "browserify-shim": "3.8.10",
+                "envify": "3.4.0",
+                "expect": "1.10.0",
+                "jsx-loader": "0.13.2",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "reactify": "^1.1.1",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "feeaacf5bfae9716b734ecc63bb3235065a8555e",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.0.0.tgz"
+            },
+            "gitHead": "eee9431801dd2cf78946887af94806facb351ad1",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                },
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0-0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.0.0"
+        },
+        "1.1.0": {
+            "_from": ".",
+            "_id": "react-modal@1.1.0",
+            "_nodeVersion": "5.7.1",
+            "_npmOperationalInternal": {
+                "host": "packages-12-west.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.1.0.tgz_1460466194782_0.3783653483260423"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.6.0",
+            "_shasum": "1bcc59e1cdc94401a64999633aea763619c2a42f",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "browserify-shim": {
+                "react": "global:React",
+                "react-dom": "global:ReactDOM"
+            },
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "browserify": "11.1.0",
+                "browserify-shim": "3.8.10",
+                "envify": "3.4.0",
+                "expect": "1.10.0",
+                "jsx-loader": "0.13.2",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "reactify": "^1.1.1",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "1bcc59e1cdc94401a64999633aea763619c2a42f",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.1.0.tgz"
+            },
+            "gitHead": "0534928315ca267100a60cd0bf344c98956e5716",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                },
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0-0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.1.0"
+        },
+        "1.1.1": {
+            "_from": ".",
+            "_id": "react-modal@1.1.1",
+            "_nodeVersion": "5.7.1",
+            "_npmOperationalInternal": {
+                "host": "packages-16-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.1.1.tgz_1460698252445_0.6276144874282181"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.6.0",
+            "_shasum": "0e2c7634f05bed609eebaa80a8649a29883b570b",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "0e2c7634f05bed609eebaa80a8649a29883b570b",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.1.1.tgz"
+            },
+            "gitHead": "fed611bd9ee125673529ac3005e7a7625c62e2bc",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                },
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0-0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.1.1"
+        },
+        "1.1.2": {
+            "_from": ".",
+            "_id": "react-modal@1.1.2",
+            "_nodeVersion": "5.7.1",
+            "_npmOperationalInternal": {
+                "host": "packages-12-west.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.1.2.tgz_1461033371108_0.03689690516330302"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.6.0",
+            "_shasum": "b1f9871792b4ce2ccc70858f1ae1783782dd5a4c",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "b1f9871792b4ce2ccc70858f1ae1783782dd5a4c",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.1.2.tgz"
+            },
+            "gitHead": "7f9bd95a42bccaafb684db70cddba87c4c796885",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                },
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0-0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.1.2"
+        },
+        "1.2.0": {
+            "_from": ".",
+            "_id": "react-modal@1.2.0",
+            "_nodeVersion": "5.7.1",
+            "_npmOperationalInternal": {
+                "host": "packages-16-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.2.0.tgz_1461276129199_0.320301525760442"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.6.0",
+            "_shasum": "edb784c3510bc27aeccc9abe4172b1075bbefce1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "edb784c3510bc27aeccc9abe4172b1075bbefce1",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.2.0.tgz"
+            },
+            "gitHead": "c55d6b481b5eee227c8d252e7c9076b14cc4cdcc",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                },
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0-0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.2.0"
+        },
+        "1.2.1": {
+            "_from": ".",
+            "_id": "react-modal@1.2.1",
+            "_nodeVersion": "5.7.1",
+            "_npmOperationalInternal": {
+                "host": "packages-16-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.2.1.tgz_1461438592113_0.26450050133280456"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.6.0",
+            "_shasum": "e26dd3fd68baa719348e7618734291447c7d16e8",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "e26dd3fd68baa719348e7618734291447c7d16e8",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.2.1.tgz"
+            },
+            "gitHead": "5661e9d80fb11ab630a57ab4dd4913b481ca3951",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                },
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0-0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.2.1"
+        },
+        "1.3.0": {
+            "_from": ".",
+            "_id": "react-modal@1.3.0",
+            "_nodeVersion": "6.0.0",
+            "_npmOperationalInternal": {
+                "host": "packages-16-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.3.0.tgz_1463501095250_0.8238731492310762"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.8.6",
+            "_shasum": "def96766bd696611db8570ca953a3a3a7dff2fa0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "def96766bd696611db8570ca953a3a3a7dff2fa0",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.3.0.tgz"
+            },
+            "gitHead": "d52238c458409bd44797cbcd2c7e43f2c4d600e8",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                },
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0-0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.3.0"
+        },
+        "1.4.0": {
+            "_from": ".",
+            "_id": "react-modal@1.4.0",
+            "_nodeVersion": "6.2.0",
+            "_npmOperationalInternal": {
+                "host": "packages-16-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.4.0.tgz_1467313931516_0.8029457975644618"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.8.9",
+            "_shasum": "c50cd02bcd3487f4b53177fa6285f1a5ad49c56e",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "c50cd02bcd3487f4b53177fa6285f1a5ad49c56e",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.4.0.tgz"
+            },
+            "gitHead": "9686635abe418ffd510dafefe4cd59c9e8a87217",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                },
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0-0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox --single-run"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.4.0"
+        },
+        "1.5.0": {
+            "_from": ".",
+            "_id": "react-modal@1.5.0",
+            "_nodeVersion": "6.6.0",
+            "_npmOperationalInternal": {
+                "host": "packages-16-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.5.0.tgz_1475893138612_0.04033300140872598"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.10.3",
+            "_shasum": "6a385f778b65ea029ff8ab3f6737c1739bd06ff2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "6a385f778b65ea029ff8ab3f6737c1739bd06ff2",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.5.0.tgz"
+            },
+            "gitHead": "be5534eb6835b6cf16a33d4002d0a1b72a12c51a",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                },
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.5.0"
+        },
+        "1.5.1": {
+            "_from": ".",
+            "_id": "react-modal@1.5.1",
+            "_nodeVersion": "6.6.0",
+            "_npmOperationalInternal": {
+                "host": "packages-12-west.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.5.1.tgz_1475899907758_0.08129170024767518"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.10.3",
+            "_shasum": "a421a954e1f26c2542f708e5490d2f687320c3db",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "a421a954e1f26c2542f708e5490d2f687320c3db",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.5.1.tgz"
+            },
+            "gitHead": "95dd2cfb44507cca1f52232b241ed1ca97267138",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                },
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.5.1"
+        },
+        "1.5.2": {
+            "_from": ".",
+            "_id": "react-modal@1.5.2",
+            "_nodeVersion": "6.6.0",
+            "_npmOperationalInternal": {
+                "host": "packages-16-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.5.2.tgz_1475936958750_0.36244864063337445"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.10.3",
+            "_shasum": "acd60f19ed93ebbc7b09ea51624c7566fc615245",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "acd60f19ed93ebbc7b09ea51624c7566fc615245",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.5.2.tgz"
+            },
+            "gitHead": "11c1fd631c5700df63169a8531783feea7897ccc",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                },
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.5.2"
+        },
+        "1.6.0": {
+            "_from": ".",
+            "_id": "react-modal@1.6.0",
+            "_nodeVersion": "7.2.0",
+            "_npmOperationalInternal": {
+                "host": "packages-18-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.6.0.tgz_1481036971535_0.8592010207939893"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.10.9",
+            "_shasum": "ccff16664c56094e0e9226492be198823bdeb065",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "deprecated": "This",
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "ccff16664c56094e0e9226492be198823bdeb065",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.6.0.tgz"
+            },
+            "gitHead": "de42f31f0bf1f5f4826e4c7e097d39bb2e17a905",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                },
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.6.0"
+        },
+        "1.6.1": {
+            "_from": ".",
+            "_id": "react-modal@1.6.1",
+            "_nodeVersion": "7.2.0",
+            "_npmOperationalInternal": {
+                "host": "packages-18-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.6.1.tgz_1481044575782_0.43966247513890266"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.10.9",
+            "_shasum": "be7a8a833cc5b6b893560f4cc73d33df17db06e8",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "be7a8a833cc5b6b893560f4cc73d33df17db06e8",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.6.1.tgz"
+            },
+            "gitHead": "3b8beaee00bb0fa628cc13d1e3a7067db7fe5cb0",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                },
+                {
+                    "email": "mzabriskie@gmail.com",
+                    "name": "mzabriskie"
+                },
+                {
+                    "email": "rpflorence@gmail.com",
+                    "name": "ryanflorence"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.6.1"
+        },
+        "1.6.2": {
+            "_from": ".",
+            "_id": "react-modal@1.6.2",
+            "_nodeVersion": "7.2.0",
+            "_npmOperationalInternal": {
+                "host": "packages-12-west.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.6.2.tgz_1481477602791_0.6518798822071403"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.10.9",
+            "_shasum": "a2fb71b4a1317715f4302dda820f08d99b2a945c",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "deprecated": "This",
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "a2fb71b4a1317715f4302dda820f08d99b2a945c",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.6.2.tgz"
+            },
+            "gitHead": "69e0fef3059078f24c3ffb8cc394c9f7c1819390",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.6.2"
+        },
+        "1.6.3": {
+            "_from": ".",
+            "_id": "react-modal@1.6.3",
+            "_nodeVersion": "7.2.0",
+            "_npmOperationalInternal": {
+                "host": "packages-12-west.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.6.3.tgz_1481551429549_0.6162375509738922"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.10.9",
+            "_shasum": "5a55bd6692365a8da724245ed11ef0f3e9fb88bf",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/rackt/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^3.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "5a55bd6692365a8da724245ed11ef0f3e9fb88bf",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.6.3.tgz"
+            },
+            "gitHead": "2cc4f3d418ffaab41aca7d237deb78f29e0a21dd",
+            "homepage": "https://github.com/rackt/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/rackt/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.6.3"
+        },
+        "1.6.4": {
+            "_from": ".",
+            "_id": "react-modal@1.6.4",
+            "_nodeVersion": "7.2.0",
+            "_npmOperationalInternal": {
+                "host": "packages-18-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.6.4.tgz_1481780947760_0.8259233913850039"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.10.9",
+            "_shasum": "639383931cbaae7946a92de9d5a7c05a4a1cab82",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "1.10.0",
+                "karma": "^0.13.22",
+                "karma-browserify": "^4.2.1",
+                "karma-chrome-launcher": "0.2.0",
+                "karma-cli": "0.1.0",
+                "karma-firefox-launcher": "0.1.6",
+                "karma-mocha": "0.2.0",
+                "karma-safari-launcher": "^0.1.1",
+                "mocha": "2.3.3",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "^1.17.3",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "639383931cbaae7946a92de9d5a7c05a4a1cab82",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.6.4.tgz"
+            },
+            "gitHead": "9f49761531d953807e2888a9a0d0aa97984eae69",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "scripts/dev-examples",
+                "test": "scripts/test --browsers Firefox"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.6.4"
+        },
+        "1.6.5": {
+            "_from": ".",
+            "_id": "react-modal@1.6.5",
+            "_nodeVersion": "7.3.0",
+            "_npmOperationalInternal": {
+                "host": "packages-12-west.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.6.5.tgz_1483204477061_0.13364521320909262"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "3.10.10",
+            "_shasum": "f720d99bd81b1def5c2c32e0ffaa48bdaf484862",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "f720d99bd81b1def5c2c32e0ffaa48bdaf484862",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-1.6.5.tgz"
+            },
+            "gitHead": "3ada4fba8133db5750decb72cede1992c5d8a40a",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "docs": "npm-run-all docs:*",
+                "docs-dev": "npm-run-all docs:clean docs:prepare docs:build:watch",
+                "docs:build": "gitbook build -g reactjs/react-modal",
+                "docs:build:watch": "gitbook serve",
+                "docs:clean": "rimraf _book",
+                "docs:prepare": "gitbook install",
+                "docs:publish": "cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:reactjs/react-modal gh-pages --force",
+                "start": "scripts/dev-examples",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.6.5"
+        },
+        "1.7.0": {
+            "_from": ".",
+            "_id": "react-modal@1.7.0",
+            "_nodeVersion": "7.6.0",
+            "_npmOperationalInternal": {
+                "host": "packages-18-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.7.0.tgz_1488426857466_0.20007769437506795"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "4.1.2",
+            "_shasum": "5328e1d7a52208103f040114dc8a839296196bd7",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "5328e1d7a52208103f040114dc8a839296196bd7",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.0.tgz"
+            },
+            "gitHead": "975e9ab320f777ffb6d18a575f79b86766f7b910",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "docs": "npm-run-all docs:*",
+                "docs-dev": "npm-run-all docs:clean docs:prepare docs:build:watch",
+                "docs:build": "gitbook build -g reactjs/react-modal",
+                "docs:build:watch": "gitbook serve",
+                "docs:clean": "rimraf _book",
+                "docs:prepare": "gitbook install",
+                "docs:publish": "cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:reactjs/react-modal gh-pages --force",
+                "start": "scripts/dev-examples",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.0"
+        },
+        "1.7.1": {
+            "_from": ".",
+            "_id": "react-modal@1.7.1",
+            "_nodeVersion": "7.6.0",
+            "_npmOperationalInternal": {
+                "host": "packages-18-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.7.1.tgz_1488466177347_0.47311057103797793"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "4.1.2",
+            "_shasum": "ad6cacd41ce7a7f779a431781e6df53337a6edc1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "ad6cacd41ce7a7f779a431781e6df53337a6edc1",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.1.tgz"
+            },
+            "gitHead": "d8e6e8451c9730a84d1cb052a408fd4941c0d4c5",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "docs": "npm-run-all docs:*",
+                "docs-dev": "npm-run-all docs:clean docs:prepare docs:build:watch",
+                "docs:build": "gitbook build -g reactjs/react-modal",
+                "docs:build:watch": "gitbook serve",
+                "docs:clean": "rimraf _book",
+                "docs:prepare": "gitbook install",
+                "docs:publish": "cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:reactjs/react-modal gh-pages --force",
+                "start": "scripts/dev-examples",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.1"
+        },
+        "1.7.10": {
+            "_id": "react-modal@1.7.10",
+            "_nodeVersion": "6.10.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.7.10.tgz_1496951029183_0.22461142647080123"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-xLs70dVTbNXQynyi1j/WV9HlQS8JIOWSbvIBwfMApXdO8pHp3xg4BYLm0wGOWjjMWe28PolVOe3qKuQbnT5G+w==",
+                "shasum": "7d55b0046cac02bfc2140463ea08fd58a9501a7a",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.10.tgz"
+            },
+            "gitHead": "5e48b5ceb7409562101ceb1d37b8efdf2ab5d1ef",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.10"
+        },
+        "1.7.11": {
+            "_id": "react-modal@1.7.11",
+            "_nodeVersion": "6.10.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.7.11.tgz_1496951283406_0.6413239939138293"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-mKKJlDp7mIWAuBpg0ZJLoGEzyVME63vs5jBy+D53R9V+hVJ775y8DXFYRGLQYSZW9IFE0qkmNSLm7HdgDGqzsg==",
+                "shasum": "70e6d38db578e8ecaa7ddc33ee24e2a433ca4848",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.11.tgz"
+            },
+            "gitHead": "5aac4a4dfbeae1c690d883e6261a55b9b5df337f",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.11"
+        },
+        "1.7.12": {
+            "_id": "react-modal@1.7.12",
+            "_nodeVersion": "8.0.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.7.12.tgz_1497058075992_0.9905644431710243"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.3",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-pz1R88GaZIieaOuY20uXLbuP9Hz1eXAwFx3DruKGc5FwkiSlKvnKaI16QxVqakH1/OuhLLTJeKjY06clFyeIuw==",
+                "shasum": "d3e29c07ddff8cd44c723a92dcd15e66a51a95bc",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.12.tgz"
+            },
+            "gitHead": "fb89f8b8dc5bec7ce72a7b86e9bda6a881bec1dd",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.12"
+        },
+        "1.7.13": {
+            "_id": "react-modal@1.7.13",
+            "_nodeVersion": "6.10.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.7.13.tgz_1497274001655_0.4280692399479449"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-COTYkkVnUf32HpCa8RVfRez1u1KbLGE1MxA+6XFhAXHHE/0PtGmsG2tfYINULNgi/2Zk3JYSCpjKzQQMYI7PyQ==",
+                "shasum": "f7b4285e6d327d31d09892a4ed3e7eeb56c3e78e",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.13.tgz"
+            },
+            "gitHead": "5cf1867e72dec7933fdb296102d12310f2402352",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.13"
+        },
+        "1.7.2": {
+            "_from": ".",
+            "_id": "react-modal@1.7.2",
+            "_nodeVersion": "7.7.1",
+            "_npmOperationalInternal": {
+                "host": "packages-12-west.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.7.2.tgz_1489032090149_0.46208976581692696"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "4.1.2",
+            "_shasum": "3c0b6d144745a819030fdbe0edf6ee3d5722eade",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "3c0b6d144745a819030fdbe0edf6ee3d5722eade",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.2.tgz"
+            },
+            "gitHead": "41938d535ddabc4de1e029210b64e31cd746000c",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "docs": "npm-run-all docs:*",
+                "docs-dev": "npm-run-all docs:clean docs:prepare docs:build:watch",
+                "docs:build": "gitbook build -g reactjs/react-modal",
+                "docs:build:watch": "gitbook serve",
+                "docs:clean": "rimraf _book",
+                "docs:prepare": "gitbook install",
+                "docs:publish": "cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:reactjs/react-modal gh-pages --force",
+                "start": "scripts/dev-examples",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.2"
+        },
+        "1.7.3": {
+            "_from": ".",
+            "_id": "react-modal@1.7.3",
+            "_nodeVersion": "7.7.1",
+            "_npmOperationalInternal": {
+                "host": "packages-12-west.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.7.3.tgz_1489454631386_0.663400806253776"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "4.1.2",
+            "_shasum": "9745448f280c92290ab1ab05c3d34ae708ef9ab3",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "9745448f280c92290ab1ab05c3d34ae708ef9ab3",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.3.tgz"
+            },
+            "gitHead": "02a16ce3949d133d64b9f27c4705db6d130ed821",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "docs": "npm-run-all docs:*",
+                "docs-dev": "npm-run-all docs:clean docs:prepare docs:build:watch",
+                "docs:build": "gitbook build -g reactjs/react-modal",
+                "docs:build:watch": "gitbook serve",
+                "docs:clean": "rimraf _book",
+                "docs:prepare": "gitbook install",
+                "docs:publish": "cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:reactjs/react-modal gh-pages --force",
+                "start": "scripts/dev-examples",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.3"
+        },
+        "1.7.4": {
+            "_from": ".",
+            "_id": "react-modal@1.7.4",
+            "_nodeVersion": "7.7.2",
+            "_npmOperationalInternal": {
+                "host": "packages-18-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.7.4.tgz_1492090726702_0.33584852959029377"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "4.1.2",
+            "_shasum": "ecbf01f0970845012b868adfb25537929e8413a8",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "deprecated": "This version let some breaking things through, please use 1.7.5 instead",
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "ecbf01f0970845012b868adfb25537929e8413a8",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.4.tgz"
+            },
+            "gitHead": "c8fbae485e322872e2746c9c1777a7fdee1affbd",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "docs": "npm-run-all docs:*",
+                "docs-dev": "npm-run-all docs:clean docs:prepare docs:build:watch",
+                "docs:build": "gitbook build -g reactjs/react-modal",
+                "docs:build:watch": "gitbook serve",
+                "docs:clean": "rimraf _book",
+                "docs:prepare": "gitbook install",
+                "docs:publish": "cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:reactjs/react-modal gh-pages --force",
+                "start": "scripts/dev-examples",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.4"
+        },
+        "1.7.5": {
+            "_from": ".",
+            "_id": "react-modal@1.7.5",
+            "_nodeVersion": "7.7.2",
+            "_npmOperationalInternal": {
+                "host": "packages-18-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.7.5.tgz_1492093321377_0.831016454147175"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "4.1.2",
+            "_shasum": "2b144d3067c8dcd95d24081d1a55eacfce86deaa",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "2b144d3067c8dcd95d24081d1a55eacfce86deaa",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.5.tgz"
+            },
+            "gitHead": "4bae32b56a21f9b1df65136a93e51fdadc92cd20",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "docs": "npm-run-all docs:*",
+                "docs-dev": "npm-run-all docs:clean docs:prepare docs:build:watch",
+                "docs:build": "gitbook build -g reactjs/react-modal",
+                "docs:build:watch": "gitbook serve",
+                "docs:clean": "rimraf _book",
+                "docs:prepare": "gitbook install",
+                "docs:publish": "cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:reactjs/react-modal gh-pages --force",
+                "start": "scripts/dev-examples",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.5"
+        },
+        "1.7.6": {
+            "_from": ".",
+            "_id": "react-modal@1.7.6",
+            "_nodeVersion": "7.7.2",
+            "_npmOperationalInternal": {
+                "host": "packages-12-west.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.7.6.tgz_1492094563064_0.554815462557599"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "4.1.2",
+            "_shasum": "ee719e480b0e0d959c2e249bcb7acc204950c755",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "ee719e480b0e0d959c2e249bcb7acc204950c755",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.6.tgz"
+            },
+            "gitHead": "708a257c0d8fc71eda0afceb661000924d2a6590",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "docs": "npm-run-all docs:*",
+                "docs-dev": "npm-run-all docs:clean docs:prepare docs:build:watch",
+                "docs:build": "gitbook build -g reactjs/react-modal",
+                "docs:build:watch": "gitbook serve",
+                "docs:clean": "rimraf _book",
+                "docs:prepare": "gitbook install",
+                "docs:publish": "cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:reactjs/react-modal gh-pages --force",
+                "start": "scripts/dev-examples",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.6"
+        },
+        "1.7.7": {
+            "_from": ".",
+            "_id": "react-modal@1.7.7",
+            "_nodeVersion": "7.7.2",
+            "_npmOperationalInternal": {
+                "host": "packages-18-east.internal.npmjs.com",
+                "tmp": "tmp/react-modal-1.7.7.tgz_1492544353110_0.7471983374562114"
+            },
+            "_npmUser": {
+                "email": "clay.diffrient@gmail.com",
+                "name": "claydiffrient"
+            },
+            "_npmVersion": "4.1.2",
+            "_shasum": "70205f51c58708c487aff681ba3fed7946e391d9",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "shasum": "70205f51c58708c487aff681ba3fed7946e391d9",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.7.tgz"
+            },
+            "gitHead": "cb799d3e4a9cacd68df4baabadb85e39023cc51b",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "clay.diffrient@gmail.com",
+                    "name": "claydiffrient"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "docs": "npm-run-all docs:*",
+                "docs-dev": "npm-run-all docs:clean docs:prepare docs:build:watch",
+                "docs:build": "gitbook build -g reactjs/react-modal",
+                "docs:build:watch": "gitbook serve",
+                "docs:clean": "rimraf _book",
+                "docs:prepare": "gitbook install",
+                "docs:publish": "cd _book && git init && git commit --allow-empty -m 'update book' && git checkout -b gh-pages && touch .nojekyll && git add . && git commit -am 'update book' && git push git@github.com:reactjs/react-modal gh-pages --force",
+                "start": "scripts/dev-examples",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.7"
+        },
+        "1.7.8": {
+            "_id": "react-modal@1.7.8",
+            "_nodeVersion": "8.0.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.7.8.tgz_1496897164100_0.7599753250833601"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.3",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-3H6WV3zcl+pZ5P0AF0ZdiYGcj34Tu90i/Y8Pq74ZtxZCbiDUyPB+reeFUt5hY69tYWOsHZfW6+QGcnnL+zDzWw==",
+                "shasum": "952f30cf7d4dd584e96c1c82c144d10e3155c95e",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.8.tgz"
+            },
+            "gitHead": "39cec6f942438b81dd75410fe534e5d6b4609bca",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.8"
+        },
+        "1.7.9": {
+            "_id": "react-modal@1.7.9",
+            "_nodeVersion": "6.10.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.7.9.tgz_1496937587386_0.30191484396345913"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-TVvcIn05ZgeF9D3N+booiYUWn+N9tT4vnj5EeWGteA+IlrI+mJxnFqxvRGy2dHoWidbcNPTMPS2AQCgObLDhEw==",
+                "shasum": "426941307a1b6696fb4ebce403e5fc4d00c31798",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.7.9.tgz"
+            },
+            "gitHead": "f4c84562dba2fc7c1d22afd17b7c1b26e31619b3",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.7.9"
+        },
+        "1.8.1": {
+            "_id": "react-modal@1.8.1",
+            "_nodeVersion": "6.10.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.8.1.tgz_1497281839989_0.5770999430678785"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-J43zC+Z8KIRH4hiceDx4tRCkWB3W5sz2inuZTIWh5NFKqjhwcK6eq+keR1a1N3kzPob7wDPM8f+0NxGBZdGTeg==",
+                "shasum": "6961caf19b591b6c94ad0b180e7f5d9cf1064859",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.8.1.tgz"
+            },
+            "gitHead": "bf5e28820090e8660b9dad7b81fa205ccc019dfd",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.8.1"
+        },
+        "1.9.1": {
+            "_id": "react-modal@1.9.1",
+            "_nodeVersion": "6.10.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.9.1.tgz_1497295663596_0.48460491304285824"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-qYG1nOH/J3IwplTSTCkBWKeKVGeoNd6x1hCAImLbVQP3AS6OOyvz57mgqYf10B2UWud3fkhKXQ7yHfJriRgBcg==",
+                "shasum": "e44ca005fcabc86be3941417b52313e23f6486b5",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.9.1.tgz"
+            },
+            "gitHead": "95693ba45603c07df0f4ababfb22770b10a7a875",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.9.1"
+        },
+        "1.9.2": {
+            "_id": "react-modal@1.9.2",
+            "_nodeVersion": "8.0.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.9.2.tgz_1497312325845_0.8984862172510475"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.3",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-4FG4SsYdJ9ncLYIP17Q8HEWRXbEsd+lHkG3vJd+koqXdPDMzP+2KZFjrkMOVvLyvXYSpgVTqEqeLFnkJ2x8+Ig==",
+                "shasum": "a921b027830512bfa50663320266b913ee1b6a81",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.9.2.tgz"
+            },
+            "gitHead": "bb15b165cde993f1f198ec3ae7903cc2ea020a90",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.9.2"
+        },
+        "1.9.3": {
+            "_id": "react-modal@1.9.3",
+            "_nodeVersion": "6.10.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.9.3.tgz_1497356494659_0.8434295228216797"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-E4Q98rVgKZMDaon/NbqhByFzM9JvaohcPn5ipZZB2/C+VHPil4W53bsunkmA0qxA/YCixOUbxSjb/fPm9kj92Q==",
+                "shasum": "dcbada604000dc8e5bef5942827de70ab163b14a",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.9.3.tgz"
+            },
+            "gitHead": "bc954aacf633de54b8a2b21ae22962ac0097e619",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.9.3"
+        },
+        "1.9.4": {
+            "_id": "react-modal@1.9.4",
+            "_nodeVersion": "6.10.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.9.4.tgz_1497359561241_0.21264941827394068"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-ourtHswaEA/KyeI20AsCOSWTC23WF3z0b1C3qzQtA5UhBOdwQ2sEK2OPJGN8u7iFGJ83etmk605aeF/i4tGVEQ==",
+                "shasum": "f6823c29ca9ecbecd9cc2a9f019e78e4319bafdd",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.9.4.tgz"
+            },
+            "gitHead": "09f8ac0cf8ed1ffaf55bcb22404d34715a741aae",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.9.4"
+        },
+        "1.9.5": {
+            "_id": "react-modal@1.9.5",
+            "_nodeVersion": "8.0.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.9.5.tgz_1497491855037_0.18504383508116007"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.3",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-To+ng2p6v830JX856Hmio3WXMRiZYukhoW0+zEQUMDaI2eEqWLF41SwLa+HUqPSQJpSUbjphuXDDwsSX8dnWiQ==",
+                "shasum": "bae52460a34a991d877603d6ea6327403c686585",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.9.5.tgz"
+            },
+            "gitHead": "34e81dbda23c1a75613709d6681861b2b06f8565",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.9.5"
+        },
+        "1.9.6": {
+            "_id": "react-modal@1.9.6",
+            "_nodeVersion": "8.0.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.9.6.tgz_1497499072340_0.19176067947410047"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.3",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-5mDRrg4sbj26O0YRz67hJrII2r+GegEPvcLUUD9LVmfxhPRASSwvjVbdUaapwkkjy7AIom6w+4aUvDkIkF4LVg==",
+                "shasum": "b3fc0947e562bfcf0a5e295b1a4bdd5f81e77d4c",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.9.6.tgz"
+            },
+            "gitHead": "3b9ddfd73c6525d3938acad8b33926c6eb0c7b56",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.9.6"
+        },
+        "1.9.7": {
+            "_id": "react-modal@1.9.7",
+            "_nodeVersion": "8.1.1",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-1.9.7.tgz_1497544126516_0.5962618647608906"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.3",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-oZNqI0ZnPD7NnfObrCMz2hxHTAw5oEuhZJ+gnyFNIQB2rR8h1YbLQTfhms1mtSJigb0J23OOWElHjXYYaKO+wg==",
+                "shasum": "07ef56790b953e3b98ef1e2989e347983c72871d",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-1.9.7.tgz"
+            },
+            "gitHead": "95e8511568b5c0f3acb3d94234498829b8eb2172",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "1.9.7"
+        },
+        "2.0.0": {
+            "_id": "react-modal@2.0.0",
+            "_nodeVersion": "8.1.1",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.0.0.tgz_1497561407875_0.9227846818976104"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.3",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "create-react-class": "^15.5.2",
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "lodash.assign": "^4.2.0",
+                "prop-types": "^15.5.7",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-core": "^6.7.4",
+                "babel-eslint": "^7.1.1",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.6.0",
+                "babel-preset-react": "^6.5.0",
+                "babel-preset-stage-2": "^6.24.1",
+                "codeclimate-test-reporter": "^0.4.0",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "eslint": "^3.9.1",
+                "eslint-config-airbnb": "latest",
+                "eslint-plugin-import": "^2.1.0",
+                "eslint-plugin-jsx-a11y": "^2.2.3",
+                "eslint-plugin-react": "^6.6.0",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "0.2.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "rimraf": "^2.5.4",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-2lE0uPP4A8//3lGaaIF9e68AdJLtWto5DVnhPnFnFhhCD6x8EvsvE28XZi2VUUKNqZynX8a582JM9mCOr/yk3A==",
+                "shasum": "5c298313165389474e78a714a8af7a8e8197c671",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.0.0.tgz"
+            },
+            "gitHead": "ec6b8e55b1e99da243dac61ceec19d86eea85095",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint lib/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.0.0"
+        },
+        "2.0.1": {
+            "_id": "react-modal@2.0.1",
+            "_nodeVersion": "6.10.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.0.1.tgz_1497623464970_0.6017484397161752"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "prop-types": "^15.5.7",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.24.1",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^7.1.1",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "codeclimate-test-reporter": "^0.4.0",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "eslint": "^3.19.0",
+                "eslint-config-airbnb": "^15.0.1",
+                "eslint-plugin-import": "^2.3.0",
+                "eslint-plugin-jsx-a11y": "^5.0.3",
+                "eslint-plugin-react": "^7.1.0",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "0.2.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-hoiLGk9xwSZ4px20/nhkrTf3bn3CBwLKdb0gQPUmoQQEQ3EFRHnC97btO1/JWSGIjkX6O96DTWCgLhuiRWKIZQ==",
+                "shasum": "bc345cc326e50b5c3cff6a994525849ae764a131",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.0.1.tgz"
+            },
+            "gitHead": "af3d1469eba5d510e3f03765cbd684a18fcd97e5",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.0.1"
+        },
+        "2.0.2": {
+            "_id": "react-modal@2.0.2",
+            "_nodeVersion": "6.10.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.0.2.tgz_1497629413639_0.40129459160380065"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "prop-types": "^15.5.7",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.24.1",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^7.1.1",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "codeclimate-test-reporter": "^0.4.0",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "eslint": "^3.19.0",
+                "eslint-config-airbnb": "^15.0.1",
+                "eslint-plugin-import": "^2.3.0",
+                "eslint-plugin-jsx-a11y": "^5.0.3",
+                "eslint-plugin-react": "^7.1.0",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "0.2.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.0.0",
+                "react-addons-test-utils": "^15.0.0",
+                "react-dom": "^15.0.0",
+                "rf-release": "0.4.0",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-ghTGgAgMYfXDQhtsqBFD/cgTjXo0o+o+KBQpwcSSrXf75bSY+LPbAL2X5a/rINzxxrOZxDGQujKkMZNdND2h6w==",
+                "shasum": "0113efbb1c3c02087580c484e08c43d06d1f6770",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.0.2.tgz"
+            },
+            "gitHead": "88d2ae1c775649af8ef79937ec7ddd4d85f8b660",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.0.2"
+        },
+        "2.0.6": {
+            "_id": "react-modal@2.0.6",
+            "_nodeVersion": "6.10.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.0.6.tgz_1497968619370_0.9813679384533316"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.3",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "prop-types": "^15.5.10",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.24.1",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^7.1.1",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "codeclimate-test-reporter": "^0.4.0",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "eslint": "^3.19.0",
+                "eslint-config-airbnb": "^15.0.1",
+                "eslint-plugin-import": "^2.3.0",
+                "eslint-plugin-jsx-a11y": "^5.0.3",
+                "eslint-plugin-react": "^7.1.0",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "0.2.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.6.1",
+                "react-dom": "^15.6.1",
+                "rf-release": "0.4.0",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-qfJZ2VM8VP2PMMfszi81jD5RmNluyYu6SGtobUNEILofXrP/FrpR5MZQBDWxv8XR0YS/5/F7mjVnht0lfYYcpA==",
+                "shasum": "00eaa806ec6b52625e25716cda07734692c99e31",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.0.6.tgz"
+            },
+            "gitHead": "8f3898a6b613a6edb8c0d2b1a255f03fc9367d71",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.0.6"
+        },
+        "2.0.7": {
+            "_id": "react-modal@2.0.7",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.0.7.tgz_1498423611925_0.18321890640072525"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.3",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "prop-types": "^15.5.10",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.24.1",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^7.1.1",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "codeclimate-test-reporter": "^0.4.0",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "eslint": "^3.19.0",
+                "eslint-config-airbnb": "^15.0.1",
+                "eslint-plugin-import": "^2.3.0",
+                "eslint-plugin-jsx-a11y": "^5.0.3",
+                "eslint-plugin-react": "^7.1.0",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "0.2.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.6.1",
+                "react-dom": "^15.6.1",
+                "rf-release": "0.4.0",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-SPpJz3lFu+rbdcBuVPxDPwbttd5g46Q6KwOSatsMU+Xwp/rRuWjPE1OATvgeVxU2SMNX4gqCR2yK3aRA1071og==",
+                "shasum": "036f313e6321014971c1d0a21215e87bd0850acd",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.0.7.tgz"
+            },
+            "gitHead": "27579ca1c216b3691926790ecacf0c65a4acc9be",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.0.7"
+        },
+        "2.1.0": {
+            "_id": "react-modal@2.1.0",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.1.0.tgz_1498525927159_0.3311240894254297"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.4",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "prop-types": "^15.5.10",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.24.1",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^7.1.1",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "codeclimate-test-reporter": "^0.4.0",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "eslint": "^3.19.0",
+                "eslint-config-airbnb": "^15.0.1",
+                "eslint-plugin-import": "^2.3.0",
+                "eslint-plugin-jsx-a11y": "^5.0.3",
+                "eslint-plugin-react": "^7.1.0",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "0.2.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.6.1",
+                "react-dom": "^15.6.1",
+                "rf-release": "0.4.0",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-mNzH9YVbgJo5j5Tu4UlbfCub8SaJ/YprUE4QIE3bmj/JivVvGNG1DKUyD22RI8J6K9Zv8mM/v9AnrGrQl8D8IQ==",
+                "shasum": "0d230d393ef17f45cc4f962bec261bb0c39d6fcd",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.1.0.tgz"
+            },
+            "gitHead": "e5090de3d937a4a46c2b3999bcbe9c3d31aba3d2",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.1.0"
+        },
+        "2.2.0": {
+            "_id": "react-modal@2.2.0",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.2.0.tgz_1498686988974_0.11417635064572096"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.4",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "prop-types": "^15.5.10",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.24.1",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^7.1.1",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "codeclimate-test-reporter": "^0.4.0",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "eslint": "^3.19.0",
+                "eslint-config-airbnb": "^15.0.1",
+                "eslint-plugin-import": "^2.3.0",
+                "eslint-plugin-jsx-a11y": "^5.0.3",
+                "eslint-plugin-react": "^7.1.0",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "0.2.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.6.1",
+                "react-dom": "^15.6.1",
+                "rf-release": "0.4.0",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-icw59/S0EadYzxacAl8dusdYuGkQhDj8OUU3OL/IipaV6PvKvOxkFaaJ5Heq0Tw36SZqxXTFKKI3GClQj/aXmQ==",
+                "shasum": "9c29e3ecd54d03ebb5a0b8e7e6769fbe6324beb4",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.2.0.tgz"
+            },
+            "gitHead": "b67ad54db13a0a4a55f2e8781db8af7e548498d0",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.2.0"
+        },
+        "2.2.1": {
+            "_id": "react-modal@2.2.1",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.2.1.tgz_1498825375241_0.2483015824109316"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.3",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "element-class": "^0.2.0",
+                "exenv": "1.2.0",
+                "prop-types": "^15.5.10",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.24.1",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^7.1.1",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "codeclimate-test-reporter": "^0.4.0",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "eslint": "^3.19.0",
+                "eslint-config-airbnb": "^15.0.1",
+                "eslint-plugin-import": "^2.3.0",
+                "eslint-plugin-jsx-a11y": "^5.0.3",
+                "eslint-plugin-react": "^7.1.0",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "0.2.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.6.1",
+                "react-dom": "^15.6.1",
+                "rf-release": "0.4.0",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-O+MREVx70XumFu0Ba1ueaxB3nPoVszXAt+l+ttimTUACKkCBc3m9idMFmHcTTJ9dM8szRZQnl61xAkVB2VFmGw==",
+                "shasum": "22563782688bbb43441ac436156d6cb5dcb60c8b",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.2.1.tgz"
+            },
+            "gitHead": "55920f96d3a10a7fe3aea5492be997027eef8e5d",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.2.1"
+        },
+        "2.2.2": {
+            "_id": "react-modal@2.2.2",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.2.2.tgz_1499793637558_0.09400225966237485"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.0.3",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "1.2.0",
+                "prop-types": "^15.5.10",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.24.1",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^7.1.1",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "codeclimate-test-reporter": "^0.4.0",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "eslint": "^3.19.0",
+                "eslint-config-airbnb": "^15.0.1",
+                "eslint-plugin-import": "^2.3.0",
+                "eslint-plugin-jsx-a11y": "^5.0.3",
+                "eslint-plugin-react": "^7.1.0",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "0.2.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.6.1",
+                "react-dom": "^15.6.1",
+                "rf-release": "0.4.0",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-tdgyEyfbyfzDUj40XtWldAQe7e+yhJDUtVSlsQ9AQCGifzWck6v1XTtIVGViVftOsEA3cBWCZCjF3rq6FPJzMg==",
+                "shasum": "4bbf98bc506e61c446c9f57329c7a488ea7d504b",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.2.2.tgz"
+            },
+            "gitHead": "8dbed58b7645bf3fe6c24988e1861bc08a7b079e",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.2.2"
+        },
+        "2.2.3": {
+            "_id": "react-modal@2.2.3",
+            "_nodeVersion": "8.2.1",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.2.3.tgz_1502404077334_0.3286687161307782"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.3.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.24.1",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^7.1.1",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "codeclimate-test-reporter": "^0.4.0",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "eslint": "^3.19.0",
+                "eslint-config-airbnb": "^15.0.1",
+                "eslint-plugin-import": "^2.3.0",
+                "eslint-plugin-jsx-a11y": "^5.0.3",
+                "eslint-plugin-react": "^7.1.0",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "0.2.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.6.1",
+                "react-dom": "^15.6.1",
+                "rf-release": "0.4.0",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-1m/qKAf7D0DTNrXJJ0XI/aw7AvmSfh+6w9lJmQO5K+XRNu+jkuuLYqjks2FcVwMkQvn0zkDGAZ/5DzCi3tuj+A==",
+                "shasum": "e22882961bbc5729a706b515dc20556fa0aa6ac8",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.2.3.tgz"
+            },
+            "gitHead": "825fd001aeb1f889641714ea439648e52fc57648",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.2.3"
+        },
+        "2.2.4": {
+            "_id": "react-modal@2.2.4",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.2.4.tgz_1502714506431_0.456759549677372"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.3.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.24.1",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^7.1.1",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "codeclimate-test-reporter": "^0.4.0",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "eslint": "^3.19.0",
+                "eslint-config-airbnb": "^15.0.1",
+                "eslint-plugin-import": "^2.3.0",
+                "eslint-plugin-jsx-a11y": "^5.0.3",
+                "eslint-plugin-react": "^7.1.0",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "0.2.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.6.1",
+                "react-dom": "^15.6.1",
+                "rf-release": "0.4.0",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-JMF2Dn5CXae7uqYWD1594WNDmQY8aCz09OmMaOmC8rNXs4dl1CSJC1a0qZdoFplkpHKVPLFRF0gqr35c46BRZw==",
+                "shasum": "a32483c3555bd7677f09bca65d82f51da3abcbc0",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.2.4.tgz"
+            },
+            "gitHead": "b9080425fefff692e4bb9549d8d1c8549a704168",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.2.4"
+        },
+        "2.3.1": {
+            "_id": "react-modal@2.3.1",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.3.1.tgz_1504639127946_0.22076051053591073"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.3.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.24.1",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^7.1.1",
+                "babel-loader": "^6.2.4",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "codeclimate-test-reporter": "^0.4.0",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "eslint": "^3.19.0",
+                "eslint-config-airbnb": "^15.0.1",
+                "eslint-plugin-import": "^2.3.0",
+                "eslint-plugin-jsx-a11y": "^5.0.3",
+                "eslint-plugin-react": "^7.1.0",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "0.2.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.6.1",
+                "react-dom": "^15.6.1",
+                "rf-release": "0.4.0",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-RY91JEEdwHREvWlq9HlUXGMCkBX9fwpMH17gG0CgE3Z/PG3mnwbIjy0Exj6CTFX5Y9dD8EPyHkwrL/04S3y2sw==",
+                "shasum": "ee1039d5d4287ad88722fa274c276c8554fc2b1b",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.3.1.tgz"
+            },
+            "gitHead": "57e9316ff343281967b395255b8e478ac98a0b37",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.3.1"
+        },
+        "2.3.2": {
+            "_id": "react-modal@2.3.2",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.3.2.tgz_1504725033503_0.7844707581680268"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.3.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "react-dom-factories": "^1.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.24.1",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^7.1.1",
+                "babel-loader": "^6.2.4",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "codeclimate-test-reporter": "^0.4.0",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "envify": "^3.4.1",
+                "eslint": "^3.19.0",
+                "eslint-config-airbnb": "^15.0.1",
+                "eslint-plugin-import": "^2.3.0",
+                "eslint-plugin-jsx-a11y": "^5.0.3",
+                "eslint-plugin-react": "^7.1.0",
+                "expect": "^1.20.2",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "0.2.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.0.0",
+                "karma-cli": "1.0.1",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.0",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^1.8.1",
+                "mocha": "3.2.0",
+                "npm-run-all": "^3.1.2",
+                "react": "^15.6.1",
+                "react-dom": "^15.6.1",
+                "rf-release": "0.4.0",
+                "sinon": "next",
+                "uglify-js": "2.4.24",
+                "webpack": "^1.12.14",
+                "webpack-dev-server": "1.11.0"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-m+urZGPk+RfUrGj0b8uraZ2dQQo/AABZ+s6aZeZxEpbhMwWZ4WhVr03iYbWTvSatSnC+5x9c2k6qm95N1ybohg==",
+                "shasum": "af9d625da218461de3e87551609dfca12d8d4946",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.3.2.tgz"
+            },
+            "gitHead": "67899f0d760167015d3aeaab662a24412e870b50",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.3.2"
+        },
+        "2.3.3": {
+            "_id": "react-modal@2.3.3",
+            "_nodeVersion": "8.6.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.3.3.tgz_1507093207363_0.5412137324456125"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.3.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.0",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.7.1",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-react": "^7.1.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "react": "^15.6.1",
+                "react-dom": "^15.6.1",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-8iBidx7rKKg65XgOqrmy2oEr0rj5wd/w3et4Y3oef7903A15pOVW8fg2H9KlcDNcaqKw/CpBIE2Kc8vcVwoqOA==",
+                "shasum": "bf4d100bbc426549b943e4294f7e9ea88e56e1a5",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.3.3.tgz"
+            },
+            "gitHead": "26d74964ea04b2a4ce4726c43c9fd3de8a38e69e",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ spec/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.3.3"
+        },
+        "2.4.1": {
+            "_id": "react-modal@2.4.1",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-2.4.1.tgz_1507302603514_0.5994301894679666"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.0",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.7.1",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-react": "^7.1.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "react": "^15.6.1",
+                "react-dom": "^15.6.1",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-3WQCn3xqkbEUvxRUO3nkeqxMNgt1F4CyEU3BiUIrg7C71tnqjQIuSE7+JXp85yFl8X1iRTJouySNpwNqv4kiWg==",
+                "shasum": "cb09b26711b148eb9f59cb180e1b7d82980ded05",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-2.4.1.tgz"
+            },
+            "gitHead": "bf9d376775cdd5bdad38f9d51aa6f02cf90c8b40",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0",
+                "react-dom": "^0.14.0 || ^15.0.0"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ spec/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "2.4.1"
+        },
+        "3.0.0": {
+            "_id": "react-modal@3.0.0",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.0.0.tgz_1507307367031_0.6904556592926383"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.0",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.7.1",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-react": "^7.1.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-LXaEz4PqJoDmmY9HvrjVD8B6ivJto5LFz4Zsn4UUsbEY77dBzguYkb2m7+7lwB3nXQx7zMe1xqCYRPC6Cv783g==",
+                "shasum": "2d8c4e0355b610f3df3fac0d60541a81bfc04324",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.0.0.tgz"
+            },
+            "gitHead": "a2a71286fc18781b235770ce0a985e6853eddb49",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ spec/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.0.0"
+        },
+        "3.0.0-alpha": {
+            "_id": "react-modal@3.0.0-alpha",
+            "_nodeVersion": "8.6.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.0.0-alpha.tgz_1507100448249_0.08420279785059392"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.3.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.0",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.7.1",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-react": "^7.1.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "react": "^16",
+                "react-dom": "^16",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-kFqyxfAKgW/Y6bWjYC5XLqW6IuZhKD5EZ/YdyL7IEc4birKl3MsF/3x2p58XK6zZGEg/XR2bPINhVKzgSWFfJA==",
+                "shasum": "927faf4f2357c9826b9f56ee9923b6a5f9fa7a02",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.0.0-alpha.tgz"
+            },
+            "gitHead": "cd10612f184542cecdb5db2a3847431c0ae83b31",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ spec/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.0.0-alpha"
+        },
+        "3.0.0-rc1": {
+            "_id": "react-modal@3.0.0-rc1",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.0.0-rc1.tgz_1507124179365_0.669721954036504"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.0",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.7.1",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-react": "^7.1.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "react": "^16",
+                "react-dom": "^16",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-KvhOBLSxv+5k9914LuzY482mnUjArWOwoit18A2xKr4hXnI7CtkUOXAFX6ihN+2Pe0PjCF27UCrftJ8s35uxOw==",
+                "shasum": "92f20c7bb9f634a99f87a195809ed3243caef7b2",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.0.0-rc1.tgz"
+            },
+            "gitHead": "45ca9d4b06a7b1bf6a4191a89c2ffb304284de4c",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ spec/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.0.0-rc1"
+        },
+        "3.0.0-rc2": {
+            "_id": "react-modal@3.0.0-rc2",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.0.0-rc2.tgz_1507134715041_0.22045750473625958"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.0",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-es2015": "^6.24.1",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.7.1",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-react": "^7.1.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-IrcQfNGhnfL+z4N0RNSJOEOd+QNvlxWCNc4YiDLzLw8zhUxRuqYecrHdxeVA++W/fKgb+aHJq0W26TeCOqUTAg==",
+                "shasum": "fff07df3d09c350462ce4454dcff9873bddde70a",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.0.0-rc2.tgz"
+            },
+            "gitHead": "cc4577c1f7c0556cb6456bdcc29db4c1e9b85309",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ spec/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.0.0-rc2"
+        },
+        "3.0.2": {
+            "_id": "react-modal@3.0.2",
+            "_nodeVersion": "8.6.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.0.2.tgz_1507993494635_0.1103380061686039"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.3.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-o4ywaxeLRZa8RSECfS5SRgCxdy5hGGrwkNUru8MMOi07hVT2rEO4h4Sy0URtwHBIcFKzWyOZnFRewrAjTw6vyg==",
+                "shasum": "275edd442f42bf133703be451446662d1bbc18fb",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.0.2.tgz"
+            },
+            "gitHead": "271b875ebbd1abc0c49652647552bda67dba3d79",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.0.2"
+        },
+        "3.0.3": {
+            "_id": "react-modal@3.0.3",
+            "_nodeVersion": "8.6.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.0.3.tgz_1508013533453_0.5381953164469451"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.3.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-+LF91u2UBvraNh2MGkfBTmKwDf95tPVHLsR7BFVxZpm3CMTrHhdr+4PGibJol7nMbcJEd0pUS9g1CM4yzSxrdA==",
+                "shasum": "276580ccf3d48edab0e34df682e1e1c74856dc8f",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.0.3.tgz"
+            },
+            "gitHead": "4ca54df3eb8efa351dcb51b04ba8131e8555700f",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.0.3"
+        },
+        "3.0.4": {
+            "_id": "react-modal@3.0.4",
+            "_nodeVersion": "8.6.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.0.4.tgz_1508367342055_0.6305836152750999"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.5.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-IvRZxJkXiDqEIl4cxCccCzP37z+YOSN+yNOkYH99Ime+n9nPSowgxkX0KfHzR2ezP72LSS3Uln54JDZXUJmLdA==",
+                "shasum": "61f3c9a701b27d2015fe5ac0c419e3c977e4092a",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.0.4.tgz"
+            },
+            "gitHead": "5f5c2f047b5d4fdf571d97949e5da11453195661",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.0.4"
+        },
+        "3.1.0": {
+            "_id": "react-modal@3.1.0",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.1.0.tgz_1508952384984_0.1309541363734752"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-4sVW7Flm6sdaQeWr8OxXqMOuothdg+jnCA4MqloP65g2iWtOtho8VeI+z3SCsqunWefbuCHCnncxIBmDgPehQQ==",
+                "shasum": "ce594f88f9ab7338ee265cfec4be3cc5253f5baa",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.0.tgz"
+            },
+            "gitHead": "417401ef54fa6ee11f74ff484acb30aa440f493f",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.1.0"
+        },
+        "3.1.10": {
+            "_id": "react-modal@3.1.10",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.1.10.tgz_1513716158569_0.4054435060825199"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-7b77AGWCkdg0YOf/qcYIGCpuwbxRwOA8P3UrUovk4grUNv+idOmHovJAx/Dcd3fuwHtgixxVjpcjVG60985MSA==",
+                "shasum": "8898b5cc4ebba78adbb8dea4c55a69818aa682cc",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.10.tgz"
+            },
+            "gitHead": "79688e85bb851b15343b2f2376ad01076a4e08d9",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.1.10"
+        },
+        "3.1.11": {
+            "_id": "react-modal@3.1.11",
+            "_nodeVersion": "9.4.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.1.11.tgz_1516113929368_0.013958348194137216"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.6.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-Pm4QAc+sWYrfRC+WRERV+JGeGZIfodZGdbvWmjPzeSWqP+EW5ATK4N1U/btNHZWFzKL1UOmkmNtozEQlEg7c+A==",
+                "shasum": "95c8223fcee7013258ad2d149c38c9f870c89958",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.11.tgz"
+            },
+            "gitHead": "0259f051c10a3e873d1dd58d970f10619262bd49",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.1.11"
+        },
+        "3.1.12": {
+            "_id": "react-modal@3.1.12",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.1.12.tgz_1517830532291_0.48130431678146124"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-WuabHQDTkM5x9AQ9xRqfHrhrgVKnNhTFYOrIeZm5Eb8M/uLs0hrHsXP/BTCg7auuBZKectYmzPaG/ueJTG4zfA==",
+                "shasum": "e80ab4e553ce946a6c96faf85eb31e0f9bd07470",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.12.tgz"
+            },
+            "gitHead": "d93fae17b944b6d50ee5342ac6de03375b07fdaf",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.1.12"
+        },
+        "3.1.13": {
+            "_hasShrinkwrap": false,
+            "_id": "react-modal@3.1.13",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal_3.1.13_1518182927918_0.34103094308394666"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "fileCount": 41,
+                "integrity": "sha512-YSNoLKd/zgfILPwx6Uio2f6JNX7UqPvWO7vGKXXpFcsDaj+z97FVxJo82dMsbca4SSitu0A9Q+Xq750CPQUAYA==",
+                "shasum": "9b27e7774e6ecdc255f489487f518eb4361716ab",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-3.1.13.tgz",
+                "unpackedSize": 435716
+            },
+            "gitHead": "63cea2c7b17e8675147468af725964dc6b4c6f2d",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.1.13"
+        },
+        "3.1.2": {
+            "_id": "react-modal@3.1.2",
+            "_nodeVersion": "8.6.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.1.2.tgz_1510008988596_0.48936065495945513"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.5.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-a3L2qP0kaqMBy4C1aojs2caUIz3kHRFlnuWJ8zsnuUmh/fKHEDASujVBiQcatn+yUosdE9hViB6JvLfkB0tN2A==",
+                "shasum": "6e1fd656315d6fc62a1edda2b5aecc9752ac6bca",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.2.tgz"
+            },
+            "gitHead": "4b19b3db484726f2f4ca5ce28698b0b77590dc0e",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.1.2"
+        },
+        "3.1.3": {
+            "_id": "react-modal@3.1.3",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.1.3.tgz_1511379493431_0.837455024709925"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-FBsaLSV+TsCA1+ULj3r9Wf3xZ3arKjfOsdom8hv3z/Gvwu+FgOFsW3w28leMNqpBBDc76KhqifzXS5LeBPDBug==",
+                "shasum": "bead112cd84681a1ccd18ee1e96c73d881793b75",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.3.tgz"
+            },
+            "gitHead": "ff9b5a41459ddc1e7a5f9b208a275452c6cd7c3f",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.1.3"
+        },
+        "3.1.4": {
+            "_id": "react-modal@3.1.4",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.1.4.tgz_1511544468179_0.4065779058728367"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-9i1hLwKvSPQirfAabu8Ptv9i9ohaqk6Hs0KhoJkJ001VHLQtsQCS+6p7bZrEKnE3Wa4AXyXrF5gieGndsL6IsA==",
+                "shasum": "eea7369ea4f05ab2897ccca2c676d7d81a5a88b0",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.4.tgz"
+            },
+            "gitHead": "99f89335030b816f7d029c729b0fd5da930a4063",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.1.4"
+        },
+        "3.1.5": {
+            "_id": "react-modal@3.1.5",
+            "_nodeVersion": "8.6.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.1.5.tgz_1511823464753_0.7878260100260377"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.5.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-EjM32L9JPVibJJgu22QySo9d+tl0POaRTmuM7LmsVkx0U+G9tl4LGLrs2DLNOQp0Oko/5nEF/Rwp/h2noucMAw==",
+                "shasum": "9cfdb7634b5003148ffb7c8ead13a36f671d744e",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.5.tgz"
+            },
+            "gitHead": "700eb4e28644f167e5c52f4dab40ef6ccadc659a",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.1.5"
+        },
+        "3.1.6": {
+            "_id": "react-modal@3.1.6",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.1.6.tgz_1512048313366_0.7013840931467712"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-4YKuBE4RMp9P+wqNeK68kQ4Q8Y8x6v3U9xrsRk2DOgWMOyf0GH5gZX841BcTlRxrZFgIKbW5n6hhOL5n4Du4tA==",
+                "shasum": "82e63f1ec86b80e242518250d066ee37fa035f8a",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.6.tgz"
+            },
+            "gitHead": "1563ece475e3d024679f839e7ab091578019aeeb",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.1.6"
+        },
+        "3.1.7": {
+            "_id": "react-modal@3.1.7",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.1.7.tgz_1512408191830_0.17507505021058023"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-pIVKqhPZxXqnewkQnjN0VJT0hn1XGJV2pwDJmKwAxPbfXZ1cAX79uO/Z3kYkpnb+2gAAusooK/AvnBjWuKQrRA==",
+                "shasum": "21feb937c95cd722bf2d375cada751fdc8189c0e",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.7.tgz"
+            },
+            "gitHead": "33e1fe12d02f4da63ec5c1705cd34d8639925277",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.1.7"
+        },
+        "3.1.8": {
+            "_id": "react-modal@3.1.8",
+            "_nodeVersion": "8.6.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.1.8.tgz_1513122353161_0.2833920316770673"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.5.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-cp5fSUBuwkyojclrxZuWXudK2kTBycbDG9Eg1t/bEPdUVBW6vDiGE+4eZg7bVwMyFtiwvyVJ2ugdCOFllNPReg==",
+                "shasum": "7d6b1958f44828babd2a1ce826c28fa40d026b0f",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.8.tgz"
+            },
+            "gitHead": "6fc445e3855da4b0a248d40319a68ba87d13bdc3",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.1.8"
+        },
+        "3.1.9": {
+            "_id": "react-modal@3.1.9",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal-3.1.9.tgz_1513715819692_0.19390780618414283"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "integrity": "sha512-GOLxgY2+NUiCdRceW/WpNrXg46N/gZIXhAh5AQVy2SfP2UdJHqQe1/wgkaNekoW12nkXb7ZyCtZ8XCwRUVI4+A==",
+                "shasum": "5bb2e233262edbce8423f5a407dace27aec963db",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.9.tgz"
+            },
+            "gitHead": "b6f684a0a1d44d789e2140d531c547f96972177c",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.1.9"
+        },
+        "3.2.1": {
+            "_hasShrinkwrap": false,
+            "_id": "react-modal@3.2.1",
+            "_nodeVersion": "8.1.2",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal_3.2.1_1518696486502_0.6933985201329498"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.4.2",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "fileCount": 41,
+                "integrity": "sha512-6idnYaDRvVRq702f1sgvMIisgHxYF4OoNDOLuWkxe0GoquI/CTVVXa9wvCFdu3vCTE85zMwX1GgUVyJfO+VnjQ==",
+                "shasum": "fa8f76aed55b67c22dcf1a1c15b05c8d11f18afe",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-3.2.1.tgz",
+                "unpackedSize": 437087
+            },
+            "gitHead": "72c57cb557353517a2030e1f92fe6fff0abf4544",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.2.1"
+        },
+        "3.3.1": {
+            "_hasShrinkwrap": false,
+            "_id": "react-modal@3.3.1",
+            "_nodeVersion": "9.5.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal_3.3.1_1519217699699_0.06574726415031185"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.6.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "fileCount": 43,
+                "integrity": "sha512-d1A8xXIvW+YVKwRMrFY5qneuC5FSa4OnOE78hgqfz+MYLb1Ai/B3D3Dzx1Zrw4ZD5rS16SKiPe5rl4UZt+AjpQ==",
+                "shasum": "7355db196482da0c7fa1cbecccf2bdd9bc366b14",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-3.3.1.tgz",
+                "unpackedSize": 450378
+            },
+            "gitHead": "857a30321c593cb22f16762c93dff7f7ac4e4e28",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.3.1"
+        },
+        "3.3.2": {
+            "_hasShrinkwrap": false,
+            "_id": "react-modal@3.3.2",
+            "_nodeVersion": "9.4.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal_3.3.2_1520903809590_0.7673794337729618"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.6.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "fileCount": 19,
+                "integrity": "sha512-DLrmPG9PyXWSNA2ve1LttnNRE9Umy3u3awFeK+72dLOksLM+EoTg8Z2h/i/DV3O8ZGvnEhacjAVXdZuRDGvaag==",
+                "shasum": "b13da9490653a7c76bc0e9600323eb1079c620e7",
+                "tarball": "http://registry.npmjs.org/react-modal/-/react-modal-3.3.2.tgz",
+                "unpackedSize": 189896
+            },
+            "gitHead": "6290db5ea5d306129e1978ecdb6c2edad1fcd31a",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.3.2"
+        },
+        "3.4.1": {
+            "_hasShrinkwrap": false,
+            "_id": "react-modal@3.4.1",
+            "_nodeVersion": "9.9.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal_3.4.1_1523969414118_0.3823776483494856"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.6.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-import-resolver-webpack": "^0.9.0",
+                "eslint-plugin-import": "^2.10.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "fileCount": 18,
+                "integrity": "sha512-xBChRXwBSa41jV/pXS3btAZqno3BJk1kK/fUBlyF9vvaDoULLFeSQKW/tfwIadEhNCaoSKN4hIdlowvOmC34Gg==",
+                "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa1e2ICRA9TVsSAnZWagAAeYkP/ReYXvQbFup6UqNUyfhS\nd3JhlQRfXC05wltSjOUbgTIs9NuXBMTFj/9j0PqGqnwXaem0U4v7LNdJ6WwN\nrB6RXh2inOBXaeFh5yYVwTBbxEbieGykkaqKn9Dix0UCldXyX5+XvXCsX9Zh\nEEQBJdODNShrBR6oR+pHaHGUDyWbTlEinL2oY7+oH8Kd7nlxDcJt/B4SBk8D\n995nlNPFaKOPW6rY5WRR0pv5o7mCUnF5LGiZMxK1HE6ju/ba6EtViprMX1Yr\ni5BDDLeINU6OLlrA/M+9QxQ3Rk739saxWqZQuFh5YFwFQc6Uo2Oyo2ZQpAMn\nHb4QvXVqlH67xACZ0h45bzb4t0tCsE1Ykb/AFqh4taThJ98B8yF9BEGJFMXU\nIRLcQo9TIeaOSAPkYEfiNK9aWDKWrg6CoFcFiwmsbLstFybTSIeKxVeWdnvF\nV8EbOfzpBr4cof3h9JEc5MjJCzepCWC5LUTXl/IQvMMsxCXwBPua0EUtosHh\n+En5BzXN4QKZ5IMNa/wEEUVlIvcaZIskC2soFTPuvK1K9fQ5doidz/7PIrN2\nXFDBuDW5BOdB47+AK0iZazqx/fnC8DSzd8dbv2BU59J77bqyF1EyuRroOp1a\nbN3B2988clFft4EzF9S8kwuOfumws5WOEPsn0lyc6uwukzL91zr+Le6fSrFU\ng9DH\r\n=LUCz\r\n-----END PGP SIGNATURE-----\r\n",
+                "shasum": "9bee876ffb1b077447abef9aa298d375625f8ecf",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.4.1.tgz",
+                "unpackedSize": 190115
+            },
+            "gitHead": "dbaa77f9fe68f0d560f33c75d2512a4e768d1ebc",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.4.1"
+        },
+        "3.4.2": {
+            "_hasShrinkwrap": false,
+            "_id": "react-modal@3.4.2",
+            "_nodeVersion": "9.9.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal_3.4.2_1524140242899_0.4700108516656103"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.6.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-import-resolver-webpack": "^0.9.0",
+                "eslint-plugin-import": "^2.10.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "fileCount": 18,
+                "integrity": "sha512-4TC3RZeKPQwgX/1q9scgOIlR8dXBVqB1lMfpBpxRDrK6fqh5zu7IbvSqPArPh+ED/4lRQwezidE7Eex4q/t73Q==",
+                "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa2IjUCRA9TVsSAnZWagAAS+0P+wTUKeJXKck5Ctuu/tze\nnpBeSou+70Z0/7Fj5GRRKE/dFfueIf8Ut+p6lJuCsebo3AHa+8KPQi4Npsz7\nGF/xvcC3C1NOItZ5j1uqHxPSXxEngEt1i+yVCw9g9A/UhGc1qmDkla9nAA28\nltqz/Ts8A+97VTQV4fNnu/hT2AGIuscSdGoHvf2zAq8sM2RAQBo15VJF3sZS\nc93a+2hDzrIwW5m1eu8UtF9jHFbnjVcYsM31h2DpcdIm36FtOTcdVNbD5q4B\nerPUNvrcLlAoxPhHKNfnCCx6TdHUiD4I4WW90zZGJuU5wbVeCptX5PWvJwxy\nVfle/KZ45+/Vt6QdzFWSFyb8vAEJJcNVfelR1a+OcQwufjDeKx6owtY1vZwZ\nqf8GQ+syc+XH+z804N9g7rj2o4FU5K23RvQWwx9u2BIBC0lmppTznNzQVWX3\ngm8I1woWxnkFDSYjbtJKYUfcOupfmU4GDAW9L8BzDO1AT/DF2d1yH86PJ6As\naBh6EIRvXSwcracE2EbgvPfbRCvqyuHYJg7f+EG8FU6/a0CeLiqawFkk2Gd6\ngvZI9ZRR0V6ZA9txjFsRVxfrTuPKrddyimKMVvGDAzwBFsMS1sNlXdw25fgt\njOnHBiWPQk2kLlS0dXUtwKUwKoQ2azLwRat87QSfa1MXhBlDk97a7Cr2d8lW\nWFNs\r\n=5udo\r\n-----END PGP SIGNATURE-----\r\n",
+                "shasum": "507ce89c528380497ec6c5adf5d7448f99ab6d27",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.4.2.tgz",
+                "unpackedSize": 190769
+            },
+            "gitHead": "a23508988cd772b613cfc32b399516482bbda425",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "module": "./src/index.js",
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.4.2"
+        },
+        "3.4.3": {
+            "_hasShrinkwrap": false,
+            "_id": "react-modal@3.4.3",
+            "_nodeVersion": "9.4.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal_3.4.3_1524535648876_0.9636325551149847"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.6.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-import-resolver-webpack": "^0.9.0",
+                "eslint-plugin-import": "^2.10.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "fileCount": 18,
+                "integrity": "sha512-IadMFO8nYYK1mu4EjPjD69WIY3RNlDieYnjRJ8emGsl0QtYRebgeGGfdOADSC10VijN8HFIAtve1xdgiwjGovg==",
+                "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa3pFiCRA9TVsSAnZWagAAuuYP/3csQF9mdOxGpg2k7WBU\n0GnktPwo/QlyV8Xqxec3e61o9HZ1Jv+FWYSdZFphSAtioQhYesbeYsjTJiH8\nwAhnrvIhJvmrYIMj680eTwJBz/IKcKHkE3U8cOQ6tZiICo+U6oYUXhS6BPXq\ncyfQuG8y8L11ak//PNKIqnopLvREyKcc4zd0VGTmfUyq/zrFRluQNXgMlC5y\nDw28KpcojQ+EjAnc/webFbHGdZrUf5g5jndCZtWQjW7a/NDKgE1SSeTxAnmJ\nFlzJgT/lqAvfjM3gaF5pGemNU+Ve25YqoCIdrve6p6goGryFpqql/skpYcz3\nwQHyyPDU5AsVjJFG/vIhLiM4iIsxIdbi2/A0Jkl8US/mRMFH7oDB15pkgxw1\napCuO2fR3nBPoI6gh+K6TxWXJ87NZn/nI2/7KZGSVD4IOIsPLJGKihbFuTIL\nHZLPGLLmWeidmF23Rzm+J7hm4/sZVRdbNfrpUnv2yIxP9aWot8gSWevJOxJf\nEERV4uAfiLm42SJ3ax+bTqbWKyYv/FvVuJNBqwrNN2asU/Ly3wJqqZ5UFZNa\nYBylRfg1PfSuHpIOButz0XjDyNSqrmnTt8aRmjD4Tf90EbsT9VW/9zMvTx9Z\nsuRH4XfrLp3JonLEUtZRzFe3u6cyoaJxEGc5fHfErTHF80vfvtqBATS6wnjg\nP+m9\r\n=kth/\r\n-----END PGP SIGNATURE-----\r\n",
+                "shasum": "e9823054948c36011585ba5a860d9dd5db97cbf9",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.4.3.tgz",
+                "unpackedSize": 190891
+            },
+            "gitHead": "a745cd3c11338517813c31c19fa681d36e356224",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "module": "./lib/index.js",
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.4.3"
+        },
+        "3.4.4": {
+            "_hasShrinkwrap": false,
+            "_id": "react-modal@3.4.4",
+            "_nodeVersion": "9.4.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal_3.4.4_1524535730075_0.3038184305901208"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.6.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-import-resolver-webpack": "^0.9.0",
+                "eslint-plugin-import": "^2.10.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "fileCount": 18,
+                "integrity": "sha512-5VYNvy301Z0xxGBQhPmDdzOcyEkUG8sU7bpRsAPI4OHgEUkbBFrpjzs/ocNI0m824/lOqTxddXzwgmDJXx3s3Q==",
+                "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa3pGyCRA9TVsSAnZWagAAOHkP/AleBZfFaolS7pVDnFuD\n7aXJbl0IMvXEgnsS883DeN44EKeAy9GzK5nDmTOM5cUPuUHdEwkSXRYejNYX\njP7p6u/P6cjSXNPBh0h1LRHtZrs6gb8l1F6k7HBlR3WEp8Y8p/HC0CQELt9/\n3/Su0Lj9MTdorSdoY/zo3dA3fn2TRSdef3yrIDQ126b2ktiCvfBDwjxFDpye\nQvazYBmYsPy22MXbzn32nNP8lYi6IwIoJOSnOHwYvSgXuKShRdfI+uJRzOja\nEF11istuVz6rmQrUoohH642S0JblB7+dkkKjbqQWvSGRONnD+JXbY5ctkCwO\nLa1zbU4DL1B92hh1VKirHoB9ig25m0EhfBtwQc1fS6k9YtzGCqxuTYvlSbpZ\nIfwWb/tTgR9BIazPG6FepCHRTEfKG4OgMCHp6uM4HHzL/POo66/7RADrdvoS\nqK6KaLL7g9jLXf7T+pV082z4IgZQUQLvgOMFA+5zlnJGNCRCQooOMoWffkjS\nhVy2NToOkge7QXTyxFvG+ajAjYyrkx+u65SZktEkIpr1vTQWB9iQxBTBdvsL\nrXA05XntJYkSy9vXdhK8QGsLfbvDVPEI0MqtVbtzJOc7tqgnmJ2kyatvQhik\nLs1RcD4c1LOZLRYnS3Wu5D6eGZl4pdYZFsUYyYAWHunntN8qENzvWUfLGl7O\n2lEX\r\n=JY9G\r\n-----END PGP SIGNATURE-----\r\n",
+                "shasum": "e9dde25e9e85a59c76831f2a2b468712a546aded",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.4.4.tgz",
+                "unpackedSize": 190852
+            },
+            "gitHead": "d6931d13657b8b8be7983ac9cea1fadbc3b2afe4",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "module": "./lib/index.js",
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.4.4"
+        },
+        "3.4.5": {
+            "_hasShrinkwrap": false,
+            "_id": "react-modal@3.4.5",
+            "_nodeVersion": "9.9.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal_3.4.5_1527862322467_0.5657295851634607"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.6.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-import-resolver-webpack": "^0.9.0",
+                "eslint-plugin-import": "^2.10.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "fileCount": 18,
+                "integrity": "sha512-fYaGmsvt4z5voC2Bl/9ngIWES4BSRYgGnTljMwuzTuYZ1BBpaZbnXia8xlvj7mF0kg3aPV+5APjZRiMfRG6vyA==",
+                "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbEVQzCRA9TVsSAnZWagAAzLwP/0ZABzhHaCOVwLvFBJp9\ncXiJXV0Wi/b1mSmzUqxvi+tr9LN6ajli+K/+7whN3f2VpvtU4PjNAgoqCmcU\nLvH5xtlpTEcwOkXuEJQ7X5NJV8uN+bx75Vc2vS40xGiaJF48eykDVHCRrvdW\nAhGm+9UZKgfq/qxVyjn9/xN253RCjHVdKrOOfXW0d/6XtbfvCRqeqvCYbG5q\ngct5v6r461CoTMVqfEyJbEqFRvCRahaUyQpSdY+9yipSWHFfx1O1c6rgePWp\nUoW9eajKViooypUAOLvEnXenhreWvogBPsiLCB/iNxmEw2G0inc9E0oHUMOS\nezjE+W5gpVdBp16jxwoLZyqZm8AWMXf3TmcBqG5mAJpfCDUaMO3kJkJA/60T\nlb5v9DXDZqbd1ezP0rZFhAaJnvNsdr0CnCyBbMBgV6uCopdtiOy8Hz7atJuj\nzsjls7WWwpNgDTWBI835QpvMGJMHJ27GWADETYouLTliT4oDD7JPj3+RzNM5\notE/0dmwYtpSxgBvfYDokYIZiHpwLo7NbxUq6RmCjgVM1XasWuMueHNrIoZ1\n0ZzGAggWnOr6mBf1jYyspBn+V5grhkCybYHJcFH1noL0ZKm2FLiUzC7efMUl\nAkTCMk+jbPyZUjHgRVHx3poG7uO2f2pEyHxuQ3z04bbINMwdXnR9jTFxT0bc\ngSN5\r\n=sqF+\r\n-----END PGP SIGNATURE-----\r\n",
+                "shasum": "75a7eefb8f4c8247278d5ce1c41249d7785d9f69",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.4.5.tgz",
+                "unpackedSize": 191407
+            },
+            "gitHead": "f715a69e31b00eaf7912595a9bd2d22ab5cecdb3",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "module": "./lib/index.js",
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.4.5"
+        },
+        "3.5.1": {
+            "_hasShrinkwrap": false,
+            "_id": "react-modal@3.5.1",
+            "_nodeVersion": "9.9.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal_3.5.1_1530710597579_0.11865461704396596"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "5.6.0",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-import-resolver-webpack": "^0.9.0",
+                "eslint-plugin-import": "^2.10.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "fileCount": 18,
+                "integrity": "sha512-GxL7ycOgKC+p641cR+V1bw5dC1faL2N86/AJlzbMVmvt1totoylgkJmn9zvLuHeuarGbB7CLfHMGpeRowaj2jQ==",
+                "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbPMpFCRA9TVsSAnZWagAAe+UP/imNOMmh7PffNqBfAsef\nQPY/y6E6abrND3ZFPwJ3RkIK1HK8YfZ8pgDwPbLT0NbK0usTqODDqUmkEbFt\n7gUxCMNOyVZ+UIKPxc7cGF0vV5p9sfcN7aBB9BbEtsfyWzALOpOuZNHyKYNJ\nTmBrHMtK3ngnic7MYT/dNP2E3KoATJ0AE43wvVSqB14CCj1bPqSuyaRDpSe5\nZSqNc4ftFl/LskJuahJB/TQCJpuupHCFj6bSDwa/m/2yKHdSgzm/qjgY91t7\nekKEi2bLQBN4Ms+bqYbn0xUdhDyyNUPsFYxa8iUHGZUO2uX4jAWMK+sxQhDq\nJeiuN+iKCpucI4X0pSuWU5MKV5kJoTrPe93goirShZln+UdTW6w+SFVZXCW1\n74vLtzwNu6tThs0M3sZIChOcMzcukB+8jmo+XReqNtNIdDOZhjGbok8R65xJ\novbbBeb4NSypxLVmJ7Wx1aVJaGE6IF/tnA279W7YK2C4HxdSu00Bn5LXrpUE\nzHxW08XedgKpxKaQOsvxeBKBXiur4xy40gqvl8yYTuxG88TCQpXo1YW5pbby\nXSdit7vckA+vrbGJd8VTYMBIRUAWV02/KTsaVk/KofM4929o7GC06hAbI0ws\n9d4+x4ae+EO/jKfG8IGBUjFS2pa9m/ZI6GMtrCXarabFU2A/V4yHF+qxXkec\nLqcT\r\n=Ffe1\r\n-----END PGP SIGNATURE-----\r\n",
+                "shasum": "33d38527def90ea324848f7d63e53acc4468a451",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.5.1.tgz",
+                "unpackedSize": 191947
+            },
+            "gitHead": "4377cc87fc6b2d4766a4aac8ffb9568adccd50c6",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "module": "./lib/index.js",
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.5.1"
+        },
+        "3.6.1": {
+            "_hasShrinkwrap": false,
+            "_id": "react-modal@3.6.1",
+            "_nodeVersion": "10.10.0",
+            "_npmOperationalInternal": {
+                "host": "s3://npm-registry-packages",
+                "tmp": "tmp/react-modal_3.6.1_1537894000266_0.7365522119758585"
+            },
+            "_npmUser": {
+                "email": "dias.h.bruno@gmail.com",
+                "name": "diasbruno"
+            },
+            "_npmVersion": "6.4.1",
+            "authors": [
+                "Ryan Florence"
+            ],
+            "bugs": {
+                "url": "https://github.com/reactjs/react-modal/issues"
+            },
+            "dependencies": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^3.0.0"
+            },
+            "description": "Accessible modal dialog component for React.JS",
+            "devDependencies": {
+                "babel-cli": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-eslint": "^8.0.1",
+                "babel-loader": "^7.1.2",
+                "babel-plugin-add-module-exports": "^0.2.1",
+                "babel-preset-env": "^1.6.0",
+                "babel-preset-react": "^6.24.1",
+                "babel-preset-stage-2": "^6.24.1",
+                "coveralls": "^2.13.1",
+                "cross-env": "^5.0.1",
+                "eslint": "^4.8.0",
+                "eslint-config-prettier": "^2.6.0",
+                "eslint-import-resolver-webpack": "^0.9.0",
+                "eslint-plugin-import": "^2.10.0",
+                "eslint-plugin-jsx-a11y": "^6.0.2",
+                "eslint-plugin-prettier": "^2.3.1",
+                "eslint-plugin-react": "^7.4.0",
+                "gitbook-cli": "^2.3.0",
+                "istanbul-instrumenter-loader": "^3.0.0",
+                "karma": "^1.3.0",
+                "karma-chrome-launcher": "2.2.0",
+                "karma-coverage": "^1.1.1",
+                "karma-firefox-launcher": "1.0.1",
+                "karma-mocha": "^1.3.0",
+                "karma-mocha-reporter": "^2.2.1",
+                "karma-sourcemap-loader": "^0.3.7",
+                "karma-webpack": "^2.0.4",
+                "mocha": "3.5.3",
+                "npm-run-all": "^4.1.1",
+                "prettier": "^1.7.4",
+                "react": "^16.0.0",
+                "react-dom": "^16.0.0",
+                "react-router": "^4.2.0",
+                "react-router-dom": "^4.2.2",
+                "should": "^13.1.0",
+                "sinon": "next",
+                "uglify-js": "3.1.1",
+                "webpack": "^3.6.0",
+                "webpack-dev-server": "2.8.2"
+            },
+            "directories": {
+                "example": "examples"
+            },
+            "dist": {
+                "fileCount": 18,
+                "integrity": "sha512-vAhnawahH1fz8A5x/X/1X20KHMe6Q0mkfU5BKPgKSVPYhMhsxtRbNHSitsoJ7/oP27xZo3naZZlwYuuzuSO1xw==",
+                "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbqmZxCRA9TVsSAnZWagAAcFkP/3qkp8Vl9b4r+1K35gGG\nWZfE7Y8J1MLMESy3/yGcVWbuQNsUTosUyOBliXHPtMLq+uaV3PpQNaQcJW5y\nen9AJNEUTPmalV/X8MuB4rJ8lmcmSncOts+ld+/qrTctRZg6pHLeTJv1Bi+z\nyFYak6BONHJEV+iMBdQnTP5zN+pbURF2eMGYzd1yO7C2eml/1AqR1veAwupC\nj/dvcpDiNUl/Gh/k0nfI74yYHC5H6Bvrh8qQ9DUwGIdTNNIgBiyDRIDu1HKq\n3TRG82ALjj6U4dgZ4+MmbthxD8poZJ/eVp0cTOGxp9OrquU4lPHY9ki470C6\nsCarFwkDKRi6jWczGL2CI612NBZlz1RHN5avspeC+qeIPRfScRlIDDPN910M\ne08Y7XpoVavf6ekGeehQeBrdL/9rSEuvhOq+bMnXjkDaQXqDiLbjGnTN5I6Y\niDoafQ87dDCWb7ESD1ciK9U3jZPAYoCJfiEKyGViAKdAtNnquiyZRirDn2lh\n/dvxg3R+beN2WEGZgOZPTLZdFi/4Z7LiD/BeLkYz5BwBMxfBW6ltF71Ddl+Z\nKqhCz9UzfjfjWUK6t5domLaNWvk2akhcZuhu+yJQ0UV8do0fLDbnZHf8/TCO\nGWTQLhDlhwsC4Fxw0afHAJc2SHorsAop/V2XNfrq+m+DT5fjHw9M6Mr3e9mU\n3PW7\r\n=DEfg\r\n-----END PGP SIGNATURE-----\r\n",
+                "shasum": "54d27a1ec2b493bbc451c7efaa3557b6af82332d",
+                "tarball": "https://registry.npmjs.org/react-modal/-/react-modal-3.6.1.tgz",
+                "unpackedSize": 192329
+            },
+            "gitHead": "2a7083179bd2247d5d3edfe25ec746a2f77835f1",
+            "homepage": "https://github.com/reactjs/react-modal",
+            "keywords": [
+                "react",
+                "react-component",
+                "modal",
+                "dialog"
+            ],
+            "license": "MIT",
+            "main": "./lib/index.js",
+            "maintainers": [
+                {
+                    "email": "dias.h.bruno@gmail.com",
+                    "name": "diasbruno"
+                }
+            ],
+            "module": "./lib/index.js",
+            "name": "react-modal",
+            "peerDependencies": {
+                "react": "^0.14.0 || ^15.0.0 || ^16",
+                "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+            },
+            "repository": {
+                "type": "git",
+                "url": "git+https://github.com/reactjs/react-modal.git"
+            },
+            "scripts": {
+                "lint": "eslint src/ specs/",
+                "start": "webpack-dev-server --inline --host 127.0.0.1 --content-base examples/",
+                "test": "cross-env NODE_ENV=test karma start"
+            },
+            "tags": [
+                "react",
+                "modal",
+                "dialog"
+            ],
+            "version": "3.6.1"
+        }
+    }
+}


### PR DESCRIPTION
Currently only for the `UpdateChecker` - need to handle updating multiple dependencies in the `FileUpdater` before this can be deployed.

Freeform notes on considerations as I was writing this:
- Requirement comes from another dependency
  - Likely that it would be fine if we updated that other dependency (unusual
    for a dependency to have a peer dependency which itself has peer
    dependencies)
  - Need to check whether it's a sub-dependency we're updating
  - Also, that other dependency could have other peer dependencies
  - In theory we should do a resolvability check
- Requirement comes from this dependency
  - NOT likely that it would be fine if we update the other dependency, as there
    may be other dependencies that use it as a peed dep (e.g., many packages
    declare react as a peed dependency)
  - Probably best to only consider updating the required dep. No harm(?)
- Both (although not circular)
  - Ignore for now. Will need to handle later