### PR TITLE
JS: Ignore URL-style versions in npm lockfiles in NpmAndYarn::FileParser::LockfileParser

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
@@ -108,6 +108,12 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         its(:length) { is_expected.to eq(9) }
       end
 
+      context "that has URL versions (i.e., is from a bad version of npm)" do
+        let(:npm_lockfile_fixture_name) { "url_versions.json" }
+        # All but 1 dependency in the lockfile has a URL version
+        its(:length) { is_expected.to eq(1) }
+      end
+
       context "that contain bad json" do
         let(:npm_lockfile_content) do
           '{ "bad": "json" "no": "comma" }'


### PR DESCRIPTION
Fixes https://sentry.io/organizations/dependabot/issues/906729855/?project=160754&referrer=RegressionActivityEmail&statsPeriod=14d