### PR TITLE
Use Python 3.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,14 +62,14 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3173AA6 \
 
 ### PYTHON
 
-# Install Python 2.7 and 3.6 with pyenv. Using pyenv lets us support multiple Pythons
+# Install Python 2.7 and 3.7 with pyenv. Using pyenv lets us support multiple Pythons
 ENV PYENV_ROOT=/usr/local/.pyenv \
     PATH="/usr/local/.pyenv/bin:$PATH"
 RUN git clone https://github.com/pyenv/pyenv.git /usr/local/.pyenv \
     && cd /usr/local/.pyenv && git checkout v1.2.11 && cd - \
-    && pyenv install 3.6.8 \
+    && pyenv install 3.7.3 \
     && pyenv install 2.7.16 \
-    && pyenv global 3.6.8
+    && pyenv global 3.7.3
 
 
 ### JAVASCRIPT

--- a/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
         let(:dependency_version) { "0.10.13" }
         let(:requirements) { [] }
 
-        it { is_expected.to eq(Gem::Version.new("0.10.15")) }
+        it { is_expected.to eq(Gem::Version.new("0.10.16")) }
       end
     end
 

--- a/python/helpers/build
+++ b/python/helpers/build
@@ -17,4 +17,4 @@ cp -r \
 
 cd "$install_dir"
 PYENV_VERSION=2.7.16 pyenv exec pip install -r "requirements.txt"
-PYENV_VERSION=3.6.8  pyenv exec pip install -r "requirements.txt"
+PYENV_VERSION=3.7.3  pyenv exec pip install -r "requirements.txt"

--- a/python/lib/dependabot/python/python_versions.rb
+++ b/python/lib/dependabot/python/python_versions.rb
@@ -4,7 +4,7 @@ module Dependabot
   module Python
     module PythonVersions
       PRE_INSTALLED_PYTHON_VERSIONS = %w(
-        3.6.8 2.7.16
+        3.7.3 2.7.16
       ).freeze
 
       # Due to an OpenSSL issue we can only install the following versions in

--- a/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe namespace::PipenvVersionResolver do
             expect(error.message).to eq(
               "pipenv.patched.notpip._internal.exceptions."\
               "UnsupportedPythonVersion: futures requires Python '>=2.6, <3' "\
-              "but the running Python is 3.6.8"
+              "but the running Python is 3.7.3"
             )
           end
       end


### PR DESCRIPTION
That. We stayed on 3.6 for a while as we want to have the most commonly used version in the Dockerfile. That's hopefully shifted to 3.7 by now.

Supporting stats: https://www.jetbrains.com/research/python-developers-survey-2018/