### PR TITLE
Collect test metadata in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,4 +38,6 @@ jobs:
       # Run tests
       - run: cd helpers/yarn && node_modules/.bin/jest
       - run: cd helpers/npm && node_modules/.bin/jest
-      - run: bundle exec rspec spec
+      - run: bundle exec rspec spec --format documentation --format RspecJunitFormatter -o ~/rspec/rspec.xml
+      - store_test_results:
+          path: ~/rspec

--- a/dependabot-core.gemspec
+++ b/dependabot-core.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.8.0"
   spec.add_development_dependency "rspec-its", "~> 1.2.0"
+  spec.add_development_dependency "rspec_junit_formatter", "~> 0.4"
   spec.add_development_dependency "rubocop", "~> 0.60.0"
   spec.add_development_dependency "vcr", "~> 4.0.0"
   spec.add_development_dependency "webmock", "~> 3.4.0"


### PR DESCRIPTION
This enables Circle's "Insights" section, which gives reports on the slowest and flakiest tests.