### PR TITLE
NPM: Fix git dependencies with invalid requires

### DIFF
--- a/npm_and_yarn/spec/fixtures/npm_lockfiles/git_sub_dep_invalid_from.json
+++ b/npm_and_yarn/spec/fixtures/npm_lockfiles/git_sub_dep_invalid_from.json
@@ -87,7 +87,7 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
       "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
       "requires": {
-        "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+        "bignumber.js": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",


### PR DESCRIPTION
Sanitise the lockfile before first install removing any invalid `from`
and `requries` for git dependencies.