### PR TITLE
Add option to cache dry-run script steps

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -9,7 +9,7 @@
 # should always be up-to-date.
 #
 # Usage:
-#   ruby bin/dry-run.rb PACKAGE_MANAGER GITHUB_REPO [DEPENDENCY]
+#   ruby bin/dry-run.rb [OPTIONS] PACKAGE_MANAGER GITHUB_REPO
 #
 # ! You'll need to have a GitHub access token (a personal access token is
 # ! fine) available as the environment variable LOCAL_GITHUB_ACCESS_TOKEN.
@@ -55,6 +55,7 @@ ENV["BUNDLE_GEMFILE"] = File.join(__dir__, "../omnibus/Gemfile")
 Bundler.setup
 
 require "optparse"
+require "json"
 
 require "dependabot/file_fetchers"
 require "dependabot/file_parsers"
@@ -80,9 +81,17 @@ require "dependabot/terraform"
 # GitHub credentials with write permission to the repo you want to update
 # (so that you can create a new branch, commit and pull request).
 # If using a private registry it's also possible to add details of that here.
-credentials = []
+
+$options = {
+  credentials: [],
+  directory: "/",
+  dependency_name: nil,
+  branch: nil,
+  cache_steps: [],
+}
+
 if ENV["LOCAL_GITHUB_ACCESS_TOKEN"]
-  credentials << {
+  $options[:credentials] << {
     "type" => "git_source",
     "host" => "github.com",
     "username" => "x-access-token",
@@ -90,61 +99,41 @@ if ENV["LOCAL_GITHUB_ACCESS_TOKEN"]
   }
 end
 
-# Directory where the base dependency files are.
-directory = "/"
-
-# Name of an individual dependency to udpate
-dependency_name = nil
+if ENV["LOCAL_CONFIG_VARIABLES"]
+  # For example:
+  # LOCAL_CONFIG_VARIABLES="[{\"type\":\"npm_registry\",\"registry\":\"registry.npmjs.org\",\"token\":\"123\"}]"
+  $options[:credentials].concat(JSON.parse(ENV["LOCAL_CONFIG_VARIABLES"]))
+end
 
 option_parse = OptionParser.new do |opts|
-  opts.banner = "usage: ruby bin/dry-run.rb [options] PACKAGE_MANAGER REPO"
+  opts.banner = "usage: ruby bin/dry-run.rb [OPTIONS] PACKAGE_MANAGER REPO"
 
   opts.on("--dir DIRECTORY", "Dependency file directory") do |value|
-    directory = value
+    $options[:directory] = value
+  end
+
+  opts.on("--branch BRANCH", "Repo branch") do |value|
+    $options[:branch] = value
   end
 
   opts.on("--dep DEPENDENCY", "Dependency to update") do |value|
-    dependency_name = value
+    $options[:dependency_name] = value
+  end
+
+  opts.on("--cache STEPS", "Cache e.g. files, dependencies, updates") do |value|
+    $options[:cache_steps].concat(value.split(",").map(&:strip))
   end
 end
+
 option_parse.parse!
 
-# Full name of the GitHub repo you want to create pull requests for.
+# Full name of the GitHub repo you want to create pull requests for
 if ARGV.length < 2
   puts option_parse.help
   exit 1
 end
-package_manager, repo_name = ARGV
 
-source = Dependabot::Source.new(
-  provider: "github",
-  repo: repo_name,
-  directory: directory,
-  branch: nil
-)
-
-# Fetch the dependency files
-puts "=> fetching dependency files"
-fetcher = Dependabot::FileFetchers.for_package_manager(package_manager).
-          new(source: source, credentials: credentials)
-files = fetcher.files
-
-# Parse the dependency files
-puts "=> parsing dependency files"
-parser = Dependabot::FileParsers.for_package_manager(package_manager).new(
-  dependency_files: files,
-  source: source,
-  credentials: credentials
-)
-dependencies = parser.parse
-
-if dependency_name.nil?
-  dependencies.select!(&:top_level?)
-else
-  dependencies.select! { |d| d.name == dependency_name }
-end
-
-puts "=> updating #{dependencies.count} dependencies"
+$package_manager, $repo_name = ARGV
 
 def show_diff(original_file, updated_file)
   if original_file.content == updated_file.content
@@ -168,16 +157,89 @@ def show_diff(original_file, updated_file)
   puts "    ~~~"
 end
 
+def cached_read(name)
+  raise "Provide something to cache" unless block_given?
+  return yield unless $options[:cache_steps].include?(name)
+
+  cache_path = File.join("tmp", $repo_name.split("/"), "cache", "#{name}.bin")
+  cache_dir = File.dirname(cache_path)
+  FileUtils.mkdir_p(cache_dir) unless Dir.exist?(cache_dir)
+  cached = File.read(cache_path) if File.exist?(cache_path)
+  return Marshal.load(cached) if cached
+
+  data = yield
+  File.write(cache_path, Marshal.dump(data))
+  data
+end
+
+source = Dependabot::Source.new(
+  provider: "github",
+  repo: $repo_name,
+  directory: $options[:directory],
+  branch: $options[:branch]
+)
+
+# Fetch the dependency files
+puts "=> fetching dependency files"
+
+fetcher = Dependabot::FileFetchers.for_package_manager($package_manager).
+          new(source: source, credentials: $options[:credentials])
+
+files = cached_read("files") { fetcher.files }
+
+# Dump dependency files in tmp/githublogin@repo-name/dependency-files
+files.map do |f|
+  files_path = File.join("tmp", $repo_name.split("/"), "dependency-files", f.name)
+  files_dir = File.dirname(files_path)
+  FileUtils.mkdir_p(files_dir) unless Dir.exist?(files_dir)
+  File.write(files_path, f.content)
+end
+
+# Parse the dependency files
+puts "=> parsing dependency files"
+parser = Dependabot::FileParsers.for_package_manager($package_manager).new(
+  dependency_files: files,
+  source: source,
+  credentials: $options[:credentials]
+)
+
+dependencies = cached_read("dependencies") { parser.parse }
+
+if $options[:dependency_name].nil?
+  dependencies.select!(&:top_level?)
+else
+  dependencies.select! { |d| d.name == $options[:dependency_name] }
+end
+
+puts "=> updating #{dependencies.count} dependencies"
+
 dependencies.each do |dep|
   puts "\n=== #{dep.name} (#{dep.version})"
-  checker = Dependabot::UpdateCheckers.for_package_manager(package_manager).new(
+  checker = Dependabot::UpdateCheckers.for_package_manager($package_manager).new(
     dependency: dep,
     dependency_files: files,
-    credentials: credentials
+    credentials: $options[:credentials]
   )
 
   puts " => checking for updates"
-  updated_deps = checker.updated_dependencies(requirements_to_unlock: :own)
+  updated_deps = cached_read("updates") do
+    requirements_to_unlock =
+      if !checker.requirements_unlocked_or_can_be?
+        if checker.can_update?(requirements_to_unlock: :none) then :none
+        else :update_not_possible
+        end
+      elsif checker.can_update?(requirements_to_unlock: :own) then :own
+      elsif checker.can_update?(requirements_to_unlock: :all) then :all
+      else :update_not_possible
+      end
+
+    return [] if requirements_to_unlock == :update_not_possible
+
+    checker.updated_dependencies(
+      requirements_to_unlock: requirements_to_unlock
+    )
+  end
+
   updated_deps.select! do |d|
     next true if d.version != d.previous_version
     d.requirements != d.previous_requirements
@@ -188,14 +250,14 @@ dependencies.each do |dep|
     next
   end
 
-  new_version = updated_deps.find { |d| d.name == dep.name }.version
-  puts " => updating to #{new_version}"
+  new_dep = updated_deps.find { |d| d.name == dep.name }
+  puts " => updating to #{new_dep.version}"
 
   # Generate updated dependency files
-  updater = Dependabot::FileUpdaters.for_package_manager(package_manager).new(
+  updater = Dependabot::FileUpdaters.for_package_manager($package_manager).new(
     dependencies: updated_deps,
     dependency_files: files,
-    credentials: credentials
+    credentials: $options[:credentials]
   )
 
   updated_files = updater.updated_dependency_files


### PR DESCRIPTION
Add `--cache=step` option to the `dry-run.rb` script.
Step can be one of: `files`, `dependencies`, `updates`

Example:

```
bin/dry-run.rb npm_and_yarn "repo-path" --cache=files,dependencies,updates
```

This marshalls the output of `files`, `dependencies` and `updated_deps`
to `tmp/github-logi@repo-name/cache/step.bin`

Also writing out all dependency files to `tmp` making debugging easier.

Next step is to use real dependency files as the cache so you could edit
these or add your own files to test against.