### PR TITLE
Nuget: support lowercase version attributes

### DIFF
--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -86,9 +86,7 @@ module Dependabot
         end
 
         def dependency_requirement(dependency_node, project_file)
-          raw_requirement =
-            dependency_node.attribute("Version")&.value&.strip ||
-            dependency_node.at_xpath("./Version")&.content&.strip
+          raw_requirement = get_node_version_value(dependency_node)
           return unless raw_requirement
 
           evaluated_value(raw_requirement, project_file)
@@ -110,9 +108,7 @@ module Dependabot
         end
 
         def req_property_name(dependency_node)
-          raw_requirement =
-            dependency_node.attribute("Version")&.value&.strip ||
-            dependency_node.at_xpath("./Version")&.content&.strip
+          raw_requirement = get_node_version_value(dependency_node)
           return unless raw_requirement
 
           return unless raw_requirement.match?(PROPERTY_REGEX)
@@ -120,6 +116,14 @@ module Dependabot
           raw_requirement.
             match(PROPERTY_REGEX).
             named_captures.fetch("property")
+        end
+
+        def get_node_version_value(node)
+          attribute = "Version"
+          node.attribute(attribute)&.value&.strip ||
+            node.at_xpath("./#{attribute}")&.content&.strip ||
+            node.attribute(attribute.downcase)&.value&.strip ||
+            node.at_xpath("./#{attribute.downcase}")&.content&.strip
         end
 
         def evaluated_value(value, project_file)

--- a/nuget/lib/dependabot/nuget/file_updater/project_file_declaration_finder.rb
+++ b/nuget/lib/dependabot/nuget/file_updater/project_file_declaration_finder.rb
@@ -51,10 +51,17 @@ module Dependabot
                         node.at_xpath("./Include")&.content&.strip
             next false unless node_name&.downcase == dependency_name&.downcase
 
-            node_requirement = node.attribute("Version")&.value&.strip ||
-                               node.at_xpath("./Version")&.content&.strip
+            node_requirement = get_node_version_value(node)
             node_requirement == declaring_requirement.fetch(:requirement)
           end
+        end
+
+        def get_node_version_value(node)
+          attribute = "Version"
+          node.attribute(attribute)&.value&.strip ||
+            node.at_xpath("./#{attribute}")&.content&.strip ||
+            node.attribute(attribute.downcase)&.value&.strip ||
+            node.at_xpath("./#{attribute.downcase}")&.content&.strip
         end
 
         def deep_find_declarations(string)

--- a/nuget/spec/dependabot/nuget/file_updater/project_file_declaration_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater/project_file_declaration_finder_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe namespace::ProjectFileDeclarationFinder do
 
           expect(declaration_strings.first).
             to eq('<PackageReference Include="Microsoft.Extensions.'\
-                  'PlatformAbstractions" Version="1.1.0"></PackageReference>')
+                  'PlatformAbstractions" version="1.1.0"></PackageReference>')
         end
       end
 

--- a/nuget/spec/dependabot/nuget/file_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
       end
 
       its(:content) { is_expected.to include 'Version="1.1.2" />' }
-      its(:content) { is_expected.to include 'Version="1.1.0">' }
+      its(:content) { is_expected.to include 'version="1.1.0">' }
 
       it "doesn't update the formatting of the project file" do
         expect(updated_csproj_file.content).to include("</PropertyGroup>\n\n")
@@ -267,7 +267,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
         end
 
         its(:content) { is_expected.to include 'Version="1.1.2" />' }
-        its(:content) { is_expected.to include 'Version="1.1.0">' }
+        its(:content) { is_expected.to include 'version="1.1.0">' }
       end
 
       describe "the updated vbproj file" do

--- a/nuget/spec/fixtures/csproj/basic.csproj
+++ b/nuget/spec/fixtures/csproj/basic.csproj
@@ -11,7 +11,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0"></PackageReference>
+    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" version="1.1.0"></PackageReference>
     <PackageReference Include="System.Collections.Specialized"><Version>4.3.0</Version></PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
Nuget supports case-insensitive version attributes (e.g. `Version` and
`Version`) for `PackageReference` entries.

Tested this with nuget and it will install the specific version. The
rest of the PackageReference attributes seem to be case-sensitive, e.g.
`Include`.