### PR TITLE
Cargo: Remove lockfile duplicates

### DIFF
--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -203,6 +203,17 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
               to include("git+ssh://git@github.com/BurntSushi/utf8-ranges#"\
                          "74dc0260efd2c5e17c35643a2b47dc508ec823fd")
             expect(updated_lockfile_content).to_not include("git+https://")
+
+            expect(updated_lockfile_content).to include(
+              "[metadata]\n"\
+              '"checksum utf8-ranges 1.0.2 (git+ssh://git@github.com/'\
+              "BurntSushi/utf8-ranges)\" = \"<none>\"\n"\
+              '"checksum utf8-ranges-parent 1.0.2 (git+ssh://git@github.com/'\
+              "dependabot-fixtures/utf8-ranges)\" = \"<none>\""
+            )
+
+            content = updated_lockfile_content
+            expect(content.scan(/name = "utf8-ranges"/).count).to eq(1)
           end
         end
 

--- a/cargo/spec/fixtures/lockfiles/git_dependency_ssh
+++ b/cargo/spec/fixtures/lockfiles/git_dependency_ssh
@@ -3,6 +3,7 @@ name = "dependabot"
 version = "0.1.0"
 dependencies = [
  "utf8-ranges 1.0.0 (git+ssh://git@github.com/BurntSushi/utf8-ranges)",
+ "utf8-ranges-parent 1.0.2 (git+ssh://git@github.com/dependabot-fixtures/utf8-ranges)",
 ]
 
 [[package]]
@@ -10,5 +11,14 @@ name = "utf8-ranges"
 version = "1.0.0"
 source = "git+ssh://git@github.com/BurntSushi/utf8-ranges#83141b376b93484341c68fbca3ca110ae5cd2708"
 
+[[package]]
+name = "utf8-ranges-parent"
+version = "1.0.2"
+source = "git+ssh://git@github.com/dependabot-fixtures/utf8-ranges#9996043f61e9bd18eead9051a238271478089bd2"
+dependencies = [
+ "utf8-ranges 1.0.0 (git+ssh://git@github.com/BurntSushi/utf8-ranges)",
+]
+
 [metadata]
 "checksum utf8-ranges 1.0.0 (git+ssh://git@github.com/BurntSushi/utf8-ranges)" = "<none>"
+"checksum utf8-ranges-parent 1.0.2 (git+ssh://git@github.com/dependabot-fixtures/utf8-ranges)" = "<none>"

--- a/cargo/spec/fixtures/manifests/git_dependency_ssh
+++ b/cargo/spec/fixtures/manifests/git_dependency_ssh
@@ -5,3 +5,4 @@ authors = ["support@dependabot.com"]
 
 [dependencies]
 utf8-ranges = { git = "ssh://git@github.com/BurntSushi/utf8-ranges" }
+utf8-ranges-parent = { git = "ssh://git@github.com/dependabot-fixtures/utf8-ranges" }


### PR DESCRIPTION
~~Needs a test.~~

Because we switch git URLs from SSH to HTTPS, we can sometimes get duplicates in the lockfile. The only way to remove them is to regex through.