### PR TITLE
NPM: Fix "premature close" for git dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -158,3 +158,14 @@ RUN bash /opt/terraform/helpers/build /opt/terraform && \
     bash /opt/npm_and_yarn/helpers/build /opt/npm_and_yarn && \
     bash /opt/hex/helpers/build /opt/hex && \
     bash /opt/composer/helpers/build /opt/composer
+
+# Force npm to run installs without downloading any files or running any
+# lifecycle hooks. This prevents npm from running prepare and prepack scripts
+# when installing git dependencies which is likely to fail inside the updater
+# container. We need to set this config globally to make it work for git
+# dependencies, which are installed by shelling out to npm without the dry-run
+# flag that was passed to the installer from the npm helpers in dependabot-core.
+#
+# Sets global config in /usr/etc/npmrc - "-g" is needed because we're running as
+# root here and not "dependabot" which is used by the updater
+RUN npm config set dry-run true -g


### PR DESCRIPTION
This error is caused by package prepare/prepack scripts that fail to
execute.

Setting `dry-run` globally is the only way to get npm to pick up the
config setting when installing git dependencies. When installing git
dependencies npm will shell out out to the cli and loosing
all config passed to the installer from `npm/updater.js`.

Code calling `npm install` from npm:
https://github.com/npm/cli/blob/latest/lib/pack.js#L293:L312