### PR TITLE
Handle gemspec with a float version number

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/gemspec_sanitizer.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/gemspec_sanitizer.rb
@@ -286,7 +286,7 @@ module Dependabot
           def replace_constant(node)
             case node.children.last&.type
             when :str, :int then nil # no-op
-            when :const, :send, :lvar, :if
+            when :float, :const, :send, :lvar, :if
               replace(
                 node.children.last.loc.expression,
                 %("#{replacement_version}")

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -526,6 +526,26 @@ RSpec.describe Dependabot::Bundler::FileParser do
               }]
             )
         end
+
+        context "with a gemspec with a float version number" do
+          let(:files) { [gemspec, gemfile] }
+
+          let(:gemspec) do
+            Dependabot::DependencyFile.new(
+              name: "version_as_float.gemspec",
+              content: gemspec_content
+            )
+          end
+          let(:gemspec_content) do
+            fixture("ruby", "gemspecs", "version_as_float")
+          end
+          let(:gemfile_fixture_name) { "imports_gemspec" }
+
+          it "doesn't include the gemspec dependency (i.e., itself" do
+            expect(dependencies.map(&:name)).
+              to match_array(%w(business statesman))
+          end
+        end
       end
 
       context "with an unparseable git dep that also appears in the gemspec" do

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -541,7 +541,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
           end
           let(:gemfile_fixture_name) { "imports_gemspec" }
 
-          it "doesn't include the gemspec dependency (i.e., itself" do
+          it "includes the gemspec dependency" do
             expect(dependencies.map(&:name)).
               to match_array(%w(business statesman))
           end

--- a/bundler/spec/dependabot/bundler/file_updater/gemspec_sanitizer_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/gemspec_sanitizer_spec.rb
@@ -184,6 +184,11 @@ RSpec.describe Dependabot::Bundler::FileUpdater::GemspecSanitizer do
         it { is_expected.to eq(%(Spec.new { |s| s.version = 1 })) }
       end
 
+      context "with an assignment to a float" do
+        let(:content) { "Spec.new { |s| s.version = 1.0 }" }
+        it { is_expected.to eq(%(Spec.new { |s| s.version = "1.5.0" })) }
+      end
+
       context "with an assignment to a File.read" do
         let(:content) { "Spec.new { |s| s.version = File.read('something') }" }
         it do

--- a/bundler/spec/fixtures/ruby/gemspecs/version_as_float
+++ b/bundler/spec/fixtures/ruby/gemspecs/version_as_float
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "version_as_float"
+  spec.version      = 1.0
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+end


### PR DESCRIPTION
The normal syntax in a Gemfile indicates versions as a string, i.e. `s.version     = '1.0.0'`.  However, bundler will recognize and accept a version number entered as a float.  This PR updates dependabot-core to handle these cases.

Paired w/@feelepxyz
