### PR TITLE
NPM: Raise git not reachable for ssh://git

### DIFF
--- a/lib/dependabot/file_updaters/java_script/npm_and_yarn/npm_lockfile_updater.rb
+++ b/lib/dependabot/file_updaters/java_script/npm_and_yarn/npm_lockfile_updater.rb
@@ -179,7 +179,6 @@ module Dependabot
               dependency_url =
                 error.message.match(UNREACHABLE_GIT).
                 named_captures.fetch("url")
-              raise if dependency_url.start_with?("ssh://")
 
               raise Dependabot::GitDependenciesNotReachable, dependency_url
             end

--- a/lib/dependabot/shared_helpers.rb
+++ b/lib/dependabot/shared_helpers.rb
@@ -118,15 +118,15 @@ module Dependabot
 
     def self.configure_git_to_use_https
       run_shell_command(
-        'git config --global --replace-all url."https://github.com/".'\
+        'git config --system --replace-all url."https://github.com/".'\
         "insteadOf ssh://git@github.com/ && "\
-        'git config --global --add url."https://github.com/".'\
+        'git config --system --add url."https://github.com/".'\
         "insteadOf ssh://git@github.com: && "\
-        'git config --global --add url."https://github.com/".'\
+        'git config --system --add url."https://github.com/".'\
         "insteadOf git@github.com: && "\
-        'git config --global --add url."https://github.com/".'\
+        'git config --system --add url."https://github.com/".'\
         "insteadOf git@github.com/ && "\
-        'git config --global --add url."https://github.com/".'\
+        'git config --system --add url."https://github.com/".'\
         "insteadOf git://github.com/"
       )
     end
@@ -136,12 +136,12 @@ module Dependabot
       # (requires git 2.9 or greater). This is required so that any --system
       # credential helpers aren't used.
       run_shell_command(
-        "git config --global --replace-all credential.helper ''"
+        "git config --system --replace-all credential.helper ''"
       )
 
       # Then add a file-based credential store that loads a file in this repo
       run_shell_command(
-        "git config --global credential.helper "\
+        "git config --system credential.helper "\
         "'store --file=#{Dir.pwd}/git.store'"
       )
 
@@ -163,8 +163,8 @@ module Dependabot
 
     def self.reset_git_config
       run_shell_command(
-        'git config --global --remove-section url."https://github.com/" '\
-        "&& git config --global --remove-section credential"
+        'git config --system --remove-section url."https://github.com/" '\
+        "&& git config --system --remove-section credential"
       )
     end
 

--- a/spec/dependabot/file_updaters/java_script/npm_and_yarn_spec.rb
+++ b/spec/dependabot/file_updaters/java_script/npm_and_yarn_spec.rb
@@ -1140,6 +1140,22 @@ RSpec.describe Dependabot::FileUpdaters::JavaScript::NpmAndYarn do
             end
           end
 
+          context "when there is a private git dep we don't have access to" do
+            let(:files) { [package_json, package_lock] }
+
+            let(:manifest_fixture_name) { "github_dependency_private.json" }
+            let(:npm_lock_fixture_name) { "github_dependency_private.json" }
+
+            let(:dependency_name) { "strict-uri-encode" }
+            let(:version) { "1.1.0" }
+            let(:requirements) { [] }
+
+            it "raises a helpful error" do
+              expect { updater.updated_dependency_files }.
+                to raise_error(Dependabot::GitDependenciesNotReachable)
+            end
+          end
+
           context "because we're updating to a non-existant version" do
             let(:yarn_lock_fixture_name) { "yarn.lock" }
             let(:npm_lock_fixture_name) { "package-lock.json" }

--- a/spec/fixtures/javascript/npm_lockfiles/github_dependency_private.json
+++ b/spec/fixtures/javascript/npm_lockfiles/github_dependency_private.json
@@ -1,0 +1,45 @@
+{
+  "name": "bump-test",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bus-replacement-service": {
+      "version": "github:hmarr/dependabot-test-private-npm-package#19c4dba3bfce7574e28f1df2138d47ab4cc665b3",
+      "from": "github:hmarr/dependabot-test-private-npm-package",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "query-string": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.0.1.tgz",
+      "integrity": "sha512-aM+MkQClojlNiKkO09tiN2Fv8jM/L7GWIjG2liWeKljlOdOPNWr+bW3KQ+w5V/uKprpezC7fAsAMsJtJ+2rLKA==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "strict-uri-encode": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.0.2.tgz",
+      "integrity": "sha1-/RnmOdiadmJWoz5hHThBXfjWBY0="
+    }
+  }
+}

--- a/spec/fixtures/javascript/package_files/github_dependency_private.json
+++ b/spec/fixtures/javascript/package_files/github_dependency_private.json
@@ -1,0 +1,23 @@
+{
+  "name": "bump-test",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gocardless/bump-test.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/gocardless/bump-test/issues"
+  },
+  "homepage": "https://github.com/gocardless/bump-test#readme",
+  "dependencies": {
+    "bus-replacement-service": "hmarr/dependabot-test-private-npm-package",
+    "query-string": "^5.0.1"
+  }
+}


### PR DESCRIPTION
Relying on SharedHelpers.with_git_configured.. to rewrite ssh://git@..
to https:// so don't need to guard against ssh:// when raising error
about unreachable git repo.