### PR TITLE
[WIP] JS: Parse aliased package details

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -978,9 +978,19 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           let(:package_json_fixture_name) { "aliased_dependency.json" }
           let(:yarn_lock_fixture_name) { "aliased_dependency.lock" }
 
-          it "doesn't include the aliased dependency" do
-            expect(top_level_dependencies.length).to eq(1)
-            expect(top_level_dependencies.map(&:name)).to eq(["etag"])
+          it "includes the aliased dependency" do
+            expect(top_level_dependencies.length).to eq(2)
+
+            expect(top_level_dependencies.first.name).to eq("my-fetch-factory")
+            expect(top_level_dependencies.first.version).to eq("0.0.1")
+            expect(top_level_dependencies.first.requirements).to eq(
+              [{
+                requirement: "^0.0.1",
+                file: "package.json",
+                groups: ["dependencies"],
+                source: { aliased_package_name: "fetch-factory" }
+              }]
+            )
           end
         end
 

--- a/npm_and_yarn/spec/fixtures/package_files/aliased_dependency.json
+++ b/npm_and_yarn/spec/fixtures/package_files/aliased_dependency.json
@@ -14,7 +14,7 @@
     },
     "homepage": "https://github.com/waltfy/PROTO_TEST#readme",
     "dependencies": {
-        "my-fetch-factory": "npm:fetch-factory@0.0.2"
+        "my-fetch-factory": "npm:fetch-factory@^0.0.1"
     },
     "devDependencies": {
         "etag": "^1.0.0"


### PR DESCRIPTION
This is a start to handling aliased JS dependencies properly. It still needs a bunch of work:
- pick up the `aliased_package_name` in the update check and file updater, and ensure those work
- look into whether aliases are allowed for transitive deps, in which case we'll need to handle in the lockfile parser, too
- maybe move the `aliased_package_name` into a metadata hash (like we do for property names in our Java package managers, for example)