### PR TITLE
Use byebug instead of pry

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -56,7 +56,7 @@ Bundler.setup
 
 require "optparse"
 require "json"
-require "pry"
+require "byebug"
 
 require "dependabot/file_fetchers"
 require "dependabot/file_parsers"

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "toml-rb", "~> 1.1", ">= 1.1.2"
 
   spec.add_development_dependency "byebug", "~> 11.0"
-  spec.add_development_dependency "pry", "~> 0.12.2"
   spec.add_development_dependency "rake", "~> 12"
   spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_development_dependency "rspec-its", "~> 1.2"


### PR DESCRIPTION
Ops didn't realise byebug was already a dev dependency.