### PR TITLE
Ruby: Handle circular dependencies at the latest version

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
@@ -124,7 +124,7 @@ module Dependabot
             # We don't have access to one of repos required
             raise Dependabot::GitDependenciesNotReachable, bad_uris
           when "Bundler::GemNotFound", "Gem::InvalidSpecificationException",
-               "Bundler::VersionConflict"
+               "Bundler::VersionConflict", "Bundler::CyclicDependencyError"
             # Bundler threw an error during resolution. Any of:
             # - the gem doesn't exist in any of the specified sources
             # - the gem wasn't specified properly

--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -261,6 +261,14 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
           its([:version]) { is_expected.to eq(Gem::Version.new("1.3.1")) }
         end
       end
+
+      context "when unlocking a git dependency would cause errors" do
+        let(:current_version) { "1.4.0" }
+        let(:gemfile_fixture_name) { "git_source_circular" }
+        let(:lockfile_fixture_name) { "git_source_circular.lock" }
+
+        its([:version]) { is_expected.to eq(Gem::Version.new("1.8.0")) }
+      end
     end
 
     context "with a private gemserver source" do
@@ -321,6 +329,27 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
           expect { subject }.
             to raise_error(Dependabot::PathDependenciesNotReachable)
         end
+      end
+    end
+
+    context "given a git source" do
+      context "where updating would cause a circular dependency" do
+        let(:gemfile_fixture_name) { "git_source_circular" }
+        let(:lockfile_fixture_name) { "git_source_circular.lock" }
+
+        let(:dependency_name) { "rubygems-circular-dependency" }
+        let(:current_version) { "3c85f0bd8d6977b4dfda6a12acf93a282c4f5bf1" }
+        let(:source) do
+          {
+            type: "git",
+            url: "https://github.com/dependabot-fixtures/"\
+                 "rubygems-circular-dependency",
+            branch: "master",
+            ref: "master"
+          }
+        end
+
+        it { is_expected.to be_nil }
       end
     end
 

--- a/bundler/spec/fixtures/ruby/gemfiles/git_source_circular
+++ b/bundler/spec/fixtures/ruby/gemfiles/git_source_circular
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "rubygems-circular-dependency", git: "https://github.com/dependabot-fixtures/rubygems-circular-dependency"
+gem "business"

--- a/bundler/spec/fixtures/ruby/lockfiles/git_source_circular.lock
+++ b/bundler/spec/fixtures/ruby/lockfiles/git_source_circular.lock
@@ -1,0 +1,20 @@
+GIT
+  remote: https://github.com/dependabot-fixtures/rubygems-circular-dependency
+  revision: 3c85f0bd8d6977b4dfda6a12acf93a282c4f5bf1
+  specs:
+    rubygems-circular-dependency (0.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business
+  rubygems-circular-dependency!
+
+BUNDLED WITH
+   1.17.3


### PR DESCRIPTION
That. Doesn't happen often, but we should quietly not update to bad versions if/when it does.