### PR TITLE
Revert "Respect platform requirements if they are set"

### DIFF
--- a/helpers/php/src/UpdateChecker.php
+++ b/helpers/php/src/UpdateChecker.php
@@ -66,15 +66,8 @@ class UpdateChecker
             ->setWhitelistTransitiveDependencies(true)
             ->setExecuteOperations(false)
             ->setDumpAutoloader(false)
-            ->setRunScripts(false);
-
-        /*
-         * If a platform is set we assume people know what they are doing and we respect the setting.
-         * If no platform is set we ignore it so that the php we run as doesn't interfere
-         */
-        if ($config->get('platform') === []) {
-            $install->setIgnorePlatformRequirements(true);
-        }
+            ->setRunScripts(false)
+            ->setIgnorePlatformRequirements(true);
 
         $install->run();
 

--- a/helpers/php/src/Updater.php
+++ b/helpers/php/src/Updater.php
@@ -74,15 +74,8 @@ class Updater
             ->setWhitelistTransitiveDependencies(true)
             ->setExecuteOperations(false)
             ->setDumpAutoloader(false)
-            ->setRunScripts(false);
-
-        /*
-         * If a platform is set we assume people know what they are doing and we respect the setting.
-         * If no platform is set we ignore it so that the php we run as doesn't interfere
-         */
-        if ($config->get('platform') === []) {
-            $install->setIgnorePlatformRequirements(true);
-        }
+            ->setRunScripts(false)
+            ->setIgnorePlatformRequirements(true);
 
         $install->run();
 


### PR DESCRIPTION
This reverts commit b72a20053b5c510f83c485c57b9ee8be3bfc0311. The reason for reverting this is I think the author of the change misunderstood what this flag actually does. It **does not** refer to if composer should use the config.platform settings when resolving dependencies. What it does do is to allow composer to continue even when the actual version of PHP is incompatible and/or there are missing extensions installed.

We can see the problem manifesting itself here: https://github.com/CachetHQ/Cachet/issues/3369.