### PR TITLE
[Composer] Fix: Fetch content of composer.json in specified working directory when calculating hash

### DIFF
--- a/composer/helpers/src/Hasher.php
+++ b/composer/helpers/src/Hasher.php
@@ -12,10 +12,12 @@ class Hasher
     {
         [$workingDirectory] = $args;
 
+        $config = $workingDirectory . '/composer.json';
+
         $io = new ExceptionIO();
-        $composer = Factory::create($io, $workingDirectory . '/composer.json');
+        $composer = Factory::create($io, $config);
         $locker = $composer->getLocker();
 
-        return $locker->getContentHash(file_get_contents(Factory::getComposerFile()));
+        return $locker->getContentHash(file_get_contents($config));
     }
 }

--- a/composer/helpers/src/Hasher.php
+++ b/composer/helpers/src/Hasher.php
@@ -8,7 +8,7 @@ use Composer\Package\Locker;
 
 class Hasher
 {
-    public static function getContentHash(array $args): ?string
+    public static function getContentHash(array $args): string
     {
         [$workingDirectory] = $args;
 

--- a/composer/helpers/src/Hasher.php
+++ b/composer/helpers/src/Hasher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Dependabot\Composer;
 
 use Composer\Factory;
+use Composer\Package\Locker;
 
 class Hasher
 {
@@ -18,6 +19,6 @@ class Hasher
         $composer = Factory::create($io, $config);
         $locker = $composer->getLocker();
 
-        return $locker->getContentHash(file_get_contents($config));
+        return Locker::getContentHash(file_get_contents($config));
     }
 }

--- a/composer/helpers/src/Hasher.php
+++ b/composer/helpers/src/Hasher.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Dependabot\Composer;
 
-use Composer\Factory;
 use Composer\Package\Locker;
 
 class Hasher
@@ -14,10 +13,6 @@ class Hasher
         [$workingDirectory] = $args;
 
         $config = $workingDirectory . '/composer.json';
-
-        $io = new ExceptionIO();
-        $composer = Factory::create($io, $config);
-        $locker = $composer->getLocker();
 
         return Locker::getContentHash(file_get_contents($config));
     }


### PR DESCRIPTION
This PR

* [x] fetches the content of `composer.json` in the specified working directory
* [x] invokes a `static` method `statically`
* [x] removes unused local variables
* [x] hardens a return type declaration

💁‍♂ Probably best reviewed commit by commit.