### PR TITLE
JS: Handle environment variables in npmrc in unexpected places

### DIFF
--- a/lib/dependabot/file_updaters/java_script/npm_and_yarn/npmrc_builder.rb
+++ b/lib/dependabot/file_updaters/java_script/npm_and_yarn/npmrc_builder.rb
@@ -86,16 +86,15 @@ module Dependabot
           end
 
           def complete_npmrc_from_credentials
-            initial_content =
-              npmrc_file.content.
-              gsub(/^.*:_authToken=\$.*/, "").
-              gsub(/^.*:_auth=\$.*/, "")
+            initial_content = npmrc_file.content.
+                              gsub(/^.*\$\{.*\}.*/, "").strip + "\n"
 
-            return initial_content unless (cred = registry_credentials.first)
+            return initial_content unless global_registry
 
-            initial_content.gsub(/^_auth\s*=\s*\${.*}/) do |ln|
-              ln.sub(/\${.*}/, cred.fetch("token"))
-            end
+            initial_content +
+              "registry = https://#{global_registry['registry']}\n"\
+              "#{global_registry_auth_line}\n"\
+              "always-auth = true\n"
           end
 
           def build_npmrc_from_yarnrc

--- a/spec/dependabot/file_updaters/java_script/npm_and_yarn/npmrc_builder_spec.rb
+++ b/spec/dependabot/file_updaters/java_script/npm_and_yarn/npmrc_builder_spec.rb
@@ -81,9 +81,7 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn::NpmrcBuilder do
 
             it "removes the env variable use" do
               expect(npmrc_content).
-                to eq(
-                  "@dependabot:registry=https://npm.fury.io/dependabot/\n\n"
-                )
+                to eq("@dependabot:registry=https://npm.fury.io/dependabot/\n")
             end
           end
 
@@ -92,9 +90,7 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn::NpmrcBuilder do
 
             it "removes the env variable use" do
               expect(npmrc_content).
-                to eq(
-                  "@dependabot:registry=https://npm.fury.io/dependabot/\n\n"
-                )
+                to eq("@dependabot:registry=https://npm.fury.io/dependabot/\n")
             end
           end
         end
@@ -114,37 +110,31 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn::NpmrcBuilder do
         let(:manifest_fixture_name) { "package.json" }
         let(:yarn_lock_fixture_name) { "yarn.lock" }
         let(:credentials) do
-          [
-            {
-              "type" => "git_source",
-              "host" => "github.com",
-              "username" => "x-access-token",
-              "password" => "token"
-            },
-            {
-              "type" => "npm_registry",
-              "registry" => "registry.npmjs.org",
-              "token" => "my_token"
-            }
-          ]
+          [{
+            "type" => "git_source",
+            "host" => "github.com",
+            "username" => "x-access-token",
+            "password" => "token"
+          }, {
+            "type" => "npm_registry",
+            "registry" => "registry.npmjs.org",
+            "token" => "my_token"
+          }]
         end
         it { is_expected.to eq("//registry.npmjs.org/:_authToken=my_token") }
 
         context "that uses basic auth" do
           let(:credentials) do
-            [
-              {
-                "type" => "git_source",
-                "host" => "github.com",
-                "username" => "x-access-token",
-                "password" => "token"
-              },
-              {
-                "type" => "npm_registry",
-                "registry" => "registry.npmjs.org",
-                "token" => "my:token"
-              }
-            ]
+            [{
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "token"
+            }, {
+              "type" => "npm_registry",
+              "registry" => "registry.npmjs.org",
+              "token" => "my:token"
+            }]
           end
           it "includes Basic auth details" do
             expect(npmrc_content).to eq(
@@ -172,37 +162,31 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn::NpmrcBuilder do
 
         context "and some credentials" do
           let(:credentials) do
-            [
-              {
-                "type" => "git_source",
-                "host" => "github.com",
-                "username" => "x-access-token",
-                "password" => "token"
-              },
-              {
-                "type" => "npm_registry",
-                "registry" => "registry.npmjs.org",
-                "token" => "my_token"
-              }
-            ]
+            [{
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "token"
+            }, {
+              "type" => "npm_registry",
+              "registry" => "registry.npmjs.org",
+              "token" => "my_token"
+            }]
           end
           it { is_expected.to eq("//registry.npmjs.org/:_authToken=my_token") }
 
           context "that match a scoped package" do
             let(:credentials) do
-              [
-                {
-                  "type" => "git_source",
-                  "host" => "github.com",
-                  "username" => "x-access-token",
-                  "password" => "token"
-                },
-                {
-                  "type" => "npm_registry",
-                  "registry" => "npm.fury.io/dependabot",
-                  "token" => "my_token"
-                }
-              ]
+              [{
+                "type" => "git_source",
+                "host" => "github.com",
+                "username" => "x-access-token",
+                "password" => "token"
+              }, {
+                "type" => "npm_registry",
+                "registry" => "npm.fury.io/dependabot",
+                "token" => "my_token"
+              }]
             end
             it "adds auth details, and scopes them correctly" do
               expect(npmrc_content).
@@ -220,19 +204,16 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn::NpmrcBuilder do
 
         context "and credentials for the private source" do
           let(:credentials) do
-            [
-              {
-                "type" => "git_source",
-                "host" => "github.com",
-                "username" => "x-access-token",
-                "password" => "token"
-              },
-              {
-                "type" => "npm_registry",
-                "registry" => "npm.fury.io/dependabot",
-                "token" => "my_token"
-              }
-            ]
+            [{
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "token"
+            }, {
+              "type" => "npm_registry",
+              "registry" => "npm.fury.io/dependabot",
+              "token" => "my_token"
+            }]
           end
 
           it "adds a global registry line, and auth details" do
@@ -247,13 +228,30 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn::NpmrcBuilder do
             let(:dependency_files) { [package_json, yarn_lock, npmrc] }
             let(:npmrc_fixture_name) { "env_global_auth" }
 
-            it "populates the already existing npmrc" do
+            it "extends the already existing npmrc" do
               expect(npmrc_content).
-                to eq("_auth = my_token\n"\
-                      "always-auth = true\n"\
+                to eq("always-auth = true\n"\
                       "strict-ssl = true\n"\
-                      "//npm.fury.io/dependabot/:_authToken=secret_token\n\n"\
+                      "//npm.fury.io/dependabot/:_authToken=secret_token\n"\
+                      "registry = https://npm.fury.io/dependabot\n"\
+                      "_authToken = my_token\n"\
+                      "always-auth = true\n\n"\
                       "//npm.fury.io/dependabot/:_authToken=my_token")
+            end
+
+            context "that uses environment variables everywhere" do
+              let(:npmrc_fixture_name) { "env_registry" }
+
+              it "extends the already existing npmrc" do
+                expect(npmrc_content).
+                  to eq("//dependabot.jfrog.io/dependabot/api/npm/"\
+                        "platform-npm/:always-auth=true\n"\
+                        "always-auth = true\n"\
+                        "registry = https://npm.fury.io/dependabot\n"\
+                        "_authToken = my_token\n"\
+                        "always-auth = true\n\n"\
+                        "//npm.fury.io/dependabot/:_authToken=my_token")
+              end
             end
           end
 
@@ -304,9 +302,7 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn::NpmrcBuilder do
 
             it "removes the env variable use" do
               expect(npmrc_content).
-                to eq(
-                  "@dependabot:registry=https://npm.fury.io/dependabot/\n\n"
-                )
+                to eq("@dependabot:registry=https://npm.fury.io/dependabot/\n")
             end
           end
         end
@@ -316,19 +312,16 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn::NpmrcBuilder do
         let(:manifest_fixture_name) { "package.json" }
         let(:npm_lock_fixture_name) { "package-lock.json" }
         let(:credentials) do
-          [
-            {
-              "type" => "git_source",
-              "host" => "github.com",
-              "username" => "x-access-token",
-              "password" => "token"
-            },
-            {
-              "type" => "npm_registry",
-              "registry" => "registry.npmjs.org",
-              "token" => "my_token"
-            }
-          ]
+          [{
+            "type" => "git_source",
+            "host" => "github.com",
+            "username" => "x-access-token",
+            "password" => "token"
+          }, {
+            "type" => "npm_registry",
+            "registry" => "registry.npmjs.org",
+            "token" => "my_token"
+          }]
         end
         it { is_expected.to eq("//registry.npmjs.org/:_authToken=my_token") }
 
@@ -351,37 +344,31 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn::NpmrcBuilder do
 
         context "and some credentials" do
           let(:credentials) do
-            [
-              {
-                "type" => "git_source",
-                "host" => "github.com",
-                "username" => "x-access-token",
-                "password" => "token"
-              },
-              {
-                "type" => "npm_registry",
-                "registry" => "registry.npmjs.org",
-                "token" => "my_token"
-              }
-            ]
+            [{
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "token"
+            }, {
+              "type" => "npm_registry",
+              "registry" => "registry.npmjs.org",
+              "token" => "my_token"
+            }]
           end
           it { is_expected.to eq("//registry.npmjs.org/:_authToken=my_token") }
 
           context "that match a scoped package" do
             let(:credentials) do
-              [
-                {
-                  "type" => "git_source",
-                  "host" => "github.com",
-                  "username" => "x-access-token",
-                  "password" => "token"
-                },
-                {
-                  "type" => "npm_registry",
-                  "registry" => "npm.fury.io/dependabot",
-                  "token" => "my_token"
-                }
-              ]
+              [{
+                "type" => "git_source",
+                "host" => "github.com",
+                "username" => "x-access-token",
+                "password" => "token"
+              }, {
+                "type" => "npm_registry",
+                "registry" => "npm.fury.io/dependabot",
+                "token" => "my_token"
+              }]
             end
             it "adds auth details, and scopes them correctly" do
               expect(npmrc_content).
@@ -399,19 +386,16 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn::NpmrcBuilder do
 
         context "and credentials for the private source" do
           let(:credentials) do
-            [
-              {
-                "type" => "git_source",
-                "host" => "github.com",
-                "username" => "x-access-token",
-                "password" => "token"
-              },
-              {
-                "type" => "npm_registry",
-                "registry" => "npm.fury.io/dependabot",
-                "token" => "my_token"
-              }
-            ]
+            [{
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "token"
+            }, {
+              "type" => "npm_registry",
+              "registry" => "npm.fury.io/dependabot",
+              "token" => "my_token"
+            }]
           end
 
           it "adds a global registry line, and token auth details" do
@@ -424,19 +408,16 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn::NpmrcBuilder do
 
           context "with basic auth credentials" do
             let(:credentials) do
-              [
-                {
-                  "type" => "git_source",
-                  "host" => "github.com",
-                  "username" => "x-access-token",
-                  "password" => "token"
-                },
-                {
-                  "type" => "npm_registry",
-                  "registry" => "npm.fury.io/dependabot",
-                  "token" => "secret:token"
-                }
-              ]
+              [{
+                "type" => "git_source",
+                "host" => "github.com",
+                "username" => "x-access-token",
+                "password" => "token"
+              }, {
+                "type" => "npm_registry",
+                "registry" => "npm.fury.io/dependabot",
+                "token" => "secret:token"
+              }]
             end
 
             it "adds a global registry line, and Basic auth details" do
@@ -455,11 +436,40 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn::NpmrcBuilder do
 
             it "populates the already existing npmrc" do
               expect(npmrc_content).
-                to eq("_auth = my_token\n"\
-                      "always-auth = true\n"\
+                to eq("always-auth = true\n"\
                       "strict-ssl = true\n"\
-                      "//npm.fury.io/dependabot/:_authToken=secret_token\n\n"\
+                      "//npm.fury.io/dependabot/:_authToken=secret_token\n"\
+                      "registry = https://npm.fury.io/dependabot\n"\
+                      "_authToken = my_token\n"\
+                      "always-auth = true\n\n"\
                       "//npm.fury.io/dependabot/:_authToken=my_token")
+            end
+
+            context "with basic auth credentials" do
+              let(:credentials) do
+                [{
+                  "type" => "git_source",
+                  "host" => "github.com",
+                  "username" => "x-access-token",
+                  "password" => "token"
+                }, {
+                  "type" => "npm_registry",
+                  "registry" => "npm.fury.io/dependabot",
+                  "token" => "secret:token"
+                }]
+              end
+
+              it "populates the already existing npmrc" do
+                expect(npmrc_content).
+                  to eq("always-auth = true\n"\
+                        "strict-ssl = true\n"\
+                        "//npm.fury.io/dependabot/:_authToken=secret_token\n"\
+                        "registry = https://npm.fury.io/dependabot\n"\
+                        "_auth = c2VjcmV0OnRva2Vu\n"\
+                        "always-auth = true\n\n"\
+                        "always-auth = true\n"\
+                        "//npm.fury.io/dependabot/:_auth=c2VjcmV0OnRva2Vu")
+              end
             end
           end
         end

--- a/spec/fixtures/javascript/npmrc/env_registry
+++ b/spec/fixtures/javascript/npmrc/env_registry
@@ -1,0 +1,6 @@
+//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
+@dependabot:registry=${REGISTRY_URL}
+//dependabot.jfrog.io/dependabot/api/npm/platform-npm/:_password=${NPM_PASSWORD}
+//dependabot.jfrog.io/dependabot/api/npm/platform-npm/:username=${NPM_USERNAME}
+//dependabot.jfrog.io/dependabot/api/npm/platform-npm/:always-auth=true
+always-auth = true


### PR DESCRIPTION
Previously, we only stripped *some* environment variables out of the `.npmrc`. We'll now strip all of them, and use the same logic for adding global registries as we do if a `.npmrc` isn't present.