### PR TITLE
Update dry-run to be more like dependabot-updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/node_modules
 /.env
 /tmp
 /pkg


### PR DESCRIPTION
Porting logging and logic from dependabot-updater and adding a few
options to customise the updater:
- `--write`: will write the updated files into the dry-run cache folder
  (initilizes a git repo to help with diffing 👌)
- `--lockfile_only`: only update the lockfile
- `--requirements_update_strategy`: chaneg how to update manifest
  requirements