### PR TITLE
Go (modules): don't update replace-pinned dependencies

### DIFF
--- a/go_modules/helpers/updatechecker/gomodfile.go
+++ b/go_modules/helpers/updatechecker/gomodfile.go
@@ -1,0 +1,44 @@
+package updatechecker
+
+import (
+	"io/ioutil"
+
+	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/modfile"
+)
+
+type goModFile struct {
+	excludes           map[string][]string
+	pinnedDependencies []string
+}
+
+func parseModFile() (goModFile, error) {
+	fileInfo := goModFile{excludes: map[string][]string{}}
+
+	data, err := ioutil.ReadFile("go.mod")
+	if err != nil {
+		return fileInfo, err
+	}
+
+	var f *modfile.File
+	// TODO library detection - don't consider exclude etc for libraries
+	if "library" == "true" {
+		f, err = modfile.ParseLax("go.mod", data, nil)
+	} else {
+		f, err = modfile.Parse("go.mod", data, nil)
+	}
+	if err != nil {
+		return fileInfo, err
+	}
+
+	for _, e := range f.Exclude {
+		fileInfo.excludes[e.Mod.Path] = append(fileInfo.excludes[e.Mod.Path], e.Mod.Version)
+	}
+
+	for _, r := range f.Replace {
+		if r.Old.Path == r.New.Path {
+			fileInfo.pinnedDependencies = append(fileInfo.pinnedDependencies, r.New.Path)
+		}
+	}
+
+	return fileInfo, nil
+}

--- a/go_modules/helpers/updatechecker/main.go
+++ b/go_modules/helpers/updatechecker/main.go
@@ -2,11 +2,9 @@ package updatechecker
 
 import (
 	"errors"
-	"io/ioutil"
 	"regexp"
 
 	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/modfetch"
-	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/modfile"
 	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/modload"
 	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/semver"
 )
@@ -48,7 +46,7 @@ func GetUpdatedVersion(args *Args) (interface{}, error) {
 		return nil, err
 	}
 
-	excludes, err := goModExcludes(args.Dependency.Name)
+	modFile, err := parseModFile()
 	if err != nil {
 		return nil, err
 	}
@@ -60,6 +58,13 @@ func GetUpdatedVersion(args *Args) (interface{}, error) {
 
 	if pseudoVersionRegexp.MatchString(currentPrerelease) {
 		return latestVersion, nil
+	}
+
+	// Don't update pinned dependencies
+	for _, d := range modFile.pinnedDependencies {
+		if d == args.Dependency.Name {
+			return latestVersion, nil
+		}
 	}
 
 Outer:
@@ -76,7 +81,7 @@ Outer:
 			continue
 		}
 
-		for _, exclude := range excludes {
+		for _, exclude := range modFile.excludes[args.Dependency.Name] {
 			if v == exclude {
 				continue Outer
 			}
@@ -86,31 +91,4 @@ Outer:
 	}
 
 	return latestVersion, nil
-}
-
-func goModExcludes(dependency string) ([]string, error) {
-	data, err := ioutil.ReadFile("go.mod")
-	if err != nil {
-		return nil, err
-	}
-
-	var f *modfile.File
-	// TODO library detection - don't consider exclude etc for libraries
-	if "library" == "true" {
-		f, err = modfile.ParseLax("go.mod", data, nil)
-	} else {
-		f, err = modfile.Parse("go.mod", data, nil)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	var excludes []string
-	for _, e := range f.Exclude {
-		if e.Mod.Path == dependency {
-			excludes = append(excludes, e.Mod.Version)
-		}
-	}
-
-	return excludes, nil
 }

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -80,6 +80,22 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
       end
     end
 
+    context "with a version pinned using the `replace` directive" do
+      let(:go_mod_content) do
+        version = dependency_version
+        <<~GOMOD
+          module foobar
+          require #{dependency_name} v#{version}
+          replace #{dependency_name} => #{dependency_name} v#{version}
+        GOMOD
+      end
+
+      it "doesn't change the version" do
+        expect(latest_resolvable_version).
+          to eq(Dependabot::GoModules::Version.new("1.0.0"))
+      end
+    end
+
     it "doesn't update to (Dependabot) ignored versions" do
       # TODO: let(:ignored_versions) { ["..."] }
     end


### PR DESCRIPTION
The replace directive can be used to pin dependencies to a specific version. Don't update the dependency in that case.

Related: https://github.com/dependabot/feedback/issues/538

See: https://github.com/golang/go/wiki/Modules#when-should-i-use-the-replace-directive