### PR TITLE
Mute sub-dependency version resolve errors

### DIFF
--- a/lib/dependabot/update_checkers/java_script/npm_and_yarn/subdependency_version_resolver.rb
+++ b/lib/dependabot/update_checkers/java_script/npm_and_yarn/subdependency_version_resolver.rb
@@ -35,6 +35,11 @@ module Dependabot
             end
 
             version_from_updated_lockfiles(updated_lockfiles)
+          rescue SharedHelpers::HelperSubprocessFailed
+            # TODO: Move error handling logic from the FileUpdater to this class
+
+            # Return nil (no update possible) if an unknown error occurred
+            nil
           end
 
           private

--- a/spec/dependabot/update_checkers/java_script/npm_and_yarn/subdependency_version_resolver_spec.rb
+++ b/spec/dependabot/update_checkers/java_script/npm_and_yarn/subdependency_version_resolver_spec.rb
@@ -83,6 +83,26 @@ RSpec.describe namespace::SubdependencyVersionResolver do
       end
     end
 
+    context "with an invalid package.json" do
+      let(:dependency_files) { [package_json, npm_lock] }
+
+      let(:manifest_fixture_name) { "non_existant_dependency.json" }
+      let(:npm_lock_fixture_name) { "subdependency_update.json" }
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "acorn",
+          version: "5.1.1",
+          requirements: [],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      it "gracefully handles package not found exception" do
+        expect(latest_resolvable_version).to be_nil
+      end
+    end
+
     context "with a yarn.lock" do
       let(:dependency_files) { [package_json, yarn_lock] }
 


### PR DESCRIPTION
Temp fix until we've moved error logic from file updater to the version resolver.