### PR TITLE
Maven: Upgrade to lowest fixed version if a dependency is vulnerable

### DIFF
--- a/maven/lib/dependabot/maven/update_checker/property_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/property_updater.rb
@@ -32,7 +32,8 @@ module Dependabot
                 dependency: dep,
                 dependency_files: dependency_files,
                 credentials: credentials,
-                ignored_versions: ignored_versions
+                ignored_versions: ignored_versions,
+                security_advisories: []
               ).versions.map { |v| v.fetch(:version) }
 
               versions.include?(updated_version(dep)) || versions.none?

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -14,41 +14,37 @@ module Dependabot
         TYPE_SUFFICES = %w(jre android java).freeze
 
         def initialize(dependency:, dependency_files:, credentials:,
-                       ignored_versions:)
-          @dependency       = dependency
-          @dependency_files = dependency_files
-          @credentials      = credentials
-          @ignored_versions = ignored_versions
-          @forbidden_urls   = []
+                       ignored_versions:, security_advisories:)
+          @dependency          = dependency
+          @dependency_files    = dependency_files
+          @credentials         = credentials
+          @ignored_versions    = ignored_versions
+          @security_advisories = security_advisories
+          @forbidden_urls      = []
         end
 
         def latest_version_details
           possible_versions = versions
 
-          unless wants_prerelease?
-            possible_versions =
-              possible_versions.
-              reject { |v| v.fetch(:version).prerelease? }
-          end
-
-          unless wants_date_based_version?
-            possible_versions =
-              possible_versions.
-              reject { |v| v.fetch(:version) > version_class.new(1900) }
-          end
-
-          possible_versions =
-            possible_versions.
-            select { |v| matches_dependency_version_type?(v.fetch(:version)) }
-
-          ignored_versions.each do |req|
-            ignore_req = Maven::Requirement.new(req.split(","))
-            possible_versions =
-              possible_versions.
-              reject { |v| ignore_req.satisfied_by?(v.fetch(:version)) }
-          end
+          possible_versions = filter_prereleases(possible_versions)
+          possible_versions = filter_date_based_versions(possible_versions)
+          possible_versions = filter_version_types(possible_versions)
+          possible_versions = filter_ignored_versions(possible_versions)
 
           possible_versions.reverse.find { |v| released?(v.fetch(:version)) }
+        end
+
+        def lowest_security_fix_version_details
+          possible_versions = versions
+
+          possible_versions = filter_prereleases(possible_versions)
+          possible_versions = filter_date_based_versions(possible_versions)
+          possible_versions = filter_version_types(possible_versions)
+          possible_versions = filter_ignored_versions(possible_versions)
+          possible_versions = filter_vulnerable_versions(possible_versions)
+          possible_versions = filter_lower_versions(possible_versions)
+
+          possible_versions.find { |v| released?(v.fetch(:version)) }
         end
 
         def versions
@@ -72,7 +68,56 @@ module Dependabot
         private
 
         attr_reader :dependency, :dependency_files, :credentials,
-                    :ignored_versions, :forbidden_urls
+                    :ignored_versions, :forbidden_urls, :security_advisories
+
+        def filter_prereleases(possible_versions)
+          return possible_versions if wants_prerelease?
+
+          possible_versions.reject { |v| v.fetch(:version).prerelease? }
+        end
+
+        def filter_date_based_versions(possible_versions)
+          return possible_versions if wants_date_based_version?
+
+          possible_versions.
+            reject { |v| v.fetch(:version) > version_class.new(1900) }
+        end
+
+        def filter_version_types(possible_versions)
+          possible_versions.
+            select { |v| matches_dependency_version_type?(v.fetch(:version)) }
+        end
+
+        def filter_ignored_versions(possible_versions)
+          versions_array = possible_versions
+
+          ignored_versions.each do |req|
+            ignore_req = Maven::Requirement.new(req.split(","))
+            versions_array =
+              versions_array.
+              reject { |v| ignore_req.satisfied_by?(v.fetch(:version)) }
+          end
+
+          versions_array
+        end
+
+        def filter_vulnerable_versions(possible_versions)
+          versions_array = possible_versions
+
+          security_advisories.each do |advisory|
+            versions_array =
+              versions_array.
+              reject { |v| advisory.vulnerable?(v.fetch(:version)) }
+          end
+
+          versions_array
+        end
+
+        def filter_lower_versions(possible_versions)
+          possible_versions.select do |v|
+            v.fetch(:version) > version_class.new(dependency.version)
+          end
+        end
 
         def wants_prerelease?
           return false unless dependency.version


### PR DESCRIPTION
That. This is pretty simple, since we don't consider resolvability for Maven. Hooks into the logic added to common [here](https://github.com/dependabot/dependabot-core/commit/0549ebab2530b8287654da00ee382e72f4814c54).

Idea is that users would prefer minimal changes when fixing a security vulnerability. We'll roll this out across all languages over time (some are harder than others!).