### PR TITLE
Yarn: Add support for missing link: path deps

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher/path_dependency_builder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher/path_dependency_builder_spec.rb
@@ -134,6 +134,18 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher::PathDependencyBuilder do
             }.to_json)
         end
       end
+
+      context "for a symlinked dependency" do
+        let(:yarn_lock_fixture_name) { "symlinked_dependency.lock" }
+
+        it "builds an imitation path dependency" do
+          expect(dependency_file).to be_a(Dependabot::DependencyFile)
+          expect(dependency_file.name).to eq("deps/etag/package.json")
+          expect(dependency_file.support_file?).to eq(true)
+          expect(dependency_file.content).
+            to eq("{\"name\":\"etag\",\"version\":\"1.8.0\"}")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Yarn supports "link:." paths for local file paths and they are
interchangeable with "file:" so treating them the same and building
unfetchable dependencies for them (for example when link dependency is
missing package.json).