### PR TITLE
Don't invoke builder during `go get -d`

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -95,6 +95,14 @@ module Dependabot
         end
 
         def dummy_main_go
+          # If we use `main` as the package name, running `go get -d` seems to
+          # invoke the build systems, which can cause problems. For instance,
+          # if the go.mod includes a module that doesn't have a top-level
+          # package, we have no way of working out the import path, so the
+          # build step fails.
+          #
+          # In due course, if we end up fetching the full repo, it might be
+          # good to switch back to `main` so we can surface more errors.
           lines = ["package dummypkg", "import ("]
           dependencies.each do |dep|
             lines << "_ \"#{dep.name}\""

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -95,12 +95,11 @@ module Dependabot
         end
 
         def dummy_main_go
-          lines = ["package main", "import ("]
+          lines = ["package dummypkg", "import ("]
           dependencies.each do |dep|
             lines << "_ \"#{dep.name}\""
           end
           lines << ")"
-          lines << "func main() {}"
           lines.join("\n")
         end
 

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -204,6 +204,21 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
                 end
             end
           end
+
+          describe "a dependency that has no top-level package" do
+            let(:dependency_name) { "github.com/prometheus/client_golang" }
+            let(:dependency_version) { "v0.9.3" }
+            let(:go_mod_body) do
+              fixture("go_mods", go_mod_fixture_name).sub(
+                "rsc.io/quote v1.4.0",
+                "github.com/prometheus/client_golang v0.9.3"
+              )
+            end
+
+            it "raises the correct error" do
+              expect { updater.updated_go_sum_content }.to_not raise_error
+            end
+          end
         end
       end
 

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -130,29 +130,6 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
             end
           end
 
-          describe "a non-existent dependency in a sub-directory" do
-            let(:dependency_name) do
-              "github.com/dependabot-fixtures" \
-              "/test-go_modules-non-existent-sub-dep"
-            end
-            let(:dependency_version) { "v1.0.0" }
-            let(:dependency_previous_version) { "v0.1.0" }
-            let(:go_mod_body) do
-              fixture("go_mods", go_mod_fixture_name).sub(
-                "rsc.io/quote v1.4.0",
-                "#{dependency_name} #{dependency_previous_version}"
-              )
-            end
-
-            it "raises the correct error" do
-              error_class = Dependabot::DependencyFileNotResolvable
-              expect { updater.updated_go_sum_content }.
-                to raise_error(error_class) do |error|
-                  expect(error.message).to include("hmarr/404")
-                end
-            end
-          end
-
           describe "a dependency who's module path has changed" do
             let(:go_mod_body) do
               fixture("go_mods", go_mod_fixture_name).sub(


### PR DESCRIPTION
If we use a package name other than `main`, we don't build anything during `go get -d`, which means we don't have to worry about a whole class of errors which previously caused us problems (such as depending on a Go module without a top-level package, as the import path can't be figured out from the go.mod alone).