### PR TITLE
JS: Fix cases where previous version the latest

### DIFF
--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -84,7 +84,7 @@ module Dependabot
         raise NotImplementedError
       end
 
-      def latest_resolvable_previous_version
+      def latest_resolvable_previous_version(_updated_version)
         dependency.version
       end
 
@@ -128,22 +128,28 @@ module Dependabot
       end
 
       def updated_dependency_without_unlock
+        version = latest_resolvable_version_with_no_unlock.to_s
+        previous_version = latest_resolvable_previous_version(version)&.to_s
+
         Dependency.new(
           name: dependency.name,
-          version: latest_resolvable_version_with_no_unlock.to_s,
+          version: version,
           requirements: dependency.requirements,
-          previous_version: latest_resolvable_previous_version&.to_s,
+          previous_version: previous_version,
           previous_requirements: dependency.requirements,
           package_manager: dependency.package_manager
         )
       end
 
       def updated_dependency_with_own_req_unlock
+        version = preferred_resolvable_version.to_s
+        previous_version = latest_resolvable_previous_version(version)&.to_s
+
         Dependency.new(
           name: dependency.name,
-          version: preferred_resolvable_version.to_s,
+          version: version,
           requirements: updated_requirements,
-          previous_version: latest_resolvable_previous_version&.to_s,
+          previous_version: previous_version,
           previous_requirements: dependency.requirements,
           package_manager: dependency.package_manager
         )

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -54,8 +54,8 @@ module Dependabot
         latest_version_finder.latest_version_with_no_unlock
       end
 
-      def latest_resolvable_previous_version
-        version_resolver.latest_resolvable_previous_version
+      def latest_resolvable_previous_version(updated_version)
+        version_resolver.latest_resolvable_previous_version(updated_version)
       end
 
       def updated_requirements

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -600,7 +600,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
   end
 
   describe "#latest_resolvable_previous_version" do
-    subject { checker.latest_resolvable_previous_version }
+    let(:updated_version) { Gem::Version.new("1.7.0") }
+    subject(:latest_resolvable_previous_version) do
+      checker.latest_resolvable_previous_version(updated_version)
+    end
 
     it "delegates to VersionResolver" do
       dummy_version_resolver =
@@ -613,14 +616,15 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           credentials: credentials,
           dependency_files: dependency_files,
           latest_version_finder: described_class::LatestVersionFinder,
-          latest_allowable_version: Gem::Version.new("1.7.0")
+          latest_allowable_version: updated_version
         ).and_return(dummy_version_resolver)
       expect(dummy_version_resolver).
         to receive(:latest_resolvable_previous_version).
-        and_return(Gem::Version.new("1.7.0"))
+        with(updated_version).
+        and_return(Gem::Version.new("1.6.0"))
 
-      expect(checker.latest_resolvable_previous_version).
-        to eq(Gem::Version.new("1.7.0"))
+      expect(latest_resolvable_previous_version).
+        to eq(Gem::Version.new("1.6.0"))
     end
   end
 


### PR DESCRIPTION
Handle cases where the latest resolvable previous version is the latest
version. This often happens if you don't have lockfiles and have
requirements update strategy set to bump_versions, where an update might
go from ^1.1.1 to ^1.1.2 (both resolve to 1.1.2).