### PR TITLE
NPM: ignore lifecycle scripts when installing@git

### DIFF
--- a/npm_and_yarn/helpers/lib/npm/peer-dependency-checker.js
+++ b/npm_and_yarn/helpers/lib/npm/peer-dependency-checker.js
@@ -38,12 +38,16 @@ async function checkPeerDependencies(
   //
   // `'prefer-offline': true` sets fetch() cache key to `force-cache`
   // https://github.com/npm/npm-registry-fetch
+  //
+  // `'ignore-scripts': true` used to disable prepare and prepack scripts
+  // which are run when installing git dependencies
   await runAsync(npm, npm.load, [
     {
       loglevel: "silent",
       force: true,
       audit: false,
       "prefer-offline": true,
+      "ignore-scripts": true,
       save: false
     }
   ]);

--- a/npm_and_yarn/helpers/lib/npm/subdependency-updater.js
+++ b/npm_and_yarn/helpers/lib/npm/subdependency-updater.js
@@ -16,12 +16,16 @@ async function updateDependencyFile(directory, lockfileName) {
   //
   // `'prefer-offline': true` sets fetch() cache key to `force-cache`
   // https://github.com/npm/npm-registry-fetch
+  //
+  // `'ignore-scripts': true` used to disable prepare and prepack scripts
+  // which are run when installing git dependencies
   await runAsync(npm, npm.load, [
     {
       loglevel: "silent",
       force: true,
       audit: false,
-      "prefer-offline": true
+      "prefer-offline": true,
+      "ignore-scripts": true
     }
   ]);
 

--- a/npm_and_yarn/helpers/lib/npm/updater.js
+++ b/npm_and_yarn/helpers/lib/npm/updater.js
@@ -31,12 +31,16 @@ async function updateDependencyFiles(directory, dependencies, lockfileName) {
   //
   // `'prefer-offline': true` sets fetch() cache key to `force-cache`
   // https://github.com/npm/npm-registry-fetch
+  //
+  // `'ignore-scripts': true` used to disable prepare and prepack scripts
+  // which are run when installing git dependencies
   await runAsync(npm, npm.load, [
     {
       loglevel: "silent",
       force: true,
       audit: false,
-      "prefer-offline": true
+      "prefer-offline": true,
+      "ignore-scripts": true
     }
   ]);
   const manifest = JSON.parse(readFile("package.json"));


### PR DESCRIPTION
When installing a package from git npm will run the scripts `prepare`
and `prepack` if defined in pacakge.json scripts.

This fails on aws and we shouldn't need to run any prepare/prepack
scripts to build a lockfile. These scripts are commonly used to babel
transpile the src.