### PR TITLE
Python: Catch ValueError and treat as a FileNotEvaluatable error

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,5 @@
+/.bundle/
+/.env
+/tmp
+/dependabot-*.gem
+Gemfile.lock

--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -32,7 +32,7 @@ module Dependabot
       ].freeze
       REQUIREMENT_FILE_EVALUATION_ERRORS = %w(
         InstallationError RequirementsFileParseError InvalidMarker
-        InvalidRequirement
+        InvalidRequirement ValueError
       ).freeze
 
       def parse

--- a/python/spec/dependabot/python/file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser_spec.rb
@@ -157,6 +157,15 @@ RSpec.describe Dependabot::Python::FileParser do
       end
     end
 
+    context "with an invalid value" do
+      let(:requirements_fixture_name) { "invalid_value.txt" }
+
+      it "raises a Dependabot::DependencyFileNotEvaluatable error" do
+        expect { parser.parse }.
+          to raise_error(Dependabot::DependencyFileNotEvaluatable)
+      end
+    end
+
     context "with invalid options" do
       let(:requirements_fixture_name) { "invalid_options.txt" }
 

--- a/python/spec/fixtures/requirements/invalid_value.txt
+++ b/python/spec/fixtures/requirements/invalid_value.txt
@@ -1,0 +1,1 @@
+- if it's uploaded, call it attachment on the serializers and fields


### PR DESCRIPTION
Fix for https://sentry.io/dependabot/backend/issues/798713617/?environment=default&referrer=alert_email. Needs to wait for Python refactor.