### PR TITLE
Support RELEASES.md changelog files

### DIFF
--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -18,7 +18,8 @@ module Dependabot
         require_relative "commits_finder"
 
         # Earlier entries are preferred
-        CHANGELOG_NAMES = %w(changelog news changes history release).freeze
+        CHANGELOG_NAMES = %w(changelog news changes history release
+                             releases).freeze
 
         attr_reader :source, :dependency, :credentials, :suggested_changelog_url
 


### PR DESCRIPTION
They're not as common as some of the others we support, but there are still [plenty out there](https://github.com/search?p=2&q=filename%3Areleases.md&type=Code).

Related:
- https://github.com/actions/toolkit/pull/143
- https://github.com/actions/toolkit/issues/104