### PR TITLE
NPM: Fix lockfile for git deps with semver version

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -676,6 +676,27 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
             to include("0c6b15a88bc10cd47f67a09506399dfc9ddc075d")
         end
 
+        context "with a from line in the package-lock" do
+          let(:files) { [package_json, package_lock] }
+          let(:npm_lock_fixture_name) { "github_dependency_semver_modern.json" }
+
+          it "updates the package-lock.json from line correctly" do
+            expect(updated_files.map(&:name)).
+              to match_array(%w(package.json package-lock.json))
+
+            parsed_package_json = JSON.parse(updated_package_json.content)
+            expect(parsed_package_json["devDependencies"]["is-number"]).
+              to eq("jonschlinkert/is-number#semver:^4.0.0")
+
+            parsed_package_lock = JSON.parse(updated_npm_lock.content)
+            expect(parsed_package_lock["dependencies"]["is-number"]["version"]).
+              to eq("github:jonschlinkert/is-number#"\
+                    "0c6b15a88bc10cd47f67a09506399dfc9ddc075d")
+            expect(parsed_package_lock["dependencies"]["is-number"]["from"]).
+              to eq("github:jonschlinkert/is-number#semver:^4.0.0")
+          end
+        end
+
         context "using Yarn semver format" do
           # npm doesn't support Yarn semver format yet
           let(:files) { [package_json, yarn_lock] }

--- a/npm_and_yarn/spec/fixtures/npm_lockfiles/github_dependency_semver_modern.json
+++ b/npm_and_yarn/spec/fixtures/npm_lockfiles/github_dependency_semver_modern.json
@@ -1,0 +1,31 @@
+{
+  "name": "bump-test",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-number": {
+      "version": "github:jonschlinkert/is-number#0024f0f6552b6375712d93a7eadaa48810588736",
+      "from": "github:jonschlinkert/is-number#semver:^2.0.0",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes lockfile updates for dependencies installed with a semver range,
for example: `yarn add graphql@graphql/graphql-js#semver:^v14.0.0`

When a semver git dependency was updated Dependabot dropped the semver
part and updated the lockfile with the new absolute version instead.

Also cleaned up the yarn updater to match the npm updater taking the
version requirement from the pacakge.json instead of constructing it
from skratch when using git shorthand syntax.