### PR TITLE
dry-run: add --commit option to fetch from

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -95,7 +95,8 @@ $options = {
   cache_steps: [],
   write: false,
   lockfile_only: false,
-  requirements_update_strategy: nil
+  requirements_update_strategy: nil,
+  commit: nil
 }
 
 if ENV["LOCAL_GITHUB_ACCESS_TOKEN"]
@@ -145,6 +146,10 @@ option_parse = OptionParser.new do |opts|
   opts.on("--requirements-update-strategy STRATEGY", opts_req_description) do |value|
     value = nil if value == "auto"
     $options[:requirements_update_strategy] = value
+  end
+
+  opts.on("--commit COMMIT", "Commit to fetch dependency files from") do |value|
+    $options[:commit] = value
   end
 end
 
@@ -263,7 +268,8 @@ source = Dependabot::Source.new(
   provider: "github",
   repo: $repo_name,
   directory: $options[:directory],
-  branch: $options[:branch]
+  branch: $options[:branch],
+  commit: $options[:commit]
 )
 
 $files = cached_dependency_files_read do

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -56,6 +56,8 @@ module Dependabot
       end
 
       def commit
+        return source.commit if source.commit
+
         branch = target_branch || default_branch_for_repo
 
         @commit ||= client_for_provider.fetch_commit(repo, branch)

--- a/common/lib/dependabot/source.rb
+++ b/common/lib/dependabot/source.rb
@@ -36,8 +36,8 @@ module Dependabot
       (?:#{AZURE_SOURCE})
     /x.freeze
 
-    attr_accessor :provider, :repo, :directory, :branch, :hostname,
-                  :api_endpoint
+    attr_accessor :provider, :repo, :directory, :branch, :commit,
+                  :hostname, :api_endpoint
 
     def self.from_url(url_string)
       return unless url_string&.match?(SOURCE_REGEX)
@@ -52,8 +52,8 @@ module Dependabot
       )
     end
 
-    def initialize(provider:, repo:, directory: nil, branch: nil, hostname: nil,
-                   api_endpoint: nil)
+    def initialize(provider:, repo:, directory: nil, branch: nil, commit: nil,
+                   hostname: nil, api_endpoint: nil)
       if (hostname.nil? ^ api_endpoint.nil?) && (provider != "codecommit")
         msg = "Both hostname and api_endpoint must be specified if either "\
               "are. Alternatively, both may be left blank to use the "\
@@ -65,6 +65,7 @@ module Dependabot
       @repo = repo
       @directory = directory
       @branch = branch
+      @commit = commit
       @hostname = hostname || default_hostname(provider)
       @api_endpoint = api_endpoint || default_api_endpoint(provider)
     end

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -13,13 +13,15 @@ RSpec.describe Dependabot::FileFetchers::Base do
       provider: provider,
       repo: repo,
       directory: directory,
-      branch: branch
+      branch: branch,
+      commit: source_commit
     )
   end
   let(:provider) { "github" }
   let(:repo) { "gocardless/bump" }
   let(:directory) { "/" }
   let(:branch) { nil }
+  let(:source_commit) { nil }
   let(:credentials) do
     [{
       "type" => "git_source",
@@ -276,6 +278,13 @@ RSpec.describe Dependabot::FileFetchers::Base do
 
         it { is_expected.to eq("8c8376e9b2e943c2c72fac4b239876f377f0305b") }
       end
+    end
+
+    # Note: only used locally when testing against specific commits
+    context "with a source commit" do
+      let(:source_commit) { "0e8b8c801024c811d434660f8cf09809f9eb9540" }
+
+      it { is_expected.to eq("0e8b8c801024c811d434660f8cf09809f9eb9540") }
     end
   end
 


### PR DESCRIPTION
Add the option to fetch manifest files from a specific commit instead of the branch head commit.

This is useful when debugging a past update that has already been fixed and merged into master.

Example:

```
bin/dry-run.rb bundler "dependabot/dependabot-core" --commit=e0c9035898dd52fc65c41454cec9c4d2611bfb37
```
