### PR TITLE
Allow gemspec dependencies to have a source (in case it's git)

### DIFF
--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -77,7 +77,7 @@ module Dependabot
                 requirements: [{
                   requirement: dependency.requirement.to_s,
                   groups: dependency.runtime? ? ["runtime"] : ["development"],
-                  source: nil,
+                  source: source_for(dependency),
                   file: gemspec.name
                 }],
                 package_manager: "bundler"

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -462,6 +462,33 @@ RSpec.describe Dependabot::Bundler::FileParser do
         end
       end
 
+      context "with an unparseable git dep that also appears in the gemspec" do
+        let(:gemfile_fixture_name) { "git_source_unparseable" }
+        let(:lockfile_fixture_name) { "git_source_unparseable.lock" }
+        let(:gemspec_content) { fixture("ruby", "gemspecs", "small_example") }
+
+        it "includes source details on the gemspec requirement" do
+          expect(dependencies.map(&:name)).to match_array(%w(business))
+          expect(dependencies.first.name).to eq("business")
+          expect(dependencies.first.version).
+            to eq("1378a2b0b446d991b7567efbc7eeeed2720e4d8f")
+          expect(dependencies.first.requirements).
+            to match_array(
+              [{
+                file: "example.gemspec",
+                requirement: "~> 1.0",
+                groups: ["runtime"],
+                source: {
+                  type: "git",
+                  url: "git@github.com:gocardless/business",
+                  branch: "master",
+                  ref: "master"
+                }
+              }]
+            )
+        end
+      end
+
       context "with two gemspecs" do
         let(:gemfile_fixture_name) { "imports_two_gemspecs" }
         let(:lockfile_fixture_name) { "imports_two_gemspecs.lock" }

--- a/bundler/spec/fixtures/ruby/gemfiles/git_source_unparseable
+++ b/bundler/spec/fixtures/ruby/gemfiles/git_source_unparseable
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+def git_gem(name, **options)
+  gem name, git: "git@github.com:gocardless/business"
+end
+
+git_gem 'business'
+
+gemspec

--- a/bundler/spec/fixtures/ruby/lockfiles/git_source_unparseable.lock
+++ b/bundler/spec/fixtures/ruby/lockfiles/git_source_unparseable.lock
@@ -1,0 +1,25 @@
+GIT
+  remote: git@github.com:gocardless/business
+  revision: 1378a2b0b446d991b7567efbc7eeeed2720e4d8f
+  specs:
+    business (1.16.0)
+
+PATH
+  remote: .
+  specs:
+    example (0.9.3)
+      business (~> 1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business!
+  example!
+
+BUNDLED WITH
+   1.17.3


### PR DESCRIPTION
That. Fixes an error we're seeing, and I don't  *think* there's any downside to this. Will merge and deploy tomorrow when I can watch it out.