### PR TITLE
Bundler: Handle path dependencies that use a .specification file

### DIFF
--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -159,16 +159,15 @@ module Dependabot
 
       def fetch_gemspecs_from_directory(dir_path)
         repo_contents(dir: dir_path, fetch_submodules: true).
-          select { |f| f.name.end_with?(".gemspec") }.
+          select { |f| f.name.end_with?(".gemspec", ".specification") }.
           map { |f| File.join(dir_path, f.name) }.
           map { |fp| fetch_file_from_host(fp, fetch_submodules: true) }
       end
 
       def fetch_path_gemspec_paths
         if lockfile
-          parsed_lockfile = ::Bundler::LockfileParser.new(
-            sanitized_lockfile_content
-          )
+          parsed_lockfile = ::Bundler::LockfileParser.
+                            new(sanitized_lockfile_content)
           parsed_lockfile.specs.
             select { |s| s.source.instance_of?(::Bundler::Source::Path) }.
             map { |s| s.source.path }.uniq

--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -265,6 +265,7 @@ module Dependabot
       def evaled_gemfiles
         dependency_files.
           reject { |f| f.name.end_with?(".gemspec") }.
+          reject { |f| f.name.end_with?(".specification") }.
           reject { |f| f.name.end_with?(".lock") }.
           reject { |f| f.name.end_with?(".ruby-version") }.
           reject { |f| f.name == "Gemfile" }.

--- a/bundler/lib/dependabot/bundler/file_parser/file_preparer.rb
+++ b/bundler/lib/dependabot/bundler/file_parser/file_preparer.rb
@@ -29,7 +29,8 @@ module Dependabot
             *evaled_gemfiles,
             lockfile,
             ruby_version_file,
-            *imported_ruby_files
+            *imported_ruby_files,
+            *specification_files
           ].compact
         end
 
@@ -45,11 +46,16 @@ module Dependabot
         def evaled_gemfiles
           dependency_files.
             reject { |f| f.name.end_with?(".gemspec") }.
+            reject { |f| f.name.end_with?(".specification") }.
             reject { |f| f.name.end_with?(".lock") }.
             reject { |f| f.name.end_with?(".ruby-version") }.
             reject { |f| f.name == "Gemfile" }.
             reject { |f| f.name == "gems.rb" }.
             reject { |f| f.name == "gems.locked" }
+        end
+
+        def specification_files
+          dependency_files.select { |f| f.name.end_with?(".specification") }
         end
 
         def lockfile

--- a/bundler/lib/dependabot/bundler/file_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater.rb
@@ -82,6 +82,7 @@ module Dependabot
         @evaled_gemfiles ||=
           dependency_files.
           reject { |f| f.name.end_with?(".gemspec") }.
+          reject { |f| f.name.end_with?(".specification") }.
           reject { |f| f.name.end_with?(".lock") }.
           reject { |f| f.name.end_with?(".ruby-version") }.
           reject { |f| f.name == "Gemfile" }.

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -247,6 +247,12 @@ module Dependabot
             FileUtils.mkdir_p(Pathname.new(path).dirname)
             File.write(path, sanitized_gemspec_content(file.content))
           end
+
+          specification_files.each do |file|
+            path = file.name
+            FileUtils.mkdir_p(Pathname.new(path).dirname)
+            File.write(path, file.content)
+          end
         end
 
         def write_imported_ruby_files
@@ -403,12 +409,17 @@ module Dependabot
           @evaled_gemfiles ||=
             dependency_files.
             reject { |f| f.name.end_with?(".gemspec") }.
+            reject { |f| f.name.end_with?(".specification") }.
             reject { |f| f.name.end_with?(".lock") }.
             reject { |f| f.name.end_with?(".ruby-version") }.
             reject { |f| f.name == "Gemfile" }.
             reject { |f| f.name == "gems.rb" }.
             reject { |f| f.name == "gems.locked" }.
             reject(&:support_file?)
+        end
+
+        def specification_files
+          dependency_files.select { |f| f.name.end_with?(".specification") }
         end
 
         def git_dependency?(dep)

--- a/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
@@ -89,7 +89,12 @@ module Dependabot
           end
 
           # No editing required for lockfile or Ruby version file
-          files += [lockfile, ruby_version_file, *imported_ruby_files].compact
+          files += [
+            lockfile,
+            ruby_version_file,
+            *imported_ruby_files,
+            *specification_files
+          ].compact
         end
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/MethodLength
@@ -119,6 +124,7 @@ module Dependabot
         def evaled_gemfiles
           dependency_files.
             reject { |f| f.name.end_with?(".gemspec") }.
+            reject { |f| f.name.end_with?(".specification") }.
             reject { |f| f.name.end_with?(".lock") }.
             reject { |f| f.name.end_with?(".ruby-version") }.
             reject { |f| f.name == "Gemfile" }.
@@ -129,6 +135,10 @@ module Dependabot
         def lockfile
           dependency_files.find { |f| f.name == "Gemfile.lock" } ||
             dependency_files.find { |f| f.name == "gems.locked" }
+        end
+
+        def specification_files
+          dependency_files.select { |f| f.name.end_with?(".specification") }
         end
 
         def top_level_gemspecs

--- a/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
@@ -446,6 +446,32 @@ RSpec.describe Dependabot::Bundler::FileFetcher do
             "bump-core"
           )
       end
+
+      context "but has a .specification file" do
+        before do
+          stub_request(:get, url + "plugins/bump-core?ref=sha").
+            with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "contents_ruby_with_specification.json"),
+              headers: { "content-type" => "application/json" }
+            )
+          stub_request(
+            :get, url + "plugins/bump-core/.specification?ref=sha"
+          ).with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "ruby_version_content.json"),
+              headers: { "content-type" => "application/json" }
+            )
+        end
+
+        it "fetches the .specification from path dependency" do
+          expect(file_fetcher_instance.files.count).to eq(3)
+          expect(file_fetcher_instance.files.map(&:name)).
+            to include("plugins/bump-core/.specification")
+        end
+      end
     end
 
     context "that has an unfetchable directory path" do

--- a/bundler/spec/dependabot/bundler/file_parser/file_preparer_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser/file_preparer_spec.rb
@@ -66,5 +66,21 @@ RSpec.describe Dependabot::Bundler::FileParser::FilePreparer do
 
       its(:content) { is_expected.to eq(ruby_version.content) }
     end
+
+    describe "the updated .specification file" do
+      subject do
+        prepared_dependency_files.find { |f| f.name == ".specification" }
+      end
+
+      let(:dependency_files) { [gemfile, lockfile, specification] }
+      let(:specification) do
+        Dependabot::DependencyFile.new(
+          content: fixture("ruby", "specifications", "statesman"),
+          name: ".specification"
+        )
+      end
+
+      its(:content) { is_expected.to eq(specification.content) }
+    end
   end
 end

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -334,6 +334,22 @@ RSpec.describe Dependabot::Bundler::FileParser do
         expect(sub_dep.requirements).to eq([])
         expect(sub_dep.top_level?).to eq(false)
       end
+
+      context "that comes from a .specification file" do
+        let(:files) { [gemfile, lockfile, specification] }
+        let(:specification) do
+          Dependabot::DependencyFile.new(
+            name: "plugins/example/.specification",
+            content: fixture("ruby", "specifications", "statesman"),
+            support_file: true
+          )
+        end
+
+        it "includes the path dependency" do
+          path_dep = dependencies.find { |dep| dep.name == "example" }
+          expect(path_dep.requirements).to eq(expected_requirements)
+        end
+      end
     end
 
     context "with a gem from a private gem source" do

--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -919,6 +919,23 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
               not_to include Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH
           end
 
+          context "as a .specification" do
+            let(:dependency_files) { [gemfile, lockfile, specification] }
+            let(:gemfile_fixture_name) { "path_source_statesman" }
+            let(:lockfile_fixture_name) { "path_source_statesman.lock" }
+            let(:specification) do
+              Dependabot::DependencyFile.new(
+                content: fixture("ruby", "specifications", "statesman"),
+                name: "vendor/gems/statesman-4.1.1/.specification",
+                support_file: true
+              )
+            end
+
+            it "updates the gem just fine" do
+              expect(file.content).to include "business (1.5.0)"
+            end
+          end
+
           context "that requires other files" do
             let(:gemspec_body) do
               fixture("ruby", "gemspecs", "no_overlap_with_require")

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -677,6 +677,21 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           let(:current_version) { "0.9.3" }
           it { is_expected.to eq(Gem::Version.new("0.9.3")) }
         end
+
+        context "that has a .specification" do
+          let(:dependency_files) { [gemfile, lockfile, specification] }
+          let(:gemfile_fixture_name) { "path_source_statesman" }
+          let(:lockfile_fixture_name) { "path_source_statesman.lock" }
+          let(:specification) do
+            Dependabot::DependencyFile.new(
+              content: fixture("ruby", "specifications", "statesman"),
+              name: "vendor/gems/statesman-4.1.1/.specification",
+              support_file: true
+            )
+          end
+
+          it { is_expected.to eq(Gem::Version.new("1.13.0")) }
+        end
       end
     end
 

--- a/bundler/spec/fixtures/github/contents_ruby_with_specification.json
+++ b/bundler/spec/fixtures/github/contents_ruby_with_specification.json
@@ -1,0 +1,50 @@
+[
+  {
+    "name": ".specification",
+    "path": ".specification",
+    "sha": "c84c73c1f1c1aa42550a08ae4f32dc955ced5f18",
+    "size": 279,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.specification?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.specification",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/c84c73c1f1c1aa42550a08ae4f32dc955ced5f18",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/.specification",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.specification?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/c84c73c1f1c1aa42550a08ae4f32dc955ced5f18",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/.specification"
+    }
+  },
+  {
+    "name": "todo.txt",
+    "path": "todo.txt",
+    "sha": "3e369beef1c9e64f0c10735d35aa8ad755daddc6",
+    "size": 1147,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/todo.txt?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/todo.txt",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/3e369beef1c9e64f0c10735d35aa8ad755daddc6",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/todo.txt",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/todo.txt?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/3e369beef1c9e64f0c10735d35aa8ad755daddc6",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/todo.txt"
+    }
+  },
+  {
+    "name": "update_definitions.sh",
+    "path": "update_definitions.sh",
+    "sha": "fbde266ea5ebd519b94d18f8f78ab825b02766df",
+    "size": 7877,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/update_definitions.sh?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/update_definitions.sh",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/fbde266ea5ebd519b94d18f8f78ab825b02766df",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/update_definitions.sh",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/update_definitions.sh?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/fbde266ea5ebd519b94d18f8f78ab825b02766df",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/develop/update_definitions.sh"
+    }
+  }
+]

--- a/bundler/spec/fixtures/ruby/gemfiles/path_source_statesman
+++ b/bundler/spec/fixtures/ruby/gemfiles/path_source_statesman
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "4.1.1", path: "vendor/gems/statesman-4.1.1"

--- a/bundler/spec/fixtures/ruby/lockfiles/path_source_statesman.lock
+++ b/bundler/spec/fixtures/ruby/lockfiles/path_source_statesman.lock
@@ -1,0 +1,19 @@
+PATH
+  remote: vendor/gems/statesman-4.1.1
+  specs:
+    statesman (4.1.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (= 4.1.1)!
+
+BUNDLED WITH
+   1.17.3

--- a/bundler/spec/fixtures/ruby/specifications/statesman
+++ b/bundler/spec/fixtures/ruby/specifications/statesman
@@ -1,0 +1,246 @@
+--- !ruby/object:Gem::Specification
+name: statesman
+version: !ruby/object:Gem::Version
+  version: 4.1.1
+platform: ruby
+authors:
+- GoCardless
+autorequire:
+bindir: bin
+cert_chain: []
+date: 2019-07-06 00:00:00.000000000 Z
+dependencies:
+- !ruby/object:Gem::Dependency
+  name: ammeter
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '1.1'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '1.1'
+- !ruby/object:Gem::Dependency
+  name: bundler
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '1.3'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '1.3'
+- !ruby/object:Gem::Dependency
+  name: gc_ruboconfig
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 2.3.9
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 2.3.9
+- !ruby/object:Gem::Dependency
+  name: mysql2
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '0.4'
+    - - "<"
+      - !ruby/object:Gem::Version
+        version: '0.6'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '0.4'
+    - - "<"
+      - !ruby/object:Gem::Version
+        version: '0.6'
+- !ruby/object:Gem::Dependency
+  name: pg
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '0.18'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '0.18'
+- !ruby/object:Gem::Dependency
+  name: pry
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '0'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '0'
+- !ruby/object:Gem::Dependency
+  name: rails
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '3.2'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '3.2'
+- !ruby/object:Gem::Dependency
+  name: rake
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 12.3.0
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 12.3.0
+- !ruby/object:Gem::Dependency
+  name: rspec
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '3.1'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '3.1'
+- !ruby/object:Gem::Dependency
+  name: rspec-its
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '1.1'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '1.1'
+- !ruby/object:Gem::Dependency
+  name: rspec-rails
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '3.1'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '3.1'
+- !ruby/object:Gem::Dependency
+  name: rspec_junit_formatter
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 0.4.0
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 0.4.0
+- !ruby/object:Gem::Dependency
+  name: sqlite3
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 1.3.6
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 1.3.6
+- !ruby/object:Gem::Dependency
+  name: timecop
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 0.9.1
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 0.9.1
+description: A statesman-like state machine library
+email:
+- developers@gocardless.com
+executables: []
+extensions: []
+extra_rdoc_files: []
+files: []
+homepage: https://github.com/gocardless/statesman
+licenses:
+- MIT
+metadata: {}
+post_install_message:
+rdoc_options: []
+require_paths:
+- lib
+required_ruby_version: !ruby/object:Gem::Requirement
+  requirements:
+  - - ">="
+    - !ruby/object:Gem::Version
+      version: '2.2'
+required_rubygems_version: !ruby/object:Gem::Requirement
+  requirements:
+  - - ">="
+    - !ruby/object:Gem::Version
+      version: '0'
+requirements: []
+rubygems_version: 3.0.3
+signing_key:
+specification_version: 4
+summary: A statesman-like state machine library
+test_files: []
+


### PR DESCRIPTION
That. `.specification` files are a thing, and are documented (a little) [here](https://gist.github.com/jordelver/4352220).