### PR TITLE
Npm: Ignore bundled sub-dependencies

### DIFF
--- a/common/.gitignore
+++ b/common/.gitignore
@@ -3,3 +3,4 @@
 /tmp
 /dependabot-*.gem
 Gemfile.lock
+.byebug_history

--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -27,11 +27,12 @@ module Dependabot
     end
 
     attr_reader :name, :version, :requirements, :package_manager,
-                :previous_version, :previous_requirements, :metadata
+                :previous_version, :previous_requirements,
+                :subdependency_metadata
 
     def initialize(name:, requirements:, package_manager:, version: nil,
                    previous_version: nil, previous_requirements: nil,
-                   metadata: nil)
+                   subdependency_metadata: nil)
       @name = name
       @version = version
       @requirements = requirements.map { |req| symbolize_keys(req) }
@@ -39,7 +40,7 @@ module Dependabot
       @previous_requirements =
         previous_requirements&.map { |req| symbolize_keys(req) }
       @package_manager = package_manager
-      @metadata = metadata
+      @subdependency_metadata = subdependency_metadata unless top_level?
 
       check_values
     end
@@ -56,8 +57,8 @@ module Dependabot
         "previous_version" => previous_version,
         "previous_requirements" => previous_requirements,
         "package_manager" => package_manager,
-        "metadata" => metadata
-      }
+        "subdependency_metadata" => subdependency_metadata
+      }.compact
     end
 
     def appears_in_lockfile?

--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -27,10 +27,11 @@ module Dependabot
     end
 
     attr_reader :name, :version, :requirements, :package_manager,
-                :previous_version, :previous_requirements
+                :previous_version, :previous_requirements, :metadata
 
     def initialize(name:, requirements:, package_manager:, version: nil,
-                   previous_version: nil, previous_requirements: nil)
+                   previous_version: nil, previous_requirements: nil,
+                   metadata: nil)
       @name = name
       @version = version
       @requirements = requirements.map { |req| symbolize_keys(req) }
@@ -38,6 +39,7 @@ module Dependabot
       @previous_requirements =
         previous_requirements&.map { |req| symbolize_keys(req) }
       @package_manager = package_manager
+      @metadata = metadata
 
       check_values
     end
@@ -53,7 +55,8 @@ module Dependabot
         "requirements" => requirements,
         "previous_version" => previous_version,
         "previous_requirements" => previous_requirements,
-        "package_manager" => package_manager
+        "package_manager" => package_manager,
+        "metadata" => metadata
       }
     end
 

--- a/common/lib/dependabot/file_parsers/base/dependency_set.rb
+++ b/common/lib/dependabot/file_parsers/base/dependency_set.rb
@@ -60,6 +60,9 @@ module Dependabot
           dependencies.find { |d| d.name&.downcase == name&.downcase }
         end
 
+        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/PerceivedComplexity
         def combined_dependency(old_dep, new_dep)
           package_manager = old_dep.package_manager
           v_cls = Utils.version_class_for_package_manager(package_manager)
@@ -75,13 +78,24 @@ module Dependabot
             else new_dep.version
             end
 
+          if old_dep.subdependency_metadata
+            subdependency_metadata = old_dep.subdependency_metadata.
+                                     merge(new_dep.subdependency_metadata || {})
+          elsif new_dep.subdependency_metadata
+            subdependency_metadata = new_dep.subdependency_metadata
+          end
+
           Dependency.new(
             name: old_dep.name,
             version: new_version,
             requirements: (old_dep.requirements + new_dep.requirements).uniq,
-            package_manager: package_manager
+            package_manager: package_manager,
+            subdependency_metadata: subdependency_metadata
           )
         end
+        # rubocop:enable Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/AbcSize
       end
     end
   end

--- a/common/spec/dependabot/dependency_spec.rb
+++ b/common/spec/dependabot/dependency_spec.rb
@@ -131,18 +131,99 @@ RSpec.describe Dependabot::Dependency do
     it { is_expected.to eq("dep") }
   end
 
-  describe "#metadata" do
-    subject(:metadata) { described_class.new(dependency_args).metadata }
+  describe "#to_h" do
+    subject(:to_h) { described_class.new(dependency_args).to_h }
+
+    context "with requirements" do
+      let(:dependency_args) do
+        {
+          name: "dep",
+          requirements:
+            [{ file: "a.rb", requirement: "1", groups: [], source: nil }],
+          package_manager: "dummy"
+        }
+      end
+
+      it do
+        expected = {
+          "name" => "dep",
+          "package_manager" => "dummy",
+          "requirements" => [{ file: "a.rb", groups: [],
+                               requirement: "1", source: nil }]
+        }
+        is_expected.to eq(expected)
+      end
+    end
+
+    context "without requirements" do
+      let(:dependency_args) do
+        {
+          name: "dep",
+          requirements: [],
+          package_manager: "dummy"
+        }
+      end
+
+      it do
+        expected = {
+          "name" => "dep",
+          "package_manager" => "dummy",
+          "requirements" => []
+        }
+        is_expected.to eq(expected)
+      end
+    end
+
+    context "with subdependency metadata" do
+      let(:dependency_args) do
+        {
+          name: "dep",
+          requirements: [],
+          package_manager: "dummy",
+          subdependency_metadata: { npm_bundled: true }
+        }
+      end
+
+      it do
+        expected = {
+          "name" => "dep",
+          "package_manager" => "dummy",
+          "requirements" => [],
+          "subdependency_metadata" => { npm_bundled: true }
+        }
+        is_expected.to eq(expected)
+      end
+    end
+  end
+
+  describe "#subdependency_metadata" do
+    subject(:subdependency_metadata) do
+      described_class.new(dependency_args).subdependency_metadata
+    end
 
     let(:dependency_args) do
       {
         name: "dep",
         requirements: [],
         package_manager: "dummy",
-        metadata: { bundled: true }
+        subdependency_metadata: { npm_bundled: true }
       }
     end
 
-    it { is_expected.to eq(bundled: true) }
+    it { is_expected.to eq(npm_bundled: true) }
+
+    context "when top level" do
+      let(:dependency_args) do
+        {
+          name: "dep",
+          requirements:
+            [{ file: "a.rb", requirement: "1", groups: [], source: nil }],
+          package_manager: "dummy",
+          subdependency_metadata: { npm_bundled: true }
+        }
+      end
+
+      it { is_expected.to eq(nil) }
+    end
   end
 end

--- a/common/spec/dependabot/dependency_spec.rb
+++ b/common/spec/dependabot/dependency_spec.rb
@@ -130,4 +130,19 @@ RSpec.describe Dependabot::Dependency do
 
     it { is_expected.to eq("dep") }
   end
+
+  describe "#metadata" do
+    subject(:metadata) { described_class.new(dependency_args).metadata }
+
+    let(:dependency_args) do
+      {
+        name: "dep",
+        requirements: [],
+        package_manager: "dummy",
+        metadata: { bundled: true }
+      }
+    end
+
+    it { is_expected.to eq(bundled: true) }
+  end
 end

--- a/common/spec/dependabot/file_parsers/base/dependency_set_spec.rb
+++ b/common/spec/dependabot/file_parsers/base/dependency_set_spec.rb
@@ -139,6 +139,73 @@ RSpec.describe Dependabot::FileParsers::Base::DependencySet do
             )
         end
       end
+
+      context "and is idential, but with different subdependency_metadata" do
+        let(:existing_subdependency_metadata) { { npm_bundled: true } }
+        let(:subdependency_metadata) { { npm_bundled: false } }
+        let(:existing_dependency) do
+          Dependabot::Dependency.new(
+            name: "business",
+            version: "1.3",
+            requirements: [],
+            package_manager: "dummy",
+            subdependency_metadata: existing_subdependency_metadata
+          )
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "business",
+            version: "1.3",
+            requirements: [],
+            package_manager: "dummy",
+            subdependency_metadata: subdependency_metadata
+          )
+        end
+
+        it { is_expected.to be_a(described_class) }
+
+        it "has a single dependency with the merged subdependency_metadata" do
+          expect(subject.dependencies.count).to eq(1)
+          expect(subject.dependencies.first.subdependency_metadata).
+            to eq(
+              npm_bundled: false
+            )
+        end
+
+        context "when existing depedency has no subdependency_metadata" do
+          let(:existing_subdependency_metadata) { nil }
+
+          it "has a single dependency with the merged subdependency_metadata" do
+            expect(subject.dependencies.count).to eq(1)
+            expect(subject.dependencies.first.subdependency_metadata).
+              to eq(
+                npm_bundled: false
+              )
+          end
+        end
+
+        context "when depedency has no subdependency_metadata" do
+          let(:subdependency_metadata) { nil }
+
+          it "has a single dependency with the merged subdependency_metadata" do
+            expect(subject.dependencies.count).to eq(1)
+            expect(subject.dependencies.first.subdependency_metadata).
+              to eq(
+                npm_bundled: true
+              )
+          end
+        end
+
+        context "when neither have subdependency_metadata" do
+          let(:existing_subdependency_metadata) { nil }
+          let(:subdependency_metadata) { nil }
+
+          it "has a single dependency with no subdependency_metadata" do
+            expect(subject.dependencies.count).to eq(1)
+            expect(subject.dependencies.first.subdependency_metadata).to be_nil
+          end
+        end
+      end
     end
 
     context "with a non-dependency object" do

--- a/npm_and_yarn/.gitignore
+++ b/npm_and_yarn/.gitignore
@@ -5,3 +5,4 @@
 /helpers/node_modules
 /helpers/install-dir
 Gemfile.lock
+.byebug_history

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -132,7 +132,8 @@ module Dependabot
                 name: name,
                 version: semver_version_for(details["version"]),
                 package_manager: "npm_and_yarn",
-                requirements: []
+                requirements: [],
+                metadata: { bundled: details["bundled"] }
               )
 
               dependency_set += recursively_fetch_npm_lock_dependencies(details)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -128,14 +128,20 @@ module Dependabot
             fetch("dependencies", {}).each do |name, details|
               next unless semver_version_for(details["version"])
 
-              dependency_set << Dependency.new(
+              dependency_args = {
                 name: name,
                 version: semver_version_for(details["version"]),
                 package_manager: "npm_and_yarn",
-                requirements: [],
-                metadata: { bundled: details["bundled"] }
-              )
+                requirements: []
+              }
 
+              if details["bundled"]
+                dependency_args[:subdependency_metadata] = {
+                  npm_bundled: details["bundled"]
+                }
+              end
+
+              dependency_set << Dependency.new(dependency_args)
               dependency_set += recursively_fetch_npm_lock_dependencies(details)
             end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -233,7 +233,7 @@ module Dependabot
         # removed from the bundled set of dependencies and moved top level
         # resulting in a bunch of package duplication which is pretty confusing.
         def bundled_dependency?
-          dependency.metadata&.fetch(:bundled)
+          dependency.subdependency_metadata&.fetch(:npm_bundled, false) || false
         end
       end
     end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -26,6 +26,7 @@ module Dependabot
 
         def latest_resolvable_version
           raise "Not a subdependency!" if dependency.requirements.any?
+          return if bundled_dependency?
 
           SharedHelpers.in_a_temporary_directory do
             write_temporary_dependency_files
@@ -213,6 +214,26 @@ module Dependabot
           @package_files ||=
             dependency_files.
             select { |f| f.name.end_with?("package.json") }
+        end
+
+        # TODO: We should try and fix this by updating the parent that's not
+        # bundled. For this case: `chokidar > fsevents > node-pre-gyp > tar` we
+        # would need to update `fsevents`
+        #
+        # We shouldn't update bundled sub-dependencies as they have been bundled
+        # into the release at an exact version by a parent using
+        # `bundledDependencies`.
+        #
+        # For example, fsevents < 2 bundles node-pre-gyp meaning all it's
+        # sub-dependnecies get bundled into the release tarball at publish time
+        # so you always get the same sub-dependency versions if you re-install a
+        # specific version of fsevents.
+        #
+        # Updating the sub-dependency by deleting the entry works but it gets
+        # removed from the bundled set of dependencies and moved top level
+        # resulting in a bunch of package duplication which is pretty confusing.
+        def bundled_dependency?
+          dependency.metadata&.fetch(:bundled)
         end
       end
     end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
@@ -134,6 +134,13 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
             end
         end
       end
+
+      context "that contain bundled dependencies" do
+        let(:npm_lockfile_fixture_name) { "bundled_sub_dependency.json" }
+        subject { dependencies.find { |d| d.name == "tar" } }
+
+        its(:metadata) { is_expected.to eq(bundled: true) }
+      end
     end
 
     context "for npm shrinkwraps" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
@@ -98,6 +98,11 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         expect(dependencies.map(&:name)).to contain_exactly("etag")
       end
 
+      it "doesn't include subdependency_metadata for unbundled dependencies" do
+        dep = dependencies.find { |d| d.name == "etag" }
+        expect(dep.subdependency_metadata).to be_nil
+      end
+
       context "that contain multiple dependencies" do
         let(:npm_lockfile_fixture_name) { "blank_requirement.json" }
 
@@ -139,7 +144,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         let(:npm_lockfile_fixture_name) { "bundled_sub_dependency.json" }
         subject { dependencies.find { |d| d.name == "tar" } }
 
-        its(:metadata) { is_expected.to eq(bundled: true) }
+        its(:subdependency_metadata) { is_expected.to eq(npm_bundled: true) }
       end
     end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -154,6 +154,29 @@ RSpec.describe namespace::SubdependencyVersionResolver do
         # the same version
         it { is_expected.to eq(Gem::Version.new("5.2.1")) }
       end
+
+      context "when sub-dependnecy is bundled" do
+        let(:manifest_fixture_name) { "bundled_sub_dependency.json" }
+        let(:npm_lock_fixture_name) { "bundled_sub_dependency.json" }
+
+        let(:dependency_name) { "tar" }
+        let(:version) { "4.4.10" }
+        let(:previous_version) { "4.4.1" }
+        let(:requirements) { [] }
+        let(:previous_requirements) { [] }
+
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "tar",
+            version: "4.4.1",
+            requirements: [],
+            package_manager: "npm_and_yarn",
+            metadata: { bundled: true }
+          )
+        end
+
+        it { is_expected.to eq(nil) }
+      end
     end
 
     context "with a yarn.lock and a package-lock.json" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe namespace::SubdependencyVersionResolver do
             version: "4.4.1",
             requirements: [],
             package_manager: "npm_and_yarn",
-            metadata: { bundled: true }
+            subdependency_metadata: { npm_bundled: true }
           )
         end
 

--- a/npm_and_yarn/spec/fixtures/npm_lockfiles/bundled_sub_dependency.json
+++ b/npm_and_yarn/spec/fixtures/npm_lockfiles/bundled_sub_dependency.json
@@ -1,0 +1,427 @@
+{
+  "name": "bundled",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "requires": {
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "requires": {
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true
+        }
+      }
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/package_files/bundled_sub_dependency.json
+++ b/npm_and_yarn/spec/fixtures/package_files/bundled_sub_dependency.json
@@ -1,0 +1,15 @@
+{
+  "name": "bundled",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "fsevents": "^1.2.4"
+  }
+}


### PR DESCRIPTION
Thinking that we shouldn't update bundled sub-dependencies as they have
been bundled into the release at an exact version by a parent using
`bundledDependencies`.

For example, fsevents < 2 bundles node-pre-gyp meaning all it's
sub-dependnecies get bundled into the release tarball at publish time so
you always get the same sub-dependency versions if you re-install a
specific version of fsevents.

Updating the sub-dependency (by deleting the entry) does seem to work
but it gets removed from the bundled set of dependencies and moved top
level resulting in a bunch of package duplication which is pretty
confusing.

To fix this properly we would need to try and update the parent but
this gets a bit crazy if we need to go up several levels which is the
case when updating `tar` here: `chokidar > fsevents > node-pre-gyp >
tar`.