### PR TITLE
Revert Python file fetching change

### DIFF
--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -364,12 +364,7 @@ module Dependabot
           map(&:strip).
           reject { |p| p.include?("://") || p.include?("git@") }
 
-        current_dir = File.dirname(req_file.name)
-
-        (uneditable_reqs + editable_reqs).map do |path|
-          path = File.join(current_dir, path) unless current_dir == "."
-          Pathname.new(path).cleanpath.to_path
-        end
+        uneditable_reqs + editable_reqs
       end
 
       def pipfile_path_setup_file_paths

--- a/python/spec/dependabot/python/file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/file_fetcher_spec.rb
@@ -890,19 +890,12 @@ RSpec.describe Dependabot::Python::FileFetcher do
                 body: fixture("github", "setup_content.json"),
                 headers: { "content-type" => "application/json" }
               )
-            stub_request(:get, url + "no_dot/setup.cfg?ref=sha").
-              with(headers: { "Authorization" => "token token" }).
-              to_return(
-                status: 404,
-                body: fixture("github", "setup_content.json"),
-                headers: { "content-type" => "application/json" }
-              )
           end
 
-          it "fetches the setup.py" do
+          it "fetches the setup.py (does not look in the nested directory)" do
             expect(file_fetcher_instance.files.count).to eq(5)
             expect(file_fetcher_instance.files.map(&:name)).
-              to include("no_dot/setup.py")
+              to include("setup.py")
           end
         end
 


### PR DESCRIPTION
Alternative to https://github.com/dependabot/dependabot-core/pull/1419.

Looking at https://github.com/aio-libs/aiohttp/issues/4122, I think we got this one wrong. Pip itself *doesn't* take into account the directory that nested requirement files are in - it  concatenates the cascading requirements into a single file and treats all of the lines as if they were written at that  level.