### PR TITLE
Make gpgme an optional dependency

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "docker_registry2", "~> 1.7", ">= 1.7.1"
   spec.add_dependency "excon", "~> 0.66"
   spec.add_dependency "gitlab", "~> 4.9"
-  spec.add_dependency "gpgme", "~> 2.0"
   spec.add_dependency "nokogiri", "~> 1.8"
   spec.add_dependency "octokit", "~> 4.6"
   spec.add_dependency "pandoc-ruby", "~> 2.0"
@@ -36,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "toml-rb", "~> 1.1", ">= 1.1.2"
 
   spec.add_development_dependency "byebug", "~> 11.0"
+  spec.add_development_dependency "gpgme", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12"
   spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_development_dependency "rspec-its", "~> 1.2"

--- a/common/lib/dependabot/pull_request_creator/commit_signer.rb
+++ b/common/lib/dependabot/pull_request_creator/commit_signer.rb
@@ -23,7 +23,8 @@ module Dependabot
         begin
           require "gpgme"
         rescue LoadError
-          raise LoadError, "Please install `gpgme` to enable commit signatures"
+          raise LoadError, "Please add `gpgme` to your Gemfile or gemspec " \
+                           "enable commit signatures"
         end
 
         email = author_details[:email]

--- a/common/lib/dependabot/pull_request_creator/commit_signer.rb
+++ b/common/lib/dependabot/pull_request_creator/commit_signer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "time"
-require "gpgme"
 require "tmpdir"
 require "dependabot/pull_request_creator"
 
@@ -21,6 +20,12 @@ module Dependabot
       end
 
       def signature
+        begin
+          require "gpgme"
+        rescue LoadError
+          raise LoadError, "Please install `gpgme` to enable commit signatures"
+        end
+
         email = author_details[:email]
 
         dir = Dir.mktmpdir


### PR DESCRIPTION
It's _really_ slow to install, and mostly not needed now that app commits are automatically signed (https://github.blog/2019-08-15-commit-signing-support-for-bots-and-other-github-apps/).