### PR TITLE
JS: Ignore aliased dependencies in lockfile parser

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -71,6 +71,7 @@ module Dependabot
           yarn_locks.each do |yarn_lock|
             parse_yarn_lock(yarn_lock).each do |req, details|
               next unless semver_version_for(details["version"])
+              next if alias_package?(req)
 
               # Note: The DependencySet will de-dupe our dependencies, so they
               # end up unique by name. That's not a perfect representation of
@@ -149,6 +150,10 @@ module Dependabot
           return if version_string.include?("#")
 
           version_string
+        end
+
+        def alias_package?(requirement)
+          requirement.include?("@npm:")
         end
 
         def parse_package_lock(package_lock)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
@@ -6,9 +6,7 @@ require "dependabot/npm_and_yarn/file_parser/lockfile_parser"
 
 RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
   subject(:lockfile_parser) do
-    described_class.new(
-      dependency_files: dependency_files
-    )
+    described_class.new(dependency_files: dependency_files)
   end
   let(:npm_lockfile) do
     Dependabot::DependencyFile.new(
@@ -55,6 +53,16 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         let(:yarn_lockfile_fixture_name) { "empty_version.lock" }
         # Lockfile contains 10 dependencies but one has an empty version
         its(:length) { is_expected.to eq(9) }
+      end
+
+      context "that contains an aliased dependency" do
+        let(:yarn_lockfile_fixture_name) { "aliased_dependency.lock" }
+
+        it "excludes the dependency" do
+          # Lockfile contains 11 dependencies but one is an alias
+          expect(dependencies.count).to eq(10)
+          expect(dependencies.map(&:name)).to_not include("my-fetch-factory")
+        end
       end
 
       context "that contain multiple dependencies" do
@@ -205,7 +213,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
           )
         end
 
-        context "when the requiremtn doesn't match" do
+        context "when the requirement doesn't match" do
           let(:requirement) { "^3.3.0" }
 
           it { is_expected.to eq(nil) }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -981,6 +981,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           it "doesn't include the aliased dependency" do
             expect(top_level_dependencies.length).to eq(1)
             expect(top_level_dependencies.map(&:name)).to eq(["etag"])
+            expect(dependencies.map(&:name)).to_not include("my-fetch-factory")
           end
         end
 


### PR DESCRIPTION
Sad fix for https://sentry.io/organizations/dependabot/issues/959275980/?project=1425239&referrer=RegressionActivityEmail.

We can't update aliased dependencies at the moment. We ignore them at the top-level, but if someone configures JS to update sub-dependencies then we'll try to update them as parsed from the lockfile.

This PR excludes them from the lockfile. We can do better than that, and fully support aliased dependencies in future, but not yet.