### PR TITLE
Reduce rubocop config spread and cover root files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,11 +2,10 @@ AllCops:
   DisplayCopNames: true
   TargetRubyVersion: 2.5
   Exclude:
-    - vendor/**/*
-    - bin/**/*
-    - tmp/**/*
-    - helpers/utils/git-credential-store-immutable
-    - helpers/python/**/*
+    - '*/vendor/**/*'
+    - '*/bin/**/*'
+    - '*/tmp/**/*'
+    - '*/helpers/**/*'
 
 Layout/DotPosition:
   EnforcedStyle: trailing
@@ -34,9 +33,9 @@ Metrics/MethodLength:
 
 Metrics/BlockLength:
   Exclude:
-    - Rakefile
-    - spec/**/*
-    - dependabot-*.gemspec
+    - '*/Rakefile'
+    - '*/spec/**/*'
+    - '*/dependabot-*.gemspec'
 
 Metrics/ParameterLists:
   CountKeywordArgs: false

--- a/bundler/.rubocop.yml
+++ b/bundler/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/cargo/.rubocop.yml
+++ b/cargo/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/common/.rubocop.yml
+++ b/common/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: config/rubocop.yml

--- a/composer/.rubocop.yml
+++ b/composer/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/dep/.rubocop.yml
+++ b/dep/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/docker/.rubocop.yml
+++ b/docker/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/elm/.rubocop.yml
+++ b/elm/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/git_submodules/.rubocop.yml
+++ b/git_submodules/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/go_modules/.rubocop.yml
+++ b/go_modules/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/gradle/.rubocop.yml
+++ b/gradle/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/hex/.rubocop.yml
+++ b/hex/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/maven/.rubocop.yml
+++ b/maven/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/npm_and_yarn/.rubocop.yml
+++ b/npm_and_yarn/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/nuget/.rubocop.yml
+++ b/nuget/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/omnibus/.rubocop.yml
+++ b/omnibus/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/python/.rubocop.yml
+++ b/python/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml

--- a/terraform/.rubocop.yml
+++ b/terraform/.rubocop.yml
@@ -1,1 +1,0 @@
-inherit_from: ../common/config/rubocop.yml


### PR DESCRIPTION
This change is aesthetic but may also help IDEs to handle Rubocop validation much better (both for perf and for overall coverage).
Except if you have specific usage?