### PR TITLE
Enable Dependabot for go_modules helpers

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -23,6 +23,6 @@ update_configs:
     directory: "/python/helpers"
     update_schedule: "live"
 
-  - package_manager: "go_modules"
+  - package_manager: "go:modules"
     directory: "/go_modules/helpers"
     update_schedule: "daily"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -22,3 +22,7 @@ update_configs:
   - package_manager: "python"
     directory: "/python/helpers"
     update_schedule: "live"
+
+  - package_manager: "go_modules"
+    directory: "/go_modules/helpers"
+    update_schedule: "daily"


### PR DESCRIPTION
Slightly embarrassing that we didn't already have this switched on!