### PR TITLE
Adds the session_token option to the codecommit client

### DIFF
--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -11,26 +11,17 @@ module Dependabot
       # Constructor methods #
       #######################
 
-      def self.for_source(source:, credentials:)
-        credential =
-          credentials.
-          select { |cred| cred["type"] == "git_source" }.
-          find { |cred| cred["region"] == source.hostname }
-
-        new(source, credential)
+      def self.for_source(source:)
+        new(source)
       end
 
       ##########
       # Client #
       ##########
 
-      def initialize(source, credentials)
+      def initialize(source)
         @source = source
-        @cc_client = Aws::CodeCommit::Client.new(
-          access_key_id: credentials&.fetch("username"),
-          secret_access_key: credentials&.fetch("password"),
-          region: credentials&.fetch("region")
-        )
+        @cc_client = Aws::CodeCommit::Client.new
       end
 
       def fetch_commit(repo, branch)

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -463,7 +463,7 @@ module Dependabot
       def codecommit_client
         @codecommit_client ||=
           Dependabot::Clients::CodeCommit.
-          for_source(source: source, credentials: credentials)
+          for_source(source: source)
       end
     end
   end

--- a/common/spec/dependabot/clients/codecommit_spec.rb
+++ b/common/spec/dependabot/clients/codecommit_spec.rb
@@ -4,17 +4,11 @@ require "aws-sdk-codecommit"
 require "spec_helper"
 require "dependabot/clients/codecommit"
 
+ENV["AWS_REGION"] = "us-east-1"
+
 RSpec.describe Dependabot::Clients::CodeCommit do
   let(:branch) { "master" }
   let(:repo) { "gocardless" }
-  let(:credentials) do
-    [{
-      "type" => "git_source",
-      "region" => "us-east-1",
-      "username" => "AWS_ACCESS_KEY_ID",
-      "password" => "AWS_SECRET_ACCESS_KEY"
-    }]
-  end
   let(:source) do
     Dependabot::Source.new(
       provider: "codecommit",
@@ -25,7 +19,7 @@ RSpec.describe Dependabot::Clients::CodeCommit do
   end
   let(:stubbed_cc_client) { Aws::CodeCommit::Client.new(stub_responses: true) }
   let(:client) do
-    described_class.for_source(source: source, credentials: credentials)
+    described_class.for_source(source: source)
   end
   before do
     allow_any_instance_of(

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -7,6 +7,8 @@ require "dependabot/source"
 require "dependabot/file_fetchers/base"
 require "dependabot/clients/codecommit"
 
+ENV["AWS_REGION"] = "us-east-1"
+
 RSpec.describe Dependabot::FileFetchers::Base do
   let(:source) do
     Dependabot::Source.new(


### PR DESCRIPTION
Currently, the codecommit client will only work with standard AWS credentials. This change should remedy that.

~When writing the client I only tested against standard AWS credentials and not with an assumed role. The assumption was that the aws-sdk would pick up any additional required env vars automagically, but that doesn't seem to be the case..~

Just tested this with removing the initialization options from the codecommit client entirely (shout out to @lorengordon) and it seems like a more robust way forward