### PR TITLE
NPM: Fix update checker for deprecated deps

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -55,8 +55,10 @@ module Dependabot
 
       def updated_requirements
         resolvable_version =
-          if [version_class, NilClass].include?(preferred_resolvable_version)
-            preferred_resolvable_version&.to_s
+          if preferred_resolvable_version.is_a?(version_class)
+            preferred_resolvable_version.to_s
+          elsif preferred_resolvable_version.nil?
+            nil
           else
             # If the preferred_resolvable_version came back as anything other
             # than a version class or `nil` it must be because this is a git

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
@@ -768,6 +768,16 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
         its([:version]) { is_expected.to eq(Gem::Version.new("1.7.0")) }
       end
     end
+
+    context "when the dependency has been deprecated" do
+      let(:registry_response) do
+        fixture("npm_responses", "etag_deprecated.json")
+      end
+
+      it "picks the latest dist-tags version" do
+        expect(subject[:version]).to eq(Gem::Version.new("1.7.0"))
+      end
+    end
   end
 
   describe "#latest_resolvable_version_with_no_unlock" do
@@ -845,6 +855,14 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
         it { is_expected.to eq(Gem::Version.new("1.5.0")) }
       end
     end
+
+    context "when the dependency has been deprecated" do
+      let(:registry_response) do
+        fixture("npm_responses", "etag_deprecated.json")
+      end
+
+      it { is_expected.to eq(nil) }
+    end
   end
 
   describe "#possible_versions" do
@@ -882,6 +900,14 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
           ]
         )
       end
+    end
+
+    context "when the dependency has been deprecated" do
+      let(:registry_response) do
+        fixture("npm_responses", "etag_deprecated.json")
+      end
+
+      it { is_expected.to eq([]) }
     end
   end
 

--- a/npm_and_yarn/spec/fixtures/npm_responses/etag_deprecated.json
+++ b/npm_and_yarn/spec/fixtures/npm_responses/etag_deprecated.json
@@ -1,0 +1,874 @@
+{
+  "_attachments": {},
+  "_id": "etag",
+  "_rev": "27-f99109879afdc9fa5a0757c26b02e51e",
+  "bugs": {
+    "url": "https://github.com/jshttp/etag/issues"
+  },
+  "contributors": [
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "Douglas Christopher Wilson"
+    },
+    {
+      "email": "david.bjorklund@gmail.com",
+      "name": "David Bjarklund"
+    }
+  ],
+  "description": "Create simple ETags",
+  "dist-tags": {
+    "latest": "1.7.0",
+    "stable": "1.5.1"
+  },
+  "homepage": "https://github.com/jshttp/etag",
+  "keywords": ["etag", "http", "res"],
+  "license": "MIT",
+  "maintainers": [
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    }
+  ],
+  "name": "etag",
+  "readme": "# etag\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nCreate simple ETags\n\n## Installation\n\n```sh\n$ npm install etag\n```\n\n## API\n\n```js\nvar etag = require('etag')\n```\n\n### etag(entity, [options])\n\nGenerate a strong ETag for the given entity. This should be the complete\nbody of the entity. Strings, `Buffer`s, and `fs.Stats` are accepted. By\ndefault, a strong ETag is generated except for `fs.Stats`, which will\ngenerate a weak ETag (this can be overwritten by `options.weak`).\n\n```js\nres.setHeader('ETag', etag(body))\n```\n\n#### Options\n\n`etag` accepts these properties in the options object.\n\n##### weak\n\nSpecifies if the generated ETag will include the weak validator mark (that\nis, the leading `W/`). The actual entity tag is the same. The default value\nis `false`, unless the `entity` is `fs.Stats`, in which case it is `true`.\n\n## Testing\n\n```sh\n$ npm test\n```\n\n## Benchmark\n\n```bash\n$ npm run-script bench\n\n> etag@1.6.0 bench nodejs-etag\n> node benchmark/index.js\n\n  http_parser@1.0\n  node@0.10.33\n  v8@3.14.5.9\n  ares@1.9.0-DEV\n  uv@0.10.29\n  zlib@1.2.3\n  modules@11\n  openssl@1.0.1j\n\n> node benchmark/body0-100b.js\n\n  100B body\n\n  1 test completed.\n  2 tests completed.\n  3 tests completed.\n  4 tests completed.\n\n* buffer - strong x 289,198 ops/sec Â±1.09% (190 runs sampled)\n* buffer - weak   x 287,838 ops/sec Â±0.91% (189 runs sampled)\n* string - strong x 284,586 ops/sec Â±1.05% (192 runs sampled)\n* string - weak   x 287,439 ops/sec Â±0.82% (192 runs sampled)\n\n> node benchmark/body1-1kb.js\n\n  1KB body\n\n  1 test completed.\n  2 tests completed.\n  3 tests completed.\n  4 tests completed.\n\n* buffer - strong x 212,423 ops/sec Â±0.75% (193 runs sampled)\n* buffer - weak   x 211,871 ops/sec Â±0.74% (194 runs sampled)\n  string - strong x 205,291 ops/sec Â±0.86% (194 runs sampled)\n  string - weak   x 208,463 ops/sec Â±0.79% (192 runs sampled)\n\n> node benchmark/body2-5kb.js\n\n  5KB body\n\n  1 test completed.\n  2 tests completed.\n  3 tests completed.\n  4 tests completed.\n\n* buffer - strong x 92,901 ops/sec Â±0.58% (195 runs sampled)\n* buffer - weak   x 93,045 ops/sec Â±0.65% (192 runs sampled)\n  string - strong x 89,621 ops/sec Â±0.68% (194 runs sampled)\n  string - weak   x 90,070 ops/sec Â±0.70% (196 runs sampled)\n\n> node benchmark/body3-10kb.js\n\n  10KB body\n\n  1 test completed.\n  2 tests completed.\n  3 tests completed.\n  4 tests completed.\n\n* buffer - strong x 54,220 ops/sec Â±0.85% (192 runs sampled)\n* buffer - weak   x 54,069 ops/sec Â±0.83% (191 runs sampled)\n  string - strong x 53,078 ops/sec Â±0.53% (194 runs sampled)\n  string - weak   x 53,849 ops/sec Â±0.47% (197 runs sampled)\n\n> node benchmark/body4-100kb.js\n\n  100KB body\n\n  1 test completed.\n  2 tests completed.\n  3 tests completed.\n  4 tests completed.\n\n* buffer - strong x 6,673 ops/sec Â±0.15% (197 runs sampled)\n* buffer - weak   x 6,716 ops/sec Â±0.12% (198 runs sampled)\n  string - strong x 6,357 ops/sec Â±0.14% (197 runs sampled)\n  string - weak   x 6,344 ops/sec Â±0.21% (197 runs sampled)\n\n> node benchmark/stats.js\n\n  stats\n\n  1 test completed.\n  2 tests completed.\n  3 tests completed.\n  4 tests completed.\n\n* real - strong x 1,671,989 ops/sec Â±0.13% (197 runs sampled)\n* real - weak   x 1,681,297 ops/sec Â±0.12% (198 runs sampled)\n  fake - strong x   927,063 ops/sec Â±0.14% (198 runs sampled)\n  fake - weak   x   914,461 ops/sec Â±0.41% (191 runs sampled)\n```\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/etag.svg\n[npm-url]: https://npmjs.org/package/etag\n[node-version-image]: https://img.shields.io/node/v/etag.svg\n[node-version-url]: http://nodejs.org/download/\n[travis-image]: https://img.shields.io/travis/jshttp/etag/master.svg\n[travis-url]: https://travis-ci.org/jshttp/etag\n[coveralls-image]: https://img.shields.io/coveralls/jshttp/etag/master.svg\n[coveralls-url]: https://coveralls.io/r/jshttp/etag?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/etag.svg\n[downloads-url]: https://npmjs.org/package/etag\n",
+  "readmeFilename": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jshttp/etag"
+  },
+  "time": {
+    "1.0.0": "2014-05-18T11:14:58.281Z",
+    "1.0.1": "2014-08-24T23:28:33.196Z",
+    "1.1.0": "2014-08-25T02:07:34.113Z",
+    "1.2.0": "2014-08-25T04:09:33.706Z",
+    "1.2.1": "2014-08-30T03:58:39.314Z",
+    "1.3.0": "2014-08-30T04:25:31.815Z",
+    "1.3.1": "2014-09-14T16:54:11.346Z",
+    "1.4.0": "2014-09-21T18:47:20.760Z",
+    "1.5.0": "2014-10-14T04:48:49.796Z",
+    "1.5.1": "2014-11-20T07:06:45.217Z",
+    "1.6.0": "2015-05-11T02:11:35.427Z",
+    "1.7.0": "2015-06-09T03:38:54.614Z",
+    "2.0.0": "2016-06-09T03:38:54.614Z",
+    "created": "2014-05-18T11:14:58.281Z",
+    "modified": "2015-06-09T03:38:54.614Z"
+  },
+  "users": {
+    "blitzprog": true,
+    "program247365": true,
+    "simplyianm": true
+  },
+  "versions": {
+    "1.0.0": {
+      "_from": ".",
+      "_id": "etag@1.0.0",
+      "_npmUser": {
+        "email": "david.bjorklund@gmail.com",
+        "name": "kesla"
+      },
+      "_npmVersion": "1.4.3",
+      "author": {
+        "email": "david.bjorklund@gmail.com",
+        "name": "David BjÃ¶rklund"
+      },
+      "bugs": {
+        "url": "https://github.com/kesla/etag/issues"
+      },
+      "description": "Small thingy to create an etag from a String or Buffer",
+      "directories": {},
+      "dist": {
+        "shasum": "db9f9610cc2bf22036d713012dff4aa7e0c96162",
+        "tarball": "http://registry.npmjs.org/etag/-/etag-1.0.0.tgz"
+      },
+      "homepage": "https://github.com/kesla/etag",
+      "license": "MIT",
+      "main": "etag.js",
+      "maintainers": [
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "kesla"
+        }
+      ],
+      "name": "etag",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/kesla/etag.git"
+      },
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "version": "1.0.0",
+      "deprecated": "Switch to elm"
+    },
+    "1.0.1": {
+      "_from": ".",
+      "_id": "etag@1.0.1",
+      "_npmUser": {
+        "email": "doug@somethingdoug.com",
+        "name": "dougwilson"
+      },
+      "_npmVersion": "1.4.21",
+      "_shasum": "2aa41de474ffc45669f25c9fedacd64fea4f6ff7",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "contributors": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "Douglas Christopher Wilson"
+        },
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "David BjÃ¶rklund"
+        }
+      ],
+      "description": "Create simple ETags",
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "directories": {},
+      "dist": {
+        "shasum": "2aa41de474ffc45669f25c9fedacd64fea4f6ff7",
+        "tarball": "http://registry.npmjs.org/etag/-/etag-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "files": ["LICENSE", "HISTORY.md", "index.js"],
+      "gitHead": "d28ee6654ff51e83f3025a73677a30ec0fe04fc8",
+      "homepage": "https://github.com/jshttp/etag",
+      "keywords": ["etag", "http", "res"],
+      "license": "MIT",
+      "maintainers": [
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "kesla"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "name": "etag",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "version": "1.0.1",
+      "deprecated": "Switch to elm"
+    },
+    "1.1.0": {
+      "_from": ".",
+      "_id": "etag@1.1.0",
+      "_npmVersion": "1.4.21",
+      "_shasum": "e44af7bbabe2f998d9fc3bee00db0d34b29c13a3",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "contributors": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "Douglas Christopher Wilson"
+        },
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "David BjÃ¶rklund"
+        }
+      ],
+      "dependencies": {
+        "crc": "2.1.1"
+      },
+      "description": "Create simple ETags",
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "directories": {},
+      "dist": {
+        "shasum": "e44af7bbabe2f998d9fc3bee00db0d34b29c13a3",
+        "tarball": "http://registry.npmjs.org/etag/-/etag-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "files": ["LICENSE", "HISTORY.md", "index.js"],
+      "gitHead": "415cebe1d2a87510ffbd102816733e2c9934d0c7",
+      "homepage": "https://github.com/jshttp/etag",
+      "keywords": ["etag", "http", "res"],
+      "license": "MIT",
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "name": "etag",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "version": "1.1.0",
+      "deprecated": "Switch to elm"
+    },
+    "1.2.0": {
+      "_from": ".",
+      "_id": "etag@1.2.0",
+      "_npmUser": {
+        "email": "doug@somethingdoug.com",
+        "name": "dougwilson"
+      },
+      "_npmVersion": "1.4.21",
+      "_shasum": "fa537a8e1b1e29aa53480b69cfceb906a47aca8a",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "contributors": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "Douglas Christopher Wilson"
+        },
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "David BjÃ¶rklund"
+        }
+      ],
+      "dependencies": {
+        "crc": "2.1.1"
+      },
+      "description": "Create simple ETags",
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "directories": {},
+      "dist": {
+        "shasum": "fa537a8e1b1e29aa53480b69cfceb906a47aca8a",
+        "tarball": "http://registry.npmjs.org/etag/-/etag-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "files": ["LICENSE", "HISTORY.md", "index.js"],
+      "gitHead": "0d38a87d4217882b31e4a34786069281631a5cb2",
+      "homepage": "https://github.com/jshttp/etag",
+      "keywords": ["etag", "http", "res"],
+      "license": "MIT",
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "name": "etag",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "version": "1.2.0",
+      "deprecated": "Switch to elm"
+    },
+    "1.2.1": {
+      "_from": ".",
+      "_id": "etag@1.2.1",
+      "_npmUser": {
+        "email": "doug@somethingdoug.com",
+        "name": "dougwilson"
+      },
+      "_npmVersion": "1.4.21",
+      "_shasum": "74b16ea7511ce0041b944852eca2a95b9afefba3",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "contributors": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "Douglas Christopher Wilson"
+        },
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "David BjÃ¶rklund"
+        }
+      ],
+      "dependencies": {
+        "buffer-crc32": "0.2.3"
+      },
+      "description": "Create simple ETags",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "1.0.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "directories": {},
+      "dist": {
+        "shasum": "74b16ea7511ce0041b944852eca2a95b9afefba3",
+        "tarball": "http://registry.npmjs.org/etag/-/etag-1.2.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "files": ["LICENSE", "HISTORY.md", "index.js"],
+      "gitHead": "4b9369db7434104ee7c449f288af03c6abe7bad3",
+      "homepage": "https://github.com/jshttp/etag",
+      "keywords": ["etag", "http", "res"],
+      "license": "MIT",
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "name": "etag",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "version": "1.2.1",
+      "deprecated": "Switch to elm"
+    },
+    "1.3.0": {
+      "_from": ".",
+      "_id": "etag@1.3.0",
+      "_npmUser": {
+        "email": "doug@somethingdoug.com",
+        "name": "dougwilson"
+      },
+      "_npmVersion": "1.4.21",
+      "_shasum": "c837debfbfe0baf7eb8e2f0bbb3d1d9cc3229697",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "contributors": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "Douglas Christopher Wilson"
+        },
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "David BjÃ¶rklund"
+        }
+      ],
+      "dependencies": {
+        "buffer-crc32": "0.2.3"
+      },
+      "description": "Create simple ETags",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "1.0.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "directories": {},
+      "dist": {
+        "shasum": "c837debfbfe0baf7eb8e2f0bbb3d1d9cc3229697",
+        "tarball": "http://registry.npmjs.org/etag/-/etag-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "files": ["LICENSE", "HISTORY.md", "index.js"],
+      "gitHead": "b1531685ee679ca8fe329202e56d429d3c02eac0",
+      "homepage": "https://github.com/jshttp/etag",
+      "keywords": ["etag", "http", "res"],
+      "license": "MIT",
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "name": "etag",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "version": "1.3.0",
+      "deprecated": "Switch to elm"
+    },
+    "1.3.1": {
+      "_from": ".",
+      "_id": "etag@1.3.1",
+      "_npmUser": {
+        "email": "doug@somethingdoug.com",
+        "name": "dougwilson"
+      },
+      "_npmVersion": "1.4.21",
+      "_shasum": "e51925728688a32dc4eea1cfa9ab4f734d055567",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "contributors": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "Douglas Christopher Wilson"
+        },
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "David BjÃ¶rklund"
+        }
+      ],
+      "dependencies": {
+        "crc": "3.0.0"
+      },
+      "description": "Create simple ETags",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "1.0.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "directories": {},
+      "dist": {
+        "shasum": "e51925728688a32dc4eea1cfa9ab4f734d055567",
+        "tarball": "http://registry.npmjs.org/etag/-/etag-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": ["LICENSE", "HISTORY.md", "index.js"],
+      "gitHead": "88a83fdccc15065893cfad6e2c7af8a379941f16",
+      "homepage": "https://github.com/jshttp/etag",
+      "keywords": ["etag", "http", "res"],
+      "license": "MIT",
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "name": "etag",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "version": "1.3.1",
+      "deprecated": "Switch to elm"
+    },
+    "1.4.0": {
+      "_from": ".",
+      "_id": "etag@1.4.0",
+      "_npmUser": {
+        "email": "doug@somethingdoug.com",
+        "name": "dougwilson"
+      },
+      "_npmVersion": "1.4.21",
+      "_shasum": "3050991615857707c04119d075ba2088e0701225",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "contributors": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "Douglas Christopher Wilson"
+        },
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "David BjÃ¶rklund"
+        }
+      ],
+      "dependencies": {
+        "crc": "3.0.0"
+      },
+      "description": "Create simple ETags",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "1.0.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "directories": {},
+      "dist": {
+        "shasum": "3050991615857707c04119d075ba2088e0701225",
+        "tarball": "http://registry.npmjs.org/etag/-/etag-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": ["LICENSE", "HISTORY.md", "index.js"],
+      "gitHead": "6b701773b06a102947cc063286e7e3f3bceae27b",
+      "homepage": "https://github.com/jshttp/etag",
+      "keywords": ["etag", "http", "res"],
+      "license": "MIT",
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "name": "etag",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "version": "1.4.0",
+      "deprecated": "Switch to elm"
+    },
+    "1.5.0": {
+      "_from": ".",
+      "_id": "etag@1.5.0",
+      "_npmUser": {
+        "email": "doug@somethingdoug.com"
+      },
+      "_npmVersion": "1.4.21",
+      "_shasum": "8ca0f7a30b4b7305f034e8902fb8ec3c321491e4",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "contributors": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "Douglas Christopher Wilson"
+        },
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "David BjÃ¶rklund"
+        }
+      ],
+      "dependencies": {
+        "crc": "3.0.0"
+      },
+      "description": "Create simple ETags",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "1.0.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "directories": {},
+      "dist": {
+        "shasum": "8ca0f7a30b4b7305f034e8902fb8ec3c321491e4",
+        "tarball": "http://registry.npmjs.org/etag/-/etag-1.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": ["LICENSE", "HISTORY.md", "index.js"],
+      "gitHead": "d42734af50250c05893f02cb900e1c71efffbc45",
+      "homepage": "https://github.com/jshttp/etag",
+      "keywords": ["etag", "http", "res"],
+      "license": "MIT",
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "name": "etag",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "version": "1.5.0",
+      "deprecated": "Switch to elm"
+    },
+    "1.5.1": {
+      "_from": ".",
+      "_id": "etag@1.5.1",
+      "_npmUser": {
+        "email": "doug@somethingdoug.com",
+        "name": "dougwilson"
+      },
+      "_npmVersion": "1.4.21",
+      "_shasum": "54c50de04ee42695562925ac566588291be7e9ea",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "contributors": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "Douglas Christopher Wilson"
+        },
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "David BjÃ¶rklund"
+        }
+      ],
+      "dependencies": {
+        "crc": "3.2.1"
+      },
+      "description": "Create simple ETags",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "1.0.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "directories": {},
+      "dist": {
+        "shasum": "54c50de04ee42695562925ac566588291be7e9ea",
+        "tarball": "http://registry.npmjs.org/etag/-/etag-1.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": ["LICENSE", "HISTORY.md", "index.js"],
+      "gitHead": "27335e2265388109e50a9f037452081dc8a8260f",
+      "homepage": "https://github.com/jshttp/etag",
+      "keywords": ["etag", "http", "res"],
+      "license": "MIT",
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "name": "etag",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "version": "1.5.1",
+      "deprecated": "Switch to elm"
+    },
+    "1.6.0": {
+      "_from": ".",
+      "_id": "etag@1.6.0",
+      "_npmUser": {
+        "email": "doug@somethingdoug.com",
+        "name": "dougwilson"
+      },
+      "_npmVersion": "1.4.28",
+      "_shasum": "8bcb2c6af1254c481dfc8b997c906ef4e442c207",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "contributors": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "Douglas Christopher Wilson"
+        },
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "David BjÃ¶rklund"
+        }
+      ],
+      "dependencies": {
+        "crc": "3.2.1"
+      },
+      "description": "Create simple ETags",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "1.0.0",
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.4",
+        "seedrandom": "2.3.11"
+      },
+      "directories": {},
+      "dist": {
+        "shasum": "8bcb2c6af1254c481dfc8b997c906ef4e442c207",
+        "tarball": "http://registry.npmjs.org/etag/-/etag-1.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": ["LICENSE", "HISTORY.md", "README.md", "index.js"],
+      "gitHead": "76a8f5250b02e85bc1c9b1b049d83b853a87df44",
+      "homepage": "https://github.com/jshttp/etag",
+      "keywords": ["etag", "http", "res"],
+      "license": "MIT",
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "name": "etag",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "version": "1.6.0",
+      "deprecated": "Switch to elm"
+    },
+    "1.7.0": {
+      "_from": ".",
+      "_id": "etag@1.7.0",
+      "_npmUser": {
+        "email": "doug@somethingdoug.com",
+        "name": "dougwilson"
+      },
+      "_npmVersion": "1.4.28",
+      "_shasum": "03d30b5f67dd6e632d2945d30d6652731a34d5d8",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "contributors": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "Douglas Christopher Wilson"
+        },
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "David BjÃ¶rklund"
+        }
+      ],
+      "description": "Create simple ETags",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "1.0.0",
+        "istanbul": "0.3.14",
+        "mocha": "~1.21.4",
+        "seedrandom": "2.3.11"
+      },
+      "directories": {},
+      "dist": {
+        "shasum": "03d30b5f67dd6e632d2945d30d6652731a34d5d8",
+        "tarball": "http://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": ["LICENSE", "HISTORY.md", "README.md", "index.js"],
+      "gitHead": "a511f5c8c930fd9546dbd88acb080f96bc788cfc",
+      "homepage": "https://github.com/jshttp/etag",
+      "keywords": ["etag", "http", "res"],
+      "license": "MIT",
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "name": "etag",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "version": "1.7.0",
+      "deprecated": "Switch to elm"
+    },
+    "2.0.0": {
+      "_from": ".",
+      "_id": "etag@2.0.0",
+      "_npmUser": {
+        "email": "doug@somethingdoug.com",
+        "name": "dougwilson"
+      },
+      "_npmVersion": "1.4.28",
+      "_shasum": "03d30b5f67dd6e632d2945d30d6652731a34d5d8",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "contributors": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "Douglas Christopher Wilson"
+        },
+        {
+          "email": "david.bjorklund@gmail.com",
+          "name": "David BjÃ¶rklund"
+        }
+      ],
+      "deprecated": "this is an obsolete implementation of a pre-0.16 installer.",
+      "description": "Create simple ETags",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "1.0.0",
+        "istanbul": "0.3.14",
+        "mocha": "~1.21.4",
+        "seedrandom": "2.3.11"
+      },
+      "directories": {},
+      "dist": {
+        "shasum": "03d30b5f67dd6e632d2945d30d6652731a34d5d8",
+        "tarball": "http://registry.npmjs.org/etag/-/etag-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": ["LICENSE", "HISTORY.md", "README.md", "index.js"],
+      "gitHead": "a511f5c8c930fd9546dbd88acb080f96bc788cfc",
+      "homepage": "https://github.com/totally-deprecated/etag",
+      "keywords": ["etag", "http", "res"],
+      "license": "MIT",
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "name": "etag",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/totally-deprecated/etag"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "version": "2.0.0"
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/npm_responses/peer_dependency_deprecated.json
+++ b/npm_and_yarn/spec/fixtures/npm_responses/peer_dependency_deprecated.json
@@ -1,0 +1,760 @@
+{
+  "_id": "react-dom",
+  "_rev": "488-1b8fe88d4b06cc2b2c3e71dd7abdb6b6",
+  "name": "react-dom",
+  "description": "React package for working with the DOM.",
+  "dist-tags": {
+    "latest": "16.3.1",
+    "next": "16.3.1"
+  },
+  "versions": {
+    "15.1.0": {
+      "name": "react-dom",
+      "version": "15.1.0",
+      "deprecated": "This version of react-dom/server contains a minor vulnerability",
+      "description": "React package for working with the DOM.",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/facebook/react.git"
+      },
+      "keywords": ["react"],
+      "license": "BSD-3-Clause",
+      "bugs": {
+        "url": "https://github.com/facebook/react/issues"
+      },
+      "homepage": "https://facebook.github.io/react/",
+      "dependencies": {},
+      "peerDependencies": {
+        "react": "^15.1.0"
+      },
+      "scripts": {
+        "start": "node server.js"
+      },
+      "_id": "react-dom@15.1.0",
+      "_shasum": "d0c2b24c8b47a41a2b9ec766662d4e686f353153",
+      "_resolved": "file:build/packages/react-dom.tgz",
+      "_from": "build/packages/react-dom.tgz",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "zpao",
+        "email": "paul@oshannessy.com"
+      },
+      "maintainers": [
+        {
+          "name": "gaearon",
+          "email": "dan.abramov@gmail.com"
+        },
+        {
+          "name": "graue",
+          "email": "scott@oceanbase.org"
+        },
+        {
+          "name": "sebmarkbage",
+          "email": "sebastian@calyptus.eu"
+        },
+        {
+          "name": "spicyj",
+          "email": "ben@benalpert.com"
+        },
+        {
+          "name": "zpao",
+          "email": "paul@oshannessy.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d0c2b24c8b47a41a2b9ec766662d4e686f353153",
+        "tarball": "https://registry.npmjs.org/react-dom/-/react-dom-15.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/react-dom-15.1.0.tgz_1463785579139_0.1863514157012105"
+      },
+      "directories": {}
+    },
+    "15.2.0": {
+      "name": "react-dom",
+      "version": "15.2.0",
+      "deprecated": "This version of react-dom/server contains a minor vulnerability",
+      "description": "React package for working with the DOM.",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/facebook/react.git"
+      },
+      "keywords": ["react"],
+      "license": "BSD-3-Clause",
+      "bugs": {
+        "url": "https://github.com/facebook/react/issues"
+      },
+      "homepage": "https://facebook.github.io/react/",
+      "dependencies": {},
+      "peerDependencies": {
+        "react": "^15.2.0"
+      },
+      "scripts": {
+        "start": "node server.js"
+      },
+      "_id": "react-dom@15.2.0",
+      "_shasum": "cc9b9a2f51e460d6a727c7b23058fe94f42c874c",
+      "_resolved": "file:build/packages/react-dom.tgz",
+      "_from": "build/packages/react-dom.tgz",
+      "_npmVersion": "2.15.5",
+      "_nodeVersion": "4.4.5",
+      "_npmUser": {
+        "name": "zpao",
+        "email": "paul@oshannessy.com"
+      },
+      "maintainers": [
+        {
+          "name": "gaearon",
+          "email": "dan.abramov@gmail.com"
+        },
+        {
+          "name": "graue",
+          "email": "scott@oceanbase.org"
+        },
+        {
+          "name": "sebmarkbage",
+          "email": "sebastian@calyptus.eu"
+        },
+        {
+          "name": "spicyj",
+          "email": "ben@benalpert.com"
+        },
+        {
+          "name": "zpao",
+          "email": "paul@oshannessy.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cc9b9a2f51e460d6a727c7b23058fe94f42c874c",
+        "tarball": "https://registry.npmjs.org/react-dom/-/react-dom-15.2.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/react-dom-15.2.0.tgz_1467399135416_0.5253081950359046"
+      },
+      "directories": {}
+    },
+    "15.4.2": {
+      "name": "react-dom",
+      "version": "15.4.2",
+      "deprecated": "This version of react-dom/server contains a minor vulnerability",
+      "description": "React package for working with the DOM.",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/facebook/react.git"
+      },
+      "keywords": ["react"],
+      "license": "BSD-3-Clause",
+      "bugs": {
+        "url": "https://github.com/facebook/react/issues"
+      },
+      "homepage": "https://facebook.github.io/react/",
+      "dependencies": {
+        "fbjs": "^0.8.1",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^15.4.2"
+      },
+      "files": [
+        "LICENSE",
+        "PATENTS",
+        "README.md",
+        "dist/",
+        "lib/",
+        "index.js",
+        "server.js"
+      ],
+      "browserify": {
+        "transform": ["loose-envify"]
+      },
+      "scripts": {
+        "start": "node server.js"
+      },
+      "_id": "react-dom@15.4.2",
+      "_shasum": "015363f05b0a1fd52ae9efdd3a0060d90695208f",
+      "_resolved": "file:build/packages/react-dom.tgz",
+      "_from": "build/packages/react-dom.tgz",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "gaearon",
+        "email": "dan.abramov@gmail.com"
+      },
+      "dist": {
+        "shasum": "015363f05b0a1fd52ae9efdd3a0060d90695208f",
+        "tarball": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fb",
+          "email": "opensource+npm@fb.com"
+        },
+        {
+          "name": "gaearon",
+          "email": "dan.abramov@gmail.com"
+        },
+        {
+          "name": "graue",
+          "email": "scott@oceanbase.org"
+        },
+        {
+          "name": "sebmarkbage",
+          "email": "sebastian@calyptus.eu"
+        },
+        {
+          "name": "spicyj",
+          "email": "ben@benalpert.com"
+        },
+        {
+          "name": "tomocchino",
+          "email": "tomocchino@gmail.com"
+        },
+        {
+          "name": "zpao",
+          "email": "paul@oshannessy.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/react-dom-15.4.2.tgz_1483733768418_0.5142030897550285"
+      },
+      "directories": {}
+    },
+    "16.3.1": {
+      "name": "react-dom",
+      "version": "16.3.1",
+      "description": "React package for working with the DOM.",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/facebook/react.git"
+      },
+      "keywords": ["react"],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/facebook/react/issues"
+      },
+      "homepage": "https://reactjs.org/",
+      "dependencies": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0"
+      },
+      "files": [
+        "LICENSE",
+        "README.md",
+        "index.js",
+        "server.js",
+        "server.browser.js",
+        "server.node.js",
+        "test-utils.js",
+        "unstable-native-dependencies.js",
+        "cjs/",
+        "umd/"
+      ],
+      "browser": {
+        "./server.js": "./server.browser.js"
+      },
+      "browserify": {
+        "transform": ["loose-envify"]
+      },
+      "scripts": {
+        "start": "node server.js"
+      },
+      "_id": "react-dom@16.3.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "gaearon",
+        "email": "dan.abramov@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-2Infg89vzahq8nfVi1GkjPqq0vrBvf0f3T0+dTtyjq4f6HKOqKixAK25Vr593O3QTx4kw/vmUtAJwerlevNWOA==",
+        "shasum": "6a3c90a4fb62f915bdbcf6204422d93a7d4ca573",
+        "tarball": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.1.tgz",
+        "fileCount": 27,
+        "unpackedSize": 2015658
+      },
+      "maintainers": [
+        {
+          "email": "acdlite@me.com",
+          "name": "acdlite"
+        },
+        {
+          "email": "briandavidvaughn@gmail.com",
+          "name": "brianvaughn"
+        },
+        {
+          "email": "clement.hoang24@gmail.com",
+          "name": "clemmy"
+        },
+        {
+          "email": "opensource+npm@fb.com",
+          "name": "fb"
+        },
+        {
+          "email": "flarnie.npm@gmail.com",
+          "name": "flarnie"
+        },
+        {
+          "email": "dan.abramov@gmail.com",
+          "name": "gaearon"
+        },
+        {
+          "email": "npm@sophiebits.com",
+          "name": "sophiebits"
+        },
+        {
+          "email": "dg@domgan.com",
+          "name": "trueadm"
+        },
+        {
+          "email": "paul@oshannessy.com",
+          "name": "zpao"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/react-dom_16.3.1_1522802356174_0.4281071102651548"
+      },
+      "_hasShrinkwrap": false,
+      "deprecated": "This version of react-dom/server contains a minor vulnerability. Please update react-dom to 16.3.3 or 16.4.2+. Learn more: https://fb.me/cve-2018-6341"
+    }
+  },
+  "readme": "",
+  "maintainers": [
+    {
+      "email": "npm@andrewclark.io",
+      "name": "acdlite"
+    },
+    {
+      "email": "briandavidvaughn@gmail.com",
+      "name": "brianvaughn"
+    },
+    {
+      "email": "opensource+npm@fb.com",
+      "name": "fb"
+    },
+    {
+      "email": "flarnie.npm@gmail.com",
+      "name": "flarnie"
+    },
+    {
+      "email": "dan.abramov@gmail.com",
+      "name": "gaearon"
+    },
+    {
+      "email": "sebastian@calyptus.eu",
+      "name": "sebmarkbage"
+    },
+    {
+      "email": "npm@sophiebits.com",
+      "name": "sophiebits"
+    },
+    {
+      "email": "threepointone@gmail.com",
+      "name": "threepointone"
+    },
+    {
+      "email": "dg@domgan.com",
+      "name": "trueadm"
+    },
+    {
+      "email": "paul@oshannessy.com",
+      "name": "zpao"
+    }
+  ],
+  "time": {
+    "modified": "2019-04-11T18:18:42.185Z",
+    "created": "2014-05-06T18:59:36.160Z",
+    "0.1.0": "2014-05-06T18:59:36.160Z",
+    "0.14.0-beta1": "2015-07-03T08:47:36.859Z",
+    "0.14.0-beta2": "2015-07-31T05:32:31.129Z",
+    "0.14.0-beta3": "2015-08-03T21:33:53.540Z",
+    "0.14.0-rc1": "2015-09-10T16:02:13.157Z",
+    "0.14.0": "2015-10-07T17:29:35.289Z",
+    "0.14.1": "2015-10-28T21:36:05.173Z",
+    "0.14.2": "2015-11-02T19:55:14.560Z",
+    "0.14.3": "2015-11-19T02:26:48.974Z",
+    "0.14.4": "2015-12-29T22:00:13.038Z",
+    "0.14.5": "2015-12-29T22:40:03.262Z",
+    "0.14.6": "2016-01-06T23:52:52.338Z",
+    "0.15.0-alpha.1": "2016-01-21T04:16:19.791Z",
+    "0.14.7": "2016-01-28T19:59:21.186Z",
+    "15.0.0-rc.1": "2016-03-08T01:07:30.431Z",
+    "15.0.0-rc.2": "2016-03-16T22:19:25.716Z",
+    "0.14.8": "2016-03-29T16:19:51.077Z",
+    "15.0.0": "2016-04-07T21:25:44.824Z",
+    "15.0.1": "2016-04-08T18:24:03.871Z",
+    "15.0.2-alpha.1": "2016-04-20T18:17:21.275Z",
+    "15.0.2-alpha.2": "2016-04-21T22:22:04.168Z",
+    "15.0.2-alpha.3": "2016-04-25T20:03:54.772Z",
+    "15.0.2-alpha.4": "2016-04-28T07:12:05.405Z",
+    "15.0.2": "2016-04-30T00:38:21.736Z",
+    "15.0.3-alpha.1": "2016-05-03T19:40:25.441Z",
+    "15.0.3-alpha.2": "2016-05-10T04:37:56.938Z",
+    "15.1.0-alpha.1": "2016-05-10T05:28:28.727Z",
+    "15.1.0": "2016-05-20T23:06:19.582Z",
+    "15.2.0-rc.1": "2016-06-15T01:30:10.969Z",
+    "15.2.0-rc.2": "2016-07-01T06:32:02.930Z",
+    "15.2.0": "2016-07-01T18:52:18.934Z",
+    "15.2.1": "2016-07-08T22:31:06.338Z",
+    "15.3.0-rc.1": "2016-07-13T18:58:27.198Z",
+    "15.3.0-rc.2": "2016-07-13T21:02:06.521Z",
+    "15.3.0-rc.3": "2016-07-21T22:59:10.004Z",
+    "15.3.0": "2016-07-29T18:38:13.089Z",
+    "15.3.1-rc.1": "2016-08-12T23:35:19.931Z",
+    "15.3.1-rc.2": "2016-08-15T22:56:22.608Z",
+    "15.3.1": "2016-08-19T18:50:14.130Z",
+    "15.3.2-rc.1": "2016-09-15T23:43:35.377Z",
+    "15.3.2": "2016-09-19T17:46:57.685Z",
+    "15.4.0-rc.1": "2016-10-04T22:35:37.609Z",
+    "15.4.0-rc.2": "2016-10-05T22:50:57.582Z",
+    "15.4.0-rc.3": "2016-10-14T19:14:23.429Z",
+    "15.4.0-rc.4": "2016-10-14T22:00:09.527Z",
+    "15.4.0": "2016-11-16T14:32:55.418Z",
+    "15.4.1": "2016-11-23T01:59:08.303Z",
+    "15.4.2": "2017-01-06T20:16:11.024Z",
+    "16.0.0-alpha": "2017-01-10T00:27:31.952Z",
+    "16.0.0-alpha.0": "2017-01-25T20:04:49.683Z",
+    "16.0.0-alpha.2": "2017-02-09T16:16:26.330Z",
+    "16.0.0-alpha.3": "2017-02-23T23:52:33.985Z",
+    "16.0.0-alpha.4": "2017-03-13T15:57:52.301Z",
+    "16.0.0-alpha.5": "2017-03-21T20:02:43.184Z",
+    "16.0.0-alpha.6": "2017-03-24T22:47:10.931Z",
+    "15.5.0-rc.1": "2017-04-05T19:04:40.321Z",
+    "16.0.0-alpha.7": "2017-04-06T18:53:51.099Z",
+    "15.5.0-rc.2": "2017-04-06T23:19:15.765Z",
+    "16.0.0-alpha.8": "2017-04-07T17:49:09.446Z",
+    "15.5.0": "2017-04-07T21:39:55.712Z",
+    "15.5.1": "2017-04-07T22:40:57.597Z",
+    "15.5.2": "2017-04-08T01:39:02.809Z",
+    "15.5.3": "2017-04-08T04:10:06.023Z",
+    "15.5.4": "2017-04-11T19:30:09.326Z",
+    "16.0.0-alpha.9": "2017-04-11T21:45:39.308Z",
+    "0.14.9": "2017-04-12T15:45:23.918Z",
+    "16.0.0-alpha.10": "2017-04-20T19:59:54.647Z",
+    "16.0.0-alpha.11": "2017-04-25T01:55:04.683Z",
+    "16.0.0-alpha.12": "2017-05-02T21:25:14.084Z",
+    "15.6.0-rc.1": "2017-06-01T17:47:56.117Z",
+    "16.0.0-alpha.13": "2017-06-09T14:00:54.767Z",
+    "15.6.0": "2017-06-13T17:29:43.818Z",
+    "15.6.1": "2017-06-15T00:05:24.745Z",
+    "16.0.0-beta.1": "2017-07-26T20:03:49.535Z",
+    "16.0.0-beta.2": "2017-07-27T17:07:08.810Z",
+    "16.0.0-beta.3": "2017-08-03T23:07:39.169Z",
+    "16.0.0-beta.4": "2017-08-08T16:09:48.852Z",
+    "16.0.0-beta.5": "2017-08-08T17:27:35.449Z",
+    "16.0.0-rc.1": "2017-09-06T23:13:40.178Z",
+    "16.0.0-rc.2": "2017-09-07T03:36:51.262Z",
+    "16.0.0-rc.3": "2017-09-14T13:09:40.591Z",
+    "15.6.2": "2017-09-26T00:10:29.803Z",
+    "16.0.0": "2017-09-26T16:00:34.718Z",
+    "16.1.0-beta": "2017-11-02T22:45:12.511Z",
+    "16.1.0-beta.1": "2017-11-07T14:57:35.815Z",
+    "16.1.0-rc": "2017-11-09T00:13:15.575Z",
+    "16.1.0": "2017-11-09T15:04:38.346Z",
+    "16.1.1": "2017-11-13T16:13:14.142Z",
+    "16.2.0": "2017-11-28T21:32:29.110Z",
+    "16.3.0-alpha.0": "2018-02-02T21:05:53.621Z",
+    "16.3.0-alpha.1": "2018-02-12T18:49:31.086Z",
+    "16.4.0-alpha.7926752": "2018-02-13T00:52:26.068Z",
+    "16.4.0-alpha.3174632": "2018-02-24T05:07:52.951Z",
+    "16.4.0-alpha.0911da3": "2018-02-27T02:14:06.198Z",
+    "16.3.0-alpha.2": "2018-03-14T20:30:11.164Z",
+    "16.3.0-alpha.3": "2018-03-22T19:48:55.388Z",
+    "16.3.0-rc.0": "2018-03-28T02:15:03.439Z",
+    "16.3.0": "2018-03-29T20:16:21.022Z",
+    "16.3.1": "2018-04-04T00:39:16.342Z",
+    "16.3.2": "2018-04-16T15:32:42.988Z",
+    "16.4.0": "2018-05-24T00:39:50.456Z",
+    "16.4.1": "2018-06-13T16:47:20.487Z",
+    "16.0.1": "2018-08-01T18:47:12.808Z",
+    "16.1.2": "2018-08-01T18:55:18.353Z",
+    "16.2.1": "2018-08-01T18:57:20.123Z",
+    "16.3.3": "2018-08-01T18:58:58.451Z",
+    "16.4.2": "2018-08-01T19:01:01.146Z",
+    "16.5.0": "2018-09-06T16:44:51.243Z",
+    "16.5.1": "2018-09-13T18:34:20.794Z",
+    "16.6.0-alpha.0": "2018-09-17T22:11:39.953Z",
+    "16.5.2": "2018-09-18T19:31:10.943Z",
+    "16.6.0-alpha.400d197": "2018-10-05T01:04:16.036Z",
+    "16.6.0-alpha.8af6728": "2018-10-10T16:22:25.206Z",
+    "16.6.0": "2018-10-23T23:36:09.900Z",
+    "16.7.0-alpha.0": "2018-10-25T16:13:39.411Z",
+    "16.6.1": "2018-11-07T02:33:26.715Z",
+    "0.0.0-d5e1bf0-aee1b84": "2018-11-12T11:46:19.943Z",
+    "0.0.0-a8988e4-1d1a717": "2018-11-12T18:56:36.086Z",
+    "0.0.0-8b3c1e4-1d1a717": "2018-11-12T21:33:09.064Z",
+    "0.0.0-0c756fb-697f004": "2018-11-13T02:17:28.935Z",
+    "16.6.2": "2018-11-13T02:39:54.918Z",
+    "0.0.0-0c756fb-f7f79fd": "2018-11-13T03:47:42.769Z",
+    "16.6.3": "2018-11-13T03:53:05.230Z",
+    "16.7.0-alpha.1": "2018-11-13T19:36:59.029Z",
+    "16.7.0-alpha.2": "2018-11-13T21:43:54.924Z",
+    "0.0.0-ed4c4a51c": "2018-11-23T21:52:00.436Z",
+    "0.0.0-88ada9819": "2018-11-29T16:32:26.583Z",
+    "0.0.0-c5b7d26c7": "2018-12-03T17:09:24.104Z",
+    "0.0.0-7325ebe4d": "2018-12-14T17:00:52.295Z",
+    "0.0.0-4a1072194": "2018-12-14T19:38:33.790Z",
+    "16.7.0": "2018-12-20T01:20:03.120Z",
+    "0.0.0-f22621f88": "2019-01-09T20:44:16.735Z",
+    "16.8.0-alpha.0": "2019-01-09T20:54:28.695Z",
+    "0.0.0-3e15b1c69": "2019-01-14T22:34:29.291Z",
+    "16.8.0-alpha.1": "2019-01-15T23:22:20.113Z",
+    "0.0.0-fec00a869": "2019-02-01T16:21:45.439Z",
+    "0.0.0-267ed9814": "2019-02-05T16:27:30.600Z",
+    "0.0.0-d1326f466": "2019-02-05T18:32:32.793Z",
+    "16.8.0": "2019-02-06T08:00:45.674Z",
+    "0.0.0-11565a207": "2019-02-06T17:30:49.584Z",
+    "16.8.1": "2019-02-06T18:15:40.963Z",
+    "0.0.0-0e4135e8c": "2019-02-13T17:56:22.091Z",
+    "0.0.0-dfabb77a9": "2019-02-14T18:38:52.767Z",
+    "16.8.2": "2019-02-14T19:01:39.847Z",
+    "0.0.0-b668168d4": "2019-02-20T19:59:48.178Z",
+    "0.0.0-29b7b775f": "2019-02-21T17:51:05.564Z",
+    "16.8.3": "2019-02-21T18:03:12.085Z",
+    "0.0.0-741aa17a3": "2019-03-05T22:55:49.151Z",
+    "16.8.4": "2019-03-05T23:11:27.913Z",
+    "0.0.0-679402a66": "2019-03-14T15:33:56.600Z",
+    "0.0.0-f9e41e3a5": "2019-03-22T15:01:36.904Z",
+    "16.8.5": "2019-03-22T16:40:36.960Z",
+    "0.0.0-297165f1e": "2019-03-28T06:15:39.054Z",
+    "16.8.6": "2019-03-28T06:24:04.243Z",
+    "0.0.0-c35e37aab": "2019-04-03T16:31:02.791Z",
+    "16.9.0-alpha.0": "2019-04-03T16:51:22.387Z",
+    "0.0.0-a9eff329c": "2019-04-11T18:18:39.189Z"
+  },
+  "homepage": "https://reactjs.org/",
+  "keywords": ["react"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebook/react.git",
+    "directory": "packages/react-dom"
+  },
+  "bugs": {
+    "url": "https://github.com/facebook/react/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "",
+  "users": {
+    "arkanciscan": true,
+    "koulmomo": true,
+    "markthethomas": true,
+    "stefanof": true,
+    "nelix": true,
+    "vbv": true,
+    "davidchubbs": true,
+    "almccann": true,
+    "panlw": true,
+    "urbantumbleweed": true,
+    "wkaifang": true,
+    "wwayne": true,
+    "digitalextremist": true,
+    "samar": true,
+    "philipjc": true,
+    "leonardorb": true,
+    "mathieuancelin": true,
+    "ambdxtrch": true,
+    "arayzou": true,
+    "evan2x": true,
+    "daniele_cammarata": true,
+    "foto": true,
+    "brandonccx": true,
+    "kerwyn": true,
+    "travm": true,
+    "bsnote": true,
+    "jolyon": true,
+    "kay.sackey": true,
+    "sobear": true,
+    "kratyk": true,
+    "ongmin": true,
+    "cfleschhut": true,
+    "brien-crean": true,
+    "highlanderkev": true,
+    "konamgil": true,
+    "ajaegle": true,
+    "qqcome110": true,
+    "modao": true,
+    "kytart": true,
+    "zhouanbo": true,
+    "mikeljames": true,
+    "freebird": true,
+    "princetoad": true,
+    "rokeyzki": true,
+    "alexandesigner": true,
+    "asm2hex": true,
+    "ferchoriverar": true,
+    "dskecse": true,
+    "pmasa": true,
+    "kaapex": true,
+    "gaboesquivel": true,
+    "josejaguirre": true,
+    "alexjsdev": true,
+    "shore12358": true,
+    "saravntbe": true,
+    "fabrianibrahim": true,
+    "septs": true,
+    "fsgdez": true,
+    "digitalblake": true,
+    "leocreatini": true,
+    "scotchulous": true,
+    "razr9": true,
+    "onufrienko": true,
+    "akarem": true,
+    "tedyhy": true,
+    "tonyseek": true,
+    "enzoferey": true,
+    "bogdanvlviv": true,
+    "natforyou": true,
+    "v3rron": true,
+    "pris54": true,
+    "davidjsalazarmoreno": true,
+    "easimonenko": true,
+    "tmurngon": true,
+    "mswanson1524": true,
+    "morogasper": true,
+    "romelperez": true,
+    "coderaiser": true,
+    "langri-sha": true,
+    "federico-garcia": true,
+    "timjk": true,
+    "qddegtya": true,
+    "rylan_yan": true,
+    "wearevilla": true,
+    "atulmy": true,
+    "tcrowe": true,
+    "hyteer": true,
+    "npmlincq": true,
+    "evdokimovm": true,
+    "kevinagin": true,
+    "chinawolf_wyp": true,
+    "nate-river": true,
+    "abpeinado": true,
+    "chrisakakay": true,
+    "oandrelopes": true,
+    "nizar-banna": true,
+    "josokinas": true,
+    "katsos": true,
+    "vinbhatt": true,
+    "rxmth": true,
+    "nisimjoseph": true,
+    "ntucker": true,
+    "cl0udw4lk3r": true,
+    "rethinkflash": true,
+    "dhanya-kr": true,
+    "sibawite": true,
+    "blittle": true,
+    "pddivine": true,
+    "qinyuhang": true,
+    "mattyboy": true,
+    "alexxnica": true,
+    "ungurys": true,
+    "chenchenalex": true,
+    "awayken": true,
+    "alexis-nava": true,
+    "linkchef": true,
+    "agamlarage": true,
+    "borasta": true,
+    "naokie": true,
+    "buzzpsych": true,
+    "shahyar": true,
+    "alek-s": true,
+    "moxiong": true,
+    "phixid": true,
+    "rayng": true,
+    "albertico88": true,
+    "rupertong": true,
+    "manojkhannakm": true,
+    "flubox": true,
+    "weisen": true,
+    "fabioppalumbo": true,
+    "majkel": true,
+    "daniellink": true,
+    "nicolaslevy": true,
+    "paulkolesnyk": true,
+    "andrelamont": true,
+    "ciro-maciel": true,
+    "jakedemonaco": true,
+    "karzanosman984": true,
+    "tiggem1993": true,
+    "dnsnx": true,
+    "kmathmann": true,
+    "akh-rman": true,
+    "sayrilamar": true,
+    "maddas": true,
+    "ksugiura": true,
+    "yangzw": true,
+    "luffy84217": true,
+    "jakedalus": true,
+    "orenschwartz": true,
+    "adamduehansen": true,
+    "alexparish": true,
+    "tonyetro": true,
+    "iceglaive": true,
+    "sternelee": true,
+    "henrybrown0": true,
+    "npmrud5g": true,
+    "gamersdelight": true,
+    "joelbandi": true,
+    "kaybeard": true,
+    "leor": true,
+    "lomocc": true,
+    "fugudesign": true,
+    "fstgeorge": true,
+    "ptitdam2001": true,
+    "tyxla": true,
+    "sshrike": true,
+    "smtnkc": true,
+    "jaredwilli": true,
+    "pilusonoka": true,
+    "derrickbeining": true,
+    "wayn": true,
+    "nguyenvanhoang26041994": true,
+    "daskepon": true,
+    "geofftech": true,
+    "severen": true,
+    "ambassador": true,
+    "pupudu": true,
+    "migkjy": true,
+    "codyschindler": true,
+    "belcour": true,
+    "freelancerumesh": true,
+    "jamal-safwat": true,
+    "ostgals": true,
+    "kainos90": true,
+    "phpjsnerd": true,
+    "sinsaints76": true,
+    "gpmetheny": true,
+    "rapt0p7": true,
+    "alexdevero": true,
+    "henriesteves": true,
+    "zachkrall": true,
+    "amiziara": true,
+    "rommguy": true,
+    "mjurincic": true,
+    "huyz": true,
+    "soutarm": true,
+    "markhe": true,
+    "astrogeek": true,
+    "wlritchie33": true,
+    "endsoul": true,
+    "fearnbuster": true,
+    "raciat": true,
+    "kazem1": true,
+    "mestar": true,
+    "juanf03": true
+  }
+}


### PR DESCRIPTION
When getting possible versions from npm registry we filter out deprecated versions which meant that deprecated packages with peer requirements returned a nil latest resolvable version which got converted into a empty version string in the updater checker causing the exception: "blank strings must not be provided as versions".