### PR TITLE
Python: Fix parsing of paths to account for multiple nesting scenarios

### DIFF
--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -364,10 +364,15 @@ module Dependabot
           map(&:strip).
           reject { |p| p.include?("://") || p.include?("git@") }
 
+        uneditable_reqs + editable_reqs
+
         current_dir = File.dirname(req_file.name)
 
         (uneditable_reqs + editable_reqs).map do |path|
-          path = File.join(current_dir, path) unless current_dir == "."
+          if current_dir != "." && path != "."
+            path = File.join(current_dir, path)
+          end
+
           Pathname.new(path).cleanpath.to_path
         end
       end


### PR DESCRIPTION
One of the fixes that we applied [here](https://github.com/dependabot/dependabot-core/pull/1413) broke parsing for [other scenarios](https://github.com/aio-libs/frozenlist/issues/10).  This PR will fix things so that both scenarios work.

Pairing w/@feelepxyz on this.