### PR TITLE
Partly revert 65c3a55 to fix git-tag based bundler update.

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
@@ -169,10 +169,7 @@ module Dependabot
           new_req = Gem::Requirement.create("= #{target_version}")
           definition.dependencies.
             find { |d| d.name == dependency.name }.
-            tap do |dep|
-              dep.instance_variable_set(:@requirement, new_req)
-              dep.source = nil if dep.source.is_a?(::Bundler::Source::Git)
-            end
+            instance_variable_set(:@requirement, new_req)
 
           definition
         end

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -1570,8 +1570,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
                 to receive(:new).with(
                   requirements: requirements,
                   update_strategy: :bump_versions,
-                  latest_version: "1.16.0",
-                  latest_resolvable_version: "1.6.0",
+                  latest_version: nil,
+                  latest_resolvable_version: nil,
                   updated_source: requirements.first[:source]
                 ).and_call_original
 

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -72,6 +72,11 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
   let(:gemspec_fixture_name) { "example" }
   let(:rubygems_url) { "https://rubygems.org/api/v1/" }
 
+  before do
+    stub_request(:get, rubygems_url + "versions/business_no_rubygems.json").
+      to_return(status: 404, body: "This rubygem could not be found.")
+  end
+
   describe "#latest_version" do
     subject { checker.latest_version }
 
@@ -101,10 +106,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "when the gem isn't on Rubygems" do
-        before do
-          stub_request(:get, rubygems_url + "versions/business.json").
-            to_return(status: 404, body: "This rubygem could not be found.")
-        end
+        let(:dependency_name) { "business_no_rubygems" }
 
         it { is_expected.to be_nil }
       end
@@ -260,10 +262,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           end
 
           context "and the gem isn't on Rubygems" do
-            before do
-              stub_request(:get, rubygems_url + "versions/business.json").
-                to_return(status: 404, body: "This rubygem could not be found.")
-            end
+            let(:dependency_name) { "business_no_rubygems" }
 
             it { is_expected.to eq(current_version) }
           end
@@ -307,9 +306,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
               }]
             end
 
+            let(:dependency_name) { "business_no_rubygems" }
             before do
-              stub_request(:get, rubygems_url + "versions/business.json").
-                to_return(status: 404, body: "This rubygem could not be found.")
               url = "https://github.com/gocardless/business.git"
               git_header = {
                 "content-type" => "application/x-git-upload-pack-advertisement"
@@ -378,10 +376,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     subject { checker.send(:latest_version_resolvable_with_full_unlock?) }
 
     context "with no latest version" do
-      before do
-        stub_request(:get, rubygems_url + "versions/business.json").
-          to_return(status: 404, body: "This rubygem could not be found.")
-      end
+      let(:dependency_name) { "business_no_rubygems" }
 
       it { is_expected.to be_falsey }
     end
@@ -845,9 +840,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
               }]
             end
 
+            let(:dependency_name) { "business_no_rubygems" }
             before do
-              stub_request(:get, rubygems_url + "versions/business.json").
-                to_return(status: 404, body: "This rubygem could not be found.")
               url = "https://github.com/gocardless/business.git"
               git_header = {
                 "content-type" => "application/x-git-upload-pack-advertisement"
@@ -1569,10 +1563,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           end
 
           context "and the reference isn't included in the new version" do
-            before do
-              stub_request(:get, rubygems_url + "versions/business.json").
-                to_return(status: 404, body: "This rubygem could not be found.")
-            end
+            let(:dependency_name) { "business_no_rubygems" }
 
             it "delegates to Bundler::RequirementsUpdater" do
               expect(requirements_updater).


### PR DESCRIPTION
To fix #1217. Needs to fix both spec and implementation.

I'm not sure about the best way to fix this, but at least reverting 65c3a55 seems to work.