### PR TITLE
Fix deployed helper paths

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
@@ -8,7 +8,7 @@ module Dependabot
       end
 
       def self.npm_helpers_dir
-        File.join(native_helpers_root, "npm_and_yarn/helpers/npm")
+        File.join(native_helpers_root, "npm")
       end
 
       def self.yarn_helper_path
@@ -16,11 +16,11 @@ module Dependabot
       end
 
       def self.yarn_helpers_dir
-        File.join(native_helpers_root, "npm_and_yarn/helpers/yarn")
+        File.join(native_helpers_root, "yarn")
       end
 
       def self.native_helpers_root
-        default_path = File.join(__dir__, "../../../..")
+        default_path = File.join(__dir__, "../../../helpers")
         ENV.fetch("DEPENDABOT_NATIVE_HELPERS_PATH", default_path)
       end
     end


### PR DESCRIPTION
As Dependabot is separated into different gems, the native helper paths don't work when installing them from a deployed gem (instead of cloning the repo).

I.e.: this proposed file works for me, but likely breaks your local clone 