### PR TITLE
Composer: Parse ranges with a wildcard as invalid

### DIFF
--- a/composer/spec/dependabot/composer/requirement_spec.rb
+++ b/composer/spec/dependabot/composer/requirement_spec.rb
@@ -50,9 +50,41 @@ RSpec.describe Dependabot::Composer::Requirement do
       it { is_expected.to eq(described_class.new(">= 0")) }
     end
 
+    context "with only a x" do
+      let(:requirement_string) { "x" }
+      it { is_expected.to eq(described_class.new(">= 0")) }
+    end
+
     context "with a *" do
       let(:requirement_string) { "1.*" }
       it { is_expected.to eq(described_class.new("~> 1.0")) }
+
+      context "in a range" do
+        let(:requirement_string) { ">= 1.x" }
+
+        it "raises a Gem::Requirement::BadRequirementError error" do
+          expect { requirement }.
+            to raise_error(Gem::Requirement::BadRequirementError) do |error|
+              expect(error.message).to eq("Illformed requirement [\">= 1.x\"]")
+            end
+        end
+      end
+    end
+
+    context "with a x" do
+      let(:requirement_string) { "1.x" }
+      it { is_expected.to eq(described_class.new("~> 1.0")) }
+
+      context "in a range" do
+        let(:requirement_string) { ">= 1.x" }
+
+        it "raises a Gem::Requirement::BadRequirementError error" do
+          expect { requirement }.
+            to raise_error(Gem::Requirement::BadRequirementError) do |error|
+              expect(error.message).to eq("Illformed requirement [\">= 1.x\"]")
+            end
+        end
+      end
     end
 
     context "with a trailing ." do

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -130,6 +130,16 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       end
     end
 
+    context "with a library that uses a dev branch" do
+      let(:dependency_files) { [manifest] }
+      let(:dependency_name) { "monolog/monolog" }
+      let(:manifest_fixture_name) { "dev_branch" }
+      let(:string_req) { "dev-1.x" }
+      let(:dependency_version) { nil }
+
+      it { is_expected.to eq(Dependabot::Composer::Version.new("1.24.0")) }
+    end
+
     context "with a local VCS source" do
       let(:manifest_fixture_name) { "local_vcs_source" }
       let(:dependency_files) { [manifest] }

--- a/composer/spec/fixtures/composer_files/dev_branch
+++ b/composer/spec/fixtures/composer_files/dev_branch
@@ -1,0 +1,6 @@
+{
+    "require": {
+        "monolog/monolog": "dev-1.x",
+        "symfony/polyfill-mbstring": "1.0.*"
+    }
+}


### PR DESCRIPTION
Ranges like `>= 1.x` are invalid in PHP (check out [this site](https://semver.mwl.be/#!?package=madewithlove%2Felasticsearcher&version=*&minimum-stability=stable) for validation). We should therefore raise if we encounter them.

Fixes https://github.com/AmazeeLabs/silverback/issues/85.