### PR TITLE
Go (modules): more detailed and specific error messages

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -65,13 +65,13 @@ module Dependabot
 
         private
 
+        GIT_ERROR_REGEX = /go: .*: git fetch .*: exit status 128/.freeze
+
         def handle_subprocess_error(path, stderr)
           case stderr
-          when /go: finding .*/
-            msg = stderr.lines.grep(/go: finding/).first.strip
-            match = /go: finding (?<require>\S+)/.match(msg)
-            msg = "could not resolve dependency #{match[:require]}" if match
-            raise Dependabot::DependencyFileNotResolvable.new, msg
+          when GIT_ERROR_REGEX
+            lines = stderr.lines.drop_while { |l| GIT_ERROR_REGEX !~ l }
+            raise Dependabot::DependencyFileNotResolvable.new, lines.join
           else
             msg = stderr.gsub(path.to_s, "").strip
             raise Dependabot::DependencyFileNotParseable.new(go_mod.path, msg)

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -66,11 +66,15 @@ module Dependabot
         private
 
         GIT_ERROR_REGEX = /go: .*: git fetch .*: exit status 128/.freeze
+        CHECKSUM_REGEX = /go: verifying .*: checksum mismatch/.freeze
 
         def handle_subprocess_error(path, stderr)
           case stderr
           when GIT_ERROR_REGEX
             lines = stderr.lines.drop_while { |l| GIT_ERROR_REGEX !~ l }
+            raise Dependabot::DependencyFileNotResolvable.new, lines.join
+          when CHECKSUM_REGEX
+            lines = stderr.lines.drop_while { |l| CHECKSUM_REGEX !~ l }
             raise Dependabot::DependencyFileNotResolvable.new, lines.join
           else
             msg = stderr.gsub(path.to_s, "").strip

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -104,8 +104,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
 
           describe "a non-existent dependency with a pseudo-version" do
             let(:go_mod_body) do
-              go_mod = fixture("go_mods", go_mod_fixture_name)
-              go_mod.sub(
+              fixture("go_mods", go_mod_fixture_name).sub(
                 "rsc.io/quote v1.4.0",
                 "github.com/hmarr/404 v0.0.0-20181216014959-b89dc648a159"
               )
@@ -116,6 +115,23 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
               expect { updater.updated_go_sum_content }.
                 to raise_error(error_class) do |error|
                   expect(error.message).to include("hmarr/404")
+                end
+            end
+          end
+
+          describe "a dependency with a checksum mismatch" do
+            let(:go_sum_body) do
+              fixture("go_mods", go_sum_fixture_name).sub(
+                "h1:sh3dZUZxJqMHuwt2YwWXqUUIe6N9gJlzZZH0eFduGkw=",
+                "h1:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
+              )
+            end
+
+            it "raises the correct error" do
+              error_class = Dependabot::DependencyFileNotResolvable
+              expect { updater.updated_go_sum_content }.
+                to raise_error(error_class) do |error|
+                  expect(error.message).to include("fatih/Color")
                 end
             end
           end


### PR DESCRIPTION
For unresolvable dependencies due to git errors, and for go.sum checksum mismatches.