### PR TITLE
Promote runs without helpers dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Before running Dependabot Core, install dependencies for the core library and
 the helpers:
 
 1. `bundle install`
-2. `cd helpers/yarn && yarn install && cd -`
-3. `cd helpers/npm && yarn install && cd -`
-4. `cd helpers/php && composer install && cd -`
+2. `cd helpers/yarn && yarn install --production && cd -`
+3. `cd helpers/npm && yarn install --production && cd -`
+4. `cd helpers/php && composer install --no-dev && cd -`
 5. `cd helpers/python && pyenv exec pip install -r requirements.txt && cd -`
 6. `cd helpers/elixir && mix deps.get && cd -`
 


### PR DESCRIPTION
Tiny changes in the README to suggest using only needed dependencies for helpers in a "production" environment.
Adding these arguments reduce run time and disk usage.