### PR TITLE
Composer: Handle php-64bit requirements

### DIFF
--- a/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
@@ -24,7 +24,10 @@ module Dependabot
         end
 
         MISSING_PLATFORM_REQ_REGEX =
-          /\sext\-.*? .*?\s(?=[^\d])|(?<=requires )php .*?\s(?=[^\d])/.freeze
+          /
+            \sext\-.*?\s.*?\s(?=[^\d])|
+            (?<=requires\s)php(?:\-[^\s]+)?\s.*?\s(?=[^\d])
+          /x.freeze
 
         def initialize(dependencies:, dependency_files:, credentials:)
           @dependencies = dependencies

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -23,7 +23,10 @@ module Dependabot
         end
 
         MISSING_PLATFORM_REQ_REGEX =
-          /\sext\-.*? .*?\s(?=[^\d])|(?<=requires )php .*?\s(?=[^\d])/.freeze
+          /
+            \sext\-.*?\s.*?\s(?=[^\d])|
+            (?<=requires\s)php(?:\-[^\s]+)?\s.*?\s(?=[^\d])
+          /x.freeze
         VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-_]+)*/.freeze
         SOURCE_TIMED_OUT_REGEX =
           /The "(?<url>[^"]+packages\.json)".*timed out/.freeze

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -200,6 +200,22 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
           end
         end
       end
+
+      context "when an odd version of PHP is specified" do
+        let(:manifest_fixture_name) { "odd_php_specified" }
+        let(:dependency_name) { "illuminate/support" }
+        let(:dependency_version) { "5.2.7" }
+        let(:requirements) do
+          [{
+            file: "composer.json",
+            requirement: "^5.2.0",
+            groups: ["runtime"],
+            source: nil
+          }]
+        end
+
+        it { is_expected.to be >= Gem::Version.new("5.2.45") }
+      end
     end
 
     context "with a dev dependency" do

--- a/composer/spec/fixtures/composer_files/odd_php_specified
+++ b/composer/spec/fixtures/composer_files/odd_php_specified
@@ -1,0 +1,7 @@
+{
+    "require": {
+        "php-64bit": "7.2.*",
+        "erusev/parsedown": "^1.6.0",
+        "illuminate/support": "^5.2.0"
+    }
+}


### PR DESCRIPTION
Extends our MissingExtension logic to cover `php-64bit` requirements. See https://sentry.io/organizations/dependabot/issues/1103546162/events/4678a36e0b4f4a73b1ec849036b2bf7a/?environment=default&project=1425239&statsPeriod=14d (private) for error report.