### PR TITLE
Bump masterminds/vcs to v1.13.1 to fix Go bitbucket support

### DIFF
--- a/go_modules/helpers/go.mod
+++ b/go_modules/helpers/go.mod
@@ -1,7 +1,7 @@
 module github.com/dependabot/dependabot-core/go_modules/helpers
 
 require (
-	github.com/Masterminds/vcs v1.13.0
+	github.com/Masterminds/vcs v1.13.1
 	github.com/dependabot/dependabot-core/go_modules/helpers/updater v0.0.0
 	github.com/dependabot/gomodules-extracted v0.0.0-20181020215834-1b2f850478a3
 )

--- a/go_modules/helpers/go.sum
+++ b/go_modules/helpers/go.sum
@@ -1,4 +1,6 @@
 github.com/Masterminds/vcs v1.13.0 h1:USF5TvZGYgIpcbNAEMLfFhHqP08tFZVlUVrmTSpqnyA=
 github.com/Masterminds/vcs v1.13.0/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
+github.com/Masterminds/vcs v1.13.1 h1:NL3G1X7/7xduQtA2sJLpVpfHTNBALVNSjob6KEjPXNQ=
+github.com/Masterminds/vcs v1.13.1/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
 github.com/dependabot/gomodules-extracted v0.0.0-20181020215834-1b2f850478a3 h1:Xj2leY0FVyZuo+p59vkIWG3dIqo+QtjskT5O1iTiywA=
 github.com/dependabot/gomodules-extracted v0.0.0-20181020215834-1b2f850478a3/go.mod h1:+dRXSrUymjpT4yzKtn1QmeknT1S/yAHRr35en18dHp8=

--- a/go_modules/helpers/go.sum
+++ b/go_modules/helpers/go.sum
@@ -1,5 +1,3 @@
-github.com/Masterminds/vcs v1.13.0 h1:USF5TvZGYgIpcbNAEMLfFhHqP08tFZVlUVrmTSpqnyA=
-github.com/Masterminds/vcs v1.13.0/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
 github.com/Masterminds/vcs v1.13.1 h1:NL3G1X7/7xduQtA2sJLpVpfHTNBALVNSjob6KEjPXNQ=
 github.com/Masterminds/vcs v1.13.1/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
 github.com/dependabot/gomodules-extracted v0.0.0-20181020215834-1b2f850478a3 h1:Xj2leY0FVyZuo+p59vkIWG3dIqo+QtjskT5O1iTiywA=


### PR DESCRIPTION
The previous version was using the BitBucket v1 API, which was recently turned off. This meant that dependabot-core would blow up when trying to resolve modules hosted on BitBucket. masterminds/vcs v1.13.1 includes https://github.com/Masterminds/vcs/pull/101, which switches it over to the BitBucket v2 API.

Should fix #1248.