### PR TITLE
Fix copy paste error in npm and Yarn README.md

### DIFF
--- a/npm_and_yarn/README.md
+++ b/npm_and_yarn/README.md
@@ -1,6 +1,6 @@
 ## `dependabot-npm_and_yarn`
 
-PHP support for [`dependabot-core`][core-repo].
+npm and Yarn support for [`dependabot-core`][core-repo].
 
 ### Running locally
 


### PR DESCRIPTION
Looks like a copy paste error :)

`npm` is written in all lowercase on purpose.