### PR TITLE
Python: Handle nested path dependencies during parsing

### DIFF
--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -181,8 +181,15 @@ module Dependabot
           each do |file|
             path = file.name
             FileUtils.mkdir_p(Pathname.new(path).dirname)
-            File.write(path, file.content)
+            File.write(path, remove_imports(file.content))
           end
+      end
+
+      def remove_imports(content)
+        content.lines.
+          reject { |l| l.match?(/^['"]?(?<path>\..*?)(?=\[|#|'|"|$)/) }.
+          reject { |l| l.match?(/^(?:-e)\s+['"]?(?<path>.*?)(?=\[|#|'|"|$)/) }.
+          join
       end
 
       def normalised_name(name)

--- a/python/spec/dependabot/python/file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe Dependabot::Python::FileParser do
       content: requirements_body
     )
   end
-  let(:requirements_body) do
-    fixture("requirements", requirements_fixture_name)
-  end
+  let(:requirements_body) { fixture("requirements", requirements_fixture_name) }
   let(:requirements_fixture_name) { "version_specified.txt" }
 
   describe "parse" do
@@ -514,6 +512,32 @@ RSpec.describe Dependabot::Python::FileParser do
             }]
           )
         end
+      end
+
+      context "in a nested requirements file" do
+        let(:files) { [requirements, child_requirements, setup_file] }
+        let(:requirements) do
+          Dependabot::DependencyFile.new(
+            name: "requirements.txt",
+            content: fixture("requirements", "cascading_nested.txt")
+          )
+        end
+        let(:child_requirements) do
+          Dependabot::DependencyFile.new(
+            name: "nested/more_requirements.txt",
+            content: fixture("requirements", "with_setup_path.txt")
+          )
+        end
+        let(:setup_file) do
+          Dependabot::DependencyFile.new(
+            name: "nested/setup.py",
+            content: fixture("setup_files", "small_needs_sanitizing.py")
+          )
+        end
+
+        # Note that the path dependency *isn't* parsed (because it's a manifest
+        # for a path dependency, not for *this* project)
+        its(:length) { is_expected.to eq(2) }
       end
 
       context "with a parse_requirements statement" do

--- a/python/spec/fixtures/requirements/cascading_nested.txt
+++ b/python/spec/fixtures/requirements/cascading_nested.txt
@@ -1,0 +1,2 @@
+psycopg2==2.6.1
+-r ./nested/more_requirements.txt


### PR DESCRIPTION
That. @rebelagentm we were going wrong with the test because the path dependency requirement line needed to come in a nested file.