### PR TITLE
Don't ignore platform requirements when updating composer packages

### DIFF
--- a/helpers/php/src/UpdateChecker.php
+++ b/helpers/php/src/UpdateChecker.php
@@ -68,14 +68,6 @@ class UpdateChecker
             ->setDumpAutoloader(false)
             ->setRunScripts(false);
 
-        /*
-         * If a platform is set we assume people know what they are doing and we respect the setting.
-         * If no platform is set we ignore it so that the php we run as doesn't interfere
-         */
-        if ($config->get('platform') === []) {
-            $install->setIgnorePlatformRequirements(true);
-        }
-
         $install->run();
 
         $installedPackages = $installationManager->getInstalledPackages();

--- a/helpers/php/src/Updater.php
+++ b/helpers/php/src/Updater.php
@@ -76,14 +76,6 @@ class Updater
             ->setDumpAutoloader(false)
             ->setRunScripts(false);
 
-        /*
-         * If a platform is set we assume people know what they are doing and we respect the setting.
-         * If no platform is set we ignore it so that the php we run as doesn't interfere
-         */
-        if ($config->get('platform') === []) {
-            $install->setIgnorePlatformRequirements(true);
-        }
-
         $install->run();
 
         $result = [


### PR DESCRIPTION
See #527 for the original change and, #868 for the reason to revert the change and 
https://github.com/dependabot/dependabot-core/pull/868#issuecomment-451957698 for the reason to drop this entirely.

If platform requirements are ignored, this will cause installation of invalid PHP packages. If `composer update` (or its dependabot equivalent) is run on a machine running PHP 7.3, it will happily pull in packages with a requirement of `"php": "^7.3"`. Since we don't know what platform the user is running on in the end, we definitely shouldn't be doing this.

Setting `config.platform` will fix this issue, but I believe the default behaviour should be to not ignore platform requirements but rather force people to define them (or at least make this configurable in the settings).

Note: I opened this PR early to give feedback on #889. I fully expect some specs to fail, I'll take a look at those once I know that the change I made has a chance of being merged.