### PR TITLE
Install php7.2-gmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" >> /etc/ap
     && echo "deb-src http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" >> /etc/apt/sources.list.d/ondrej-php.list \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C \
     && apt-get update \
-    && apt-get install -y php7.2 php7.2-xml php7.2-json php7.2-zip php7.2-mbstring php7.2-intl php7.2-common php7.2-gettext php7.2-curl php-xdebug php7.2-bcmath php-gmp php7.2-imagick php7.2-gd php7.2-redis php7.2-soap php7.2-ldap php7.2-memcached php7.2-sqlite3 php7.2-apcu php7.2-mongodb php-zmq \
+    && apt-get install -y php7.2 php7.2-xml php7.2-json php7.2-zip php7.2-mbstring php7.2-intl php7.2-common php7.2-gettext php7.2-curl php-xdebug php7.2-bcmath php7.2-gmp php7.2-imagick php7.2-gd php7.2-redis php7.2-soap php7.2-ldap php7.2-memcached php7.2-sqlite3 php7.2-apcu php7.2-mongodb php-zmq \
     && curl -sS https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer
 


### PR DESCRIPTION
`ext-gmp` seems to be reported missing so trying to install the gmp for php 7.2:

```
erorus/db2 dev-master requires ext-gmp * -> the requested PHP extension gmp is missing from your system.
```