### PR TITLE
[WIP] Add support for gemspec path option

### DIFF
--- a/lib/dependabot/file_fetchers/ruby/bundler.rb
+++ b/lib/dependabot/file_fetchers/ruby/bundler.rb
@@ -8,6 +8,7 @@ module Dependabot
   module FileFetchers
     module Ruby
       class Bundler < Dependabot::FileFetchers::Base
+        require "dependabot/file_fetchers/ruby/bundler/gemspec_finder"
         require "dependabot/file_fetchers/ruby/bundler/path_gemspec_finder"
         require "dependabot/file_fetchers/ruby/bundler/child_gemfile_finder"
         require "dependabot/file_fetchers/ruby/bundler/require_relative_finder"
@@ -30,9 +31,9 @@ module Dependabot
           fetched_files = []
           fetched_files << gemfile if gemfile
           fetched_files << lockfile if gemfile && lockfile
+          fetched_files += child_gemfiles
           fetched_files += gemspecs
           fetched_files << ruby_version_file if ruby_version_file
-          fetched_files += child_gemfiles
           fetched_files += path_gemspecs
           fetched_files += require_relative_files(fetched_files)
 
@@ -64,10 +65,29 @@ module Dependabot
         end
 
         def gemspecs
-          gemspecs = repo_contents.select { |f| f.name.end_with?(".gemspec") }
-          @gemspecs ||= gemspecs.map { |gs| fetch_file_from_host(gs.name) }
+          return @gemspecs if defined?(@gemspecs)
+
+          gemspecs_paths =
+            gemspec_directories.
+            flat_map do |d|
+              repo_contents(dir: d).
+                select { |f| f.name.end_with?(".gemspec") }.
+                map { |f| File.join(d, f.name) }
+            end
+
+          @gemspecs = gemspecs_paths.map { |n| fetch_file_from_host(n) }
         rescue Octokit::NotFound
           []
+        end
+
+        def gemspec_directories
+          gemfiles = ([gemfile] + child_gemfiles).compact
+          directories =
+            gemfiles.flat_map do |file|
+              GemspecFinder.new(gemfile: file).gemspec_directories
+            end.uniq
+
+          directories.empty? ? ["."] : directories
         end
 
         def ruby_version_file
@@ -83,7 +103,7 @@ module Dependabot
           gemspec_files = []
           unfetchable_gems = []
 
-          gemspec_paths.each do |path|
+          path_gemspec_paths.each do |path|
             # Get any gemspecs at the path itself
             gemspecs_at_path = fetch_gemspecs_from_directory(path)
 
@@ -112,8 +132,8 @@ module Dependabot
           gemspec_files.tap { |ar| ar.each { |f| f.support_file = true } }
         end
 
-        def gemspec_paths
-          fetch_gemspec_paths.map { |path| Pathname.new(path) }
+        def path_gemspec_paths
+          fetch_path_gemspec_paths.map { |path| Pathname.new(path) }
         end
 
         def require_relative_files(files)
@@ -136,7 +156,7 @@ module Dependabot
             map { |fp| fetch_file_from_host(fp) }
         end
 
-        def fetch_gemspec_paths
+        def fetch_path_gemspec_paths
           if lockfile
             parsed_lockfile = ::Bundler::LockfileParser.new(
               sanitized_lockfile_content

--- a/lib/dependabot/file_fetchers/ruby/bundler.rb
+++ b/lib/dependabot/file_fetchers/ruby/bundler.rb
@@ -37,13 +37,21 @@ module Dependabot
           fetched_files += path_gemspecs
           fetched_files += require_relative_files(fetched_files)
 
+          fetched_files = uniq_files(fetched_files)
+
           check_required_files_present
 
           unless self.class.required_files_in?(fetched_files.map(&:name))
             raise "Invalid set of files: #{fetched_files.map(&:name)}"
           end
 
-          fetched_files.uniq
+          fetched_files
+        end
+
+        def uniq_files(fetched_files)
+          uniq_files = fetched_files.reject(&:support_file?).uniq
+          uniq_files += fetched_files.
+                        reject { |f| uniq_files.map(&:name).include?(f.name) }
         end
 
         def check_required_files_present

--- a/lib/dependabot/file_fetchers/ruby/bundler/gemspec_finder.rb
+++ b/lib/dependabot/file_fetchers/ruby/bundler/gemspec_finder.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "pathname"
+require "parser/current"
+require "dependabot/file_fetchers/ruby/bundler"
+require "dependabot/errors"
+
+module Dependabot
+  module FileFetchers
+    module Ruby
+      class Bundler
+        # Finds the directories of any gemspecs declared using `gemspec` in the
+        # passed Gemfile.
+        class GemspecFinder
+          def initialize(gemfile:)
+            @gemfile = gemfile
+          end
+
+          def gemspec_directories
+            ast = Parser::CurrentRuby.parse(gemfile.content)
+            find_gemspec_paths(ast)
+          rescue Parser::SyntaxError
+            raise Dependabot::DependencyFileNotParseable, gemfile.path
+          end
+
+          private
+
+          attr_reader :gemfile
+
+          # rubocop:disable Security/Eval
+          def find_gemspec_paths(node)
+            return [] unless node.is_a?(Parser::AST::Node)
+
+            if declares_gemspec_dependency?(node)
+              path_node = path_node_for_gem_declaration(node)
+              return [clean_path(".")] unless path_node
+
+              begin
+                # We use eval here, but we know what we're doing. The
+                # FileFetchers helper method should only ever be run in an
+                # isolated environment
+                path = eval(path_node.loc.expression.source)
+              rescue StandardError
+                return []
+              end
+              return [clean_path(path)]
+            end
+
+            node.children.flat_map do |child_node|
+              find_gemspec_paths(child_node)
+            end
+          end
+          # rubocop:enable Security/Eval
+
+          def current_dir
+            @current_dir ||= gemfile.name.rpartition("/").first
+            @current_dir = nil if @current_dir == ""
+            @current_dir
+          end
+
+          def declares_gemspec_dependency?(node)
+            return false unless node.is_a?(Parser::AST::Node)
+
+            node.children[1] == :gemspec
+          end
+
+          def clean_path(path)
+            if Pathname.new(path).absolute?
+              base_path = Pathname.new(File.expand_path(Dir.pwd))
+              path = Pathname.new(path).relative_path_from(base_path).to_s
+            end
+            path = File.join(current_dir, path) unless current_dir.nil?
+            Pathname.new(path).cleanpath
+          end
+
+          def path_node_for_gem_declaration(node)
+            return unless node.children.last.is_a?(Parser::AST::Node)
+            return unless node.children.last.type == :hash
+
+            kwargs_node = node.children.last
+
+            path_hash_pair =
+              kwargs_node.children.
+              find { |hash_pair| key_from_hash_pair(hash_pair) == :path }
+
+            return unless path_hash_pair
+
+            path_hash_pair.children.last
+          end
+
+          def key_from_hash_pair(node)
+            node.children.first.children.first.to_sym
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dependabot/file_parsers/ruby/bundler.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler.rb
@@ -279,7 +279,7 @@ module Dependabot
         def gemspecs
           # The gemspecs for this project will be at the top level
           @gemspecs ||= prepared_dependency_files.select do |file|
-            file.name.match?(%r{^*\.gemspec$})
+            file.name.match?(/^*\.gemspec$/)
           end
         end
 

--- a/lib/dependabot/file_parsers/ruby/bundler.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler.rb
@@ -280,7 +280,7 @@ module Dependabot
           # Path gemspecs are excluded (they're supporting files)
           @gemspecs ||= prepared_dependency_files.
                         select { |file| file.name.end_with?(".gemspec") }.
-                        reject { |file| file.support_file? }
+                        reject(&:support_file?)
         end
 
         def imported_ruby_files

--- a/lib/dependabot/file_parsers/ruby/bundler.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler.rb
@@ -137,8 +137,7 @@ module Dependabot
           @parsed_gemspecs ||= {}
           @parsed_gemspecs[file.name] ||=
             SharedHelpers.in_a_temporary_directory do
-              File.write(file.name, file.content)
-              imported_ruby_files.each do |f|
+              [file, *imported_ruby_files].each do |f|
                 path = f.name
                 FileUtils.mkdir_p(Pathname.new(path).dirname)
                 File.write(path, f.content)
@@ -280,7 +279,7 @@ module Dependabot
         def gemspecs
           # The gemspecs for this project will be at the top level
           @gemspecs ||= prepared_dependency_files.select do |file|
-            file.name.match?(%r{^[^/]*\.gemspec$})
+            file.name.match?(%r{^*\.gemspec$})
           end
         end
 

--- a/lib/dependabot/file_parsers/ruby/bundler.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler.rb
@@ -277,10 +277,10 @@ module Dependabot
         end
 
         def gemspecs
-          # The gemspecs for this project will be at the top level
-          @gemspecs ||= prepared_dependency_files.select do |file|
-            file.name.match?(/^*\.gemspec$/)
-          end
+          # Path gemspecs are excluded (they're supporting files)
+          @gemspecs ||= prepared_dependency_files.
+                        select { |file| file.name.end_with?(".gemspec") }.
+                        reject { |file| file.support_file? }
         end
 
         def imported_ruby_files

--- a/lib/dependabot/file_parsers/ruby/bundler/file_preparer.rb
+++ b/lib/dependabot/file_parsers/ruby/bundler/file_preparer.rb
@@ -20,7 +20,8 @@ module Dependabot
               files << DependencyFile.new(
                 name: file.name,
                 content: sanitize_gemspec_content(file.content),
-                directory: file.directory
+                directory: file.directory,
+                support_file: file.support_file?
               )
             end
 

--- a/lib/dependabot/file_updaters/ruby/bundler.rb
+++ b/lib/dependabot/file_updaters/ruby/bundler.rb
@@ -16,7 +16,7 @@ module Dependabot
             /^Gemfile\.lock$/,
             /^gems\.rb$/,
             /^gems\.locked$/,
-            %r{^[^/]*\.gemspec$}
+            /^*\.gemspec$/
           ]
         end
 
@@ -113,7 +113,9 @@ module Dependabot
         end
 
         def top_level_gemspecs
-          dependency_files.select { |f| f.name.match?(%r{^[^/]*\.gemspec$}) }
+          dependency_files.
+            select { |file| file.name.end_with?(".gemspec") }.
+            reject(&:support_file?)
         end
       end
     end

--- a/lib/dependabot/file_updaters/ruby/bundler/lockfile_updater.rb
+++ b/lib/dependabot/file_updaters/ruby/bundler/lockfile_updater.rb
@@ -94,10 +94,10 @@ module Dependabot
             File.write(lockfile.name, sanitized_lockfile_body)
 
             top_level_gemspecs.each do |gemspec|
-              File.write(
-                gemspec.name,
-                sanitized_gemspec_content(updated_gemspec_content(gemspec))
-              )
+              path = gemspec.name
+              FileUtils.mkdir_p(Pathname.new(path).dirname)
+              updated_content = updated_gemspec_content(gemspec)
+              File.write(path, sanitized_gemspec_content(updated_content))
             end
 
             write_ruby_version_file
@@ -248,7 +248,9 @@ module Dependabot
           end
 
           def top_level_gemspecs
-            dependency_files.select { |f| f.name.match?(%r{^[^/]*\.gemspec$}) }
+            dependency_files.
+              select { |file| file.name.end_with?(".gemspec") }.
+              reject(&:support_file?)
           end
 
           def ruby_version_file

--- a/lib/dependabot/pull_request_creator.rb
+++ b/lib/dependabot/pull_request_creator.rb
@@ -136,9 +136,7 @@ module Dependabot
     end
 
     def library?
-      if files.map(&:name).any? { |name| name.match?(%r{^[^/]*\.gemspec$}) }
-        return true
-      end
+      return true if files.any? { |file| file.name.end_with?(".gemspec") }
 
       dependencies.none?(&:appears_in_lockfile?)
     end

--- a/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -155,7 +155,7 @@ module Dependabot
       end
 
       def library?
-        if files.map(&:name).any? { |name| name.match?(%r{^[^/]*\.gemspec$}) }
+        if files.map(&:name).any? { |name| name.end_with?(".gemspec") }
           return true
         end
 

--- a/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/lib/dependabot/pull_request_creator/message_builder.rb
@@ -708,8 +708,7 @@ module Dependabot
       end
 
       def library?
-        filenames = files.map(&:name)
-        return true if filenames.any? { |nm| nm.match?(%r{^[^/]*\.gemspec$}) }
+        return true if files.map(&:name).any? { |nm| nm.end_with?(".gemspec") }
 
         dependencies.none?(&:appears_in_lockfile?)
       end

--- a/lib/dependabot/update_checkers/ruby/bundler/file_preparer.rb
+++ b/lib/dependabot/update_checkers/ruby/bundler/file_preparer.rb
@@ -76,7 +76,8 @@ module Dependabot
               files << DependencyFile.new(
                 name: file.name,
                 content: sanitize_gemspec_content(file.content),
-                directory: file.directory
+                directory: file.directory,
+                support_file: file.support_file?
               )
             end
 
@@ -132,7 +133,9 @@ module Dependabot
           end
 
           def top_level_gemspecs
-            dependency_files.select { |f| f.name.match?(%r{^[^/]*\.gemspec$}) }
+            dependency_files.
+              select { |f| f.name.end_with?(".gemspec") }.
+              reject(&:support_file?)
           end
 
           def ruby_version_file

--- a/spec/dependabot/file_fetchers/ruby/bundler/gemspec_finder_spec.rb
+++ b/spec/dependabot/file_fetchers/ruby/bundler/gemspec_finder_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/file_fetchers/ruby/bundler/gemspec_finder"
+
+RSpec.describe Dependabot::FileFetchers::Ruby::Bundler::GemspecFinder do
+  let(:finder) { described_class.new(gemfile: gemfile) }
+
+  let(:gemfile) do
+    Dependabot::DependencyFile.new(content: gemfile_body, name: gemfile_name)
+  end
+  let(:gemfile_name) { "Gemfile" }
+  let(:gemfile_body) { fixture("ruby", "gemfiles", "Gemfile") }
+
+  describe "#gemspec_directories" do
+    subject(:gemspec_directories) { finder.gemspec_directories }
+
+    context "when the file does not include any gemspecs" do
+      let(:gemfile_body) { fixture("ruby", "gemfiles", "Gemfile") }
+      it { is_expected.to eq([]) }
+    end
+
+    context "with invalid Ruby in the Gemfile" do
+      let(:gemfile_body) { fixture("ruby", "gemfiles", "invalid_ruby") }
+
+      it "raises a helpful error" do
+        expect { finder.gemspec_directories }.to raise_error do |error|
+          expect(error).to be_a(Dependabot::DependencyFileNotParseable)
+          expect(error.file_name).to eq("Gemfile")
+        end
+      end
+    end
+
+    context "when the file does include a gemspec reference" do
+      let(:gemfile_body) { fixture("ruby", "gemfiles", "imports_gemspec") }
+      it { is_expected.to eq([Pathname.new(".")]) }
+
+      context "that has a path specified" do
+        let(:gemfile_body) do
+          fixture("ruby", "gemfiles", "imports_gemspec_from_path")
+        end
+
+        it { is_expected.to eq([Pathname.new("subdir")]) }
+
+        context "when this Gemfile is already in a nested directory" do
+          let(:gemfile_name) { "nested/Gemfile" }
+          it { is_expected.to eq([Pathname.new("nested/subdir")]) }
+        end
+      end
+    end
+  end
+end

--- a/spec/dependabot/file_fetchers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_fetchers/ruby/bundler_spec.rb
@@ -642,6 +642,45 @@ RSpec.describe Dependabot::FileFetchers::Ruby::Bundler do
       expect(file_fetcher_instance.files.map(&:name)).
         to include("business.gemspec")
     end
+
+    context "that has a path specified" do
+      before do
+        stub_request(:get, url + "Gemfile?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "gemfile_with_path_gemspec_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "contents_ruby_no_lockfile.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "dev?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "contents_ruby_library.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "dev/business.gemspec?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "gemspec_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+      end
+
+      it "fetches gemspec" do
+        expect(file_fetcher_instance.files.count).to eq(2)
+        expect(file_fetcher_instance.files.map(&:name)).
+          to include("dev/business.gemspec")
+      end
+    end
   end
 
   context "with only a gemspec and a Gemfile" do

--- a/spec/dependabot/file_parsers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/bundler_spec.rb
@@ -433,6 +433,33 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
         expect(dependencies.map(&:name)).to match_array(%w(business statesman))
       end
 
+      context "with a gemspec from a specific path" do
+        let(:gemfile_fixture_name) { "imports_gemspec_from_path" }
+        let(:lockfile_fixture_name) { "imports_gemspec_from_path.lock" }
+        let(:gemspec) do
+          Dependabot::DependencyFile.new(
+            name: "subdir/example.gemspec",
+            content: fixture("ruby", "gemspecs", "small_example")
+          )
+        end
+
+        it "fetches details from the gemspec" do
+          expect(dependencies.map(&:name)).
+            to match_array(%w(business))
+          expect(dependencies.map(&:requirements)).
+            to match_array(
+              [
+                [{
+                  requirement: "~> 1.0",
+                  groups: ["runtime"],
+                  source: nil,
+                  file: "subdir/example.gemspec"
+                }]
+              ]
+            )
+        end
+      end
+
       context "with two gemspecs" do
         let(:gemfile_fixture_name) { "imports_two_gemspecs" }
         let(:lockfile_fixture_name) { "imports_two_gemspecs.lock" }

--- a/spec/dependabot/file_parsers/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_parsers/ruby/bundler_spec.rb
@@ -288,7 +288,8 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
       let(:gemspec) do
         Dependabot::DependencyFile.new(
           name: "plugins/example/example.gemspec",
-          content: fixture("ruby", "gemspecs", "example")
+          content: fixture("ruby", "gemspecs", "example"),
+          support_file: true
         )
       end
 
@@ -445,17 +446,21 @@ RSpec.describe Dependabot::FileParsers::Ruby::Bundler do
 
         it "fetches details from the gemspec" do
           expect(dependencies.map(&:name)).
-            to match_array(%w(business))
-          expect(dependencies.map(&:requirements)).
+            to match_array(%w(business statesman))
+          expect(dependencies.first.name).to eq("business")
+          expect(dependencies.first.requirements).
             to match_array(
-              [
-                [{
-                  requirement: "~> 1.0",
-                  groups: ["runtime"],
-                  source: nil,
-                  file: "subdir/example.gemspec"
-                }]
-              ]
+              [{
+                file: "Gemfile",
+                requirement: "~> 1.4.0",
+                groups: [:default],
+                source: nil
+              }, {
+                file: "subdir/example.gemspec",
+                requirement: "~> 1.0",
+                groups: ["runtime"],
+                source: nil
+              }]
             )
         end
       end

--- a/spec/dependabot/file_updaters/ruby/bundler_spec.rb
+++ b/spec/dependabot/file_updaters/ruby/bundler_spec.rb
@@ -880,7 +880,8 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
           let(:gemspec) do
             Dependabot::DependencyFile.new(
               content: gemspec_body,
-              name: "plugins/example/example.gemspec"
+              name: "plugins/example/example.gemspec",
+              support_file: true
             )
           end
 
@@ -1068,6 +1069,52 @@ RSpec.describe Dependabot::FileUpdaters::Ruby::Bundler do
             it "returns an updated Gemfile and Gemfile.lock" do
               expect(updated_files.map(&:name)).
                 to match_array(["Gemfile", "Gemfile.lock"])
+            end
+          end
+
+          context "when updating a gemspec with a path" do
+            let(:gemfile_fixture_name) { "imports_gemspec_from_path" }
+            let(:lockfile_fixture_name) { "imports_gemspec_from_path.lock" }
+            let(:gemspec) do
+              Dependabot::DependencyFile.new(
+                content: gemspec_body,
+                name: "subdir/example.gemspec"
+              )
+            end
+            let(:dependency) do
+              Dependabot::Dependency.new(
+                name: "business",
+                version: "1.8.0",
+                previous_version: "1.4.0",
+                requirements: [{
+                  file: "subdir/example.gemspec",
+                  requirement: requirement,
+                  groups: [],
+                  source: nil
+                }, {
+                  file: "Gemfile",
+                  requirement: requirement,
+                  groups: [],
+                  source: nil
+                }],
+                previous_requirements: [{
+                  file: "subdir/example.gemspec",
+                  requirement: "~> 1.0",
+                  groups: [],
+                  source: nil
+                }, {
+                  file: "Gemfile",
+                  requirement: "~> 1.4.0",
+                  groups: [],
+                  source: nil
+                }],
+                package_manager: "bundler"
+              )
+            end
+
+            it "returns an updated gemspec, Gemfile and Gemfile.lock" do
+              expect(updated_files.map(&:name)).
+                to match_array(%w(Gemfile Gemfile.lock subdir/example.gemspec))
             end
           end
 

--- a/spec/dependabot/update_checkers/ruby/bundler/file_preparer_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler/file_preparer_spec.rb
@@ -339,7 +339,8 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler::FilePreparer do
       let(:gemspec) do
         Dependabot::DependencyFile.new(
           content: gemspec_body,
-          name: "some/example.gemspec"
+          name: "some/example.gemspec",
+          support_file: true
         )
       end
       let(:gemspec_body) { fixture("ruby", "gemspecs", "small_example") }

--- a/spec/dependabot/update_checkers/ruby/bundler_spec.rb
+++ b/spec/dependabot/update_checkers/ruby/bundler_spec.rb
@@ -652,7 +652,8 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
         let(:gemspec) do
           Dependabot::DependencyFile.new(
             content: fixture("ruby", "gemspecs", gemspec_fixture_name),
-            name: "plugins/example/example.gemspec"
+            name: "plugins/example/example.gemspec",
+            support_file: true
           )
         end
         let(:gemspec_fixture_name) { "no_overlap" }
@@ -1146,25 +1147,50 @@ RSpec.describe Dependabot::UpdateCheckers::Ruby::Bundler do
       let(:gemfile_fixture_name) { "imports_gemspec" }
       let(:gemspec_fixture_name) { "small_example" }
       let(:requirements) do
-        [
-          {
-            file: "Gemfile",
-            requirement: "~> 1.2.0",
-            groups: [],
-            source: nil
-          },
-          {
-            file: "example.gemspec",
-            requirement: "~> 1.0",
-            groups: [],
-            source: nil
-          }
-        ]
+        [{
+          file: "Gemfile",
+          requirement: "~> 1.2.0",
+          groups: [],
+          source: nil
+        }, {
+          file: "example.gemspec",
+          requirement: "~> 1.0",
+          groups: [],
+          source: nil
+        }]
       end
 
       it "doesn't just fall back to latest_version" do
         expect(checker.latest_resolvable_version).
           to eq(Gem::Version.new("1.8.0"))
+      end
+
+      context "when the gemspec has a path" do
+        let(:gemfile_fixture_name) { "imports_gemspec_from_path" }
+        let(:gemspec) do
+          Dependabot::DependencyFile.new(
+            content: fixture("ruby", "gemspecs", gemspec_fixture_name),
+            name: "subdir/example.gemspec"
+          )
+        end
+        let(:requirements) do
+          [{
+            file: "Gemfile",
+            requirement: "~> 1.2.0",
+            groups: [],
+            source: nil
+          }, {
+            file: "subdir/example.gemspec",
+            requirement: "~> 1.0",
+            groups: [],
+            source: nil
+          }]
+        end
+
+        it "doesn't just fall back to latest_version" do
+          expect(checker.latest_resolvable_version).
+            to eq(Gem::Version.new("1.8.0"))
+        end
       end
 
       context "when an old required ruby is specified in the gemspec" do

--- a/spec/fixtures/github/gemfile_with_path_gemspec_content.json
+++ b/spec/fixtures/github/gemfile_with_path_gemspec_content.json
@@ -1,0 +1,18 @@
+{
+    "name": "Gemfile",
+    "path": "Gemfile",
+    "sha": "dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+    "size": 291,
+    "url": "https://api.github.com/repos/gocardless/bump/contents/Gemfile?ref=master",
+    "html_url": "https://github.com/gocardless/bump/blob/master/Gemfile",
+    "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+    "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/Gemfile?token=ABF4KfGg6a7sE1n1i2rrhUvqAKRhIkPiks5WD8X5wA%3D%3D",
+    "type": "file",
+    "content": "IyBmcm96ZW5fc3RyaW5nX2xpdGVyYWw6IHRydWUKc291cmNlICJodHRwczov\nL3J1YnlnZW1zLm9yZyIKCmdlbXNwZWMgcGF0aDogJy4vZGV2Jwo=\n",
+    "encoding": "base64",
+    "_links": {
+        "self": "https://api.github.com/repos/gocardless/bump/contents/Gemfile?ref=master",
+        "git": "https://api.github.com/repos/gocardless/bump/git/blobs/dbce0c9e2e7efd19139c2c0aeb0110e837812c2f",
+        "html": "https://github.com/gocardless/bump/blob/master/Gemfile"
+    }
+}

--- a/spec/fixtures/ruby/gemfiles/imports_gemspec_from_path
+++ b/spec/fixtures/ruby/gemfiles/imports_gemspec_from_path
@@ -2,3 +2,6 @@
 source "https://rubygems.org"
 
 gemspec path: 'subdir'
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/spec/fixtures/ruby/gemfiles/imports_gemspec_from_path
+++ b/spec/fixtures/ruby/gemfiles/imports_gemspec_from_path
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec path: 'subdir'

--- a/spec/fixtures/ruby/lockfiles/imports_gemspec_from_path.lock
+++ b/spec/fixtures/ruby/lockfiles/imports_gemspec_from_path.lock
@@ -7,13 +7,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    business (1.13.0)
+    business (1.4.0)
+    statesman (1.2.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  business (~> 1.4.0)
   example!
+  statesman (~> 1.2.0)
 
 BUNDLED WITH
-   1.16.1
+   1.15.3

--- a/spec/fixtures/ruby/lockfiles/imports_gemspec_from_path.lock
+++ b/spec/fixtures/ruby/lockfiles/imports_gemspec_from_path.lock
@@ -1,0 +1,19 @@
+PATH
+  remote: subdir
+  specs:
+    example (0.9.3)
+      business (~> 1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.13.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  example!
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
We were seeing an error for one of [our Gemfiles](https://github.com/UKGovernmentBEIS/beis-mspsds/blob/master/shared-web/Gemfile#L5):

```
Bundler::Dsl::DSLError with message: 
[!] There was an error parsing `Gemfile`: There are no gemspecs at /home/dependabot/dependabot-updater/dependabot_tmp_dir/shared-web/dev. Bundler cannot continue.

 #  from /home/dependabot/dependabot-updater/dependabot_tmp_dir/shared-web/Gemfile:5
 #  -------------------------------------------
 #  gemspec
 >  gemspec path: "./dev"
 #  
 #  -------------------------------------------
```

We're using the `path` option [as described here](https://bundler.io/v1.17/rubygems.html) but the [parsing code only supports gemspecs at the top level](https://github.com/dependabot/dependabot-core/blob/master/lib/dependabot/file_parsers/ruby/bundler.rb#L281).

I've made a naive change to correct this but it seems like it breaks another test relating to path based `gem` dependencies. The correct solution might involve checking whether the `*.gemspec` file is part of a `gemspec qq, path: './some/path'` or `gem qq, path: './some/path'` declaration (as opposed to assuming that top level `*.gemspec`s are part of a `gemspec` declaration, which we're currently doing).

I couldn't see an obvious way to see which declaration (`gem` or `gemspec`) the `DependencyFile` was from, so I thought I'd ask! Do you have any thoughts for how we could do this?

Let me know if you need any more information. Thanks for the awesome service! 😃 