### PR TITLE
Use service pack to determine existing branches

### DIFF
--- a/common/lib/dependabot/git_metadata_fetcher.rb
+++ b/common/lib/dependabot/git_metadata_fetcher.rb
@@ -22,6 +22,14 @@ module Dependabot
       @tags ||= tags_for_upload_pack(upload_pack)
     end
 
+    def ref_names
+      @ref_names ||=
+        upload_pack.lines.
+        select { |l| l.split(" ")[-1].start_with?("refs/tags", "refs/heads") }.
+        map { |line| line.split(%r{ refs/(tags|heads)/}).last.strip }.
+        reject { |l| l.end_with?("^{}") }
+    end
+
     private
 
     attr_reader :url, :credentials


### PR DESCRIPTION
We've seen a few errors from GitHub when requesting the `git/refs/heads/<branch_name>` endpoint, and can replace it with fetching the upload pack for the repo. That's likely to be quicker, so we should give it a try.