### PR TITLE
PHP: Remove overzealous use of shellwords

### DIFF
--- a/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
@@ -53,7 +53,7 @@ module Dependabot
         def run_update_helper
           SharedHelpers.with_git_configured(credentials: credentials) do
             SharedHelpers.run_helper_subprocess(
-              command: Shellwords.join(["php", php_helper_path]),
+              command: "php -d memory_limit=-1 #{php_helper_path}",
               function: "update",
               env: credentials_env,
               args: [

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -65,9 +65,8 @@ module Dependabot
 
         def run_update_checker
           SharedHelpers.with_git_configured(credentials: credentials) do
-            cmd_parts = ["php", "-d", "memory_limit=-1", php_helper_path]
             SharedHelpers.run_helper_subprocess(
-              command: Shellwords.join(cmd_parts),
+              command: "php -d memory_limit=-1 #{php_helper_path}",
               function: "get_latest_resolvable_version",
               args: [
                 Dir.pwd,


### PR DESCRIPTION
That. There's no user input to sanitize here, and we don't want the `memory_limit =-1` to get escaped.

I did a sweep of the codebase and there are no other places where we have this problem.