### PR TITLE
Update dry run to cache editable dependency files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ vendor
 /go_modules/helpers/install-dir
 /npm_and_yarn/helpers/node_modules
 /npm_and_yarn/helpers/install-dir
+/dry-run


### PR DESCRIPTION
Dumping cached dependency files individually with file extensions making it possoble to edit the cache and re-run the script. This is helpful when trying to narrow down a reproduction case.

When running the dry run script it will always dump the dependency files in: `dry-run/account/repo/branch/directory/*` (omitting branch and directory unless they are set)

To read from the cache pass `--cache=files` to the script: `bin/dry-run.rb npm_and_yarn "dependabot/website" --cache=files`

You can edit the contents of this folder (make sure it's in sync with the `cache-manifest.json` file) and re-run against the edited cache.

## Minimal example with only local cache
If you run the dry run with `bin/dry-run.rb npm_and_yarn "test/test" --cache=files` you'll need a `cache-manifest.json` in `./dry-run/test/test` with the file metadata and corresponding files , for example:

`./dry-run/test/test/cache-manifest.json`:

```json
[
  {
    "name": "package.json"
  }
]
```

You can change any of the `DependencyFile` defaults by extending the cache manifest hash:

```json
[
  {
    "name": "package.json",
    "directory": "/app",
    "symlink_target": "./symlink",
    "support_file": true
  }
]
```

`./dry-run/test/test/package.json`:
```json
{
  "dependencies": {
    "extend": "1.8.2"
  }
}
```