### PR TITLE
#1194 fix docker tag regex to support common tag format with 'v' prefix

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -12,6 +12,7 @@ module Dependabot
   module Docker
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       VERSION_REGEX = /(?<version>[0-9]+(?:\.[a-zA-Z0-9]+)*)/.freeze
+      VERSION_STARTS_V = /^v#{VERSION_REGEX}$/.freeze
       VERSION_WITH_SFX = /^#{VERSION_REGEX}(?<suffix>-[a-z0-9.\-]+)?$/.freeze
       VERSION_WITH_PFX = /^(?<prefix>[a-z0-9.\-]+-)?#{VERSION_REGEX}$/.freeze
       VERSION_WITH_PFX_AND_SFX =
@@ -19,6 +20,7 @@ module Dependabot
         freeze
       NAME_WITH_VERSION =
         /
+          #{VERSION_STARTS_V}|
           #{VERSION_WITH_PFX}|
           #{VERSION_WITH_SFX}|
           #{VERSION_WITH_PFX_AND_SFX}

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -6,13 +6,13 @@ require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
 require "dependabot/errors"
 require "dependabot/docker/version"
+require "dependabot/docker/requirement"
 require "dependabot/docker/utils/credentials_finder"
 
 module Dependabot
   module Docker
     class UpdateChecker < Dependabot::UpdateCheckers::Base
-      VERSION_REGEX = /(?<version>[0-9]+(?:\.[a-zA-Z0-9]+)*)/.freeze
-      VERSION_STARTS_V = /^v#{VERSION_REGEX}$/.freeze
+      VERSION_REGEX = /v?(?<version>[0-9]+(?:\.[a-zA-Z0-9]+)*)/.freeze
       VERSION_WITH_SFX = /^#{VERSION_REGEX}(?<suffix>-[a-z0-9.\-]+)?$/.freeze
       VERSION_WITH_PFX = /^(?<prefix>[a-z0-9.\-]+-)?#{VERSION_REGEX}$/.freeze
       VERSION_WITH_PFX_AND_SFX =
@@ -20,7 +20,6 @@ module Dependabot
         freeze
       NAME_WITH_VERSION =
         /
-          #{VERSION_STARTS_V}|
           #{VERSION_WITH_PFX}|
           #{VERSION_WITH_SFX}|
           #{VERSION_WITH_PFX_AND_SFX}

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("artful-20170916") }
     end
 
-    context "when the dependency's version has a 'v' in front of numeric version" do
+    context "when the dependency's version has 'v' before numeric version" do
       let(:dependency_name) { "kube-state-metrics" }
       let(:version) { "v1.5.0" }
       let(:dependency) do

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -178,6 +178,27 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("artful-20170916") }
     end
 
+    context "when the dependency's version has a 'v' in front of numeric version" do
+      let(:dependency_name) { "kube-state-metrics" }
+      let(:version) { "v1.5.0" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: version,
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: { registry: "k8s.gcr.io" }
+          }],
+          package_manager: "docker"
+        )
+      end
+      let(:repo_url) { "https://k8s.gcr.io/v2/kube-state-metrics/" }
+      let(:registry_tags) { fixture("docker", "registry_tags", "gcr_io.json") }
+      it { is_expected.to eq("v1.6.0") }
+    end
+
     context "when the dependency has SHA suffices that should be ignored" do
       let(:registry_tags) do
         fixture("docker", "registry_tags", "sha_suffices.json")

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -43,9 +43,8 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
   let(:version) { "17.04" }
   let(:source) { { tag: version } }
   let(:repo_url) { "https://registry.hub.docker.com/v2/library/ubuntu/" }
-  let(:registry_tags) do
-    fixture("docker", "registry_tags", "ubuntu_no_latest.json")
-  end
+  let(:registry_tags) { fixture("docker", "registry_tags", tags_fixture_name) }
+  let(:tags_fixture_name) { "ubuntu_no_latest.json" }
 
   before do
     auth_url = "https://auth.docker.io/token?service=registry.docker.io"
@@ -105,7 +104,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     context "when the 'latest' version is just a more precise one" do
       let(:dependency_name) { "python" }
       let(:version) { "3.6" }
-      let(:registry_tags) { fixture("docker", "registry_tags", "python.json") }
+      let(:tags_fixture_name) { "python.json" }
       let(:headers_response) do
         fixture("docker", "registry_manifest_headers", "ubuntu_17.10.json")
       end
@@ -145,7 +144,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     end
 
     context "when there is a latest tag" do
-      let(:registry_tags) { fixture("docker", "registry_tags", "ubuntu.json") }
+      let(:tags_fixture_name) { "ubuntu.json" }
       let(:headers_response) do
         fixture("docker", "registry_manifest_headers", "ubuntu_17.10.json")
       end
@@ -178,31 +177,14 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("artful-20170916") }
     end
 
-    context "when the dependency's version has 'v' before numeric version" do
-      let(:dependency_name) { "kube-state-metrics" }
+    context "when the dependency's version starts with a 'v'" do
       let(:version) { "v1.5.0" }
-      let(:dependency) do
-        Dependabot::Dependency.new(
-          name: dependency_name,
-          version: version,
-          requirements: [{
-            requirement: nil,
-            groups: [],
-            file: "Dockerfile",
-            source: { registry: "k8s.gcr.io" }
-          }],
-          package_manager: "docker"
-        )
-      end
-      let(:repo_url) { "https://k8s.gcr.io/v2/kube-state-metrics/" }
-      let(:registry_tags) { fixture("docker", "registry_tags", "gcr_io.json") }
+      let(:tags_fixture_name) { "kube_state_metrics.json" }
       it { is_expected.to eq("v1.6.0") }
     end
 
     context "when the dependency has SHA suffices that should be ignored" do
-      let(:registry_tags) do
-        fixture("docker", "registry_tags", "sha_suffices.json")
-      end
+      let(:tags_fixture_name) { "sha_suffices.json" }
       let(:version) { "7.2-0.1" }
       it { is_expected.to eq("7.2-0.3.1") }
 
@@ -248,9 +230,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
             )
           end
           let(:repo_url) { "https://registry-host.io:5000/v2/ubuntu/" }
-          let(:registry_tags) do
-            fixture("docker", "registry_tags", "ubuntu_no_latest.json")
-          end
+          let(:tags_fixture_name) { "ubuntu_no_latest.json" }
 
           it "raises" do
             expect { checker.latest_version }.
@@ -263,7 +243,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     context "when the dependency's version has a suffix" do
       let(:dependency_name) { "ruby" }
       let(:version) { "2.4.0-slim" }
-      let(:registry_tags) { fixture("docker", "registry_tags", "ruby.json") }
+      let(:tags_fixture_name) { "ruby.json" }
       before do
         tags_url = "https://registry.hub.docker.com/v2/library/ruby/tags/list"
         stub_request(:get, tags_url).
@@ -276,9 +256,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     context "when the dependency's version has a prefix and a suffix" do
       let(:dependency_name) { "adoptopenjdk/openjdk11" }
       let(:version) { "jdk-11.0.2.7-alpine-slim" }
-      let(:registry_tags) do
-        fixture("docker", "registry_tags", "openjdk11.json")
-      end
+      let(:tags_fixture_name) { "openjdk11.json" }
       let(:repo_url) do
         "https://registry.hub.docker.com/v2/adoptopenjdk/openjdk11/"
       end
@@ -320,7 +298,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
     context "when the dependency has a namespace" do
       let(:dependency_name) { "moj/ruby" }
-      let(:registry_tags) { fixture("docker", "registry_tags", "ruby.json") }
+      let(:tags_fixture_name) { "ruby.json" }
       before do
         tags_url = "https://registry.hub.docker.com/v2/moj/ruby/tags/list"
         stub_request(:get, tags_url).
@@ -353,7 +331,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     context "when the latest version is a pre-release" do
       let(:dependency_name) { "python" }
       let(:version) { "3.5" }
-      let(:registry_tags) { fixture("docker", "registry_tags", "python.json") }
+      let(:tags_fixture_name) { "python.json" }
       before do
         tags_url = "https://registry.hub.docker.com/v2/library/python/tags/list"
         stub_request(:get, tags_url).
@@ -369,7 +347,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     end
 
     context "when the latest tag points to an older version" do
-      let(:registry_tags) { fixture("docker", "registry_tags", "dotnet.json") }
+      let(:tags_fixture_name) { "dotnet.json" }
       let(:headers_response) do
         fixture("docker", "registry_manifest_headers", "ubuntu_17.10.json")
       end
@@ -429,7 +407,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     context "when the dependency's version has a suffix with periods" do
       let(:dependency_name) { "python" }
       let(:version) { "3.6.2-alpine3.6" }
-      let(:registry_tags) { fixture("docker", "registry_tags", "python.json") }
+      let(:tags_fixture_name) { "python.json" }
       before do
         tags_url = "https://registry.hub.docker.com/v2/library/python/tags/list"
         stub_request(:get, tags_url).
@@ -454,9 +432,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
           package_manager: "docker"
         )
       end
-      let(:registry_tags) do
-        fixture("docker", "registry_tags", "ubuntu_no_latest.json")
-      end
+      let(:tags_fixture_name) { "ubuntu_no_latest.json" }
 
       context "without authentication credentials" do
         before do

--- a/docker/spec/fixtures/docker/registry_tags/gcr_io.json
+++ b/docker/spec/fixtures/docker/registry_tags/gcr_io.json
@@ -1,0 +1,4 @@
+{
+    "name": "kube-state-metrics",
+    "tags": ["v1.5.0", "v1.6.0"]
+}

--- a/docker/spec/fixtures/docker/registry_tags/gcr_io.json
+++ b/docker/spec/fixtures/docker/registry_tags/gcr_io.json
@@ -1,4 +1,0 @@
-{
-    "name": "kube-state-metrics",
-    "tags": ["v1.5.0", "v1.6.0"]
-}

--- a/docker/spec/fixtures/docker/registry_tags/kube_state_metrics.json
+++ b/docker/spec/fixtures/docker/registry_tags/kube_state_metrics.json
@@ -1,0 +1,203 @@
+{
+    "child": [],
+    "manifest": {
+        "sha256:15c89813ccd3d426c2023df9c1ab2edff33a279ac9779be488a3e4463c555739": {
+            "imageSizeBytes": "6780847",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v1.3.1"
+            ],
+            "timeCreatedMs": "1524216160338",
+            "timeUploadedMs": "1524216904115"
+        },
+        "sha256:215e94b068075298cb866f119b7884b52f78261a3116d52da3bcd7fb3f216f45": {
+            "imageSizeBytes": "10038648",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v1+prettyjws",
+            "tag": [
+                "v0.2.0"
+            ],
+            "timeCreatedMs": "1474537722597",
+            "timeUploadedMs": "1474538948671"
+        },
+        "sha256:249d036d5cebecf86d0f7dc3894aec249a1ac0107cd72678f7beea80df03dc50": {
+            "imageSizeBytes": "10024426",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v0.4.0"
+            ],
+            "timeCreatedMs": "1487154466072",
+            "timeUploadedMs": "1487154652739"
+        },
+        "sha256:37c4ddfa160043a7fd73703b7cae41cf38b692ca19c1dff722293c90a386b59f": {
+            "imageSizeBytes": "10676570",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v1.5.0"
+            ],
+            "timeCreatedMs": "1547200357273",
+            "timeUploadedMs": "1547470381771"
+        },
+        "sha256:45fa82f5887bb1d0f52696a1b7b9ad1e081fe8d1f720258aa2d960a28e78d4a4": {
+            "imageSizeBytes": "8586027",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v1.1.0-rc.0"
+            ],
+            "timeCreatedMs": "1507803069707",
+            "timeUploadedMs": "1507804265946"
+        },
+        "sha256:49b0d96d872c3c85959d57bcb9bc4e661fda9e66991490b2ec738464396a4010": {
+            "imageSizeBytes": "9288304",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v1.4.0"
+            ],
+            "timeCreatedMs": "1535712151207",
+            "timeUploadedMs": "1535714594176"
+        },
+        "sha256:53416b3d560a1b821b7e302460a387fef887ce72206c3ccbf82fd9e2d1f71fd9": {
+            "imageSizeBytes": "8586024",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v1.1.0"
+            ],
+            "timeCreatedMs": "1508409515171",
+            "timeUploadedMs": "1508411047660"
+        },
+        "sha256:55de3d663a6d5bdeb8f87fc8ee364f07775b23612f2d4938ef6f09810677c634": {
+            "imageSizeBytes": "10163340",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v1.0.0-rc.1"
+            ],
+            "timeCreatedMs": "1501680226392",
+            "timeUploadedMs": "1501680681946"
+        },
+        "sha256:5b1c49bf1e47ea731db9b162115e847278de9a0c4ce390f96b22e8b373880cc9": {
+            "imageSizeBytes": "8935207",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v1.3.0"
+            ],
+            "timeCreatedMs": "1523533423938",
+            "timeUploadedMs": "1523534493090"
+        },
+        "sha256:5b933aa0556f4410b3aeeeabfdbb1dd0769eaad9d4c31a2e0a906acf805493bd": {
+            "imageSizeBytes": "9927197",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v1+prettyjws",
+            "tag": [
+                "v0.3.0"
+            ],
+            "timeCreatedMs": "1476816853352",
+            "timeUploadedMs": "1476817772722"
+        },
+        "sha256:65d4e8e285deb9b7eac2e1d5bc0f9408c438bae9117fcf4ca1ef3a16b06bc24a": {
+            "imageSizeBytes": "8935207",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v1.3.0-rc.0"
+            ],
+            "timeCreatedMs": "1522065538503",
+            "timeUploadedMs": "1522065696210"
+        },
+        "sha256:8566372bd88c6de72462b4b8b4cc3a49121b91f5dd971e047e814b89d657fd1b": {
+            "imageSizeBytes": "10163340",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v1.0.0"
+            ],
+            "timeCreatedMs": "1502278099212",
+            "timeUploadedMs": "1502278308383"
+        },
+        "sha256:953a3b6bf0046333c656fcfa2fc3a08f4055dc3fbd5b1dcdcdf865a2534db526": {
+            "imageSizeBytes": "8923553",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v1.2.0"
+            ],
+            "timeCreatedMs": "1516020793197",
+            "timeUploadedMs": "1516021407482"
+        },
+        "sha256:b8b536771d5c23a9344c90662b2ca9ba00421e050ae593264bc51803470a2526": {
+            "imageSizeBytes": "10454407",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v1.0.1"
+            ],
+            "timeCreatedMs": "1503923932205",
+            "timeUploadedMs": "1503925239231"
+        },
+        "sha256:c6fe216dd978fab3099069db9a1970fe9810479a1c61a3cfe40389978501bc3f": {
+            "imageSizeBytes": "6780849",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [],
+            "timeCreatedMs": "1523547428484",
+            "timeUploadedMs": "1523548918815"
+        },
+        "sha256:c98991f50115fe6188d7b4213690628f0149cf160ac47daf9f21366d7cc62740": {
+            "imageSizeBytes": "12176267",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v1.6.0"
+            ],
+            "timeCreatedMs": "1557149025125",
+            "timeUploadedMs": "1557229943504"
+        },
+        "sha256:e913a24b0a0a89e23968d5e3fbf99501d17c04011fb54b24df0aca6bea232022": {
+            "imageSizeBytes": "10034535",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v0.5.0"
+            ],
+            "timeCreatedMs": "1494236243587",
+            "timeUploadedMs": "1494237662166"
+        },
+        "sha256:f10a63848dbb9823ab2b870e5d656107bf5c4905d33ba7ecb4e4165c228787d2": {
+            "imageSizeBytes": "10023925",
+            "layerId": "",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tag": [
+                "v0.4.1"
+            ],
+            "timeCreatedMs": "1487154587695",
+            "timeUploadedMs": "1487156439117"
+        }
+    },
+    "name": "kube-state-metrics",
+    "tags": [
+        "v0.2.0",
+        "v0.3.0",
+        "v0.4.0",
+        "v0.4.1",
+        "v0.5.0",
+        "v1.0.0",
+        "v1.0.0-rc.1",
+        "v1.0.1",
+        "v1.1.0",
+        "v1.1.0-rc.0",
+        "v1.2.0",
+        "v1.3.0",
+        "v1.3.0-rc.0",
+        "v1.3.1",
+        "v1.4.0",
+        "v1.5.0",
+        "v1.6.0"
+    ]
+}


### PR DESCRIPTION
Suggesting least invasive change to the regex to support the tags like 'v1.5.0'