### PR TITLE
[Composer] Enhancement: Validate composer.json and composer.lock

### DIFF
--- a/composer/helpers/build
+++ b/composer/helpers/build
@@ -10,5 +10,7 @@ fi
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cd "$helpers_dir"
+
+composer validate --no-check-publish
 composer install
 composer run lint -- --dry-run


### PR DESCRIPTION
This PR

* [x] runs `composer validate --no-check-publish`

💁‍♂ This ensures that `composer.json` is valid, and that `composer.lock` is in sync. The `--no-check-publish` option can be used to ignore requirements for publication on https://packagist.org.

For reference, see https://getcomposer.org/doc/03-cli.md#validate.