### PR TITLE
JS: Handle GitHub shorthand links in MetadataFinder

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -113,10 +113,14 @@ module Dependabot
       end
 
       def get_url(details)
-        case details
-        when String then details
-        when Hash then details.fetch("url", nil)
-        end
+        url =
+          case details
+          when String then details
+          when Hash then details.fetch("url", nil)
+          end
+        return url unless url&.match?(%r{^[\w.-]+/[\w.-]+$})
+
+        "https://github.com/" + url
       end
 
       def get_directory(details)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
@@ -138,6 +138,20 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
       end
     end
 
+    context "when there's a link using GitHub shorthand" do
+      let(:npm_latest_version_response) { nil }
+      let(:npm_all_versions_response) do
+        fixture("npm_response_string_shorthand.json")
+      end
+
+      it { is_expected.to eq("https://github.com/jshttp/etag") }
+
+      it "caches the call to npm" do
+        2.times { source_url }
+        expect(WebMock).to have_requested(:get, npm_url).once
+      end
+    end
+
     context "when there isn't a source link in the npm response" do
       let(:npm_latest_version_response) { nil }
       let(:npm_all_versions_response) do
@@ -155,9 +169,7 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
     context "when the npm link resolves to a redirect" do
       let(:redirect_url) { "https://registry.npmjs.org/eTag" }
       let(:npm_latest_version_response) { nil }
-      let(:npm_all_versions_response) do
-        fixture("npm_responses", "etag.json")
-      end
+      let(:npm_all_versions_response) { fixture("npm_responses", "etag.json") }
 
       before do
         stub_request(:get, npm_url).
@@ -174,9 +186,7 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
       before { stub_request(:get, npm_url + "/latest").to_return(status: 404) }
       before { stub_request(:get, npm_url + "/latest").to_return(status: 404) }
       let(:npm_latest_version_response) { nil }
-      let(:npm_all_versions_response) do
-        fixture("npm_responses", "etag.json")
-      end
+      let(:npm_all_versions_response) { fixture("npm_responses", "etag.json") }
 
       # Not an ideal error, but this should never happen
       specify { expect { finder.source_url }.to raise_error(JSON::ParserError) }
@@ -191,9 +201,7 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
       end
       let(:dependency_name) { "@etag/etag" }
       let(:npm_latest_version_response) { nil }
-      let(:npm_all_versions_response) do
-        fixture("npm_responses", "etag.json")
-      end
+      let(:npm_all_versions_response) { fixture("npm_responses", "etag.json") }
 
       it "requests the escaped name" do
         finder.source_url

--- a/npm_and_yarn/spec/fixtures/npm_response_string_shorthand.json
+++ b/npm_and_yarn/spec/fixtures/npm_response_string_shorthand.json
@@ -1,0 +1,893 @@
+{
+    "_attachments": {},
+    "_id": "etag",
+    "_rev": "27-f99109879afdc9fa5a0757c26b02e51e",
+    "bugs": {
+        "url": "jshttp/etag/issues"
+    },
+    "contributors": [
+        {
+            "email": "doug@somethingdoug.com",
+            "name": "Douglas Christopher Wilson"
+        },
+        {
+            "email": "david.bjorklund@gmail.com",
+            "name": "David Bjarklund"
+        }
+    ],
+    "description": "Create simple ETags",
+    "dist-tags": {
+        "latest": "1.7.0"
+    },
+    "homepage": "jshttp/etag",
+    "keywords": [
+        "etag",
+        "http",
+        "res"
+    ],
+    "license": "MIT",
+    "maintainers": [
+        {
+            "email": "doug@somethingdoug.com",
+            "name": "dougwilson"
+        }
+    ],
+    "name": "etag",
+    "readme": "# etag\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nCreate simple ETags\n\n## Installation\n\n```sh\n$ npm install etag\n```\n\n## API\n\n```js\nvar etag = require('etag')\n```\n\n### etag(entity, [options])\n\nGenerate a strong ETag for the given entity. This should be the complete\nbody of the entity. Strings, `Buffer`s, and `fs.Stats` are accepted. By\ndefault, a strong ETag is generated except for `fs.Stats`, which will\ngenerate a weak ETag (this can be overwritten by `options.weak`).\n\n```js\nres.setHeader('ETag', etag(body))\n```\n\n#### Options\n\n`etag` accepts these properties in the options object.\n\n##### weak\n\nSpecifies if the generated ETag will include the weak validator mark (that\nis, the leading `W/`). The actual entity tag is the same. The default value\nis `false`, unless the `entity` is `fs.Stats`, in which case it is `true`.\n\n## Testing\n\n```sh\n$ npm test\n```\n\n## Benchmark\n\n```bash\n$ npm run-script bench\n\n> etag@1.6.0 bench nodejs-etag\n> node benchmark/index.js\n\n  http_parser@1.0\n  node@0.10.33\n  v8@3.14.5.9\n  ares@1.9.0-DEV\n  uv@0.10.29\n  zlib@1.2.3\n  modules@11\n  openssl@1.0.1j\n\n> node benchmark/body0-100b.js\n\n  100B body\n\n  1 test completed.\n  2 tests completed.\n  3 tests completed.\n  4 tests completed.\n\n* buffer - strong x 289,198 ops/sec Â±1.09% (190 runs sampled)\n* buffer - weak   x 287,838 ops/sec Â±0.91% (189 runs sampled)\n* string - strong x 284,586 ops/sec Â±1.05% (192 runs sampled)\n* string - weak   x 287,439 ops/sec Â±0.82% (192 runs sampled)\n\n> node benchmark/body1-1kb.js\n\n  1KB body\n\n  1 test completed.\n  2 tests completed.\n  3 tests completed.\n  4 tests completed.\n\n* buffer - strong x 212,423 ops/sec Â±0.75% (193 runs sampled)\n* buffer - weak   x 211,871 ops/sec Â±0.74% (194 runs sampled)\n  string - strong x 205,291 ops/sec Â±0.86% (194 runs sampled)\n  string - weak   x 208,463 ops/sec Â±0.79% (192 runs sampled)\n\n> node benchmark/body2-5kb.js\n\n  5KB body\n\n  1 test completed.\n  2 tests completed.\n  3 tests completed.\n  4 tests completed.\n\n* buffer - strong x 92,901 ops/sec Â±0.58% (195 runs sampled)\n* buffer - weak   x 93,045 ops/sec Â±0.65% (192 runs sampled)\n  string - strong x 89,621 ops/sec Â±0.68% (194 runs sampled)\n  string - weak   x 90,070 ops/sec Â±0.70% (196 runs sampled)\n\n> node benchmark/body3-10kb.js\n\n  10KB body\n\n  1 test completed.\n  2 tests completed.\n  3 tests completed.\n  4 tests completed.\n\n* buffer - strong x 54,220 ops/sec Â±0.85% (192 runs sampled)\n* buffer - weak   x 54,069 ops/sec Â±0.83% (191 runs sampled)\n  string - strong x 53,078 ops/sec Â±0.53% (194 runs sampled)\n  string - weak   x 53,849 ops/sec Â±0.47% (197 runs sampled)\n\n> node benchmark/body4-100kb.js\n\n  100KB body\n\n  1 test completed.\n  2 tests completed.\n  3 tests completed.\n  4 tests completed.\n\n* buffer - strong x 6,673 ops/sec Â±0.15% (197 runs sampled)\n* buffer - weak   x 6,716 ops/sec Â±0.12% (198 runs sampled)\n  string - strong x 6,357 ops/sec Â±0.14% (197 runs sampled)\n  string - weak   x 6,344 ops/sec Â±0.21% (197 runs sampled)\n\n> node benchmark/stats.js\n\n  stats\n\n  1 test completed.\n  2 tests completed.\n  3 tests completed.\n  4 tests completed.\n\n* real - strong x 1,671,989 ops/sec Â±0.13% (197 runs sampled)\n* real - weak   x 1,681,297 ops/sec Â±0.12% (198 runs sampled)\n  fake - strong x   927,063 ops/sec Â±0.14% (198 runs sampled)\n  fake - weak   x   914,461 ops/sec Â±0.41% (191 runs sampled)\n```\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/etag.svg\n[npm-url]: https://npmjs.org/package/etag\n[node-version-image]: https://img.shields.io/node/v/etag.svg\n[node-version-url]: http://nodejs.org/download/\n[travis-image]: https://img.shields.io/travis/jshttp/etag/master.svg\n[travis-url]: https://travis-ci.org/jshttp/etag\n[coveralls-image]: https://img.shields.io/coveralls/jshttp/etag/master.svg\n[coveralls-url]: https://coveralls.io/r/jshttp/etag?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/etag.svg\n[downloads-url]: https://npmjs.org/package/etag\n",
+    "readmeFilename": "README.md",
+    "repository": {
+        "type": "git",
+        "url": "jshttp/etag"
+    },
+    "time": {
+        "1.0.0": "2014-05-18T11:14:58.281Z",
+        "1.0.1": "2014-08-24T23:28:33.196Z",
+        "1.1.0": "2014-08-25T02:07:34.113Z",
+        "1.2.0": "2014-08-25T04:09:33.706Z",
+        "1.2.1": "2014-08-30T03:58:39.314Z",
+        "1.3.0": "2014-08-30T04:25:31.815Z",
+        "1.3.1": "2014-09-14T16:54:11.346Z",
+        "1.4.0": "2014-09-21T18:47:20.760Z",
+        "1.5.0": "2014-10-14T04:48:49.796Z",
+        "1.5.1": "2014-11-20T07:06:45.217Z",
+        "1.6.0": "2015-05-11T02:11:35.427Z",
+        "1.7.0": "2015-06-09T03:38:54.614Z",
+        "created": "2014-05-18T11:14:58.281Z",
+        "modified": "2015-06-09T03:38:54.614Z"
+    },
+    "users": {
+        "blitzprog": true,
+        "program247365": true,
+        "simplyianm": true
+    },
+    "versions": {
+        "1.0.0": {
+            "_from": ".",
+            "_id": "etag@1.0.0",
+            "_npmUser": {
+                "email": "david.bjorklund@gmail.com",
+                "name": "kesla"
+            },
+            "_npmVersion": "1.4.3",
+            "author": {
+                "email": "david.bjorklund@gmail.com",
+                "name": "David BjÃ¶rklund"
+            },
+            "bugs": {
+                "url": "https://github.com/kesla/etag/issues"
+            },
+            "description": "Small thingy to create an etag from a String or Buffer",
+            "directories": {},
+            "dist": {
+                "shasum": "db9f9610cc2bf22036d713012dff4aa7e0c96162",
+                "tarball": "http://registry.npmjs.org/etag/-/etag-1.0.0.tgz"
+            },
+            "homepage": "https://github.com/kesla/etag",
+            "license": "MIT",
+            "main": "etag.js",
+            "maintainers": [
+                {
+                    "email": "david.bjorklund@gmail.com",
+                    "name": "kesla"
+                }
+            ],
+            "name": "etag",
+            "repository": {
+                "type": "git",
+                "url": "git://github.com/kesla/etag.git"
+            },
+            "scripts": {
+                "test": "echo \"Error: no test specified\" && exit 1"
+            },
+            "version": "1.0.0"
+        },
+        "1.0.1": {
+            "_from": ".",
+            "_id": "etag@1.0.1",
+            "_npmUser": {
+                "email": "doug@somethingdoug.com",
+                "name": "dougwilson"
+            },
+            "_npmVersion": "1.4.21",
+            "_shasum": "2aa41de474ffc45669f25c9fedacd64fea4f6ff7",
+            "bugs": {
+                "url": "jshttp/etag/issues"
+            },
+            "contributors": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "Douglas Christopher Wilson"
+                },
+                {
+                    "email": "david.bjorklund@gmail.com",
+                    "name": "David BjÃ¶rklund"
+                }
+            ],
+            "description": "Create simple ETags",
+            "devDependencies": {
+                "istanbul": "0.3.0",
+                "mocha": "~1.21.4"
+            },
+            "directories": {},
+            "dist": {
+                "shasum": "2aa41de474ffc45669f25c9fedacd64fea4f6ff7",
+                "tarball": "http://registry.npmjs.org/etag/-/etag-1.0.1.tgz"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            },
+            "files": [
+                "LICENSE",
+                "HISTORY.md",
+                "index.js"
+            ],
+            "gitHead": "d28ee6654ff51e83f3025a73677a30ec0fe04fc8",
+            "homepage": "jshttp/etag",
+            "keywords": [
+                "etag",
+                "http",
+                "res"
+            ],
+            "license": "MIT",
+            "maintainers": [
+                {
+                    "email": "david.bjorklund@gmail.com",
+                    "name": "kesla"
+                },
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "dougwilson"
+                }
+            ],
+            "name": "etag",
+            "repository": {
+                "type": "git",
+                "url": "jshttp/etag"
+            },
+            "scripts": {
+                "test": "mocha --reporter spec --bail --check-leaks test/",
+                "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+                "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+            },
+            "version": "1.0.1"
+        },
+        "1.1.0": {
+            "_from": ".",
+            "_id": "etag@1.1.0",
+            "_npmUser": {
+                "email": "doug@somethingdoug.com",
+                "name": "dougwilson"
+            },
+            "_npmVersion": "1.4.21",
+            "_shasum": "e44af7bbabe2f998d9fc3bee00db0d34b29c13a3",
+            "bugs": {
+                "url": "jshttp/etag/issues"
+            },
+            "contributors": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "Douglas Christopher Wilson"
+                },
+                {
+                    "email": "david.bjorklund@gmail.com",
+                    "name": "David BjÃ¶rklund"
+                }
+            ],
+            "dependencies": {
+                "crc": "2.1.1"
+            },
+            "description": "Create simple ETags",
+            "devDependencies": {
+                "istanbul": "0.3.0",
+                "mocha": "~1.21.4"
+            },
+            "directories": {},
+            "dist": {
+                "shasum": "e44af7bbabe2f998d9fc3bee00db0d34b29c13a3",
+                "tarball": "http://registry.npmjs.org/etag/-/etag-1.1.0.tgz"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            },
+            "files": [
+                "LICENSE",
+                "HISTORY.md",
+                "index.js"
+            ],
+            "gitHead": "415cebe1d2a87510ffbd102816733e2c9934d0c7",
+            "homepage": "jshttp/etag",
+            "keywords": [
+                "etag",
+                "http",
+                "res"
+            ],
+            "license": "MIT",
+            "maintainers": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "dougwilson"
+                }
+            ],
+            "name": "etag",
+            "repository": {
+                "type": "git",
+                "url": "jshttp/etag"
+            },
+            "scripts": {
+                "test": "mocha --reporter spec --bail --check-leaks test/",
+                "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+                "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+            },
+            "version": "1.1.0"
+        },
+        "1.2.0": {
+            "_from": ".",
+            "_id": "etag@1.2.0",
+            "_npmUser": {
+                "email": "doug@somethingdoug.com",
+                "name": "dougwilson"
+            },
+            "_npmVersion": "1.4.21",
+            "_shasum": "fa537a8e1b1e29aa53480b69cfceb906a47aca8a",
+            "bugs": {
+                "url": "jshttp/etag/issues"
+            },
+            "contributors": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "Douglas Christopher Wilson"
+                },
+                {
+                    "email": "david.bjorklund@gmail.com",
+                    "name": "David BjÃ¶rklund"
+                }
+            ],
+            "dependencies": {
+                "crc": "2.1.1"
+            },
+            "description": "Create simple ETags",
+            "devDependencies": {
+                "istanbul": "0.3.0",
+                "mocha": "~1.21.4"
+            },
+            "directories": {},
+            "dist": {
+                "shasum": "fa537a8e1b1e29aa53480b69cfceb906a47aca8a",
+                "tarball": "http://registry.npmjs.org/etag/-/etag-1.2.0.tgz"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            },
+            "files": [
+                "LICENSE",
+                "HISTORY.md",
+                "index.js"
+            ],
+            "gitHead": "0d38a87d4217882b31e4a34786069281631a5cb2",
+            "homepage": "jshttp/etag",
+            "keywords": [
+                "etag",
+                "http",
+                "res"
+            ],
+            "license": "MIT",
+            "maintainers": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "dougwilson"
+                }
+            ],
+            "name": "etag",
+            "repository": {
+                "type": "git",
+                "url": "jshttp/etag"
+            },
+            "scripts": {
+                "test": "mocha --reporter spec --bail --check-leaks test/",
+                "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+                "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+            },
+            "version": "1.2.0"
+        },
+        "1.2.1": {
+            "_from": ".",
+            "_id": "etag@1.2.1",
+            "_npmUser": {
+                "email": "doug@somethingdoug.com",
+                "name": "dougwilson"
+            },
+            "_npmVersion": "1.4.21",
+            "_shasum": "74b16ea7511ce0041b944852eca2a95b9afefba3",
+            "bugs": {
+                "url": "jshttp/etag/issues"
+            },
+            "contributors": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "Douglas Christopher Wilson"
+                },
+                {
+                    "email": "david.bjorklund@gmail.com",
+                    "name": "David BjÃ¶rklund"
+                }
+            ],
+            "dependencies": {
+                "buffer-crc32": "0.2.3"
+            },
+            "description": "Create simple ETags",
+            "devDependencies": {
+                "beautify-benchmark": "0.2.4",
+                "benchmark": "1.0.0",
+                "istanbul": "0.3.0",
+                "mocha": "~1.21.4",
+                "seedrandom": "~2.3.6"
+            },
+            "directories": {},
+            "dist": {
+                "shasum": "74b16ea7511ce0041b944852eca2a95b9afefba3",
+                "tarball": "http://registry.npmjs.org/etag/-/etag-1.2.1.tgz"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            },
+            "files": [
+                "LICENSE",
+                "HISTORY.md",
+                "index.js"
+            ],
+            "gitHead": "4b9369db7434104ee7c449f288af03c6abe7bad3",
+            "homepage": "jshttp/etag",
+            "keywords": [
+                "etag",
+                "http",
+                "res"
+            ],
+            "license": "MIT",
+            "maintainers": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "dougwilson"
+                }
+            ],
+            "name": "etag",
+            "repository": {
+                "type": "git",
+                "url": "jshttp/etag"
+            },
+            "scripts": {
+                "bench": "node benchmark/index.js",
+                "test": "mocha --reporter spec --bail --check-leaks test/",
+                "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+                "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+            },
+            "version": "1.2.1"
+        },
+        "1.3.0": {
+            "_from": ".",
+            "_id": "etag@1.3.0",
+            "_npmUser": {
+                "email": "doug@somethingdoug.com",
+                "name": "dougwilson"
+            },
+            "_npmVersion": "1.4.21",
+            "_shasum": "c837debfbfe0baf7eb8e2f0bbb3d1d9cc3229697",
+            "bugs": {
+                "url": "jshttp/etag/issues"
+            },
+            "contributors": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "Douglas Christopher Wilson"
+                },
+                {
+                    "email": "david.bjorklund@gmail.com",
+                    "name": "David BjÃ¶rklund"
+                }
+            ],
+            "dependencies": {
+                "buffer-crc32": "0.2.3"
+            },
+            "description": "Create simple ETags",
+            "devDependencies": {
+                "beautify-benchmark": "0.2.4",
+                "benchmark": "1.0.0",
+                "istanbul": "0.3.0",
+                "mocha": "~1.21.4",
+                "seedrandom": "~2.3.6"
+            },
+            "directories": {},
+            "dist": {
+                "shasum": "c837debfbfe0baf7eb8e2f0bbb3d1d9cc3229697",
+                "tarball": "http://registry.npmjs.org/etag/-/etag-1.3.0.tgz"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            },
+            "files": [
+                "LICENSE",
+                "HISTORY.md",
+                "index.js"
+            ],
+            "gitHead": "b1531685ee679ca8fe329202e56d429d3c02eac0",
+            "homepage": "jshttp/etag",
+            "keywords": [
+                "etag",
+                "http",
+                "res"
+            ],
+            "license": "MIT",
+            "maintainers": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "dougwilson"
+                }
+            ],
+            "name": "etag",
+            "repository": {
+                "type": "git",
+                "url": "jshttp/etag"
+            },
+            "scripts": {
+                "bench": "node benchmark/index.js",
+                "test": "mocha --reporter spec --bail --check-leaks test/",
+                "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+                "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+            },
+            "version": "1.3.0"
+        },
+        "1.3.1": {
+            "_from": ".",
+            "_id": "etag@1.3.1",
+            "_npmUser": {
+                "email": "doug@somethingdoug.com",
+                "name": "dougwilson"
+            },
+            "_npmVersion": "1.4.21",
+            "_shasum": "e51925728688a32dc4eea1cfa9ab4f734d055567",
+            "bugs": {
+                "url": "jshttp/etag/issues"
+            },
+            "contributors": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "Douglas Christopher Wilson"
+                },
+                {
+                    "email": "david.bjorklund@gmail.com",
+                    "name": "David BjÃ¶rklund"
+                }
+            ],
+            "dependencies": {
+                "crc": "3.0.0"
+            },
+            "description": "Create simple ETags",
+            "devDependencies": {
+                "beautify-benchmark": "0.2.4",
+                "benchmark": "1.0.0",
+                "istanbul": "0.3.2",
+                "mocha": "~1.21.4",
+                "seedrandom": "~2.3.6"
+            },
+            "directories": {},
+            "dist": {
+                "shasum": "e51925728688a32dc4eea1cfa9ab4f734d055567",
+                "tarball": "http://registry.npmjs.org/etag/-/etag-1.3.1.tgz"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "files": [
+                "LICENSE",
+                "HISTORY.md",
+                "index.js"
+            ],
+            "gitHead": "88a83fdccc15065893cfad6e2c7af8a379941f16",
+            "homepage": "jshttp/etag",
+            "keywords": [
+                "etag",
+                "http",
+                "res"
+            ],
+            "license": "MIT",
+            "maintainers": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "dougwilson"
+                }
+            ],
+            "name": "etag",
+            "repository": {
+                "type": "git",
+                "url": "jshttp/etag"
+            },
+            "scripts": {
+                "bench": "node benchmark/index.js",
+                "test": "mocha --reporter spec --bail --check-leaks test/",
+                "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+                "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+            },
+            "version": "1.3.1"
+        },
+        "1.4.0": {
+            "_from": ".",
+            "_id": "etag@1.4.0",
+            "_npmUser": {
+                "email": "doug@somethingdoug.com",
+                "name": "dougwilson"
+            },
+            "_npmVersion": "1.4.21",
+            "_shasum": "3050991615857707c04119d075ba2088e0701225",
+            "bugs": {
+                "url": "jshttp/etag/issues"
+            },
+            "contributors": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "Douglas Christopher Wilson"
+                },
+                {
+                    "email": "david.bjorklund@gmail.com",
+                    "name": "David BjÃ¶rklund"
+                }
+            ],
+            "dependencies": {
+                "crc": "3.0.0"
+            },
+            "description": "Create simple ETags",
+            "devDependencies": {
+                "beautify-benchmark": "0.2.4",
+                "benchmark": "1.0.0",
+                "istanbul": "0.3.2",
+                "mocha": "~1.21.4",
+                "seedrandom": "~2.3.6"
+            },
+            "directories": {},
+            "dist": {
+                "shasum": "3050991615857707c04119d075ba2088e0701225",
+                "tarball": "http://registry.npmjs.org/etag/-/etag-1.4.0.tgz"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            },
+            "files": [
+                "LICENSE",
+                "HISTORY.md",
+                "index.js"
+            ],
+            "gitHead": "6b701773b06a102947cc063286e7e3f3bceae27b",
+            "homepage": "jshttp/etag",
+            "keywords": [
+                "etag",
+                "http",
+                "res"
+            ],
+            "license": "MIT",
+            "maintainers": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "dougwilson"
+                }
+            ],
+            "name": "etag",
+            "repository": {
+                "type": "git",
+                "url": "jshttp/etag"
+            },
+            "scripts": {
+                "bench": "node benchmark/index.js",
+                "test": "mocha --reporter spec --bail --check-leaks test/",
+                "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+                "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+            },
+            "version": "1.4.0"
+        },
+        "1.5.0": {
+            "_from": ".",
+            "_id": "etag@1.5.0",
+            "_npmUser": {
+                "email": "doug@somethingdoug.com",
+                "name": "dougwilson"
+            },
+            "_npmVersion": "1.4.21",
+            "_shasum": "8ca0f7a30b4b7305f034e8902fb8ec3c321491e4",
+            "bugs": {
+                "url": "jshttp/etag/issues"
+            },
+            "contributors": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "Douglas Christopher Wilson"
+                },
+                {
+                    "email": "david.bjorklund@gmail.com",
+                    "name": "David BjÃ¶rklund"
+                }
+            ],
+            "dependencies": {
+                "crc": "3.0.0"
+            },
+            "description": "Create simple ETags",
+            "devDependencies": {
+                "beautify-benchmark": "0.2.4",
+                "benchmark": "1.0.0",
+                "istanbul": "0.3.2",
+                "mocha": "~1.21.4",
+                "seedrandom": "~2.3.6"
+            },
+            "directories": {},
+            "dist": {
+                "shasum": "8ca0f7a30b4b7305f034e8902fb8ec3c321491e4",
+                "tarball": "http://registry.npmjs.org/etag/-/etag-1.5.0.tgz"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            },
+            "files": [
+                "LICENSE",
+                "HISTORY.md",
+                "index.js"
+            ],
+            "gitHead": "d42734af50250c05893f02cb900e1c71efffbc45",
+            "homepage": "jshttp/etag",
+            "keywords": [
+                "etag",
+                "http",
+                "res"
+            ],
+            "license": "MIT",
+            "maintainers": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "dougwilson"
+                }
+            ],
+            "name": "etag",
+            "repository": {
+                "type": "git",
+                "url": "jshttp/etag"
+            },
+            "scripts": {
+                "bench": "node benchmark/index.js",
+                "test": "mocha --reporter spec --bail --check-leaks test/",
+                "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+                "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+            },
+            "version": "1.5.0"
+        },
+        "1.5.1": {
+            "_from": ".",
+            "_id": "etag@1.5.1",
+            "_npmUser": {
+                "email": "doug@somethingdoug.com",
+                "name": "dougwilson"
+            },
+            "_npmVersion": "1.4.21",
+            "_shasum": "54c50de04ee42695562925ac566588291be7e9ea",
+            "bugs": {
+                "url": "jshttp/etag/issues"
+            },
+            "contributors": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "Douglas Christopher Wilson"
+                },
+                {
+                    "email": "david.bjorklund@gmail.com",
+                    "name": "David BjÃ¶rklund"
+                }
+            ],
+            "dependencies": {
+                "crc": "3.2.1"
+            },
+            "description": "Create simple ETags",
+            "devDependencies": {
+                "beautify-benchmark": "0.2.4",
+                "benchmark": "1.0.0",
+                "istanbul": "0.3.2",
+                "mocha": "~1.21.4",
+                "seedrandom": "~2.3.6"
+            },
+            "directories": {},
+            "dist": {
+                "shasum": "54c50de04ee42695562925ac566588291be7e9ea",
+                "tarball": "http://registry.npmjs.org/etag/-/etag-1.5.1.tgz"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            },
+            "files": [
+                "LICENSE",
+                "HISTORY.md",
+                "index.js"
+            ],
+            "gitHead": "27335e2265388109e50a9f037452081dc8a8260f",
+            "homepage": "jshttp/etag",
+            "keywords": [
+                "etag",
+                "http",
+                "res"
+            ],
+            "license": "MIT",
+            "maintainers": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "dougwilson"
+                }
+            ],
+            "name": "etag",
+            "repository": {
+                "type": "git",
+                "url": "jshttp/etag"
+            },
+            "scripts": {
+                "bench": "node benchmark/index.js",
+                "test": "mocha --reporter spec --bail --check-leaks test/",
+                "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+                "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+            },
+            "version": "1.5.1"
+        },
+        "1.6.0": {
+            "_from": ".",
+            "_id": "etag@1.6.0",
+            "_npmUser": {
+                "email": "doug@somethingdoug.com",
+                "name": "dougwilson"
+            },
+            "_npmVersion": "1.4.28",
+            "_shasum": "8bcb2c6af1254c481dfc8b997c906ef4e442c207",
+            "bugs": {
+                "url": "jshttp/etag/issues"
+            },
+            "contributors": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "Douglas Christopher Wilson"
+                },
+                {
+                    "email": "david.bjorklund@gmail.com",
+                    "name": "David BjÃ¶rklund"
+                }
+            ],
+            "dependencies": {
+                "crc": "3.2.1"
+            },
+            "description": "Create simple ETags",
+            "devDependencies": {
+                "beautify-benchmark": "0.2.4",
+                "benchmark": "1.0.0",
+                "istanbul": "0.3.9",
+                "mocha": "~1.21.4",
+                "seedrandom": "2.3.11"
+            },
+            "directories": {},
+            "dist": {
+                "shasum": "8bcb2c6af1254c481dfc8b997c906ef4e442c207",
+                "tarball": "http://registry.npmjs.org/etag/-/etag-1.6.0.tgz"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            },
+            "files": [
+                "LICENSE",
+                "HISTORY.md",
+                "README.md",
+                "index.js"
+            ],
+            "gitHead": "76a8f5250b02e85bc1c9b1b049d83b853a87df44",
+            "homepage": "jshttp/etag",
+            "keywords": [
+                "etag",
+                "http",
+                "res"
+            ],
+            "license": "MIT",
+            "maintainers": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "dougwilson"
+                }
+            ],
+            "name": "etag",
+            "repository": {
+                "type": "git",
+                "url": "jshttp/etag"
+            },
+            "scripts": {
+                "bench": "node benchmark/index.js",
+                "test": "mocha --reporter spec --bail --check-leaks test/",
+                "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+                "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+            },
+            "version": "1.6.0"
+        },
+        "1.7.0": {
+            "_from": ".",
+            "_id": "etag@1.7.0",
+            "_npmUser": {
+                "email": "doug@somethingdoug.com",
+                "name": "dougwilson"
+            },
+            "_npmVersion": "1.4.28",
+            "_shasum": "03d30b5f67dd6e632d2945d30d6652731a34d5d8",
+            "bugs": {
+                "url": "jshttp/etag/issues"
+            },
+            "contributors": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "Douglas Christopher Wilson"
+                },
+                {
+                    "email": "david.bjorklund@gmail.com",
+                    "name": "David BjÃ¶rklund"
+                }
+            ],
+            "description": "Create simple ETags",
+            "devDependencies": {
+                "beautify-benchmark": "0.2.4",
+                "benchmark": "1.0.0",
+                "istanbul": "0.3.14",
+                "mocha": "~1.21.4",
+                "seedrandom": "2.3.11"
+            },
+            "directories": {},
+            "dist": {
+                "shasum": "03d30b5f67dd6e632d2945d30d6652731a34d5d8",
+                "tarball": "http://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            },
+            "files": [
+                "LICENSE",
+                "HISTORY.md",
+                "README.md",
+                "index.js"
+            ],
+            "gitHead": "a511f5c8c930fd9546dbd88acb080f96bc788cfc",
+            "homepage": "jshttp/etag",
+            "keywords": [
+                "etag",
+                "http",
+                "res"
+            ],
+            "license": "MIT",
+            "maintainers": [
+                {
+                    "email": "doug@somethingdoug.com",
+                    "name": "dougwilson"
+                }
+            ],
+            "name": "etag",
+            "repository": "jshttp/etag",
+            "scripts": {
+                "bench": "node benchmark/index.js",
+                "test": "mocha --reporter spec --bail --check-leaks test/",
+                "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+                "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+            },
+            "version": "1.7.0"
+        }
+    }
+}


### PR DESCRIPTION
Documented [here](https://docs.npmjs.com/files/package.json#repository).

As reported by a user on Twitter.