### PR TITLE
NPM: Handle 403 Forbidden when updating lockfiles

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -114,19 +114,19 @@ module Dependabot
         def credential_lines_for_npmrc
           lines = []
           registry_credentials.each do |cred|
-            registry = cred.fetch("registry")
+            registry = cred.fetch("registry").sub(%r{\/?$}, "/")
 
             lines << registry_scope(registry) if registry_scope(registry)
 
             token = cred.fetch("token")
             if token.include?(":")
               encoded_token = Base64.encode64(token).delete("\n")
-              lines << "//#{registry}/:_auth=#{encoded_token}"
+              lines << "//#{registry}:_auth=#{encoded_token}"
             elsif Base64.decode64(token).ascii_only? &&
                   Base64.decode64(token).include?(":")
-              lines << %(//#{registry}/:_auth=#{token.delete("\n")})
+              lines << %(//#{registry}:_auth=#{token.delete("\n")})
             else
-              lines << "//#{registry}/:_authToken=#{token}"
+              lines << "//#{registry}:_authToken=#{token}"
             end
           end
 
@@ -163,7 +163,7 @@ module Dependabot
           # This just seems unlikely
           return unless scopes.uniq.count == 1
 
-          "@#{scopes.first}:registry=https://#{registry}/"
+          "@#{scopes.first}:registry=https://#{registry}"
         end
 
         def registry_credentials

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npmrc_builder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npmrc_builder_spec.rb
@@ -175,6 +175,28 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
           end
           it { is_expected.to eq("//registry.npmjs.org/:_authToken=my_token") }
 
+          context "where the registry has a trailing slash" do
+            let(:credentials) do
+              [{
+                "type" => "git_source",
+                "host" => "github.com",
+                "username" => "x-access-token",
+                "password" => "token"
+              }, {
+                "type" => "npm_registry",
+                "registry" => "artifactory.jfrog.com"\
+                              "/artifactory/api/npm/dependabot/",
+                "token" => "my_token"
+              }]
+            end
+
+            it "only adds a single trailing slash" do
+              expect(npmrc_content).
+                to eq("//artifactory.jfrog.com/"\
+                      "artifactory/api/npm/dependabot/:_authToken=my_token")
+            end
+          end
+
           context "that match a scoped package" do
             let(:credentials) do
               [{


### PR DESCRIPTION
Seems to handle the case when we auth against artifactory and get
"Unable to authenticate, need: Basic realm="Artifactory Realm""

This seems to be caused by a trailing slash in the registry host as set
in config variables. When we write this out in npmrc we add another
trailing slash and this seems to cause the above error. Changing to a
single trailing slash returns a 403 Forbidden error.