### PR TITLE
[WIP] Rust: Update target-specific dependencies

### DIFF
--- a/cargo/lib/dependabot/cargo/file_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser.rb
@@ -59,8 +59,8 @@ module Dependabot
       def manifest_dependencies
         dependency_set = DependencySet.new
 
-        DEPENDENCY_TYPES.each do |type|
-          manifest_files.each do |file|
+        manifest_files.each do |file|
+          DEPENDENCY_TYPES.each do |type|
             parsed_file(file).fetch(type, {}).each do |name, requirement|
               next unless name == name_from_declaration(name, requirement)
               next if lockfile && !version_from_lockfile(name, requirement)
@@ -76,6 +76,25 @@ module Dependabot
                   source: source_from_declaration(requirement)
                 }]
               )
+            end
+
+            parsed_file(file).fetch("target", {}).each do |_, t_details|
+              t_details.fetch(type, {}).each do |name, requirement|
+                next unless name == name_from_declaration(name, requirement)
+                next if lockfile && !version_from_lockfile(name, requirement)
+
+                dependency_set << Dependency.new(
+                  name: name,
+                  version: version_from_lockfile(name, requirement),
+                  package_manager: "cargo",
+                  requirements: [{
+                    requirement: requirement_from_declaration(requirement),
+                    file: file.name,
+                    groups: [type],
+                    source: source_from_declaration(requirement)
+                  }]
+                )
+              end
             end
           end
         end

--- a/cargo/lib/dependabot/cargo/file_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser.rb
@@ -65,17 +65,7 @@ module Dependabot
               next unless name == name_from_declaration(name, requirement)
               next if lockfile && !version_from_lockfile(name, requirement)
 
-              dependency_set << Dependency.new(
-                name: name,
-                version: version_from_lockfile(name, requirement),
-                package_manager: "cargo",
-                requirements: [{
-                  requirement: requirement_from_declaration(requirement),
-                  file: file.name,
-                  groups: [type],
-                  source: source_from_declaration(requirement)
-                }]
-              )
+              dependency_set << build_dependency(name, requirement, type, file)
             end
 
             parsed_file(file).fetch("target", {}).each do |_, t_details|
@@ -83,23 +73,28 @@ module Dependabot
                 next unless name == name_from_declaration(name, requirement)
                 next if lockfile && !version_from_lockfile(name, requirement)
 
-                dependency_set << Dependency.new(
-                  name: name,
-                  version: version_from_lockfile(name, requirement),
-                  package_manager: "cargo",
-                  requirements: [{
-                    requirement: requirement_from_declaration(requirement),
-                    file: file.name,
-                    groups: [type],
-                    source: source_from_declaration(requirement)
-                  }]
-                )
+                dependency_set <<
+                  build_dependency(name, requirement, type, file)
               end
             end
           end
         end
 
         dependency_set
+      end
+
+      def build_dependency(name, requirement, type, file)
+        Dependency.new(
+          name: name,
+          version: version_from_lockfile(name, requirement),
+          package_manager: "cargo",
+          requirements: [{
+            requirement: requirement_from_declaration(requirement),
+            file: file.name,
+            groups: [type],
+            source: source_from_declaration(requirement)
+          }]
+        )
       end
 
       def lockfile_dependencies

--- a/cargo/spec/dependabot/cargo/file_parser_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_parser_spec.rb
@@ -503,7 +503,7 @@ RSpec.describe Dependabot::Cargo::FileParser do
         its(:length) { is_expected.to eq(2) }
 
         describe "the first dependency" do
-          subject(:dependency) { dependencies.first }
+          subject(:dependency) { top_level_dependencies.first }
 
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
@@ -526,7 +526,7 @@ RSpec.describe Dependabot::Cargo::FileParser do
           let(:lockfile_fixture_name) { "blank_version" }
 
           describe "the first dependency" do
-            subject(:dependency) { dependencies.first }
+            subject(:dependency) { top_level_dependencies.first }
 
             it "has the right details" do
               expect(dependency).to be_a(Dependabot::Dependency)
@@ -535,6 +535,29 @@ RSpec.describe Dependabot::Cargo::FileParser do
               expect(dependency.requirements).to eq(
                 [{
                   requirement: nil,
+                  file: "Cargo.toml",
+                  groups: ["dependencies"],
+                  source: nil
+                }]
+              )
+            end
+          end
+        end
+
+        context "with a target-specific dependency" do
+          let(:manifest_fixture_name) { "target_dependency" }
+          let(:lockfile_fixture_name) { "target_dependency" }
+
+          describe "the last dependency" do
+            subject(:dependency) { top_level_dependencies.last }
+
+            it "has the right details" do
+              expect(dependency).to be_a(Dependabot::Dependency)
+              expect(dependency.name).to eq("time")
+              expect(dependency.version).to eq("0.1.38")
+              expect(dependency.requirements).to eq(
+                [{
+                  requirement: "0.1.12",
                   file: "Cargo.toml",
                   groups: ["dependencies"],
                   source: nil

--- a/cargo/spec/dependabot/cargo/file_parser_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_parser_spec.rb
@@ -554,10 +554,10 @@ RSpec.describe Dependabot::Cargo::FileParser do
             it "has the right details" do
               expect(dependency).to be_a(Dependabot::Dependency)
               expect(dependency.name).to eq("time")
-              expect(dependency.version).to eq("0.1.38")
+              expect(dependency.version).to eq("0.1.12")
               expect(dependency.requirements).to eq(
                 [{
-                  requirement: "0.1.12",
+                  requirement: "<= 0.1.12",
                   file: "Cargo.toml",
                   groups: ["dependencies"],
                   source: nil

--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -111,6 +111,16 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
         end
       end
 
+      context "with a target-specific dependency" do
+        let(:manifest_fixture_name) { "target_dependency" }
+        let(:lockfile_fixture_name) { "target_dependency" }
+
+        it "updates the dependency version in the lockfile" do
+          expect(updated_lockfile_content).
+            to include(%(name = "time"\nversion = "0.1.40"))
+        end
+      end
+
       context "with a blank requirement" do
         let(:manifest_fixture_name) { "blank_version" }
         let(:lockfile_fixture_name) { "blank_version" }

--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -114,6 +114,23 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
       context "with a target-specific dependency" do
         let(:manifest_fixture_name) { "target_dependency" }
         let(:lockfile_fixture_name) { "target_dependency" }
+        let(:dependency_previous_version) { "0.1.12" }
+        let(:requirements) do
+          [{
+            file: "Cargo.toml",
+            requirement: "<= 0.1.38",
+            groups: [],
+            source: nil
+          }]
+        end
+        let(:previous_requirements) do
+          [{
+            file: "Cargo.toml",
+            requirement: "<= 0.1.12",
+            groups: [],
+            source: nil
+          }]
+        end
 
         it "updates the dependency version in the lockfile" do
           expect(updated_lockfile_content).

--- a/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::ManifestUpdater do
 
       context "with a target-specific dependency" do
         let(:manifest_fixture_name) { "target_dependency" }
-        it { is_expected.to include(%(time = "0.1.38")) }
+        it { is_expected.to include(%(time = "<= 0.1.38")) }
       end
 
       context "with an optional dependency" do

--- a/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
@@ -65,6 +65,11 @@ RSpec.describe Dependabot::Cargo::FileUpdater::ManifestUpdater do
         it { is_expected.to include(%(business_time = "0.1.12")) }
       end
 
+      context "with a target-specific dependency" do
+        let(:manifest_fixture_name) { "target_dependency" }
+        it { is_expected.to include(%(time = "0.1.38")) }
+      end
+
       context "with an optional dependency" do
         let(:manifest_fixture_name) { "optional_dependency" }
         let(:dependency_name) { "utf8-ranges" }

--- a/cargo/spec/dependabot/cargo/update_checker/file_preparer_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/file_preparer_spec.rb
@@ -81,6 +81,21 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::FilePreparer do
             to include('regex = ">= 0.1.41"')
         end
 
+        context "the a target-specific dependency" do
+          let(:manifest_fixture_name) { "target_dependency" }
+          let(:lockfile_fixture_name) { "target_dependency" }
+          let(:dependency_name) { "time" }
+          let(:dependency_version) { "0.1.12" }
+          let(:string_req) { "<= 0.1.12" }
+
+          it "updates the requirement" do
+            expect(prepared_manifest_file.content).
+              to include('time = ">= 0.1.12"')
+            expect(prepared_manifest_file.content).
+              to_not include('time = "<= 0.1.12"')
+          end
+        end
+
         context "without a lockfile" do
           let(:dependency_files) { [manifest] }
           let(:dependency_version) { nil }

--- a/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
@@ -99,8 +99,8 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
       let(:manifest_fixture_name) { "target_dependency" }
       let(:lockfile_fixture_name) { "target_dependency" }
       let(:dependency_name) { "time" }
-      let(:dependency_version) { "0.1.38" }
-      let(:string_req) { "0.1.12" }
+      let(:dependency_version) { "0.1.12" }
+      let(:string_req) { "<=0.1.12" }
 
       it { is_expected.to be >= Gem::Version.new("0.1.41") }
     end

--- a/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
@@ -95,6 +95,16 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
       it { is_expected.to be >= Gem::Version.new("0.2.10") }
     end
 
+    context "with a target-specific dependency" do
+      let(:manifest_fixture_name) { "target_dependency" }
+      let(:lockfile_fixture_name) { "target_dependency" }
+      let(:dependency_name) { "time" }
+      let(:dependency_version) { "0.1.38" }
+      let(:string_req) { "0.1.12" }
+
+      it { is_expected.to be >= Gem::Version.new("0.1.41") }
+    end
+
     context "with a yanked version (for another dependency)" do
       let(:manifest_fixture_name) { "yanked_version" }
       let(:lockfile_fixture_name) { "yanked_version" }

--- a/cargo/spec/fixtures/lockfiles/target_dependency
+++ b/cargo/spec/fixtures/lockfiles/target_dependency
@@ -1,0 +1,90 @@
+[[package]]
+name = "aho-corasick"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dependabot"
+version = "0.1.0"
+dependencies = [
+ "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "time"
+version = "0.1.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum aho-corasick 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f5314d38125dc9b9ca99ed19a516eb19feac7bf8b22b5b32993c971bf8cb2a4d"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
+"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "4499ef755e709fbfe334ecbc3206537e84952ead5347791b0f54c2b75fe63a28"
+"checksum regex-syntax 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a21935ce5a4dfa48e3ded1aefbbe353fb9ab258b0d3fa0bd168bef00797b3dc7"
+"checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/cargo/spec/fixtures/lockfiles/target_dependency
+++ b/cargo/spec/fixtures/lockfiles/target_dependency
@@ -1,6 +1,6 @@
 [[package]]
 name = "aho-corasick"
-version = "0.3.4"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -10,9 +10,14 @@ dependencies = [
 name = "dependabot"
 version = "0.1.0"
 dependencies = [
- "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "gcc"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"
@@ -25,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.40"
+version = "0.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -33,39 +38,55 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "regex"
-version = "0.1.41"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.2.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "time"
-version = "0.1.38"
+name = "thread-id"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "thread_local"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
@@ -78,13 +99,16 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum aho-corasick 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f5314d38125dc9b9ca99ed19a516eb19feac7bf8b22b5b32993c971bf8cb2a4d"
+"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
+"checksum gcc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "08fa0b80a2193b08b8d38acb18d0cdb9ff00a287389bb59e685d907d1b4bf072"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
-"checksum regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "4499ef755e709fbfe334ecbc3206537e84952ead5347791b0f54c2b75fe63a28"
-"checksum regex-syntax 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a21935ce5a4dfa48e3ded1aefbbe353fb9ab258b0d3fa0bd168bef00797b3dc7"
-"checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
+"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
+"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
+"checksum time 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "615f31b68e20d17a912d0a91a398b9bd2ee7eb7c5b02d8c67589b898bbb38216"
+"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/cargo/spec/fixtures/manifests/target_dependency
+++ b/cargo/spec/fixtures/manifests/target_dependency
@@ -7,4 +7,4 @@ authors = ["support@dependabot.com"]
 regex = "0.1.41"
 
 [target.x86_64-pc-windows-gnu.dependencies]
-time = "0.1.12"
+time = "<= 0.1.12"

--- a/cargo/spec/fixtures/manifests/target_dependency
+++ b/cargo/spec/fixtures/manifests/target_dependency
@@ -1,0 +1,10 @@
+[package]
+name = "dependabot" # the name of the package
+version = "0.1.0"    # the current version, obeying semver
+authors = ["support@dependabot.com"]
+
+[dependencies]
+regex = "0.1.41"
+
+[target.x86_64-pc-windows-gnu.dependencies]
+time = "0.1.12"


### PR DESCRIPTION
See https://github.com/dependabot/feedback/issues/448 for details.

TODO:
- `FilePreparer` needs to handle target-specific dependencies
- `FileUpdater` needs to handle target-specific dependencies when pinning