### PR TITLE
Strip @ character from branch name

### DIFF
--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -29,7 +29,7 @@ module Dependabot
               elsif dependencies.count > 1 && updating_a_dependency_set?
                 dependency_set.fetch(:group)
               else
-                dependencies.map(&:name).join("-and-").tr(":", "-")
+                dependencies.map(&:name).join("-and-").tr(":", "-").tr("@", "")
               end
 
             dep = dependencies.first

--- a/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
@@ -268,6 +268,23 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
       end
     end
 
+    context "with an @ in the name" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "@storybook/addon-knobs",
+          version: "5.1.9",
+          previous_version: "5.0.11",
+          package_manager: "npm_and_yarn",
+          requirements: []
+        )
+      end
+
+      it "strips @ character" do
+        expect(new_branch_name).
+          to eq("dependabot/npm_and_yarn/storybook/addon-knobs-5.1.9")
+      end
+    end
+
     context "with SHA-1 versions" do
       let(:dependency) do
         Dependabot::Dependency.new(


### PR DESCRIPTION
Despite "@" character is perfectly fine as a part of a Git branch name,
it is not allowed inside a Docker tag. It can break some workflows when
branch name is used as a Docker tag for corresponding Docker image.

Replacing it with something safer like "at-" string solves the problem.
UPD: It's been decided to strip the `@` character from branch name altogether.