### PR TITLE
Python: Update poetry sub-dependencies to a specific version

### DIFF
--- a/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
@@ -169,6 +169,34 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
         expect(lockfile_obj["metadata"]["content-hash"]).
           to start_with("82505f37a0da79b1e0f8d5c715d5435ef9318adf4df0e7372bde")
       end
+
+      context "with a sub-dependency" do
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: "2018.11.29",
+            previous_version: "2018.4.16",
+            package_manager: "pip",
+            requirements: [],
+            previous_requirements: []
+          )
+        end
+        let(:dependency_name) { "certifi" }
+
+        it "updates the lockfile successfully" do
+          expect(updated_files.map(&:name)).to eq(%w(poetry.lock))
+
+          updated_lockfile = updated_files.find { |f| f.name == "poetry.lock" }
+
+          lockfile_obj = TomlRB.parse(updated_lockfile.content)
+          certifi = lockfile_obj["package"].find { |d| d["name"] == "certifi" }
+
+          expect(certifi["version"]).to eq("2018.11.29")
+
+          expect(lockfile_obj["metadata"]["content-hash"]).
+            to start_with("82505f37a0da79b1e0f8d5c715d5435ef9318adf4df0e73")
+        end
+      end
     end
   end
 end

--- a/python/spec/fixtures/pyproject_files/latest_subdep_blocked.toml
+++ b/python/spec/fixtures/pyproject_files/latest_subdep_blocked.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "PythonProjects"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+description = "Various small python projects."
+
+[tool.poetry.dependencies]
+python = "^3.6"
+requests = "2.18.4"

--- a/python/spec/fixtures/pyproject_locks/latest_subdep_blocked.lock
+++ b/python/spec/fixtures/pyproject_locks/latest_subdep_blocked.lock
@@ -1,0 +1,65 @@
+[[package]]
+category = "main"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "2018.4.16"
+
+[[package]]
+category = "main"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "3.0.4"
+
+[[package]]
+category = "main"
+description = "Internationalized Domain Names in Applications (IDNA)"
+name = "idna"
+optional = false
+platform = "UNKNOWN"
+python-versions = "*"
+version = "2.5"
+
+[[package]]
+category = "main"
+description = "Python HTTP for Humans."
+name = "requests"
+optional = false
+python-versions = "*"
+version = "2.18.4"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<3.1.0"
+idna = ">=2.5,<2.7"
+urllib3 = ">=1.21.1,<1.23"
+
+[package.extras]
+security = ["cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+
+[[package]]
+category = "main"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
+optional = false
+platform = "*"
+python-versions = "*"
+version = "1.21.1"
+
+[metadata]
+content-hash = "a8d5762e953227a34625a209e9cc67a1c6fb2d7a971845829cf2f9cf61a5bd7c"
+platform = "*"
+python-versions = "^3.6"
+
+[metadata.hashes]
+certifi = ["13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7", "9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"]
+chardet = ["84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae", "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"]
+idna = ["3cb5ce08046c4e3a560fc02f138d0ac63e00f8ce5901a56b32ec8b7994082aab", "cc19709fd6d0cbfed39ea875d29ba6d4e22c0cebc510a76d6302a28385e8bb70"]
+requests = ["6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b", "9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"]
+urllib3 = ["8ed6d5c1ff9d6ba84677310060d6a3a78ca3072ce0684cb3c645023009c114b1", "b14486978518ca0901a76ba973d7821047409d7f726f22156b24e83fd71382a5"]


### PR DESCRIPTION
Previously, when updating a Poetry sub-dependency, we always updated it to the latest (resolvable) version. This meant the `PoetryVersionResolver#resolvable?` method was broken for sub-dependencies, and the ignore conditions weren't considered when updating Poetry sub-dependencies.

This PR fixes both of the above by temporarily creating top-level requirements for Poetry sub-dependencies when assessing version resolvability and updating lockfiles.