### PR TITLE
Add error context when helper subprocesses fail

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "toml-rb"
+require "open3"
 require "dependabot/git_commit_checker"
 require "dependabot/cargo/file_updater"
 require "dependabot/cargo/file_updater/manifest_updater"
@@ -85,18 +86,21 @@ module Dependabot
         end
 
         def run_shell_command(command)
-          raw_response = nil
-          IO.popen(command, err: %i(child out)) do |process|
-            raw_response = process.read
-          end
+          start = Time.now
+          stdout, process = Open3.capture2e(command)
+          time_taken = start - Time.now
 
           # Raise an error with the output from the shell session if Cargo
           # returns a non-zero status
-          return if $CHILD_STATUS.success?
+          return if process.success?
 
           raise SharedHelpers::HelperSubprocessFailed.new(
-            raw_response,
-            command
+            message: stdout,
+            error_context: {
+              command: command,
+              time_taken: time_taken,
+              process_exit_value: process.to_s
+            }
           )
         end
 

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "toml-rb"
+require "open3"
 require "dependabot/shared_helpers"
 require "dependabot/cargo/update_checker"
 require "dependabot/cargo/version"
@@ -90,18 +91,21 @@ module Dependabot
         end
 
         def run_cargo_command(command)
-          raw_response = nil
-          IO.popen(command, err: %i(child out)) do |process|
-            raw_response = process.read
-          end
+          start = Time.now
+          stdout, process = Open3.capture2e(command)
+          time_taken = start - Time.now
 
           # Raise an error with the output from the shell session if Cargo
           # returns a non-zero status
-          return if $CHILD_STATUS.success?
+          return if process.success?
 
           raise SharedHelpers::HelperSubprocessFailed.new(
-            raw_response,
-            command
+            message: stdout,
+            error_context: {
+              command: command,
+              time_taken: time_taken,
+              process_exit_value: process.to_s
+            }
           )
         end
 

--- a/elm/lib/dependabot/elm/update_checker/elm_19_version_resolver.rb
+++ b/elm/lib/dependabot/elm/update_checker/elm_19_version_resolver.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "open3"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/elm/file_parser"
@@ -113,18 +114,21 @@ module Dependabot
         end
 
         def run_shell_command(command)
-          raw_response = nil
-          IO.popen(command, err: %i(child out)) do |process|
-            raw_response = process.read
-          end
+          start = Time.now
+          stdout, process = Open3.capture2e(command)
+          time_taken = start - Time.now
 
           # Raise an error with the output from the shell session if Elm
           # returns a non-zero status
-          return raw_response if $CHILD_STATUS.success?
+          return stdout if process.success?
 
           raise SharedHelpers::HelperSubprocessFailed.new(
-            raw_response,
-            command
+            message: stdout,
+            error_context: {
+              command: command,
+              time_taken: time_taken,
+              process_exit_value: process.to_s
+            }
           )
         end
 

--- a/helpers/test/run.rb
+++ b/helpers/test/run.rb
@@ -7,6 +7,9 @@ case request["function"]
 when "error"
   $stdout.write(JSON.dump(error: "Something went wrong"))
   exit 1
+when "useful_error"
+  $stderr.write("Some useful error")
+  exit 1
 when "hard_error"
   puts "Oh no!"
   exit 0

--- a/hex/.gitignore
+++ b/hex/.gitignore
@@ -2,5 +2,6 @@
 /.env
 /tmp
 /deps
+/helpers/deps/
 /dependabot-*.gem
 Gemfile.lock

--- a/hex/lib/dependabot/hex/file_parser.rb
+++ b/hex/lib/dependabot/hex/file_parser.rb
@@ -50,7 +50,7 @@ module Dependabot
             command: "mix run #{elixir_helper_path}",
             function: "parse",
             args: [Dir.pwd],
-            popen_opts: { err: %i(child out) }
+            stderr_to_stdout: true
           )
         end
       rescue Dependabot::SharedHelpers::HelperSubprocessFailed => error

--- a/hex/lib/dependabot/hex/update_checker/version_resolver.rb
+++ b/hex/lib/dependabot/hex/update_checker/version_resolver.rb
@@ -59,7 +59,7 @@ module Dependabot
             args: [Dir.pwd,
                    dependency.name,
                    organization_credentials],
-            popen_opts: { err: %i(child out) }
+            stderr_to_stdout: true
           )
         end
 

--- a/lib/dependabot/update_checkers/go/dep/version_resolver.rb
+++ b/lib/dependabot/update_checkers/go/dep/version_resolver.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "toml-rb"
+require "open3"
 require "dependabot/shared_helpers"
 require "dependabot/update_checkers/go/dep"
 require "dependabot/errors"
@@ -94,18 +95,21 @@ module Dependabot
           end
 
           def run_shell_command(command, env = {})
-            raw_response = nil
-            IO.popen(env, command, err: %i(child out)) do |process|
-              raw_response = process.read
-            end
+            start = Time.now
+            stdout, process = Open3.capture2e(env, command)
+            time_taken = start - Time.now
 
             # Raise an error with the output from the shell session if dep
             # returns a non-zero status
-            return if $CHILD_STATUS.success?
+            return if process.success?
 
             raise SharedHelpers::HelperSubprocessFailed.new(
-              raw_response,
-              command
+              message: stdout,
+              error_context: {
+                command: command,
+                time_taken: time_taken,
+                process_exit_value: process.to_s
+              }
             )
           end
 

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "open3"
 require "dependabot/python/requirement_parser"
 require "dependabot/python/file_fetcher"
 require "dependabot/python/file_updater"
@@ -117,20 +118,24 @@ module Dependabot
           ).updated_dependency_files
         end
 
+        # rubocop:disable Metrics/MethodLength
         def run_command(command)
           command = command.dup
-          raw_response = nil
-          IO.popen(command, err: %i(child out)) do |process|
-            raw_response = process.read
-          end
+          start = Time.now
+          stdout, process = Open3.capture2e(command)
+          time_taken = start - Time.now
 
           # Raise an error with the output from the shell session if
           # pip-compile returns a non-zero status
-          return if $CHILD_STATUS.success?
+          return if process.success?
 
           raise SharedHelpers::HelperSubprocessFailed.new(
-            raw_response,
-            command
+            message: stdout,
+            error_context: {
+              command: command,
+              time_taken: time_taken,
+              process_exit_value: process.to_s
+            }
           )
         rescue SharedHelpers::HelperSubprocessFailed => error
           original_error ||= error
@@ -149,6 +154,7 @@ module Dependabot
         ensure
           FileUtils.remove_entry(".python-version", true)
         end
+        # rubocop:enable Metrics/MethodLength
 
         def error_suggests_bad_python_version?(message)
           return true if message.include?("not find a version that satisfies")

--- a/python/lib/dependabot/python/update_checker/pipfile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipfile_version_resolver.rb
@@ -2,7 +2,7 @@
 
 require "excon"
 require "toml-rb"
-
+require "open3"
 require "dependabot/errors"
 require "dependabot/shared_helpers"
 require "dependabot/python/file_parser"
@@ -452,17 +452,26 @@ module Dependabot
           end
         end
 
-        def run_pipenv_command(cmd)
+        # rubocop:disable Metrics/MethodLength
+        def run_pipenv_command(command)
           set_up_python_environment
 
-          raw_response = nil
-          IO.popen(cmd, err: %i(child out)) { |p| raw_response = p.read }
+          start = Time.now
+          stdout, process = Open3.capture2e(command)
+          time_taken = start - Time.now
 
           # Raise an error with the output from the shell session if Pipenv
           # returns a non-zero status
-          return if $CHILD_STATUS.success?
+          return if process.success?
 
-          raise SharedHelpers::HelperSubprocessFailed.new(raw_response, cmd)
+          raise SharedHelpers::HelperSubprocessFailed.new(
+            message: stdout,
+            error_context: {
+              command: command,
+              time_taken: time_taken,
+              process_exit_value: process.to_s
+            }
+          )
         rescue SharedHelpers::HelperSubprocessFailed => error
           original_error ||= error
           msg = error.message
@@ -477,11 +486,12 @@ module Dependabot
 
           @using_python_two = true
           add_python_two_requirement_to_pipfile
-          cmd = cmd.gsub("pipenv ", "pipenv --two ")
+          command = command.gsub("pipenv ", "pipenv --two ")
           retry
         ensure
           @using_python_two = nil
         end
+        # rubocop:enable Metrics/MethodLength
 
         def may_be_using_wrong_python_version?(error_message)
           return false if python_requirement_specified?

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -2,7 +2,7 @@
 
 require "excon"
 require "toml-rb"
-
+require "open3"
 require "dependabot/errors"
 require "dependabot/shared_helpers"
 require "dependabot/python/file_parser"
@@ -251,18 +251,21 @@ module Dependabot
         end
 
         def run_poetry_command(command)
-          raw_response = nil
-          IO.popen(command, err: %i(child out)) do |process|
-            raw_response = process.read
-          end
+          start = Time.now
+          stdout, process = Open3.capture2e(command)
+          time_taken = start - Time.now
 
           # Raise an error with the output from the shell session if Pipenv
           # returns a non-zero status
-          return if $CHILD_STATUS.success?
+          return if process.success?
 
           raise SharedHelpers::HelperSubprocessFailed.new(
-            raw_response,
-            command
+            message: stdout,
+            error_context: {
+              command: command,
+              time_taken: time_taken,
+              process_exit_value: process.to_s
+            }
           )
         end
 

--- a/spec/dependabot/shared_helpers_spec.rb
+++ b/spec/dependabot/shared_helpers_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Dependabot::SharedHelpers do
     let(:function) { "example" }
     let(:args) { ["foo"] }
     let(:env) { nil }
+    let(:stderr_to_stdout) { false }
 
     subject(:run_subprocess) do
       project_root = File.join(File.dirname(__FILE__), "../..")
@@ -64,7 +65,8 @@ RSpec.describe Dependabot::SharedHelpers do
         command: command,
         function: function,
         args: args,
-        env: env
+        env: env,
+        stderr_to_stdout: stderr_to_stdout
       )
     end
 
@@ -78,6 +80,21 @@ RSpec.describe Dependabot::SharedHelpers do
 
         it "runs the function passed, as expected" do
           expect(run_subprocess).to eq("function" => function, "args" => args)
+        end
+      end
+
+      context "when sending stderr to stdout" do
+        let(:stderr_to_stdout) { true }
+        let(:function) { "useful_error" }
+
+        it "raises a HelperSubprocessFailed error with stderr output" do
+          expect { run_subprocess }.
+            to raise_error(
+              Dependabot::SharedHelpers::HelperSubprocessFailed
+            ) do |error|
+              expect(error.message).
+                to include("Some useful error")
+            end
         end
       end
     end

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,5 @@
+/.bundle/
+/.env
+/tmp
+/dependabot-*.gem
+Gemfile.lock


### PR DESCRIPTION
Switch from `IO.popen` to `Open3.capture3` to get separate stdout and
stderr, adding stderr to Sentry error context.

Adding error context to debug these Sentries with no useful information:
https://sentry.io/dependabot/backend/issues/831291825/events/41548068139/