### PR TITLE
Undefined names: Add missing imports

### DIFF
--- a/python/spec/fixtures/setup_files/with_open.py
+++ b/python/spec/fixtures/setup_files/with_open.py
@@ -1,4 +1,6 @@
 import codecs
+import io
+import os
 from setuptools import setup, find_packages
 
 file = open("some_file", "r")

--- a/python/spec/fixtures/setup_files/with_pbr.py
+++ b/python/spec/fixtures/setup_files/with_pbr.py
@@ -1,6 +1,6 @@
-from setuptools import setup
+import setuptools
 
-setup(
+setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=['raven'],
     setup_requires=['pbr'],


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/dependabot/dependabot-core on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./python/spec/fixtures/setup_files/with_open.py:10:9: F821 undefined name 'io'
file3 = io.open("some_file", "r")
        ^
./python/spec/fixtures/setup_files/with_open.py:16:17: F821 undefined name 'os'
    return open(os.path.join(os.path.dirname(__file__), fname)).read()
                ^
./python/spec/fixtures/setup_files/with_open.py:16:30: F821 undefined name 'os'
    return open(os.path.join(os.path.dirname(__file__), fname)).read()
                             ^
./python/spec/fixtures/setup_files/with_parse_reqs.py:3:29: F821 undefined name 'parse_requirements'
reqs = [str(r.req) for r in parse_requirements('requirements.txt', session=PipSession()) if r.req is not None]
                            ^
./python/spec/fixtures/setup_files/with_parse_reqs.py:3:76: F821 undefined name 'PipSession'
reqs = [str(r.req) for r in parse_requirements('requirements.txt', session=PipSession()) if r.req is not None]
                                                                           ^
./python/spec/fixtures/setup_files/with_pbr.py:4:14: F821 undefined name 'setuptools'
    packages=setuptools.find_packages(),
             ^
6     F821 undefined name 'io'
6
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree