### PR TITLE
Align GitLab PR creator with generic options

### DIFF
--- a/dependabot-core.gemspec
+++ b/dependabot-core.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler", ">= 1.16", "< 3.0.0"
   spec.add_dependency "docker_registry2", "~> 1.4"
   spec.add_dependency "excon", "~> 0.55"
-  spec.add_dependency "gitlab", "~> 4.8"
+  spec.add_dependency "gitlab", "~> 4.9"
   spec.add_dependency "gpgme", "~> 2.0"
   spec.add_dependency "nokogiri", "~> 1.8"
   spec.add_dependency "octokit", "~> 4.6"

--- a/lib/dependabot/pull_request_creator.rb
+++ b/lib/dependabot/pull_request_creator.rb
@@ -97,7 +97,9 @@ module Dependabot
         pr_name: message_builder.pr_name,
         author_details: author_details,
         labeler: labeler,
-        assignee: assignees&.first
+        approvers: reviewers,
+        assignee: assignees&.first,
+        milestone: milestone
       )
     end
 

--- a/spec/dependabot/pull_request_creator/gitlab_spec.rb
+++ b/spec/dependabot/pull_request_creator/gitlab_spec.rb
@@ -248,5 +248,28 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
         end
       end
     end
+
+    context "when a approvers has been requested" do
+      let(:approvers) { { "approvers" => [1_394_555] } }
+      before do
+        stub_request(
+          :put,
+          "#{repo_api_url}/merge_requests/5/approvers"
+        ).to_return(
+          status: 200,
+          body: fixture("gitlab", "merge_request.json"),
+          headers: json_header
+        )
+      end
+
+      it "adds the approvers to the MR correctly" do
+        creator.create
+
+        expect(WebMock).
+          to have_requested(
+            :put, "#{repo_api_url}/merge_requests/5/approvers"
+          )
+      end
+    end
   end
 end

--- a/spec/dependabot/pull_request_creator/gitlab_spec.rb
+++ b/spec/dependabot/pull_request_creator/gitlab_spec.rb
@@ -252,23 +252,19 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
     context "when a approvers has been requested" do
       let(:approvers) { { "approvers" => [1_394_555] } }
       before do
-        stub_request(
-          :put,
-          "#{repo_api_url}/merge_requests/5/approvers"
-        ).to_return(
-          status: 200,
-          body: fixture("gitlab", "merge_request.json"),
-          headers: json_header
-        )
+        stub_request(:put, "#{repo_api_url}/merge_requests/5/approvers").
+          to_return(
+            status: 200,
+            body: fixture("gitlab", "merge_request.json"),
+            headers: json_header
+          )
       end
 
       it "adds the approvers to the MR correctly" do
         creator.create
 
         expect(WebMock).
-          to have_requested(
-            :put, "#{repo_api_url}/merge_requests/5/approvers"
-          )
+          to have_requested(:put, "#{repo_api_url}/merge_requests/5/approvers")
       end
     end
   end

--- a/spec/dependabot/pull_request_creator/gitlab_spec.rb
+++ b/spec/dependabot/pull_request_creator/gitlab_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
       pr_name: pr_name,
       author_details: author_details,
       labeler: labeler,
-      assignee: assignee
+      approvers: approvers,
+      assignee: assignee,
+      milestone: milestone
     )
   end
 
@@ -40,7 +42,9 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
   let(:pr_description) { "PR msg" }
   let(:pr_name) { "PR name" }
   let(:author_details) { nil }
+  let(:approvers) { nil }
   let(:assignee) { nil }
+  let(:milestone) { nil }
   let(:labeler) do
     Dependabot::PullRequestCreator::Labeler.new(
       source: source,

--- a/spec/dependabot/pull_request_creator_spec.rb
+++ b/spec/dependabot/pull_request_creator_spec.rb
@@ -146,7 +146,9 @@ RSpec.describe Dependabot::PullRequestCreator do
             pr_name: "PR name",
             author_details: author_details,
             labeler: instance_of(described_class::Labeler),
-            assignee: nil
+            approvers: reviewers,
+            assignee: nil,
+            milestone: milestone
           ).and_return(dummy_creator)
         expect(dummy_creator).to receive(:create)
         creator.create


### PR DESCRIPTION
This PR add the following options to the GitLab PR creator:
* `milestone` same as GitHub `milestone`
* `approvers` same as GitHub `reviewers`