### PR TITLE
Sign commits on behalf of an org

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -61,7 +61,7 @@ module Dependabot
         message = commit_subject + "\n\n"
         message += commit_message_intro
         message += metadata_links
-        message += "\n\n" + signoff_message if signoff_message
+        message += "\n\n" + message_trailers if message_trailers
         message
       end
 
@@ -89,11 +89,25 @@ module Dependabot
         "\n\n#{pr_message_footer}"
       end
 
+      def message_trailers
+        return unless on_behalf_of_message || signoff_message
+
+        [on_behalf_of_message, signoff_message].compact.join("\n")
+      end
+
       def signoff_message
         return unless author_details.is_a?(Hash)
         return unless author_details[:name] && author_details[:email]
 
         "Signed-off-by: #{author_details[:name]} <#{author_details[:email]}>"
+      end
+
+      def on_behalf_of_message
+        return unless author_details.is_a?(Hash)
+        return unless author_details[:org_name] && author_details[:org_email]
+
+        "On-behalf-of: @#{author_details[:org_name]} "\
+        "<#{author_details[:org_email]}>"
       end
 
       def library_pr_name

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1479,6 +1479,24 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         expect(commit_message).
           to end_with("\n\nSigned-off-by: dependabot <support@dependabot.com>")
       end
+
+      context "that includes org details" do
+        let(:author_details) do
+          {
+            email: "support@dependabot.com",
+            name: "dependabot",
+            org_email: "support@tutum.com",
+            org_name: "tutum"
+          }
+        end
+
+        it "includes an on-behalf-of line" do
+          expect(commit_message).to end_with(
+            "\n\nOn-behalf-of: @tutum <support@tutum.com>\n"\
+            "Signed-off-by: dependabot <support@dependabot.com>"
+          )
+        end
+      end
     end
 
     context "for a repo that uses gitmoji commits" do


### PR DESCRIPTION
That. See https://github.blog/changelog/2019-03-15-creating-a-commit-on-behalf-of-an-organization/.