### PR TITLE
Better submodule fetching

### DIFF
--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -158,10 +158,10 @@ module Dependabot
       end
 
       def fetch_gemspecs_from_directory(dir_path)
-        repo_contents(dir: dir_path).
+        repo_contents(dir: dir_path, fetch_submodules: true).
           select { |f| f.name.end_with?(".gemspec") }.
           map { |f| File.join(dir_path, f.name) }.
-          map { |fp| fetch_file_from_host(fp) }
+          map { |fp| fetch_file_from_host(fp, fetch_submodules: true) }
       end
 
       def fetch_path_gemspec_paths

--- a/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
@@ -392,6 +392,13 @@ RSpec.describe Dependabot::Bundler::FileFetcher do
               body: fixture("github", "gemspec_content.json"),
               headers: { "content-type" => "application/json" }
             )
+          stub_request(:get, sub_url + "bump-core?ref=sha2").
+            with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: "[]",
+              headers: { "content-type" => "application/json" }
+            )
         end
 
         it "fetches gemspec from path dependency" do
@@ -444,6 +451,9 @@ RSpec.describe Dependabot::Bundler::FileFetcher do
     context "that has an unfetchable directory path" do
       before do
         stub_request(:get, url + "plugins/bump-core?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(status: 404)
+        stub_request(:get, url + "plugins?ref=sha").
           with(headers: { "Authorization" => "token token" }).
           to_return(status: 404)
       end

--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -113,7 +113,7 @@ module Dependabot
             next if previously_fetched_files.map(&:name).include?(path)
             next if file.name == path
 
-            fetched_file = fetch_file_from_host_or_submodule(path).
+            fetched_file = fetch_file_from_host(path, fetch_submodules: true).
                            tap { |f| f.support_file = true }
             previously_fetched_files << fetched_file
             grandchild_requirement_files =

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -259,6 +259,12 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
         stub_request(:get, url + "src/s3/Cargo.toml?ref=sha").
           with(headers: { "Authorization" => "token token" }).
           to_return(status: 404, headers: json_header)
+        stub_request(:get, url + "src/s3?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(status: 404, headers: json_header)
+        stub_request(:get, url + "src?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(status: 404, headers: json_header)
       end
 
       it "raises a PathDependenciesNotReachable error" do
@@ -288,6 +294,12 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
 
         before do
           stub_request(:get, url + "gen/photoslibrary1/Cargo.toml?ref=sha").
+            with(headers: { "Authorization" => "token token" }).
+            to_return(status: 404, headers: json_header)
+          stub_request(:get, url + "gen/photoslibrary1?ref=sha").
+            with(headers: { "Authorization" => "token token" }).
+            to_return(status: 404, headers: json_header)
+          stub_request(:get, url + "gen?ref=sha").
             with(headers: { "Authorization" => "token token" }).
             to_return(status: 404, headers: json_header)
         end

--- a/composer/lib/dependabot/composer/file_fetcher.rb
+++ b/composer/lib/dependabot/composer/file_fetcher.rb
@@ -104,11 +104,11 @@ module Dependabot
           map { |f| path.gsub(/\*$/, f.name) }
       end
 
-      def fetch_file_with_root_fallback(filename, type: "file")
+      def fetch_file_with_root_fallback(filename)
         path = Pathname.new(File.join(directory, filename)).cleanpath.to_path
 
         begin
-          fetch_file_from_host(filename, type: type)
+          fetch_file_from_host(filename, fetch_submodules: true)
         rescue Dependabot::DependencyFileNotFound
           # If the file isn't found at the full path, try looking for it
           # without considering the directory (i.e., check if the path should
@@ -117,9 +117,9 @@ module Dependabot
 
           DependencyFile.new(
             name: cleaned_filename,
-            content: fetch_file_content(cleaned_filename),
+            content: _fetch_file_content(cleaned_filename),
             directory: directory,
-            type: type
+            type: "file"
           )
         end
       rescue Octokit::NotFound, Gitlab::Error::NotFound

--- a/composer/spec/dependabot/composer/file_fetcher_spec.rb
+++ b/composer/spec/dependabot/composer/file_fetcher_spec.rb
@@ -263,6 +263,15 @@ RSpec.describe Dependabot::Composer::FileFetcher do
             to_return(status: 404)
           stub_request(
             :get,
+            url + "components/bump-core?ref=sha"
+          ).with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: "[]",
+              headers: { "content-type" => "application/json" }
+            )
+          stub_request(
+            :get,
             base_url + "components/bump-core/composer.json?ref=sha"
           ).with(headers: { "Authorization" => "token token" }).
             to_return(

--- a/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb
+++ b/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb
@@ -65,7 +65,7 @@ module Dependabot
       end
 
       def fetch_github_submodule_commit(path)
-        content = github_client_for_source.contents(
+        content = github_client.contents(
           repo,
           path: path,
           ref: commit

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -69,7 +69,7 @@ module Dependabot
             )
           ].flatten
         rescue Dependabot::DependencyFileNotFound
-          raise unless fetch_file_from_host_or_submodule(path)
+          raise unless fetch_file_from_host(path, fetch_submodules: true)
 
           [] # Ignore any child submodules (since we can't update them)
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -118,7 +118,7 @@ module Dependabot
           next if fetched_files.map(&:name).include?(cleaned_name)
 
           begin
-            file = fetch_file_from_host(filename)
+            file = fetch_file_from_host(filename, fetch_submodules: true)
             package_json_files << file
           rescue Dependabot::DependencyFileNotFound
             unfetchable_deps << [name, path]

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -138,6 +138,12 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
           stub_request(:get, File.join(url, "deps/etag/package.json?ref=sha")).
             with(headers: { "Authorization" => "token token" }).
             to_return(status: 404)
+          stub_request(:get, File.join(url, "deps/etag?ref=sha")).
+            with(headers: { "Authorization" => "token token" }).
+            to_return(status: 404)
+          stub_request(:get, File.join(url, "deps?ref=sha")).
+            with(headers: { "Authorization" => "token token" }).
+            to_return(status: 404)
         end
 
         it "fetches the package.json and ignores the missing path dep" do
@@ -368,6 +374,12 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     context "that has an unfetchable path" do
       before do
         stub_request(:get, File.join(url, "deps/etag/package.json?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(status: 404)
+        stub_request(:get, File.join(url, "deps/etag?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(status: 404)
+        stub_request(:get, File.join(url, "deps?ref=sha")).
           with(headers: { "Authorization" => "token token" }).
           to_return(status: 404)
       end

--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -252,15 +252,16 @@ module Dependabot
         end
         return [] if path == "setup.py" && setup_file
 
-        path_setup_files << fetch_file_from_host(path).
+        path_setup_files << fetch_file_from_host(path, fetch_submodules: true).
                             tap { |f| f.support_file = true }
 
         return path_setup_files unless path.end_with?(".py")
 
         begin
           cfg_path = path.gsub(/\.py$/, ".cfg")
-          path_setup_files << fetch_file_from_host(cfg_path).
-                              tap { |f| f.support_file = true }
+          path_setup_files <<
+            fetch_file_from_host(cfg_path, fetch_submodules: true).
+            tap { |f| f.support_file = true }
         rescue Dependabot::DependencyFileNotFound
           # Ignore lack of a setup.cfg
           nil

--- a/python/spec/dependabot/python/file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/file_fetcher_spec.rb
@@ -661,6 +661,13 @@ RSpec.describe Dependabot::Python::FileFetcher do
             stub_request(:get, url + "my/setup.cfg?ref=sha").
               with(headers: { "Authorization" => "token token" }).
               to_return(status: 404)
+            stub_request(:get, url + "my?ref=sha").
+              with(headers: { "Authorization" => "token token" }).
+              to_return(
+                status: 200,
+                body: "[]",
+                headers: { "content-type" => "application/json" }
+              )
             stub_request(:get, url + "my-single/setup.py?ref=sha").
               with(headers: { "Authorization" => "token token" }).
               to_return(
@@ -671,6 +678,13 @@ RSpec.describe Dependabot::Python::FileFetcher do
             stub_request(:get, url + "my-single/setup.cfg?ref=sha").
               with(headers: { "Authorization" => "token token" }).
               to_return(status: 404)
+            stub_request(:get, url + "my-single?ref=sha").
+              with(headers: { "Authorization" => "token token" }).
+              to_return(
+                status: 200,
+                body: "[]",
+                headers: { "content-type" => "application/json" }
+              )
             stub_request(:get, url + "my-other/setup.py?ref=sha").
               with(headers: { "Authorization" => "token token" }).
               to_return(
@@ -813,6 +827,13 @@ RSpec.describe Dependabot::Python::FileFetcher do
             stub_request(:get, url + "flowmachine/setup.cfg?ref=sha").
               with(headers: { "Authorization" => "token token" }).
               to_return(status: 404)
+            stub_request(:get, url + "flowmachine?ref=sha").
+              with(headers: { "Authorization" => "token token" }).
+              to_return(
+                status: 200,
+                body: "[]",
+                headers: { "content-type" => "application/json" }
+              )
             stub_request(:get, url + "flowclient/setup.py?ref=sha").
               with(headers: { "Authorization" => "token token" }).
               to_return(
@@ -823,6 +844,13 @@ RSpec.describe Dependabot::Python::FileFetcher do
             stub_request(:get, url + "flowclient/setup.cfg?ref=sha").
               with(headers: { "Authorization" => "token token" }).
               to_return(status: 404)
+            stub_request(:get, url + "flowclient?ref=sha").
+              with(headers: { "Authorization" => "token token" }).
+              to_return(
+                status: 200,
+                body: "[]",
+                headers: { "content-type" => "application/json" }
+              )
           end
 
           it "fetches the setup.py" do


### PR DESCRIPTION
Previously, Dependabot would fetch files at the top-level of submodules, if required. That was a little half-arsed.

Now, the FileFetcher can be told whether you want to fetch files from submodules (for support files this will be true, for files we might want to update it will be false). If it is asked to fetch files from submodules it will dive deep into those submodules to find the file.