### PR TITLE
JS: Add error context when no files where updated

### DIFF
--- a/lib/dependabot/file_updaters/java_script/npm_and_yarn/npm_lockfile_updater.rb
+++ b/lib/dependabot/file_updaters/java_script/npm_and_yarn/npm_lockfile_updater.rb
@@ -35,10 +35,7 @@ module Dependabot
                   run_current_npm_update(lockfile_name: lockfile_name)
                 end
                 updated_content = updated_files.fetch(lockfile_name)
-                updated_content = post_process_npm_lockfile(updated_content)
-                raise "No change!" if lockfile.content == updated_content
-
-                updated_content
+                post_process_npm_lockfile(updated_content)
               end
           rescue SharedHelpers::HelperSubprocessFailed => error
             handle_npm_updater_error(error, lockfile)


### PR DESCRIPTION
Remove redundant guard in npm lockfile updater, raised in
`FileUpdaters::JavaScript::NpmAndYarn`