### PR TITLE
go_modules: detect missing/invalid dependency with pseudo version

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -88,6 +88,7 @@ module Dependabot
           end
       end
 
+      # rubocop:disable Metrics/AbcSize
       def handle_parser_error(path, stderr)
         case stderr
         when /go: .*: unknown revision/
@@ -109,6 +110,7 @@ module Dependabot
           raise Dependabot::DependencyFileNotParseable.new(go_mod.path, msg)
         end
       end
+      # rubocop:enable Metrics/AbcSize
 
       def rev_identifier?(dep)
         dep["Version"]&.match?(GIT_VERSION_REGEX)

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -99,6 +99,11 @@ module Dependabot
         when /go: errors parsing go.mod/
           msg = stderr.gsub(path.to_s, "").strip
           raise Dependabot::DependencyFileNotParseable.new(go_mod.path, msg)
+        when /go: finding .*/
+          msg = stderr.lines.grep(/go: finding/).first.strip
+          match = /go: finding (?<require>\S+)/.match(msg)
+          msg = "could not resolve dependency #{match[:require]}" if match
+          raise Dependabot::DependencyFileNotResolvable.new, msg
         else
           msg = stderr.gsub(path.to_s, "").strip
           raise Dependabot::DependencyFileNotParseable.new(go_mod.path, msg)

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -158,6 +158,21 @@ RSpec.describe Dependabot::GoModules::FileParser do
       end
     end
 
+    describe "a non-existent dependency with a pseudo-version" do
+      let(:go_mod_content) do
+        go_mod = fixture("go_mods", go_mod_fixture_name)
+        go_mod.sub("rsc.io/quote v1.4.0",
+                   "github.com/hmarr/404 v0.0.0-20181216014959-b89dc648a159")
+      end
+
+      it "raises the correct error" do
+        expect { parser.parse }.
+          to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
+            expect(error.message).to include("hmarr/404")
+          end
+      end
+    end
+
     describe "a non-semver vanity URL that 404s but includes meta tags" do
       subject(:dependency) do
         dependencies.find { |d| d.name == "gonum.org/v1/plot" }

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -101,6 +101,24 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
             is_expected.
               to_not include(%(rsc.io/quote v1.4.0/go.mod h1:))
           end
+
+          describe "a non-existent dependency with a pseudo-version" do
+            let(:go_mod_body) do
+              go_mod = fixture("go_mods", go_mod_fixture_name)
+              go_mod.sub(
+                "rsc.io/quote v1.4.0",
+                "github.com/hmarr/404 v0.0.0-20181216014959-b89dc648a159"
+              )
+            end
+
+            it "raises the correct error" do
+              error_class = Dependabot::DependencyFileNotResolvable
+              expect { updater.updated_go_sum_content }.
+                to raise_error(error_class) do |error|
+                  expect(error.message).to include("hmarr/404")
+                end
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Serve a better error message when a dependency can't be cloned.