### PR TITLE
Allow commit_message_options to be passed to pull request creator

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -16,7 +16,7 @@ module Dependabot
 
     attr_reader :source, :dependencies, :files, :base_commit,
                 :credentials, :pr_message_footer, :custom_labels,
-                :author_details, :signature_key, :signoff_details,
+                :author_details, :signature_key, :commit_message_options,
                 :vulnerabilities_fixed,
                 :reviewers, :assignees, :milestone, :branch_name_separator,
                 :branch_name_prefix, :github_redirection_service,
@@ -25,7 +25,7 @@ module Dependabot
     def initialize(source:, base_commit:, dependencies:, files:, credentials:,
                    pr_message_footer: nil, custom_labels: nil,
                    author_details: nil, signature_key: nil,
-                   signoff_details: nil,
+                   commit_message_options: {},
                    reviewers: nil, assignees: nil, milestone: nil,
                    vulnerabilities_fixed: {}, branch_name_separator: "/",
                    branch_name_prefix: "dependabot",
@@ -40,7 +40,7 @@ module Dependabot
       @pr_message_footer          = pr_message_footer
       @author_details             = author_details
       @signature_key              = signature_key
-      @signoff_details            = signoff_details
+      @commit_message_options     = commit_message_options
       @custom_labels              = custom_labels
       @reviewers                  = reviewers
       @assignees                  = assignees
@@ -127,7 +127,7 @@ module Dependabot
           dependencies: dependencies,
           files: files,
           credentials: credentials,
-          signoff_details: signoff_details,
+          commit_message_options: commit_message_options,
           pr_message_footer: pr_message_footer,
           vulnerabilities_fixed: vulnerabilities_fixed,
           github_redirection_service: github_redirection_service

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -15,18 +15,18 @@ module Dependabot
       require_relative "pr_name_prefixer"
 
       attr_reader :source, :dependencies, :files, :credentials,
-                  :pr_message_footer, :signoff_details, :vulnerabilities_fixed,
-                  :github_redirection_service
+                  :pr_message_footer, :commit_message_options,
+                  :vulnerabilities_fixed, :github_redirection_service
 
       def initialize(source:, dependencies:, files:, credentials:,
-                     pr_message_footer: nil, signoff_details: nil,
+                     pr_message_footer: nil, commit_message_options: {},
                      vulnerabilities_fixed: {}, github_redirection_service: nil)
         @dependencies               = dependencies
         @files                      = files
         @source                     = source
         @credentials                = credentials
         @pr_message_footer          = pr_message_footer
-        @signoff_details            = signoff_details
+        @commit_message_options     = commit_message_options
         @vulnerabilities_fixed      = vulnerabilities_fixed
         @github_redirection_service = github_redirection_service
       end
@@ -127,6 +127,7 @@ module Dependabot
       end
 
       def signoff_message
+        signoff_details = commit_message_options[:signoff_details]
         return unless signoff_details.is_a?(Hash)
         return unless signoff_details[:name] && signoff_details[:email]
 
@@ -134,6 +135,7 @@ module Dependabot
       end
 
       def on_behalf_of_message
+        signoff_details = commit_message_options[:signoff_details]
         return unless signoff_details.is_a?(Hash)
         return unless signoff_details[:org_name] && signoff_details[:org_email]
 
@@ -525,6 +527,7 @@ module Dependabot
             source: source,
             dependencies: dependencies,
             credentials: credentials,
+            commit_message_options: commit_message_options,
             security_fix: vulnerabilities_fixed.values.flatten.any?
           )
       end

--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -4,6 +4,7 @@ require "dependabot/clients/github_with_retries"
 require "dependabot/clients/gitlab_with_retries"
 require "dependabot/pull_request_creator"
 
+# rubocop:disable Metrics/ClassLength
 module Dependabot
   class PullRequestCreator
     class PrNamePrefixer
@@ -25,11 +26,13 @@ module Dependabot
                             twisted_rightwards_arrows whale wheelchair
                             white_check_mark wrench zap).freeze
 
-      def initialize(source:, dependencies:, credentials:, security_fix: false)
-        @dependencies = dependencies
-        @source       = source
-        @credentials  = credentials
-        @security_fix = security_fix
+      def initialize(source:, dependencies:, credentials:, security_fix: false,
+                     commit_message_options: {})
+        @dependencies           = dependencies
+        @source                 = source
+        @credentials            = credentials
+        @security_fix           = security_fix
+        @commit_message_options = commit_message_options
       end
 
       def pr_name_prefix
@@ -39,45 +42,63 @@ module Dependabot
       end
 
       def capitalize_first_word?
-        case last_dependabot_commit_style
-        when :gitmoji then true
-        when :conventional_prefix, :conventional_prefix_with_scope
-          last_dependabot_commit_message.match?(/: (\[Security\] )?(B|U)/)
-        else
-          if using_angular_commit_messages? || using_eslint_commit_messages?
-            prefixes = ANGULAR_PREFIXES + ESLINT_PREFIXES
-            semantic_msgs = recent_commit_messages.select do |message|
-              prefixes.any? { |pre| message.match?(/#{pre}[:(]/i) }
-            end
-
-            return true if semantic_msgs.all? { |m| m.match?(/:\s+\[?[A-Z]/) }
-            return false if semantic_msgs.all? { |m| m.match?(/:\s+\[?[a-z]/) }
-          end
-
-          !commit_prefix&.match(/\A[a-z]/)
+        if commit_message_options.key?(:prefix)
+          return !commit_message_options[:prefix]&.strip&.match?(/\A[a-z]/)
         end
+
+        if last_dependabot_commit_style
+          return capitalise_first_word_from_last_dependabot_commit_style
+        end
+
+        capitalise_first_word_from_previous_commits
       end
 
       private
 
-      attr_reader :source, :dependencies, :credentials
+      attr_reader :source, :dependencies, :credentials, :commit_message_options
 
       def security_fix?
         @security_fix
       end
 
       def commit_prefix
-        # If there is a previous Dependabot commit, and it used a known style,
-        # use that as our model for subsequent commits
+        # If a preferred prefix has been explicitly provided, use it
+        if commit_message_options.key?(:prefix)
+          return prefix_from_explicitly_provided_details
+        end
+
+        # Otherwise, if there is a previous Dependabot commit and it used a
+        # known style, use that as our model for subsequent commits
+        if last_dependabot_commit_style
+          return prefix_for_last_dependabot_commit_style
+        end
+
+        # Otherwise we need to detect the user's preferred style from the
+        # existing commits on their repo
+        build_commit_prefix_from_previous_commits
+      end
+
+      def prefix_from_explicitly_provided_details
+        unless commit_message_options.key?(:prefix)
+          raise "No explicitly provided prefix!"
+        end
+
+        prefix = commit_message_options[:prefix].to_s
+        return if prefix.empty?
+
+        prefix += "(#{scope})" if commit_message_options[:include_scope]
+        prefix += ":" if prefix.match?(/[A-Za-z0-9\)\]]\Z/)
+        prefix += " " unless prefix.end_with?(" ")
+        prefix
+      end
+
+      def prefix_for_last_dependabot_commit_style
         case last_dependabot_commit_style
         when :gitmoji then "⬆️ "
         when :conventional_prefix then "#{last_dependabot_commit_prefix}: "
         when :conventional_prefix_with_scope
           "#{last_dependabot_commit_prefix}(#{scope}): "
-        else
-          # Otherwise we need to detect the user's preferred style from the
-          # existing commits on their repo
-          build_commit_prefix_from_previous_commits
+        else raise "Unknown commit style #{last_dependabot_commit_style}"
         end
       end
 
@@ -102,6 +123,29 @@ module Dependabot
 
       def scope
         dependencies.any?(&:production?) ? "deps" : "deps-dev"
+      end
+
+      def capitalise_first_word_from_last_dependabot_commit_style
+        case last_dependabot_commit_style
+        when :gitmoji then true
+        when :conventional_prefix, :conventional_prefix_with_scope
+          last_dependabot_commit_message.match?(/: (\[[Ss]ecurity\] )?(B|U)/)
+        else raise "Unknown commit style #{last_dependabot_commit_style}"
+        end
+      end
+
+      def capitalise_first_word_from_previous_commits
+        if using_angular_commit_messages? || using_eslint_commit_messages?
+          prefixes = ANGULAR_PREFIXES + ESLINT_PREFIXES
+          semantic_msgs = recent_commit_messages.select do |message|
+            prefixes.any? { |pre| message.match?(/#{pre}[:(]/i) }
+          end
+
+          return true if semantic_msgs.all? { |m| m.match?(/:\s+\[?[A-Z]/) }
+          return false if semantic_msgs.all? { |m| m.match?(/:\s+\[?[a-z]/) }
+        end
+
+        !commit_prefix&.match(/\A[a-z]/)
       end
 
       def last_dependabot_commit_style
@@ -250,11 +294,12 @@ module Dependabot
       end
 
       def last_dependabot_commit_message
-        case source.provider
-        when "github" then last_github_dependabot_commit_message
-        when "gitlab" then last_gitlab_dependabot_commit_message
-        else raise "Unsupported provider: #{source.provider}"
-        end
+        @last_dependabot_commit_message ||=
+          case source.provider
+          when "github" then last_github_dependabot_commit_message
+          when "gitlab" then last_gitlab_dependabot_commit_message
+          else raise "Unsupported provider: #{source.provider}"
+          end
       end
 
       def last_github_dependabot_commit_message
@@ -305,3 +350,4 @@ module Dependabot
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       files: files,
       credentials: credentials,
       pr_message_footer: pr_message_footer,
-      signoff_details: signoff_details,
+      commit_message_options: { signoff_details: signoff_details },
       vulnerabilities_fixed: vulnerabilities_fixed,
       github_redirection_service: github_redirection_service
     )

--- a/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
       source: source,
       dependencies: dependencies,
       credentials: credentials,
+      commit_message_options: commit_message_options,
       security_fix: security_fix
     )
   end
@@ -40,6 +41,7 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
       "password" => "token"
     }]
   end
+  let(:commit_message_options) { {} }
   let(:security_fix) { false }
 
   let(:json_header) { { "Content-Type" => "application/json" } }
@@ -186,6 +188,39 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
       context "with a security vulnerability fixed" do
         let(:security_fix) { true }
         it { is_expected.to eq("⬆️🔒 ") }
+      end
+    end
+
+    context "when commit_message_options are provided" do
+      let(:commit_message_options) do
+        {
+          prefix: prefix,
+          include_scope: include_scope
+        }.compact
+      end
+      let(:prefix) { "custom" }
+      let(:include_scope) { nil }
+
+      it { is_expected.to eq("custom: ") }
+
+      context "with a security vulnerability fixed" do
+        let(:security_fix) { true }
+        it { is_expected.to eq("custom: [security] ") }
+
+        context "with a capitalised prefix" do
+          let(:prefix) { "Custom" }
+          it { is_expected.to eq("Custom: [Security] ") }
+        end
+      end
+
+      context "when asked to include the scope" do
+        let(:include_scope) { true }
+        it { is_expected.to eq("custom(deps): ") }
+      end
+
+      context "when asked not to include the scope" do
+        let(:include_scope) { false }
+        it { is_expected.to eq("custom: ") }
       end
     end
   end


### PR DESCRIPTION
Allows a hash of commit message options to be passed to the pull request creator. The allowed options are:
- `signoff_details` which works as currently used
- `prefix` which allows a prefix to be specified
- `include_scope` which takes a boolean to determine with the dependency's scope should be included in the prefix

The intention is for `prefix` and `include_scope` to be allowed keys under `commit_message` in Dependabot's config files, and for this to provide a robust way for folks to specify that they want to use a particular commit style. A config file might look like:

```yaml
version: 1
update_configs:
  - package_manager: "ruby:bundler"
    directory: "/"
    update_schedule: "live"
    commit_message:
      - prefix: "chore"
      - include_scope: true
```

One deficiency here is that the same prefix will be used for all commits, so this won't help folks who want to specify `fix` for some commits and `build` for others. That's a pity, but we can iterate towards a solution there if required.

Another option I've toyed with including but so far excluded is `downcase_subject`, as some conventions require that the entire first line of the commit message is downcased. That would be easy to add later.