### PR TITLE
[Composer] Enhancement: Rename namespace

### DIFF
--- a/composer/README.md
+++ b/composer/README.md
@@ -1,6 +1,6 @@
 ## `dependabot-composer`
 
-PHP support for [`dependabot-core`][core-repo].
+PHP (Composer) support for [`dependabot-core`][core-repo].
 
 ### Running locally
 

--- a/composer/helpers/bin/run
+++ b/composer/helpers/bin/run
@@ -3,7 +3,7 @@
 
 declare(strict_types=1);
 
-namespace Dependabot\PHP;
+namespace Dependabot\Composer;
 
 require __DIR__ . '/../vendor/autoload.php';
 

--- a/composer/helpers/composer.json
+++ b/composer/helpers/composer.json
@@ -9,7 +9,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Dependabot\\PHP\\": "src/"
+            "Dependabot\\Composer\\": "src/"
         }
     },
     "scripts": {

--- a/composer/helpers/src/DependabotInstallationManager.php
+++ b/composer/helpers/src/DependabotInstallationManager.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Dependabot\PHP;
+namespace Dependabot\Composer;
 
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;

--- a/composer/helpers/src/DependabotPluginManager.php
+++ b/composer/helpers/src/DependabotPluginManager.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Dependabot\PHP;
+namespace Dependabot\Composer;
 
 use Composer\Package\PackageInterface;
 use Composer\Plugin\PluginManager;

--- a/composer/helpers/src/ExceptionIO.php
+++ b/composer/helpers/src/ExceptionIO.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Dependabot\PHP;
+namespace Dependabot\Composer;
 
 use Composer\IO\NullIO;
 

--- a/composer/helpers/src/Hasher.php
+++ b/composer/helpers/src/Hasher.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Dependabot\PHP;
+namespace Dependabot\Composer;
 
 use Composer\Factory;
 

--- a/composer/helpers/src/UpdateChecker.php
+++ b/composer/helpers/src/UpdateChecker.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Dependabot\PHP;
+namespace Dependabot\Composer;
 
 use Composer\Factory;
 use Composer\Installer;

--- a/composer/helpers/src/Updater.php
+++ b/composer/helpers/src/Updater.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Dependabot\PHP;
+namespace Dependabot\Composer;
 
 use Composer\Factory;
 use Composer\Installer;


### PR DESCRIPTION
This PR

* [x] renames the `Dependabot\PHP` namespace to `Dependabot\Composer`

💁‍♂ There are other package managers for PHP, so renaming the namespace makes room for those.