### PR TITLE
JS: Parse the semver version, rather than the git SHA, for git reqs with a semver specification

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -137,6 +137,8 @@ module Dependabot
             # or that the current branch is behind, we switch to that release.
             if git_branch_or_ref_in_release?(latest_release&.fetch(:version))
               latest_release.fetch(:version)
+            elsif version_class.correct?(dependency.version)
+              latest_git_version_details[:version]
             else
               latest_git_version_details[:sha]
             end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -771,9 +771,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
 
             it { is_expected.to be_a(Dependabot::Dependency) }
             its(:name) { is_expected.to eq("is-number") }
-            its(:version) do
-              is_expected.to eq("63d5b26c793194bf7f341a7203e0e5568c753539")
-            end
+            its(:version) { is_expected.to eq("2.0.2") }
             its(:requirements) do
               is_expected.to eq(
                 [{
@@ -802,9 +800,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
 
               it { is_expected.to be_a(Dependabot::Dependency) }
               its(:name) { is_expected.to eq("is-number") }
-              its(:version) do
-                is_expected.to eq("63d5b26c793194bf7f341a7203e0e5568c753539")
-              end
+              its(:version) { is_expected.to eq("2.0.2") }
               its(:requirements) do
                 is_expected.to eq(
                   [{

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/package_json_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/package_json_updater_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
         let(:dependency) do
           Dependabot::Dependency.new(
             name: "is-number",
-            version: "d5ac0584ee9ae7bd9288220a39780f155b9ad4c8",
+            version: "4.0.0",
             package_manager: "npm_and_yarn",
             requirements: [{
               requirement: "^4.0.0",

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -650,6 +650,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         let(:ref) { "master" }
         let(:old_req) { "^2.0.0" }
         let(:old_ref) { "master" }
+        let(:previous_version) { "2.0.2" }
+        let(:version) { "4.0.0" }
 
         let(:manifest_fixture_name) { "github_dependency_semver.json" }
         let(:yarn_lock_fixture_name) { "github_dependency_semver.lock" }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -331,10 +331,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       context "with a requirement" do
         let(:ref) { "master" }
         let(:req) { "^2.0.0" }
+        let(:current_version) { "2.0.2" }
 
-        it "fetches the latest SHA-1 hash of the latest version tag" do
-          expect(checker.latest_version).
-            to eq("0c6b15a88bc10cd47f67a09506399dfc9ddc075d")
+        it "fetches the latest version tag" do
+          expect(checker.latest_version).to eq("4.0.0")
         end
 
         context "but there are no tags" do


### PR DESCRIPTION
That. Fixes https://github.com/dependabot/feedback/issues/344.