### PR TITLE
Go (modules): prevent all pseudo version updates

### DIFF
--- a/go_modules/helpers/updatechecker/main.go
+++ b/go_modules/helpers/updatechecker/main.go
@@ -3,11 +3,16 @@ package updatechecker
 import (
 	"errors"
 	"io/ioutil"
+	"regexp"
 
 	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/modfetch"
 	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/modfile"
 	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/modload"
 	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/semver"
+)
+
+var (
+	pseudoVersionRegexp = regexp.MustCompile(`-\d{14}-[0-9a-f]{12}$`)
 )
 
 type Dependency struct {
@@ -52,6 +57,10 @@ func GetUpdatedVersion(args *Args) (interface{}, error) {
 	currentMajor := semver.Major(currentVersion)
 	currentPrerelease := semver.Prerelease(currentVersion)
 	latestVersion := args.Dependency.Version
+
+	if pseudoVersionRegexp.MatchString(currentPrerelease) {
+		return latestVersion, nil
+	}
 
 Outer:
 	for _, v := range versions {

--- a/go_modules/helpers/updatechecker/main.go
+++ b/go_modules/helpers/updatechecker/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	pseudoVersionRegexp = regexp.MustCompile(`-\d{14}-[0-9a-f]{12}$`)
+	pseudoVersionRegexp = regexp.MustCompile(`\b\d{14}-[0-9a-f]{12}$`)
 )
 
 type Dependency struct {

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -5,6 +5,7 @@ require "dependabot/update_checkers/base"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/go_modules/native_helpers"
+require "dependabot/go_modules/version"
 
 module Dependabot
   module GoModules

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -113,11 +113,21 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
     it "doesn't updates Git SHAs to releases that don't include them"
 
     context "for Git pseudo-versions" do
-      let(:dependency_version) { "1.2.0-pre2.0.20181018214848-1f3e41dce654" }
+      context "with releases available" do
+        let(:dependency_version) { "1.0.0-20181018214848-ab544413d0d3" }
 
-      pending "updates to newer commits to master" do
-        expect(latest_resolvable_version.to_s).
-          to eq("1.2.0-pre2.0.20181018214848-bbed29f74d16")
+        it "doesn't update them, currently" do
+          expect(latest_resolvable_version.to_s).to eq(dependency_version)
+        end
+      end
+
+      context "with newer revisions available" do
+        let(:dependency_version) { "1.2.0-pre2.0.20181018214848-1f3e41dce654" }
+
+        pending "updates to newer commits to master" do
+          expect(latest_resolvable_version.to_s).
+            to eq("1.2.0-pre2.0.20181018214848-bbed29f74d16")
+        end
       end
     end
 


### PR DESCRIPTION
We do want to support this in the future, but it needs more thought - we should do it well or not at all.