### PR TITLE
npm: ingore platform and engine checks on install

### DIFF
--- a/helpers/npm/lib/subdependency-updater.js
+++ b/helpers/npm/lib/subdependency-updater.js
@@ -9,7 +9,11 @@ async function updateDependencyFile(directory, lockfileName) {
   const readFile = fileName =>
     fs.readFileSync(path.join(directory, fileName)).toString();
 
-  await runAsync(npm, npm.load, [{ loglevel: "silent" }]);
+  // `force: true` ignores checks for platform (os, cpu) and engines
+  // in npm/lib/install/validate-args.js
+  // Platform is checked and raised from (EBADPLATFORM):
+  // https://github.com/npm/npm-install-checks
+  await runAsync(npm, npm.load, [{ loglevel: "silent", force: true }]);
 
   const dryRun = true;
   const initialInstaller = new installer.Installer(directory, dryRun, [], {


### PR DESCRIPTION
Ignore "os", "engine" and "cpu" checks when updating peer/sub
dependencies (we already do this for top level deps).