### PR TITLE
Go (modules): Handle module path mismatch errors

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -176,4 +176,19 @@ module Dependabot
       super(msg)
     end
   end
+
+  class GoModulePathMismatch < DependabotError
+    attr_reader :go_mod, :declared_path, :discovered_path
+
+    def initialize(go_mod, declared_path, discovered_path)
+      @go_mod = go_mod
+      @declared_path = declared_path
+      @discovered_path = discovered_path
+
+      msg = "The module path '#{declared_path}' found in #{go_mod} doesn't "\
+            "match the actual path '#{discovered_path}' in the dependency's "\
+            "go.mod"
+      super(msg)
+    end
+  end
 end

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -135,9 +135,26 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
 
             it "raises the correct error" do
               error_class = Dependabot::DependencyFileNotResolvable
-              expect { puts updater.updated_go_sum_content }.
+              expect { updater.updated_go_sum_content }.
                 to raise_error(error_class) do |error|
                   expect(error.message).to include("hmarr/404")
+                end
+            end
+          end
+
+          describe "a dependency who's module path has changed" do
+            let(:go_mod_body) do
+              fixture("go_mods", go_mod_fixture_name).sub(
+                "rsc.io/quote v1.4.0",
+                "gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.2"
+              )
+            end
+
+            it "raises the correct error" do
+              error_class = Dependabot::GoModulePathMismatch
+              expect { updater.updated_go_sum_content }.
+                to raise_error(error_class) do |error|
+                  expect(error.message).to include("github.com/DATA-DOG")
                 end
             end
           end


### PR DESCRIPTION
Caused by the module path specified in a `go.mod` requirement differing from the module path declared in the dependency's `go.mod` `module ...` line.