### PR TITLE
PHP: Handle loosely specified PHP versions for libraries better

### DIFF
--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -268,6 +268,17 @@ module Dependabot
 
           true
         rescue SharedHelpers::HelperSubprocessFailed => e
+          if e.message.include?("requires php") ||
+             e.message.include?("requested PHP extension")
+            missing_extensions =
+              e.message.scan(MISSING_PLATFORM_REQ_REGEX).
+              map do |extension_string|
+                name, requirement = extension_string.strip.split(" ", 2)
+                { name: name, requirement: requirement }
+              end
+            raise MissingExtensions, missing_extensions
+          end
+
           raise Dependabot::DependencyFileNotResolvable, e.message
         end
 

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -448,6 +448,13 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
         let(:files) { [composer_file] }
 
         it { is_expected.to be_nil }
+
+        context "and the conflict comes from a loose PHP version" do
+          let(:manifest_fixture_name) { "version_conflict_library" }
+          let(:files) { [composer_file] }
+
+          it { is_expected.to be_nil }
+        end
       end
     end
 

--- a/composer/spec/fixtures/composer_files/version_conflict_library
+++ b/composer/spec/fixtures/composer_files/version_conflict_library
@@ -1,0 +1,9 @@
+{
+    "type": "library",
+    "require": {
+        "php": ">=5",
+        "phalcon/devtools": "~3.2",
+        "longman/telegram-bot": "*",
+        "james-heinrich/getid3": "^1.9"
+    }
+}


### PR DESCRIPTION
If we get a resolution error on a library when trying to update its version we should check whether it is due to our PHP version. If it is we should relax it.