### PR TITLE
go_modules: handle vanity urls that return non-200 responses

### DIFF
--- a/go_modules/helpers/go.mod
+++ b/go_modules/helpers/go.mod
@@ -11,3 +11,5 @@ replace github.com/dependabot/dependabot-core/go_modules/helpers/importresolver 
 replace github.com/dependabot/dependabot-core/go_modules/helpers/updater => ./updater
 
 replace github.com/dependabot/dependabot-core/go_modules/helpers/updatechecker => ./updatechecker
+
+replace github.com/Masterminds/vcs => github.com/dependabot/vcs v1.12.1-0.20190208210831-56e31f59151a

--- a/go_modules/helpers/go.sum
+++ b/go_modules/helpers/go.sum
@@ -4,3 +4,5 @@ github.com/dependabot/dependabot-core v0.74.6 h1:SB2Oyie+Ex9ARXLHbFrnoQSWSixAG4O
 github.com/dependabot/dependabot-core v0.79.4 h1:d3/V6TTj+58ULw6824RK2zR+esZQw3bU/vRkCtCh4JU=
 github.com/dependabot/gomodules-extracted v0.0.0-20181020215834-1b2f850478a3 h1:Xj2leY0FVyZuo+p59vkIWG3dIqo+QtjskT5O1iTiywA=
 github.com/dependabot/gomodules-extracted v0.0.0-20181020215834-1b2f850478a3/go.mod h1:+dRXSrUymjpT4yzKtn1QmeknT1S/yAHRr35en18dHp8=
+github.com/dependabot/vcs v1.12.1-0.20190208210831-56e31f59151a h1:dMBRaMtCTAIDGAGHaRM2aWAZiX/XE/vYA22hMSeP2s0=
+github.com/dependabot/vcs v1.12.1-0.20190208210831-56e31f59151a/go.mod h1:VErcEjWcfFq7vHXBfBqbDzYX9kEterYg+1hcSpwFX6A=

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -158,6 +158,23 @@ RSpec.describe Dependabot::GoModules::FileParser do
       end
     end
 
+    describe "a non-semver vanity URL that 404s but includes meta tags" do
+      subject(:dependency) do
+        dependencies.find { |d| d.name == "gonum.org/v1/plot" }
+      end
+
+      let(:go_mod_content) do
+        go_mod = fixture("go_mods", go_mod_fixture_name)
+        go_mod.sub("rsc.io/quote v1.4.0",
+                   "gonum.org/v1/plot v0.0.0-20181116082555-59819fff2fb9")
+      end
+
+      it "has the right details" do
+        expect(dependency).to be_a(Dependabot::Dependency)
+        expect(dependency.name).to eq("gonum.org/v1/plot")
+      end
+    end
+
     describe "a v2+ dependency without the major version in the path" do
       let(:go_mod_content) do
         go_mod = fixture("go_mods", go_mod_fixture_name)

--- a/go_modules/spec/dependabot/go_modules/path_converter_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/path_converter_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe Dependabot::GoModules::PathConverter do
       it { is_expected.to eq("https://github.com/cloudfoundry/bytefmt") }
     end
 
+    context "with a vanity URL that 404s, but is otherwise valid" do
+      let(:path) { "gonum.org/v1/gonum" }
+      it { is_expected.to eq("https://github.com/gonum/gonum") }
+    end
+
     context "with a path that already includes a scheme" do
       let(:path) { "https://github.com/drewolson/testflight" }
       it { is_expected.to eq("https://github.com/drewolson/testflight") }


### PR DESCRIPTION
Switches us to fork of vcs.

Once https://github.com/Masterminds/vcs/pull/92 is merged we can switch
back.