### PR TITLE
Missing pip support in dry-run

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -48,6 +48,7 @@ $LOAD_PATH << "./hex/lib"
 $LOAD_PATH << "./maven/lib"
 $LOAD_PATH << "./npm_and_yarn/lib"
 $LOAD_PATH << "./nuget/lib"
+$LOAD_PATH << "./python/lib"
 $LOAD_PATH << "./terraform/lib"
 
 require "bundler"
@@ -77,6 +78,7 @@ require "dependabot/hex"
 require "dependabot/maven"
 require "dependabot/npm_and_yarn"
 require "dependabot/nuget"
+require "dependabot/python"
 require "dependabot/terraform"
 
 # GitHub credentials with write permission to the repo you want to update


### PR DESCRIPTION
After pulling dependabot-core image and building dependabot-core-development, I tried `bin/dry-run.rb` with several projects and found out that `pip` support was missing:

```
[dependabot-core-dev] ~/dependabot-core $ bin/dry-run.rb pip UPC/mailtoticket
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.3-compliant syntax, but you are running 2.6.2.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> fetching dependency files
Traceback (most recent call last):
        1: from bin/dry-run.rb:187:in `<main>'
/home/dependabot/dependabot-core/common/lib/dependabot/file_fetchers.rb:11:in `for_package_manager': Unsupported package_manager pip (RuntimeError)
```

Hope this helps!
