### PR TITLE
NPM: Raise helpful error when lockfile is corrupt

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -1802,7 +1802,12 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           let(:files) { [package_json, package_lock] }
           it "raises a helpful error" do
             expect { updated_files }.
-              to raise_error(Dependabot::DependencyFileNotResolvable)
+              to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
+                expect(error.message).
+                  to include(
+                    "lockfile has some corrupt entries with missing versions"
+                  )
+              end
           end
         end
       end


### PR DESCRIPTION
Adding a better error message when the lockfile is corrupt with
instructions to re-generating the lockfile.

Previously when a version was missing from some entries in package-lock
or npm-shrinkwrap you get a pretty unhelpful error saying:
`Cannot read property 'match' of undefined`