### PR TITLE
Dep: fix fsnotify-related panic

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -139,6 +139,7 @@ dependencies.each do |dep|
     credentials: credentials
   )
 
+  puts " => checking for updates"
   updated_deps = checker.updated_dependencies(requirements_to_unlock: :own)
   updated_deps.select! do |d|
     next true if d.version != d.previous_version

--- a/spec/dependabot/file_updaters/go/dep/lockfile_updater_spec.rb
+++ b/spec/dependabot/file_updaters/go/dep/lockfile_updater_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe Dependabot::FileUpdaters::Go::Dep::LockfileUpdater do
       end
     end
 
-    context "with fsnotify as a dependency" do
+    context "with fsnotify as a direct dependency" do
       let(:manifest_fixture_name) { "fsnotify_dep.toml" }
       let(:lockfile_fixture_name) { "fsnotify_dep.lock" }
       let(:previous_requirements) do
@@ -320,6 +320,29 @@ RSpec.describe Dependabot::FileUpdaters::Go::Dep::LockfileUpdater do
       let(:dependency_name) { "gopkg.in/fsnotify.v1" }
       let(:dependency_version) { "1.2.0" }
       let(:dependency_previous_version) { "1.2.0" }
+
+      it "updates the lockfile correctly" do
+        expect { updated_lockfile_content }.to_not raise_error
+      end
+    end
+
+    context "with fsnotify as a transitive dependency" do
+      let(:manifest_fixture_name) { "fsnotify_trans_dep.toml" }
+      let(:lockfile_fixture_name) { "fsnotify_trans_dep.lock" }
+      let(:previous_requirements) do
+        [{
+          file: "Gopkg.toml",
+          requirement: "~1.6.0",
+          groups: [],
+          source: {
+            type: "default",
+            source: "github.com/onsi/ginkgo"
+          }
+        }]
+      end
+      let(:dependency_name) { "github.com/onsi/ginkgo" }
+      let(:dependency_version) { "1.7.0" }
+      let(:dependency_previous_version) { "1.6.0" }
 
       it "updates the lockfile correctly" do
         expect { updated_lockfile_content }.to_not raise_error

--- a/spec/dependabot/update_checkers/go/dep_spec.rb
+++ b/spec/dependabot/update_checkers/go/dep_spec.rb
@@ -368,6 +368,18 @@ RSpec.describe Dependabot::UpdateCheckers::Go::Dep do
         end
       end
     end
+
+    context "with fsnotify as a dependency" do
+      let(:manifest_fixture_name) { "fsnotify_trans_dep.toml" }
+      let(:lockfile_fixture_name) { "fsnotify_trans_dep.lock" }
+      let(:req_str) { "1.6.0" }
+      let(:dependency_name) { "github.com/onsi/ginkgo" }
+      let(:dependency_version) { "1.6.0" }
+
+      it "unlocks the manifest and gets the correct version" do
+        expect(latest_resolvable_version).to eq(Gem::Version.new("1.7.0"))
+      end
+    end
   end
 
   describe "#latest_resolvable_version_with_no_unlock" do

--- a/spec/fixtures/go/gopkg_locks/fsnotify_trans_dep.lock
+++ b/spec/fixtures/go/gopkg_locks/fsnotify_trans_dep.lock
@@ -1,0 +1,34 @@
+
+[[projects]]
+  digest = "1:a7fd918fb5bd2188436785c0424f8a50b4addfedf37a2b14d796be2a927b8007"
+  name = "github.com/onsi/ginkgo"
+  packages = [
+    ".",
+    "config",
+    "internal/codelocation",
+    "internal/containernode",
+    "internal/failer",
+    "internal/leafnodes",
+    "internal/remote",
+    "internal/spec",
+    "internal/spec_iterator",
+    "internal/specrunner",
+    "internal/suite",
+    "internal/testingtproxy",
+    "internal/writer",
+    "reporters",
+    "reporters/stenographer",
+    "reporters/stenographer/support/go-colorable",
+    "reporters/stenographer/support/go-isatty",
+    "types",
+  ]
+  pruneopts = ""
+  revision = "3774a09d95489ccaa16032e0770d08ea77ba6184"
+  version = "v1.6.0"
+
+[solve-meta]
+  analyzer-name = "dep"
+  analyzer-version = 1
+  input-imports = ["github.com/onsi/ginkgo"]
+  solver-name = "gps-cdcl"
+  solver-version = 1

--- a/spec/fixtures/go/gopkg_tomls/fsnotify_trans_dep.toml
+++ b/spec/fixtures/go/gopkg_tomls/fsnotify_trans_dep.toml
@@ -1,0 +1,3 @@
+[[constraint]]
+  name = "github.com/onsi/ginkgo"
+  version = "1.6.0"


### PR DESCRIPTION
It was still occurring for transitive dependencies. Always adding an override for fsnotify seems to fix it in all cases, and doesn't appear to do anything to the lockfile when fsnotify isn't used.