### PR TITLE
PHP: Use the global variable $memory when freeing it

### DIFF
--- a/composer/helpers/bin/run
+++ b/composer/helpers/bin/run
@@ -50,6 +50,7 @@ date_default_timezone_set('Europe/London');
 $memory = str_repeat('*', 1024 * 1024);
 
 register_shutdown_function(function (): void {
+    global $memory;
     $memory = null;
     $error = error_get_last();
     if (null !== $error) {


### PR DESCRIPTION
Without using the global variable, a new local variable is created.
https://3v4l.org/4TbmN vs https://3v4l.org/06HcL