### PR TITLE
Fetch files from symlinked directories if fetching submodules

### DIFF
--- a/common/spec/fixtures/github/symlinked_file_content.json
+++ b/common/spec/fixtures/github/symlinked_file_content.json
@@ -1,18 +1,18 @@
 {
+    "_links": {
+        "git": "https://api.github.com/repos/hiki/hikidoc/git/blobs/573fcc3b5952e689528763484bac0b461e844c3b",
+        "html": "https://github.com/hiki/hikidoc/blob/master/requirements.txt",
+        "self": "https://api.github.com/repos/hiki/hikidoc/contents/requirements.txt?ref=master"
+    },
+    "download_url": "https://raw.githubusercontent.com/hiki/hikidoc/master/requirements.txt",
+    "encoding": "base64",
+    "git_url": "https://api.github.com/repos/hiki/hikidoc/git/blobs/573fcc3b5952e689528763484bac0b461e844c3b",
+    "html_url": "https://github.com/hiki/hikidoc/blob/master/requirements.txt",
     "name": "requirements.txt",
     "path": "requirements.txt",
     "sha": "573fcc3b5952e689528763484bac0b461e844c3b",
     "size": 926,
-    "url": "https://api.github.com/repos/hiki/hikidoc/contents/requirements.txt?ref=master",
-    "html_url": "https://github.com/hiki/hikidoc/blob/master/requirements.txt",
-    "git_url": "https://api.github.com/repos/hiki/hikidoc/git/blobs/573fcc3b5952e689528763484bac0b461e844c3b",
-    "download_url": "https://raw.githubusercontent.com/hiki/hikidoc/master/requirements.txt",
-    "type": "symlink",
     "target": "symlinked/requirements.txt",
-    "encoding": "base64",
-    "_links": {
-        "self": "https://api.github.com/repos/hiki/hikidoc/contents/requirements.txt?ref=master",
-        "git": "https://api.github.com/repos/hiki/hikidoc/git/blobs/573fcc3b5952e689528763484bac0b461e844c3b",
-        "html": "https://github.com/hiki/hikidoc/blob/master/requirements.txt"
-    }
+    "type": "symlink",
+    "url": "https://api.github.com/repos/hiki/hikidoc/contents/requirements.txt?ref=master"
 }

--- a/common/spec/fixtures/github/symlinked_repo.json
+++ b/common/spec/fixtures/github/symlinked_repo.json
@@ -1,0 +1,17 @@
+{
+    "_links": {
+        "git": "https://api.github.com/repos/minimum2scp/dependabot-example-02/git/blobs/e7ed2cce4eda76280b4a1b1edc97c3b5b6f52c2b",
+        "html": "https://github.com/minimum2scp/dependabot-example-02/blob/master/app/gems/sample_private_lib1",
+        "self": "https://api.github.com/repos/minimum2scp/dependabot-example-02/contents/app/gems/sample_private_lib1?ref=master"
+    },
+    "download_url": "https://raw.githubusercontent.com/minimum2scp/dependabot-example-02/master/app/gems/sample_private_lib1",
+    "git_url": "https://api.github.com/repos/minimum2scp/dependabot-example-02/git/blobs/e7ed2cce4eda76280b4a1b1edc97c3b5b6f52c2b",
+    "html_url": "https://github.com/minimum2scp/dependabot-example-02/blob/master/app/gems/sample_private_lib1",
+    "name": "sample_private_lib1",
+    "path": "app/gems/sample_private_lib1",
+    "sha": "e7ed2cce4eda76280b4a1b1edc97c3b5b6f52c2b",
+    "size": 25,
+    "target": "symlinked/repo",
+    "type": "symlink",
+    "url": "https://api.github.com/repos/minimum2scp/dependabot-example-02/contents/app/gems/sample_private_lib1?ref=master"
+}


### PR DESCRIPTION
When fetching support files, there's no reason we shouldn't fetch them from symlinked directories. This isn't the last word on fetching symlinked files (it only applies for directories) but it's a step in the right direction and will fix https://github.com/minimum2scp/dependabot-example-02/issues/23.