### PR TITLE
Merged pr filtering

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -32,7 +32,7 @@ module Dependabot
                    branch_name_separator: "/", branch_name_prefix: "dependabot",
                    label_language: false, automerge_candidate: false,
                    github_redirection_service: "github-redirect.dependabot.com",
-                   custom_headers: nil)
+                   custom_headers: nil, require_up_to_date_base: false)
       @dependencies               = dependencies
       @source                     = source
       @base_commit                = base_commit
@@ -53,6 +53,7 @@ module Dependabot
       @automerge_candidate        = automerge_candidate
       @github_redirection_service = github_redirection_service
       @custom_headers             = custom_headers
+      @require_up_to_date_base    = require_up_to_date_base
 
       check_dependencies_have_previous_version
     end
@@ -84,6 +85,10 @@ module Dependabot
       @automerge_candidate
     end
 
+    def require_up_to_date_base?
+      @require_up_to_date_base
+    end
+
     def github_creator
       Github.new(
         source: source,
@@ -100,7 +105,8 @@ module Dependabot
         reviewers: reviewers,
         assignees: assignees,
         milestone: milestone,
-        custom_headers: custom_headers
+        custom_headers: custom_headers,
+        require_up_to_date_base: require_up_to_date_base?
       )
     end
 

--- a/common/spec/dependabot/pull_request_creator/github_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/github_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
       labeler: labeler,
       reviewers: reviewers,
       assignees: assignees,
-      milestone: milestone
+      milestone: milestone,
+      require_up_to_date_base: require_up_to_date_base
     )
   end
 
@@ -49,6 +50,7 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
   let(:reviewers) { nil }
   let(:assignees) { nil }
   let(:milestone) { nil }
+  let(:require_up_to_date_base) { false }
   let(:labeler) do
     Dependabot::PullRequestCreator::Labeler.new(
       source: source,
@@ -464,28 +466,47 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
           end
           let(:base_commit) { "basecommitsha" }
 
-          it "does not create a PR" do
-            expect(creator.create).to be_nil
+          it "creates a PR" do
+            creator.create
+
             expect(WebMock).
-              to_not have_requested(:post, "#{repo_api_url}/pulls")
+              to have_requested(:post, "#{repo_api_url}/pulls").
+              with(
+                body: {
+                  base: "master",
+                  head: "dependabot/bundler/business-1.5.0",
+                  title: "PR name",
+                  body: "PR msg"
+                }
+              )
           end
 
-          context "and the commit we're branching off of is up-to-date" do
-            let(:base_commit) { "7bb4e41ce5164074a0920d5b5770d196b4d90104" }
+          context "when `require_up_to_date_base` is true" do
+            let(:require_up_to_date_base) { true }
 
-            it "creates a PR" do
-              creator.create
-
+            it "does not create a PR" do
+              expect(creator.create).to be_nil
               expect(WebMock).
-                to have_requested(:post, "#{repo_api_url}/pulls").
-                with(
-                  body: {
-                    base: "master",
-                    head: "dependabot/bundler/business-1.5.0",
-                    title: "PR name",
-                    body: "PR msg"
-                  }
-                )
+                to_not have_requested(:post, "#{repo_api_url}/pulls")
+            end
+
+            context "and the commit we're branching off of is up-to-date" do
+              let(:base_commit) { "7bb4e41ce5164074a0920d5b5770d196b4d90104" }
+
+              it "creates a PR" do
+                creator.create
+
+                expect(WebMock).
+                  to have_requested(:post, "#{repo_api_url}/pulls").
+                  with(
+                    body: {
+                      base: "master",
+                      head: "dependabot/bundler/business-1.5.0",
+                      title: "PR name",
+                      body: "PR msg"
+                    }
+                  )
+              end
             end
           end
         end

--- a/common/spec/dependabot/pull_request_creator/github_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/github_spec.rb
@@ -462,20 +462,31 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
               headers: json_header
             )
           end
+          let(:base_commit) { "basecommitsha" }
 
-          it "creates a PR" do
-            creator.create
-
+          it "does not create a PR" do
+            expect(creator.create).to be_nil
             expect(WebMock).
-              to have_requested(:post, "#{repo_api_url}/pulls").
-              with(
-                body: {
-                  base: "master",
-                  head: "dependabot/bundler/business-1.5.0",
-                  title: "PR name",
-                  body: "PR msg"
-                }
-              )
+              to_not have_requested(:post, "#{repo_api_url}/pulls")
+          end
+
+          context "and the commit we're branching off of is up-to-date" do
+            let(:base_commit) { "7bb4e41ce5164074a0920d5b5770d196b4d90104" }
+
+            it "creates a PR" do
+              creator.create
+
+              expect(WebMock).
+                to have_requested(:post, "#{repo_api_url}/pulls").
+                with(
+                  body: {
+                    base: "master",
+                    head: "dependabot/bundler/business-1.5.0",
+                    title: "PR name",
+                    body: "PR msg"
+                  }
+                )
+            end
           end
         end
       end

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -197,7 +197,8 @@ RSpec.describe Dependabot::PullRequestCreator do
             labeler: instance_of(described_class::Labeler),
             reviewers: reviewers,
             assignees: assignees,
-            milestone: milestone
+            milestone: milestone,
+            require_up_to_date_base: false
           ).and_return(dummy_creator)
         expect(dummy_creator).to receive(:create)
         creator.create


### PR DESCRIPTION
Currently, there is a danger that Dependabot creates many PRs for the same update if it kicks off several update jobs during which a PR gets merged. That sucks - see [these PRs](https://github.com/reload/acdc/pulls?q=is%3Apr+is%3Aclosed) for an example of things going wrong.

This PR adds a `require_up_to_date_base` option to `PullRequestCreator`. When passed, Dependabot will check whether the commit SHA it's using is up-to-date, and bail out if it's not. That will allow us to prevent races like the above.

Builds on https://github.com/dependabot/dependabot-core/pull/1308.