### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/spm/.gitignore
+++ b/spm/.gitignore
@@ -1,0 +1,2 @@
+/.bundle/
+Gemfile.lock

--- a/spm/Gemfile
+++ b/spm/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'dependabot-common', path: "../common"
+
+gemspec

--- a/spm/dependabot-spm.gemspec
+++ b/spm/dependabot-spm.gemspec
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'find'
+
+Gem::Specification.new do |spec|
+  common_gemspec =
+    Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
+
+  spec.name        = "dependabot-spm"
+  spec.summary     = "Swift Package Manager support for dependabot-common"
+  spec.version     = common_gemspec.version
+  spec.description = common_gemspec.description
+
+  spec.author      = common_gemspec.author
+  spec.email       = common_gemspec.email
+  spec.homepage    = common_gemspec.homepage
+  spec.license     = common_gemspec.license
+
+  spec.require_path = "lib"
+  spec.files = Dir["lib/**/*"]
+
+  spec.required_ruby_version = common_gemspec.required_ruby_version
+  spec.required_rubygems_version = common_gemspec.required_rubygems_version
+
+  spec.add_dependency "dependabot-common", Dependabot::VERSION
+
+  common_gemspec.development_dependencies.each do |dep|
+    spec.add_development_dependency dep.name, dep.requirement.to_s
+  end
+end

--- a/spm/lib/dependabot/spm/file_fetcher.rb
+++ b/spm/lib/dependabot/spm/file_fetcher.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'dependabot/file_fetchers'
+require 'dependabot/file_fetchers/base'
+
+module Dependabot
+  module Spm
+    class FileFetcher < Dependabot::FileFetchers::Base
+      
+    end
+  end
+end

--- a/spm/spec/dependabot/spm/file_fetcher_spec.rb
+++ b/spm/spec/dependabot/spm/file_fetcher_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'dependabot/spm/file_fetcher'
+require_common_spec 'file_fetchers/shared_examples_for_file_fetchers'
+
+RSpec.describe Dependabot::Spm::FileFetcher do
+  it_behaves_like "a dependency file fetcher"
+
+  
+end

--- a/spm/spec/spec_helper.rb
+++ b/spm/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+def common_dir
+  @common_dir ||= Gem::Specification.find_by_name("dependabot-common").gem_dir
+end
+
+def require_common_spec(path)
+  require "#{common_dir}/spec/dependabot/#{path}"
+end
+
+require "#{common_dir}/spec/spec_helper.rb"


### PR DESCRIPTION
Add support for [Swift Package Manager](https://swift.org/package-manager/) to Dependabot Core.