### PR TITLE
NPM/Yarn: Filter dependency files

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_files_filterer.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_files_filterer.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "dependabot/utils"
+
+module Dependabot
+  module NpmAndYarn
+    class DependencyFilesFilterer
+      def initialize(dependency_files:, dependencies:)
+        @dependencies = dependencies
+        @dependency_files = dependency_files
+      end
+
+      def filtered_files
+        dependency_files.select do |file|
+          if manifest?(file)
+            package_manifests.include?(file)
+          elsif lockfile?(file)
+            package_manifests.any? do |package_file|
+              File.dirname(package_file.name) == File.dirname(file.name)
+            end
+          else
+            # Include all non-manifest/lockfiles
+            # e.g. .npmrc, lerna.json
+            true
+          end
+        end
+      end
+
+      def filtered_package_files
+        filtered_files.select { |f| manifest?(f) }
+      end
+
+      def filtered_lockfiles
+        filtered_files.select { |f| lockfile?(f) }
+      end
+
+      private
+
+      attr_reader :dependency_files, :dependencies
+
+      def dependency_manifest_requirements
+        @dependency_manifest_requirements ||=
+          dependencies.flat_map do |dep|
+            dep.requirements.map { |requirement| requirement[:file] }
+          end
+      end
+
+      def package_manifests
+        @package_manifests ||=
+          dependency_files.select do |file|
+            next unless manifest?(file)
+
+            root_manifest?(file) ||
+              dependency_manifest_requirements.include?(file.name)
+          end
+      end
+
+      def root_manifest?(file)
+        file.name == "package.json"
+      end
+
+      def manifest?(file)
+        file.name.end_with?("package.json")
+      end
+
+      def lockfile?(file)
+        file.name.end_with?(
+          "package-lock.json",
+          "yarn.lock",
+          "npm-shrinkwrap.json"
+        )
+      end
+    end
+  end
+end
+
+Dependabot::Utils.register_version_class(
+  "npm_and_yarn",
+  Dependabot::NpmAndYarn::DependencyFilesFilterer
+)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -157,7 +157,9 @@ module Dependabot
       end
 
       def updated_yarn_lock_content(yarn_lock)
-        yarn_lockfile_updater.updated_yarn_lock_content(yarn_lock)
+        @updated_yarn_lock_content ||= {}
+        @updated_yarn_lock_content[yarn_lock.name] ||=
+          yarn_lockfile_updater.updated_yarn_lock_content(yarn_lock)
       end
 
       def yarn_lockfile_updater
@@ -170,11 +172,15 @@ module Dependabot
       end
 
       def updated_package_lock_content(package_lock)
-        npm_lockfile_updater.updated_lockfile_content(package_lock)
+        @updated_package_lock_content ||= {}
+        @updated_package_lock_content[package_lock.name] ||=
+          npm_lockfile_updater.updated_lockfile_content(package_lock)
       end
 
       def updated_shrinkwrap_content(shrinkwrap)
-        npm_lockfile_updater.updated_lockfile_content(shrinkwrap)
+        @updated_shrinkwrap_content ||= {}
+        @updated_shrinkwrap_content[shrinkwrap.name] ||=
+          npm_lockfile_updater.updated_lockfile_content(shrinkwrap)
       end
 
       def npm_lockfile_updater

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -17,6 +17,7 @@ module Dependabot
     class UpdateChecker
       class VersionResolver
         require_relative "latest_version_finder"
+        require_relative "dependency_files_filterer"
 
         TIGHTLY_COUPLED_MONOREPOS = {
           "vue" => %w(vue vue-template-compiler)
@@ -181,7 +182,7 @@ module Dependabot
           SharedHelpers.in_a_temporary_directory do
             write_temporary_dependency_files
 
-            package_files.flat_map do |file|
+            filtered_package_files.flat_map do |file|
               path = Pathname.new(file.name).dirname
               run_checker(path: path, version: version)
             rescue SharedHelpers::HelperSubprocessFailed => error
@@ -316,13 +317,25 @@ module Dependabot
             select { |dep| dep[:requiring_dep_name] == dependency.name }
         end
 
+        def lockfiles_for_path(lockfiles:, path:)
+          lockfiles.select do |lockfile|
+            File.dirname(lockfile.name) == File.dirname(path)
+           end
+        end
+
         def run_checker(path:, version:)
           if [*package_locks, *shrinkwraps].any?
             run_npm_checker(path: path, version: version)
+          # If there are both yarn lockfiles and npm lockfiles only run the
+          # yarn updater, yarn is also used when only a package.json exists
+          if lockfiles_for_path(lockfiles: yarn_locks, path: path).any? ||
+             lockfiles_for_path(lockfiles: lockfiles, path: path).none?
+            return run_yarn_checker(path: path, version: version)
           end
 
           run_yarn_checker(path: path, version: version) if yarn_locks.any?
           run_yarn_checker(path: path, version: version) if lockfiles.none?
+          run_npm_checker(path: path, version: version)
         end
 
         def run_yarn_checker(path:, version:)
@@ -453,6 +466,14 @@ module Dependabot
           @package_files ||=
             dependency_files.
             select { |f| f.name.end_with?("package.json") }
+        end
+
+        def filtered_package_files
+          @filtered_package_files ||=
+            DependencyFilesFilterer.new(
+              dependency_files: dependency_files,
+              dependencies: [dependency]
+            ).filtered_package_files
         end
 
         def yarn_helper_path

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -320,12 +320,10 @@ module Dependabot
         def lockfiles_for_path(lockfiles:, path:)
           lockfiles.select do |lockfile|
             File.dirname(lockfile.name) == File.dirname(path)
-           end
+          end
         end
 
         def run_checker(path:, version:)
-          if [*package_locks, *shrinkwraps].any?
-            run_npm_checker(path: path, version: version)
           # If there are both yarn lockfiles and npm lockfiles only run the
           # yarn updater, yarn is also used when only a package.json exists
           if lockfiles_for_path(lockfiles: yarn_locks, path: path).any? ||
@@ -333,8 +331,6 @@ module Dependabot
             return run_yarn_checker(path: path, version: version)
           end
 
-          run_yarn_checker(path: path, version: version) if yarn_locks.any?
-          run_yarn_checker(path: path, version: version) if lockfiles.none?
           run_npm_checker(path: path, version: version)
         end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_files_filterer_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_files_filterer_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/npm_and_yarn/dependency_files_filterer"
+
+RSpec.describe Dependabot::NpmAndYarn::DependencyFilesFilterer do
+  subject(:filtered_files) do
+    described_class.new(
+      dependency_files: dependency_files,
+      dependencies: dependencies
+    ).filtered_files
+  end
+
+  let(:dependency_files) do
+    [
+      package_json,
+      yarn_lock,
+      npm_lock,
+      nested_package_json,
+      nested_shrinkwrap
+    ]
+  end
+
+  let(:dependencies) { [dependency] }
+
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "etag",
+      version: "1.0.0",
+      requirements: [{
+        file: "package.json",
+        requirement: "^1.0.0",
+        groups: ["dependencies"],
+        source: nil
+      }],
+      package_manager: "npm_and_yarn"
+    )
+  end
+
+  let(:package_json) do
+    Dependabot::DependencyFile.new(
+      name: "package.json",
+      content: "{}"
+    )
+  end
+  let(:yarn_lock) do
+    Dependabot::DependencyFile.new(
+      name: "yarn.lock",
+      content: "{}"
+    )
+  end
+  let(:npm_lock) do
+    Dependabot::DependencyFile.new(
+      name: "package-lock.json",
+      content: "{}"
+    )
+  end
+  let(:nested_package_json) do
+    Dependabot::DependencyFile.new(
+      name: "helpers/package.json",
+      content: "{}"
+    )
+  end
+  let(:nested_shrinkwrap) do
+    Dependabot::DependencyFile.new(
+      name: "helpers/npm-shrinkwrap.json",
+      content: "{}"
+    )
+  end
+
+  describe ".filtered_files" do
+    it do
+      is_expected.to contain_exactly(package_json, yarn_lock, npm_lock)
+    end
+
+    context "with no requirements" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "etag",
+          version: "1.0.0",
+          requirements: [],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      it do
+        is_expected.to contain_exactly(
+          package_json,
+          yarn_lock,
+          npm_lock
+        )
+      end
+    end
+
+    context "with a nested dependency requirement" do
+      let(:dependencies) { [nested_dependency] }
+
+      let(:nested_dependency) do
+        Dependabot::Dependency.new(
+          name: "react",
+          version: "16.7.0",
+          requirements: [{
+            file: "helpers/package.json",
+            requirement: "^16.7.0",
+            groups: ["dependencies"],
+            source: nil
+          }],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      it do
+        is_expected.to contain_exactly(
+          package_json,
+          yarn_lock,
+          npm_lock,
+          nested_package_json,
+          nested_shrinkwrap
+        )
+      end
+
+      context "with multiple dependencies" do
+        let(:dependency_files) do
+          [
+            package_json,
+            yarn_lock,
+            npm_lock,
+            other_package_json,
+            nested_package_json,
+            nested_shrinkwrap
+          ]
+        end
+        let(:dependencies) { [dependency, other_dependency] }
+
+        let(:other_package_json) do
+          Dependabot::DependencyFile.new(
+            name: "other/package.json",
+            content: "{}"
+          )
+        end
+
+        let(:other_dependency) do
+          Dependabot::Dependency.new(
+            name: "react",
+            version: "16.7.0",
+            requirements: [{
+              file: "other/package.json",
+              requirement: "^16.7.0",
+              groups: ["dependencies"],
+              source: nil
+            }],
+            package_manager: "npm_and_yarn"
+          )
+        end
+
+        it do
+          is_expected.to contain_exactly(
+            package_json,
+            yarn_lock,
+            npm_lock,
+            other_package_json
+          )
+        end
+      end
+    end
+  end
+
+  describe ".filtered_package_files" do
+    subject(:filtered_package_files) do
+      described_class.new(
+        dependency_files: dependency_files,
+        dependencies: dependencies
+      ).filtered_package_files
+    end
+
+    it do
+      is_expected.to contain_exactly(package_json)
+    end
+  end
+
+  describe ".filtered_lockfiles" do
+    subject(:filtered_lockfiles) do
+      described_class.new(
+        dependency_files: dependency_files,
+        dependencies: dependencies
+      ).filtered_lockfiles
+    end
+
+    it do
+      is_expected.to contain_exactly(yarn_lock, npm_lock)
+    end
+  end
+end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -869,7 +869,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
       let(:path_dep) do
         Dependabot::DependencyFile.new(
           name: "deps/etag/package.json",
-          content: fixture("package_files", "etag.json")
+          content: fixture("package_files", "etag.json"),
+          support_file: true
         )
       end
       let(:dependency_name) { "lodash" }


### PR DESCRIPTION
Omit package files and lockfiles that are not related to the dependencies being checked/updated.

The aim is to speed up large repos like this one (has 100 dependency files): https://github.com/AxaGuilDEv/react-toolkit

From testing on a few dependencies that needed to be updated the number of dependency files went from 100 to ~10.

Also removed a few duplicate calls to lockfile updates.