### PR TITLE
Fetch yarn file path resolutions from manifest

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -171,9 +171,14 @@ module Dependabot
         current_dir = nil if current_dir == ""
         path_dep_starts = %w(file: / ./ ../ ~/ link:.)
 
-        dependency_objects =
-          JSON.parse(file.content).
-          values_at(*NpmAndYarn::FileParser::DEPENDENCY_TYPES).compact
+        # Fetch yarn "file:" path "resolutions" so that we can resolve the
+        # lockfile. This pattern seems to be used to replace a sub-dependency
+        # with a local mock version.
+        dependency_types = NpmAndYarn::FileParser::DEPENDENCY_TYPES +
+                           ["resolutions"]
+        dependency_objects = JSON.parse(file.content).
+                             values_at(*dependency_types).
+                             compact
 
         unless dependency_objects.all? { |o| o.is_a?(Hash) }
           raise Dependabot::DependencyFileNotParseable, file.path

--- a/npm_and_yarn/spec/fixtures/github/package_json_with_yarn_resolution_file_content.json
+++ b/npm_and_yarn/spec/fixtures/github/package_json_with_yarn_resolution_file_content.json
@@ -1,0 +1,18 @@
+{
+  "name": "package.json",
+  "path": "package.json",
+  "sha": "5c7b3419e0056515122b981f1566ebe22c208251",
+  "size": 594,
+  "url": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+  "html_url": "https://github.com/gocardless/bump/blob/master/package.json",
+  "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+  "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/package.json?token=ABMwe0apDiKCctWHnEHnszRBAebVHjQnks5WJWD9wA%3D%3D",
+  "type": "file",
+  "content": "eyJuYW1lIjoieWFybi1yZXNvbHV0aW9ucyIsInZlcnNpb24iOiIxLjAuMCIsImRlc2NyaXB0aW9uIjoiIiwibWFpbiI6ImluZGV4LmpzIiwic2NyaXB0cyI6eyJ0ZXN0IjoiZWNobyBcIkVycm9yOiBubyB0ZXN0IHNwZWNpZmllZFwiICYmIGV4aXQgMSJ9LCJrZXl3b3JkcyI6W10sImF1dGhvciI6IiIsImxpY2Vuc2UiOiJJU0MiLCJkZXBlbmRlbmNpZXMiOnsianMteWFtbCI6Il4zLjEzLjEifSwicmVzb2x1dGlvbnMiOnsianMteWFtbC8qKi9zcHJpbnRmLWpzIjoiZmlsZTouL21vY2tzL3NwcmludGYtanMifX0=",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+    "git": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+    "html": "https://github.com/gocardless/bump/blob/master/package.json"
+  }
+}


### PR DESCRIPTION
This fixes yarn lockfile resolution with file paths coming from a
resolutions declaration, for example:

```json
"resolutions": {
  "js-yaml/**/sprintf-js": "file:./mocks/sprintf-js"
}
```

Yarn supports selective version "resolutions" to override the version of
sub-dependencies. Usually this is used to force a sub-dependency to a
patched/working version when the parent isn't being updated but you can
also set a file path.