### PR TITLE
Bundler: Fall back to unlocking all sub-dependencies in lockfile updater

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -172,6 +172,8 @@ module Dependabot
                       map(&:name).map(&:to_s)
           allowed_new_unlocks = all_deps - top_level - dependencies_to_unlock
 
+          raise if allowed_new_unlocks.none?
+
           # Unlock any sub-dependencies that Bundler reports caused the
           # conflict
           potentials_deps =
@@ -181,10 +183,15 @@ module Dependabot
               tree.find { |req| allowed_new_unlocks.include?(req.name) }
             end.compact.map(&:name)
 
-          # If there's nothing more we can unlock, give up
-          raise if potentials_deps.none?
+          # If there are specific dependencies we can unlock, unlock them
+          if potentials_deps.any?
+            return dependencies_to_unlock.append(*potentials_deps)
+          end
 
-          dependencies_to_unlock.append(*potentials_deps)
+          # Fall back to unlocking *all* sub-dependencies. This is required
+          # because Bundler's VersionConflict objects don't include enough
+          # information to chart the full path through all conflicts unwound
+          dependencies_to_unlock.append(*allowed_new_unlocks)
         end
 
         def build_definition(dependencies_to_unlock)


### PR DESCRIPTION
In complicated resolution cases, Bundler's `VersionConflict` error class may not have all of the details required to determine which sub-dependencies to unlock. This is rare, but it can happen.

In such cases, the update will make it through the version resolver (which unlocks all sub-dependencies to check resolvability speedily) but fail during the FileUpdater's lockfile generation. That sucks.

This PR adds a fallback to lockfile generation:  if the above happens, attempt to unlock all sub-dependencies, like we do in the UpdateChecker.  This will result in a PR with a lot of sub-dependencies unlocked, but that's not so bad (top-level dependencies *won't* be unlocked, and this case is rare anyway).