### PR TITLE
Upgrade to Go 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" >> /etc/ap
 ### GO
 
 # Install Go and dep
-RUN curl https://dl.google.com/go/go1.12.9.linux-amd64.tar.gz | tar -xz -C /opt \
+RUN curl https://dl.google.com/go/go1.13.linux-amd64.tar.gz | tar -xz -C /opt \
     && wget -O /opt/go/bin/dep https://github.com/golang/dep/releases/download/v0.5.4/dep-linux-amd64 \
     && chmod +x /opt/go/bin/dep \
     && mkdir /opt/go/gopath

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" >> /etc/ap
 ### GO
 
 # Install Go and dep
-RUN curl https://dl.google.com/go/go1.13.linux-amd64.tar.gz | tar -xz -C /opt \
+RUN curl https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz | tar -xz -C /opt \
     && wget -O /opt/go/bin/dep https://github.com/golang/dep/releases/download/v0.5.4/dep-linux-amd64 \
     && chmod +x /opt/go/bin/dep \
     && mkdir /opt/go/gopath

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -81,7 +81,8 @@ module Dependabot
         ].freeze
         MODULE_PATH_MISMATCH_REGEXES = [
           /go: ([^@\s]+)(?:@[^\s]+)?: .* has non-.* module path "(.*)" at/,
-          /go: ([^@\s]+)(?:@[^\s]+)?: .* unexpected module path "(.*)"/
+          /go: ([^@\s]+)(?:@[^\s]+)?: .* unexpected module path "(.*)"/,
+          /go: ([^@\s]+)(?:@[^\s]+)?: .* declares its path as: ([\S]*)/m
         ].freeze
 
         def local_replacements

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -89,6 +89,13 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
           it { is_expected.to include("go 1.12") }
         end
 
+        context "for a go 1.13 go.mod" do
+          let(:go_mod_body) do
+            fixture("go_mods", go_mod_fixture_name).sub(/go 1.12/, "go 1.13")
+          end
+          it { is_expected.to include("go 1.13") }
+        end
+
         context "with a go.sum" do
           let(:go_sum) do
             Dependabot::DependencyFile.new(name: "go.sum", content: go_sum_body)


### PR DESCRIPTION
It's the current stable version, so we should be using it.