### PR TITLE
.NET: Upgrade to lowest fixed version if a dependency is vulnerable

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/property_updater.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/property_updater.rb
@@ -30,7 +30,8 @@ module Dependabot
                 dependency: dep,
                 dependency_files: dependency_files,
                 credentials: credentials,
-                ignored_versions: ignored_versions
+                ignored_versions: ignored_versions,
+                security_advisories: []
               ).versions.map { |v| v.fetch(:version) }
 
               versions.include?(target_version) || versions.none?


### PR DESCRIPTION
Same as https://github.com/dependabot/dependabot-core/pull/1107, but for .NET.