### PR TITLE
Parse `git@github.com:` Terraform module sources

### DIFF
--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -194,7 +194,8 @@ module Dependabot
       # rubocop:disable Metrics/PerceivedComplexity
       def source_type(source_string)
         return :path if source_string.start_with?(".")
-        return :github if source_string.start_with?("github.com/")
+        return :github if source_string.start_with?("github.com/",
+                                                    "git@github.com:")
         return :bitbucket if source_string.start_with?("bitbucket.org/")
         return :git if source_string.start_with?("git::")
         return :mercurial if source_string.start_with?("hg::")

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
     context "with git sources" do
       let(:terraform_fixture_name) { "git_tags.tf" }
 
-      its(:length) { is_expected.to eq(5) }
+      its(:length) { is_expected.to eq(6) }
 
       describe "the first dependency (which uses git:: with a tag)" do
         subject(:dependency) { dependencies.first }
@@ -236,6 +236,30 @@ RSpec.describe Dependabot::Terraform::FileParser do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("dns")
           expect(dependency.version).to eq("0.2.5")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+
+      describe "the sixth dependency (which uses git@github.com SSH prefix)" do
+        subject(:dependency) { dependencies[5] }
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: "main.tf",
+            source: {
+              type: "git",
+              url: "git@github.com:cloudposse/terraform-null-label.git",
+              branch: nil,
+              ref: "tags/0.3.7"
+            }
+          }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("github_ssh_without_protocol")
+          expect(dependency.version).to eq("0.3.7")
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end

--- a/terraform/spec/fixtures/config_files/git_tags.tf
+++ b/terraform/spec/fixtures/config_files/git_tags.tf
@@ -131,3 +131,13 @@ module "duplicate_label" {
   attributes = ["${compact(concat(var.attributes, list("origin")))}"]
   tags       = "${var.tags}"
 }
+
+module "github_ssh_without_protocol" {
+  source     = "git@github.com:cloudposse/terraform-null-label.git?ref=tags/0.3.7"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+  tags       = "${var.tags}"
+}


### PR DESCRIPTION
Terraform handles a module source prefixed by `git@github.com:` as a
type of Git repo pointing to GitHub automatically[1][2]. This commit adds
parsing of these GitHub SSH sources to match the existing parsing for
GitHub HTTP sources.

[1]https://www.terraform.io/docs/modules/sources.html#github
[2]https://github.com/hashicorp/terraform/blob/6fe2703/vendor/github.com/hashicorp/go-getter/detect_github.go#L20-L21

---

Example repo: https://github.com/gruntwork-io/terragrunt-infrastructure-modules-example/blob/master/consul/main.tf#L28

![screen shot 2019-02-28 at 16 26 02](https://user-images.githubusercontent.com/482089/53584918-a7e07780-3b7c-11e9-8c5d-2d2ba00c7840.png)
