### PR TITLE
Use clean git config and don't let git erase credentials

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - vendor/**/*
     - bin/**/*
     - tmp/**/*
+    - helpers/utils/git-credential-store-immutable
 
 Layout/DotPosition:
   EnforcedStyle: trailing

--- a/helpers/utils/git-credential-store-immutable
+++ b/helpers/utils/git-credential-store-immutable
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require "shellwords"
+
+# Valid commands are: `get`, `store`, `erase`. We only want to let `get`
+# through, as the others mutate the credential store.
+if ARGV.include?("get")
+  args = ARGV.map { |arg| Shellwords.escape(arg) }.join(" ")
+  exec "git credential-store #{args}"
+end

--- a/lib/dependabot/shared_helpers.rb
+++ b/lib/dependabot/shared_helpers.rb
@@ -137,17 +137,15 @@ module Dependabot
     end
 
     def self.configure_git_credentials(credentials)
-      # First, reset the credential helpers by appending an empty string to them
-      # (requires git 2.9 or greater). This is required so that any --global
-      # credential helpers aren't used.
-      run_shell_command(
-        "git config --global --replace-all credential.helper ''"
-      )
-
-      # Then add a file-based credential store that loads a file in this repo
+      # Then add a file-based credential store that loads a file in this repo.
+      # Under the hood this uses git credential-store, but it's invoked through
+      # an wrapper binary that only allows non-mutative commands. Without this,
+      # whenever the credentials are deemed to be invalid, they're erased.
+      credential_helper_path =
+        File.join(__dir__, "../../helpers/utils/git-credential-store-immutable")
       run_shell_command(
         "git config --global credential.helper "\
-        "'store --file=#{Dir.pwd}/git.store'"
+        "'#{credential_helper_path} --file=#{Dir.pwd}/git.store'"
       )
 
       # Build the content for our credentials file


### PR DESCRIPTION
Two changes to the git credentials configuration:

1. Instead of adding lines into an existing global git config (then removing them afterwards), we take a backup of the pre-existing git config and start from scratch. This is important because CircleCI runs `git config --global url."ssh://git@github.com".insteadOf "https://github.com"` at the start of a test run, which means we end up using git over SSH rather than HTTPS.
2. The git credential store is now wrapped in an executable that filters out commands that would mutate the store. Previously, the credential store was getting nuked when credentials were invalid, causing an authentication prompt to appear and wait for user input.