### PR TITLE
Python: Move Python version requirement detection into its own class

### DIFF
--- a/python/lib/dependabot/python/file_parser/python_requirement_parser.rb
+++ b/python/lib/dependabot/python/file_parser/python_requirement_parser.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require "toml-rb"
+require "open3"
+require "dependabot/errors"
+require "dependabot/shared_helpers"
+require "dependabot/python/file_parser"
+require "dependabot/python/requirement"
+
+module Dependabot
+  module Python
+    class FileParser
+      class PythonRequirementParser
+        attr_reader :dependency_files
+
+        def initialize(dependency_files:)
+          @dependency_files = dependency_files
+        end
+
+        # TODO: Parse setup.py and setup.cfg to get python requirement
+        def user_specified_requirement
+          pipfile_python_requirement ||
+            pyproject_python_requirement ||
+            python_version_file_version ||
+            runtime_file_python_version
+        end
+
+        # TODO: Add better Python version detection using dependency versions
+        # (e.g., Django 2.x implies Python 3)
+        def imputed_requirements
+          requirement_files.flat_map do |file|
+            file.content.lines.
+              select { |l| l.include?(";") && l.include?("python") }.
+              map { |l| l.match(/python_version(?<req>.*?["'].*?['"])/) }.
+              compact.
+              map { |re| re.named_captures.fetch("req").gsub(/['"]/, "") }.
+              select do |r|
+                requirement_class.new(r)
+                true
+              rescue Gem::Requirement::BadRequirementError
+                false
+              end
+          end
+        end
+
+        private
+
+        def pipfile_python_requirement
+          return unless pipfile
+
+          parsed_pipfile = TomlRB.parse(pipfile.content)
+          requirement =
+            parsed_pipfile.dig("requires", "python_full_version") ||
+            parsed_pipfile.dig("requires", "python_version")
+          return unless requirement&.match?(/^\d/)
+
+          requirement
+        end
+
+        def pyproject_python_requirement
+          return unless pyproject
+
+          pyproject_object = TomlRB.parse(pyproject.content)
+          poetry_object = pyproject_object.dig("tool", "poetry")
+
+          poetry_object&.dig("dependencies", "python") ||
+            poetry_object&.dig("dev-dependencies", "python")
+        end
+
+        def python_version_file_version
+          return unless python_version_file
+
+          file_version = python_version_file.content.strip
+          return if file_version&.empty?
+          return unless pyenv_versions.include?("#{file_version}\n")
+
+          file_version
+        end
+
+        def runtime_file_python_version
+          return unless runtime_file
+
+          file_version = runtime_file.content.
+                         match(/(?<=python-).*/)&.to_s&.strip
+          return if file_version&.empty?
+          return unless pyenv_versions.include?("#{file_version}\n")
+
+          file_version
+        end
+
+        def pipenv_python_requirement
+          pipfile_lock_python_version || pipfile_python_requirement
+        end
+
+        def pipfile_lock_python_version
+          return unless pipfile_lock
+
+          JSON.parse(pipfile_lock.content).dig(
+            "_meta",
+            "host-environment-markers",
+            "python_full_version"
+          )
+        end
+
+        def pyenv_versions
+          @pyenv_versions ||= run_command("pyenv install --list")
+        end
+
+        def run_command(command, env: {})
+          start = Time.now
+          command = SharedHelpers.escape_command(command)
+          stdout, process = Open3.capture2e(env, command)
+          time_taken = Time.now - start
+
+          return stdout if process.success?
+
+          raise SharedHelpers::HelperSubprocessFailed.new(
+            message: stdout,
+            error_context: {
+              command: command,
+              time_taken: time_taken,
+              process_exit_value: process.to_s
+            }
+          )
+        end
+
+        def requirement_class
+          Dependabot::Python::Requirement
+        end
+
+        def pipfile
+          dependency_files.find { |f| f.name == "Pipfile" }
+        end
+
+        def pipfile_lock
+          dependency_files.find { |f| f.name == "Pipfile.lock" }
+        end
+
+        def pyproject
+          dependency_files.find { |f| f.name == "pyproject.toml" }
+        end
+
+        def setup_files
+          dependency_files.select { |f| f.name.end_with?("setup.py") }
+        end
+
+        def setup_cfg_files
+          dependency_files.select { |f| f.name.end_with?("setup.cfg") }
+        end
+
+        def python_version_file
+          dependency_files.find { |f| f.name == ".python-version" }
+        end
+
+        def runtime_file
+          dependency_files.find { |f| f.name.end_with?("runtime.txt") }
+        end
+
+        def requirement_files
+          dependency_files.select { |f| f.name.end_with?(".txt") }
+        end
+      end
+    end
+  end
+end

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -3,6 +3,7 @@
 require "open3"
 require "dependabot/python/requirement_parser"
 require "dependabot/python/file_fetcher"
+require "dependabot/python/file_parser/python_requirement_parser"
 require "dependabot/python/file_updater"
 require "dependabot/shared_helpers"
 require "dependabot/python/native_helpers"
@@ -524,60 +525,42 @@ module Dependabot
         end
 
         def python_version
-          # TODO: Add better Python version detection using dependency versions
-          # (e.g., Django 2.x implies Python 3)
           @python_version ||=
             user_specified_python_version ||
-            python_version_from_compiled_requirements ||
+            python_version_matching_imputed_requirements ||
             PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.first
         end
 
         def user_specified_python_version
-          file_version = python_version_file&.content&.strip
-          file_version ||= runtime_file_python_version
+          return unless python_requirement_parser.user_specified_requirement
 
-          return unless file_version
-          return unless pyenv_versions.include?("#{file_version}\n")
-
-          file_version
+          user_specified_requirement =
+            Dependabot::Python::Requirement.new(
+              python_requirement_parser.user_specified_requirement
+            )
+          python_version_matching([user_specified_requirement])
         end
 
-        def runtime_file_python_version
-          return unless runtime_file
-
-          runtime_file.content.match(/(?<=python-).*/)&.to_s&.strip
+        def python_version_matching_imputed_requirements
+          compiled_file_python_requirement_markers =
+            python_requirement_parser.imputed_requirements.map do |r|
+              Dependabot::Python::Requirement.new(r)
+            end
+          python_version_matching(compiled_file_python_requirement_markers)
         end
 
-        def python_version_from_compiled_requirements
+        def python_version_matching(requirements)
           PythonVersions::SUPPORTED_VERSIONS_TO_ITERATE.find do |version_string|
             version = Python::Version.new(version_string)
-            compiled_file_python_requirement_markers.all? do |req|
-              req.satisfied_by?(version)
-            end
+            requirements.all? { |req| req.satisfied_by?(version) }
           end
         end
 
-        def compiled_file_python_requirement_markers
-          @python_requirement_strings ||=
-            compiled_files.flat_map do |file|
-              file.content.lines.
-                select { |l| l.include?(";") && l.include?("python") }.
-                map { |l| l.match(/python_version(?<req>.*?["'].*?['"])/) }.
-                compact.
-                map { |re| re.named_captures.fetch("req").gsub(/['"]/, "") }.
-                select do |r|
-                  requirement_class.new(r)
-                  true
-                rescue Gem::Requirement::BadRequirementError
-                  false
-                end
-            end
-
-          @python_requirement_strings.map { |r| requirement_class.new(r) }
-        end
-
-        def pyenv_versions
-          @pyenv_versions ||= run_command("pyenv install --list")
+        def python_requirement_parser
+          @python_requirement_parser ||=
+            FileParser::PythonRequirementParser.new(
+              dependency_files: dependency_files
+            )
         end
 
         def pre_installed_python?(version)
@@ -598,18 +581,6 @@ module Dependabot
 
         def setup_cfg_files
           dependency_files.select { |f| f.name.end_with?("setup.cfg") }
-        end
-
-        def python_version_file
-          dependency_files.find { |f| f.name == ".python-version" }
-        end
-
-        def runtime_file
-          dependency_files.find { |f| f.name.end_with?("runtime.txt") }
-        end
-
-        def requirement_class
-          Python::Requirement
         end
       end
       # rubocop:enable Metrics/ClassLength

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -6,6 +6,7 @@ require "open3"
 require "dependabot/errors"
 require "dependabot/shared_helpers"
 require "dependabot/python/file_parser"
+require "dependabot/python/file_parser/python_requirement_parser"
 require "dependabot/python/file_updater/pyproject_preparer"
 require "dependabot/python/update_checker"
 require "dependabot/python/version"
@@ -14,7 +15,6 @@ require "dependabot/python/native_helpers"
 require "dependabot/python/python_versions"
 require "dependabot/python/authed_url_builder"
 
-# rubocop:disable Metrics/ClassLength
 module Dependabot
   module Python
     class UpdateChecker
@@ -189,19 +189,8 @@ module Dependabot
         end
 
         def python_version
-          pyproject_object = TomlRB.parse(pyproject.content)
-          poetry_object = pyproject_object.dig("tool", "poetry")
-
-          requirement =
-            poetry_object&.dig("dependencies", "python") ||
-            poetry_object&.dig("dev-dependencies", "python")
-
-          unless requirement
-            return python_version_file_version || runtime_file_python_version
-          end
-
-          requirements =
-            Python::Requirement.requirements_array(requirement)
+          requirement = user_specified_python_requirement
+          requirements = Python::Requirement.requirements_array(requirement)
 
           version = PythonVersions::SUPPORTED_VERSIONS_TO_ITERATE.find do |v|
             requirements.any? { |r| r.satisfied_by?(Python::Version.new(v)) }
@@ -215,23 +204,15 @@ module Dependabot
           raise DependencyFileNotResolvable, msg
         end
 
-        def python_version_file_version
-          file_version = python_version_file&.content&.strip
-
-          return unless file_version
-          return unless pyenv_versions.include?("#{file_version}\n")
-
-          file_version
+        def user_specified_python_requirement
+          python_requirement_parser.user_specified_requirement
         end
 
-        def runtime_file_python_version
-          return unless runtime_file
-
-          runtime_file.content.match(/(?<=python-).*/)&.to_s&.strip
-        end
-
-        def pyenv_versions
-          @pyenv_versions ||= run_poetry_command("pyenv install --list")
+        def python_requirement_parser
+          @python_requirement_parser ||=
+            FileParser::PythonRequirementParser.new(
+              dependency_files: dependency_files
+            )
         end
 
         def pre_installed_python?(version)
@@ -324,14 +305,6 @@ module Dependabot
           poetry_lock || pyproject_lock
         end
 
-        def python_version_file
-          dependency_files.find { |f| f.name == ".python-version" }
-        end
-
-        def runtime_file
-          dependency_files.find { |f| f.name.end_with?("runtime.txt") }
-        end
-
         def run_poetry_command(command)
           start = Time.now
           command = SharedHelpers.escape_command(command)
@@ -360,4 +333,3 @@ module Dependabot
     end
   end
 end
-# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
Removes a bunch of duplication, and creates a single place for us to make improvements to our Python version detection (including, for example., parsing the `setup.py` and getting the `python_requires` out of it, or adding imputed requirements based on the Django version being used).