### PR TITLE
[Composer] Enhancement: Keep packages sorted in composer.json

### DIFF
--- a/composer/helpers/composer.json
+++ b/composer/helpers/composer.json
@@ -1,8 +1,8 @@
 {
     "require": {
-        "composer/composer": "^1.8",
         "php": "^7.1",
-        "ext-json": "*"
+        "ext-json": "*",
+        "composer/composer": "^1.8"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.9"
@@ -16,5 +16,8 @@
         "lint": [
             "php-cs-fixer fix"
         ]
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer/helpers/composer.lock
+++ b/composer/helpers/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0a836a111e69979b563d5454ae60e86",
+    "content-hash": "9334db84b58cb747a3d462d165a75240",
     "packages": [
         {
             "name": "composer/ca-bundle",


### PR DESCRIPTION
This PR

* [x] keeps packages sorted in `composer.json`

💁‍♂ I ran

```
 $ composer config sort-packages true
```

followed by

```
 $ composer require php:^7.1
```

to trigger sorting.

For reference, see https://getcomposer.org/doc/06-config.md#sort-packages.