### PR TITLE
Gradle: Upgrade to lowest fixed version if a dependency is vulnerable

### DIFF
--- a/gradle/lib/dependabot/gradle/update_checker.rb
+++ b/gradle/lib/dependabot/gradle/update_checker.rb
@@ -27,6 +27,13 @@ module Dependabot
         latest_version
       end
 
+      def lowest_resolvable_security_fix_version
+        return nil if version_comes_from_multi_dependency_property?
+        return nil if version_comes_from_dependency_set?
+
+        lowest_security_fix_version_details&.fetch(:version)
+      end
+
       def latest_resolvable_version_with_no_unlock
         # Irrelevant, since Gradle has a single dependency file.
         #
@@ -45,8 +52,8 @@ module Dependabot
 
         RequirementsUpdater.new(
           requirements: dependency.requirements,
-          latest_version: latest_version&.to_s,
-          source_url: latest_version_details&.fetch(:source_url),
+          latest_version: preferred_resolvable_version&.to_s,
+          source_url: preferred_version_details&.fetch(:source_url),
           properties_to_update: property_names
         ).updated_requirements
       end
@@ -84,8 +91,19 @@ module Dependabot
         super
       end
 
+      def preferred_version_details
+        return lowest_security_fix_version_details if vulnerable?
+
+        latest_version_details
+      end
+
       def latest_version_details
         @latest_version_details ||= version_finder.latest_version_details
+      end
+
+      def lowest_security_fix_version_details
+        @lowest_security_fix_version_details ||=
+          version_finder.lowest_security_fix_version_details
       end
 
       def version_finder
@@ -93,7 +111,8 @@ module Dependabot
           VersionFinder.new(
             dependency: dependency,
             dependency_files: dependency_files,
-            ignored_versions: ignored_versions
+            ignored_versions: ignored_versions,
+            security_advisories: security_advisories
           )
       end
 

--- a/gradle/lib/dependabot/gradle/update_checker/multi_dependency_updater.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/multi_dependency_updater.rb
@@ -27,7 +27,8 @@ module Dependabot
               VersionFinder.new(
                 dependency: dep,
                 dependency_files: dependency_files,
-                ignored_versions: ignored_versions
+                ignored_versions: ignored_versions,
+                security_advisories: []
               ).versions.
                 map { |v| v.fetch(:version) }.
                 include?(target_version)
@@ -81,10 +82,6 @@ module Dependabot
           @dependency_set ||= dependency.requirements.
                               find { |r| r.dig(:metadata, :dependency_set) }&.
                               dig(:metadata, :dependency_set)
-        end
-
-        def pom
-          dependency_files.find { |f| f.name == "pom.xml" }
         end
 
         def updated_requirements(dep)

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -10,11 +10,13 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
     described_class.new(
       dependency: dependency,
       dependency_files: dependency_files,
-      ignored_versions: ignored_versions
+      ignored_versions: ignored_versions,
+      security_advisories: security_advisories
     )
   end
   let(:version_class) { Dependabot::Gradle::Version }
   let(:ignored_versions) { [] }
+  let(:security_advisories) { [] }
 
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -126,6 +128,25 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
       its([:source_url]) do
         is_expected.to eq("https://maven.google.com")
       end
+    end
+  end
+
+  describe "#lowest_security_fix_version_details" do
+    subject { finder.lowest_security_fix_version_details }
+
+    let(:dependency_version) { "18.0" }
+    let(:security_advisories) do
+      [
+        Dependabot::SecurityAdvisory.new(
+          package_manager: "gradle",
+          safe_versions: ["> 19.0"]
+        )
+      ]
+    end
+
+    its([:version]) { is_expected.to eq(version_class.new("20.0")) }
+    its([:source_url]) do
+      is_expected.to eq("https://repo.maven.apache.org/maven2")
     end
   end
 


### PR DESCRIPTION
Same as #1107, but for Gradle.