### PR TITLE
Bundler: Remove existing load paths before loading git dependency gemspecs

### DIFF
--- a/bundler/lib/dependabot/monkey_patches/bundler/git_source_patch.rb
+++ b/bundler/lib/dependabot/monkey_patches/bundler/git_source_patch.rb
@@ -25,3 +25,37 @@ module Bundler
     end
   end
 end
+
+module Bundler
+  class Source
+    class Git < Path
+      private
+
+      def serialize_gemspecs_in(destination)
+        original_load_paths = $LOAD_PATH.dup
+        reduced_load_paths = original_load_paths.
+                             reject { |p| p.include?("/gems/") }
+
+        $LOAD_PATH.shift until $LOAD_PATH.empty?
+        reduced_load_paths.each { |p| $LOAD_PATH << p }
+
+        if destination.relative?
+          destination = destination.expand_path(Bundler.root)
+        end
+        Dir["#{destination}/#{@glob}"].each do |spec_path|
+          # Evaluate gemspecs and cache the result. Gemspecs
+          # in git might require git or other dependencies.
+          # The gemspecs we cache should already be evaluated.
+          spec = Bundler.load_gemspec_uncached(spec_path)
+          next unless spec
+
+          Bundler.rubygems.set_installed_by_version(spec)
+          Bundler.rubygems.validate(spec)
+          File.open(spec_path, "wb") { |file| file.write(spec.to_ruby) }
+        end
+        $LOAD_PATH.shift until $LOAD_PATH.empty?
+        original_load_paths.each { |p| $LOAD_PATH << p }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes a very niche bug. Will write a test, and maybe refine the approach here, too.