### PR TITLE
Force local cache for npm installs

### DIFF
--- a/npm_and_yarn/helpers/npm/lib/subdependency-updater.js
+++ b/npm_and_yarn/helpers/npm/lib/subdependency-updater.js
@@ -13,7 +13,17 @@ async function updateDependencyFile(directory, lockfileName) {
   // in npm/lib/install/validate-args.js
   // Platform is checked and raised from (EBADPLATFORM):
   // https://github.com/npm/npm-install-checks
-  await runAsync(npm, npm.load, [{ loglevel: "silent", force: true }]);
+  //
+  // `'prefer-offline': true` sets fetch() cache key to `force-cache`
+  // https://github.com/npm/npm-registry-fetch
+  await runAsync(npm, npm.load, [
+    {
+      loglevel: "silent",
+      force: true,
+      audit: false,
+      "prefer-offline": true
+    }
+  ]);
 
   const dryRun = true;
   const initialInstaller = new installer.Installer(directory, dryRun, [], {

--- a/npm_and_yarn/helpers/npm/lib/updater.js
+++ b/npm_and_yarn/helpers/npm/lib/updater.js
@@ -28,7 +28,17 @@ async function updateDependencyFiles(directory, dependencies, lockfileName) {
   // in npm/lib/install/validate-args.js
   // Platform is checked and raised from (EBADPLATFORM):
   // https://github.com/npm/npm-install-checks
-  await runAsync(npm, npm.load, [{ loglevel: "silent", force: true }]);
+  //
+  // `'prefer-offline': true` sets fetch() cache key to `force-cache`
+  // https://github.com/npm/npm-registry-fetch
+  await runAsync(npm, npm.load, [
+    {
+      loglevel: "silent",
+      force: true,
+      audit: false,
+      "prefer-offline": true
+    }
+  ]);
   const oldPackage = JSON.parse(readFile("package.json"));
 
   const dryRun = true;


### PR DESCRIPTION
Sadly this will probably not have the desired effect. I've not managed to get reliable run times locally so want to get this out and test on a live run.

- Enable `prefer-offline` setting in npm which sets 'force-cache' in the npm fork of fetch (using the local cache folder `~/.npm`)
- Turn off audit for npm helpers
- Removed redundant cleanup installer from peer dep checker (only want peer dependency warnings)
