### PR TITLE
NPM: Fix lockfile for git dependencies using tags

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -465,11 +465,15 @@ module Dependabot
           # Switch from details back for git dependencies (they will have
           # changed because we locked them)
           git_dependencies_to_lock.each do |_, details|
-            next unless details[:from]
+            next unless details[:version] && details[:from]
 
-            new_r = /"from": "#{Regexp.quote(details[:from])}#[^\"]+"/
-            old_r = %("from": "#{details[:from]}")
-            updated_content = updated_content.gsub(new_r, old_r)
+            # When locking git dependencies in package.json we set the version
+            # to be the git commit from the lockfile "version" field which
+            # updates the lockfile "from" field to the new git commit when we
+            # run npm install
+            locked_from = %("from": "#{details[:version]}")
+            original_from = %("from": "#{details[:from]}")
+            updated_content = updated_content.gsub(locked_from, original_from)
           end
 
           # Switch back the protocol of tarball resolutions if they've changed

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -2146,6 +2146,86 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
             to eq("1.2.4")
         end
       end
+
+      context "when there are git tag dependencies not being updated" do
+        let(:manifest_fixture_name) { "git_tag_dependencies.json" }
+        let(:npm_lock_fixture_name) { "git_tag_dependencies.json" }
+        let(:dependency_name) { "etag" }
+        let(:requirements) do
+          [{
+            requirement: "^1.8.1",
+            file: "package.json",
+            groups: ["dependencies"],
+            source: nil
+          }]
+        end
+        let(:previous_requirements) do
+          [{
+            requirement: "^1.8.0",
+            file: "package.json",
+            groups: ["dependencies"],
+            source: nil
+          }]
+        end
+        let(:previous_version) { "1.8.0" }
+        let(:version) { "1.8.1" }
+
+        it "doesn't update git dependencies" do
+          expect(updated_files.map(&:name)).
+            to match_array(%w(package.json package-lock.json))
+
+          parsed_package_json = JSON.parse(updated_package_json.content)
+          expect(parsed_package_json["dependencies"]["Select2"]).
+            to eq("git+https://github.com/select2/select2.git#3.4.8")
+
+          parsed_package_lock = JSON.parse(updated_npm_lock.content)
+          expect(parsed_package_lock["dependencies"]["Select2"]["from"]).
+            to eq("git+https://github.com/select2/select2.git#3.4.8")
+          expect(parsed_package_lock["dependencies"]["Select2"]["version"]).
+            to eq("git+https://github.com/select2/select2.git#"\
+                  "b5f3b2839c48c53f9641d6bb1bccafc5260c7620")
+        end
+      end
+
+      context "when there are git ref dependencies not being updated" do
+        let(:manifest_fixture_name) { "git_ref_dependencies.json" }
+        let(:npm_lock_fixture_name) { "git_ref_dependencies.json" }
+        let(:dependency_name) { "etag" }
+        let(:requirements) do
+          [{
+            requirement: "^1.8.1",
+            file: "package.json",
+            groups: ["dependencies"],
+            source: nil
+          }]
+        end
+        let(:previous_requirements) do
+          [{
+            requirement: "^1.8.0",
+            file: "package.json",
+            groups: ["dependencies"],
+            source: nil
+          }]
+        end
+        let(:previous_version) { "1.8.0" }
+        let(:version) { "1.8.1" }
+
+        it "doesn't update git dependencies" do
+          expect(updated_files.map(&:name)).
+            to match_array(%w(package.json package-lock.json))
+
+          parsed_package_json = JSON.parse(updated_package_json.content)
+          expect(parsed_package_json["dependencies"]["Select2"]).
+            to eq("git+https://github.com/select2/select2.git#3.x")
+
+          parsed_package_lock = JSON.parse(updated_npm_lock.content)
+          expect(parsed_package_lock["dependencies"]["Select2"]["from"]).
+            to eq("git+https://github.com/select2/select2.git#3.x")
+          expect(parsed_package_lock["dependencies"]["Select2"]["version"]).
+            to eq("git+https://github.com/select2/select2.git#"\
+                  "170c88460ac69639b57dfa03cfea0dadbf3c2bad")
+        end
+      end
     end
 
     #######################

--- a/npm_and_yarn/spec/fixtures/npm_lockfiles/git_ref_dependencies.json
+++ b/npm_and_yarn/spec/fixtures/npm_lockfiles/git_ref_dependencies.json
@@ -1,0 +1,17 @@
+{
+  "name": "git-ref",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "Select2": {
+      "version": "git+https://github.com/select2/select2.git#170c88460ac69639b57dfa03cfea0dadbf3c2bad",
+      "from": "git+https://github.com/select2/select2.git#3.x"
+    },
+    "etag": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/npm_lockfiles/git_tag_dependencies.json
+++ b/npm_and_yarn/spec/fixtures/npm_lockfiles/git_tag_dependencies.json
@@ -1,0 +1,17 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "Select2": {
+      "version": "git+https://github.com/select2/select2.git#b5f3b2839c48c53f9641d6bb1bccafc5260c7620",
+      "from": "git+https://github.com/select2/select2.git#3.4.8"
+    },
+    "etag": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/package_files/git_ref_dependencies.json
+++ b/npm_and_yarn/spec/fixtures/package_files/git_ref_dependencies.json
@@ -1,0 +1,15 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "Select2": "git+https://github.com/select2/select2.git#3.x",
+    "etag": "^1.8.0"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/package_files/git_tag_dependencies.json
+++ b/npm_and_yarn/spec/fixtures/package_files/git_tag_dependencies.json
@@ -1,0 +1,15 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "Select2": "git+https://github.com/select2/select2.git#3.4.8",
+    "etag": "^1.8.0"
+  }
+}


### PR DESCRIPTION
Fixes the logic to restore locked git dependencies in npm lockfiles using tags/refs.

When updating a npm dependency we need to lock git dependencies specified in `package.json` to a commit so npm doesn't unintentionally update them.

We handle this by updating the `package.json` version with the resolved git commit from the lockfile and restore this after update.

After a `npm install` this commit sha is set in the lockfile so we need to restore it to the original value (plain git url or with tags/refs).