### PR TITLE
[Composer] Enhancement: Run php-cs-fixer with --diff and --verbose options

### DIFF
--- a/composer/helpers/composer.json
+++ b/composer/helpers/composer.json
@@ -14,7 +14,7 @@
     },
     "scripts": {
         "lint": [
-            "php-cs-fixer fix"
+            "php-cs-fixer fix --diff --verbose"
         ]
     }
 }


### PR DESCRIPTION
This PR

* [x] runs `php-cs-fixer` with `--diff` and `--verbose` options

💁‍♂ The former shows a diff, the latter shows progress and is generally more verbose.

~~❓ Couldn't find this being run anywhere in CI, should it be?~~ Never mind, spotted it in https://github.com/dependabot/dependabot-core/blob/c621705e067c067082ed9b2d8afa224e35a858bb/composer/helpers/build#L14.