### PR TITLE
PHP: Assume compatible platform by default without ignoring checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" >> /etc/ap
     && echo "deb-src http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" >> /etc/apt/sources.list.d/ondrej-php.list \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C \
     && apt-get update \
-    && apt-get install -y php7.2 php7.2-xml php7.2-json php7.2-zip php7.2-mbstring php7.2-intl php7.2-common php7.2-gettext php7.2-curl php-xdebug php7.2-bcmath php7.2-gmp php7.2-imagick php7.2-gd php7.2-redis php7.2-soap php7.2-ldap php7.2-memcached php7.2-sqlite3 php7.2-apcu php7.2-mongodb php-zmq \
+    && apt-get install -y php7.2 php7.2-common php7.2-curl php7.2-json php7.2-zip \
     && curl -sS https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer
 

--- a/composer/helpers/src/UpdateChecker.php
+++ b/composer/helpers/src/UpdateChecker.php
@@ -70,11 +70,63 @@ class UpdateChecker
 
         /*
          * If a platform is set we assume people know what they are doing and we respect the setting.
-         * If no platform is set we ignore it so that the php we run as doesn't interfere
+         * If no platform is set we assume platform compatibility.
          */
-        if ($config->get('platform') === []) {
-            $install->setIgnorePlatformRequirements(true);
-        }
+        $platform = array_merge([
+            'php' => '*',
+            'ext-apcu' => '*',
+            'ext-bcmath' => '*',
+            'ext-bz2' => '*',
+            'ext-curl' => '*',
+            'ext-fileinfo' => '*',
+            'ext-gd' => '*',
+            'ext-gd2' => '*',
+            'ext-gettext' => '*',
+            'ext-gmp' => '*',
+            'ext-intl' => '*',
+            'ext-imagick' => '*',
+            'ext-imap' => '*',
+            'ext-interbase' => '*',
+            'ext-json' => '*',
+            'ext-ldap' => '*',
+            'ext-mbstring' => '*',
+            'ext-memcached' => '*',
+            'ext-mongodb' => '*',
+            'ext-exif' => '*',
+            'ext-mysqli' => '*',
+            'ext-oci8_12c' => '*',
+            'ext-odbc' => '*',
+            'ext-openssl' => '*',
+            'ext-pdo_firebird' => '*',
+            'ext-pdo_mysql' => '*',
+            'ext-pdo_oci' => '*',
+            'ext-pdo_odbc' => '*',
+            'ext-pdo_pgsql' => '*',
+            'ext-pdo_sqlite' => '*',
+            'ext-pgsql' => '*',
+            'ext-redis' => '*',
+            'ext-shmop' => '*',
+            'ext-snmp' => '*',
+            'ext-soap' => '*',
+            'ext-sockets' => '*',
+            'ext-sodium' => '*',
+            'ext-sqlite3' => '*',
+            'ext-tidy' => '*',
+            'ext-xdebug' => '*',
+            'ext-xml' => '*',
+            'ext-xmlrpc' => '*',
+            'ext-xsl' => '*',
+            'ext-zip' => '*',
+            'ext-zmq' => '*',
+        ], $config->get('platform'));
+
+        $config->merge(
+            [
+                'config' => [
+                    'platform' => $platform,
+                ],
+            ]
+        );
 
         $install->run();
 

--- a/composer/helpers/src/Updater.php
+++ b/composer/helpers/src/Updater.php
@@ -78,11 +78,63 @@ class Updater
 
         /*
          * If a platform is set we assume people know what they are doing and we respect the setting.
-         * If no platform is set we ignore it so that the php we run as doesn't interfere
+         * If no platform is set we assume platform compatibility.
          */
-        if ($config->get('platform') === []) {
-            $install->setIgnorePlatformRequirements(true);
-        }
+        $platform = array_merge([
+            'php' => '*',
+            'ext-apcu' => '*',
+            'ext-bcmath' => '*',
+            'ext-bz2' => '*',
+            'ext-curl' => '*',
+            'ext-fileinfo' => '*',
+            'ext-gd' => '*',
+            'ext-gd2' => '*',
+            'ext-gettext' => '*',
+            'ext-gmp' => '*',
+            'ext-intl' => '*',
+            'ext-imagick' => '*',
+            'ext-imap' => '*',
+            'ext-interbase' => '*',
+            'ext-json' => '*',
+            'ext-ldap' => '*',
+            'ext-mbstring' => '*',
+            'ext-memcached' => '*',
+            'ext-mongodb' => '*',
+            'ext-exif' => '*',
+            'ext-mysqli' => '*',
+            'ext-oci8_12c' => '*',
+            'ext-odbc' => '*',
+            'ext-openssl' => '*',
+            'ext-pdo_firebird' => '*',
+            'ext-pdo_mysql' => '*',
+            'ext-pdo_oci' => '*',
+            'ext-pdo_odbc' => '*',
+            'ext-pdo_pgsql' => '*',
+            'ext-pdo_sqlite' => '*',
+            'ext-pgsql' => '*',
+            'ext-redis' => '*',
+            'ext-shmop' => '*',
+            'ext-snmp' => '*',
+            'ext-soap' => '*',
+            'ext-sockets' => '*',
+            'ext-sodium' => '*',
+            'ext-sqlite3' => '*',
+            'ext-tidy' => '*',
+            'ext-xdebug' => '*',
+            'ext-xml' => '*',
+            'ext-xmlrpc' => '*',
+            'ext-xsl' => '*',
+            'ext-zip' => '*',
+            'ext-zmq' => '*',
+        ], $config->get('platform'));
+
+        $config->merge(
+            [
+                'config' => [
+                    'platform' => $platform,
+                ],
+            ]
+        );
 
         $install->run();
 


### PR DESCRIPTION
While waiting for https://github.com/composer/composer/issues/7884 as explained in #890, what about assuming full compatibility by default without breaking explicit requirements?
When platform config is provided, we still use these requirement without the needed to provide real extensions locally elsewhere required.

Refs: #527 & #394