### PR TITLE
Add support for VS Code Remote Development on Docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,127 @@
+{
+  "name": "Ruby",
+  "dockerFile": "../Dockerfile.development",
+
+  "workspaceFolder": "/home/dependabot/dependabot-core",
+
+  "runArgs": [
+    "-u", "dependabot",
+
+    "-v", "${localWorkspaceFolder}/.vscode:/home/dependabot/dependabot-core/.vscode",
+    "-v", "${localWorkspaceFolder}/.gitignore:/home/dependabot/dependabot-core/.gitignore",
+    "-v", "${localWorkspaceFolder}/.rubocop.yml:/home/dependabot/dependabot-core/.rubocop.yml",
+    "-v", "${localWorkspaceFolder}/bin:/home/dependabot/dependabot-core/bin",
+    "-v", "${localWorkspaceFolder}/common/Gemfile:/home/dependabot/dependabot-core/common/Gemfile",
+    "-v", "${localWorkspaceFolder}/common/dependabot-common.gemspec:/home/dependabot/dependabot-core/common/dependabot-common.gemspec",
+    "-v", "${localWorkspaceFolder}/common/bin:/home/dependabot/dependabot-core/common/bin",
+    "-v", "${localWorkspaceFolder}/common/lib:/home/dependabot/dependabot-core/common/lib",
+    "-v", "${localWorkspaceFolder}/common/spec:/home/dependabot/dependabot-core/common/spec",
+    "-v", "${localWorkspaceFolder}/bundler/dependabot-bundler.gemspec:/home/dependabot/dependabot-core/bundler/dependabot-bundler.gemspec",
+    "-v", "${localWorkspaceFolder}/bundler/Gemfile:/home/dependabot/dependabot-core/bundler/Gemfile",
+    "-v", "${localWorkspaceFolder}/bundler/lib:/home/dependabot/dependabot-core/bundler/lib",
+    "-v", "${localWorkspaceFolder}/bundler/spec:/home/dependabot/dependabot-core/bundler/spec",
+    "-v", "${localWorkspaceFolder}/cargo/dependabot-cargo.gemspec:/home/dependabot/dependabot-core/cargo/dependabot-core.gemspec",
+    "-v", "${localWorkspaceFolder}/cargo/Gemfile:/home/dependabot/dependabot-core/cargo/Gemfile",
+    "-v", "${localWorkspaceFolder}/cargo/lib:/home/dependabot/dependabot-core/cargo/lib",
+    "-v", "${localWorkspaceFolder}/cargo/spec:/home/dependabot/dependabot-core/cargo/spec",
+    "-v", "${localWorkspaceFolder}/composer/dependabot-composer.gemspec:/home/dependabot/dependabot-core/composer/dependabot-composer.gemspec",
+    "-v", "${localWorkspaceFolder}/composer/Gemfile:/home/dependabot/dependabot-core/composer/Gemfile",
+    "-v", "${localWorkspaceFolder}/composer/lib:/home/dependabot/dependabot-core/composer/lib",
+    "-v", "${localWorkspaceFolder}/composer/spec:/home/dependabot/dependabot-core/composer/spec",
+    "-v", "${localWorkspaceFolder}/dep/dependabot-dep.gemspec:/home/dependabot/dependabot-core/dep/dependabot-dep.gemspec",
+    "-v", "${localWorkspaceFolder}/dep/Gemfile:/home/dependabot/dependabot-core/dep/Gemfile",
+    "-v", "${localWorkspaceFolder}/dep/lib:/home/dependabot/dependabot-core/dep/lib",
+    "-v", "${localWorkspaceFolder}/dep/spec:/home/dependabot/dependabot-core/dep/spec",
+    "-v", "${localWorkspaceFolder}/docker/dependabot-docker.gemspec:/home/dependabot/dependabot-core/docker/dependabot-docker.gemspec",
+    "-v", "${localWorkspaceFolder}/docker/Gemfile:/home/dependabot/dependabot-core/docker/Gemfile",
+    "-v", "${localWorkspaceFolder}/docker/lib:/home/dependabot/dependabot-core/docker/lib",
+    "-v", "${localWorkspaceFolder}/docker/spec:/home/dependabot/dependabot-core/docker/spec",
+    "-v", "${localWorkspaceFolder}/elm/dependabot-elm.gemspec:/home/dependabot/dependabot-core/elm/dependabot-elm.gemspec",
+    "-v", "${localWorkspaceFolder}/elm/Gemfile:/home/dependabot/dependabot-core/elm/Gemfile",
+    "-v", "${localWorkspaceFolder}/elm/lib:/home/dependabot/dependabot-core/elm/lib",
+    "-v", "${localWorkspaceFolder}/elm/spec:/home/dependabot/dependabot-core/elm/spec",
+    "-v", "${localWorkspaceFolder}/git_submodules/dependabot-git_submodules.gemspec:/home/dependabot/dependabot-core/git_submodules/dependabot-core.gemspec",
+    "-v", "${localWorkspaceFolder}/git_submodules/Gemfile:/home/dependabot/dependabot-core/git_submodules/Gemfile",
+    "-v", "${localWorkspaceFolder}/git_submodules/lib:/home/dependabot/dependabot-core/git_submodules/lib",
+    "-v", "${localWorkspaceFolder}/git_submodules/spec:/home/dependabot/dependabot-core/git_submodules/spec",
+    "-v", "${localWorkspaceFolder}/github_actions/dependabot-github_actions.gemspec:/home/dependabot/dependabot-core/github_actions/dependabot-core.gemspec",
+    "-v", "${localWorkspaceFolder}/github_actions/Gemfile:/home/dependabot/dependabot-core/github_actions/Gemfile",
+    "-v", "${localWorkspaceFolder}/github_actions/lib:/home/dependabot/dependabot-core/github_actions/lib",
+    "-v", "${localWorkspaceFolder}/github_actions/spec:/home/dependabot/dependabot-core/github_actions/spec",
+    "-v", "${localWorkspaceFolder}/go_modules/dependabot-go_modules.gemspec:/home/dependabot/dependabot-core/go_modules/dependabot-go_modules.gemspec",
+    "-v", "${localWorkspaceFolder}/go_modules/Gemfile:/home/dependabot/dependabot-core/go_modules/Gemfile",
+    "-v", "${localWorkspaceFolder}/go_modules/lib:/home/dependabot/dependabot-core/go_modules/lib",
+    "-v", "${localWorkspaceFolder}/go_modules/spec:/home/dependabot/dependabot-core/go_modules/spec",
+    "-v", "${localWorkspaceFolder}/gradle/dependabot-gradle.gemspec:/home/dependabot/dependabot-core/gradle/dependabot-gradle.gemspec",
+    "-v", "${localWorkspaceFolder}/gradle/Gemfile:/home/dependabot/dependabot-core/gradle/Gemfile",
+    "-v", "${localWorkspaceFolder}/gradle/lib:/home/dependabot/dependabot-core/gradle/lib",
+    "-v", "${localWorkspaceFolder}/gradle/spec:/home/dependabot/dependabot-core/gradle/spec",
+    "-v", "${localWorkspaceFolder}/hex/dependabot-hex.gemspec:/home/dependabot/dependabot-core/hex/dependabot-hex.gemspec",
+    "-v", "${localWorkspaceFolder}/hex/Gemfile:/home/dependabot/dependabot-core/hex/Gemfile",
+    "-v", "${localWorkspaceFolder}/hex/lib:/home/dependabot/dependabot-core/hex/lib",
+    "-v", "${localWorkspaceFolder}/hex/spec:/home/dependabot/dependabot-core/hex/spec",
+    "-v", "${localWorkspaceFolder}/maven/dependabot-maven.gemspec:/home/dependabot/dependabot-core/maven/dependabot-core.gemspec",
+    "-v", "${localWorkspaceFolder}/maven/Gemfile:/home/dependabot/dependabot-core/maven/Gemfile",
+    "-v", "${localWorkspaceFolder}/maven/lib:/home/dependabot/dependabot-core/maven/lib",
+    "-v", "${localWorkspaceFolder}/maven/spec:/home/dependabot/dependabot-core/maven/spec",
+    "-v", "${localWorkspaceFolder}/npm_and_yarn/dependabot-npm_and_yarn.gemspec:/home/dependabot/dependabot-core/npm_and_yarn/dependabot-npm_and_yarn.gemspec",
+    "-v", "${localWorkspaceFolder}/npm_and_yarn/Gemfile:/home/dependabot/dependabot-core/npm_and_yarn/Gemfile",
+    "-v", "${localWorkspaceFolder}/npm_and_yarn/lib:/home/dependabot/dependabot-core/npm_and_yarn/lib",
+    "-v", "${localWorkspaceFolder}/npm_and_yarn/spec:/home/dependabot/dependabot-core/npm_and_yarn/spec",
+    "-v", "${localWorkspaceFolder}/nuget/dependabot-nuget.gemspec:/home/dependabot/dependabot-core/nuget/dependabot-core.gemspec",
+    "-v", "${localWorkspaceFolder}/nuget/Gemfile:/home/dependabot/dependabot-core/nuget/Gemfile",
+    "-v", "${localWorkspaceFolder}/nuget/lib:/home/dependabot/dependabot-core/nuget/lib",
+    "-v", "${localWorkspaceFolder}/nuget/spec:/home/dependabot/dependabot-core/nuget/spec",
+    "-v", "${localWorkspaceFolder}/python/dependabot-python.gemspec:/home/dependabot/dependabot-core/python/dependabot-python.gemspec",
+    "-v", "${localWorkspaceFolder}/python/Gemfile:/home/dependabot/dependabot-core/python/Gemfile",
+    "-v", "${localWorkspaceFolder}/python/lib:/home/dependabot/dependabot-core/python/lib",
+    "-v", "${localWorkspaceFolder}/python/spec:/home/dependabot/dependabot-core/python/spec",
+    "-v", "${localWorkspaceFolder}/terraform/dependabot-terraform.gemspec:/home/dependabot/dependabot-core/terraform/dependabot-terraform.gemspec",
+    "-v", "${localWorkspaceFolder}/terraform/Gemfile:/home/dependabot/dependabot-core/terraform/Gemfile",
+    "-v", "${localWorkspaceFolder}/terraform/lib:/home/dependabot/dependabot-core/terraform/lib",
+    "-v", "${localWorkspaceFolder}/terraform/spec:/home/dependabot/dependabot-core/terraform/spec",
+    "-v", "${localWorkspaceFolder}/omnibus/Gemfile:/home/dependabot/dependabot-core/omnibus/Gemfile",
+    "-v", "${localWorkspaceFolder}/omnibus/dependabot-omnibus.gemspec:/home/dependabot/dependabot-core/omnibus/dependabot-omnibus.gemspec",
+    "-v", "${localWorkspaceFolder}/omnibus/lib:/home/dependabot/dependabot-core/omnibus/lib",
+    "-v", "${localWorkspaceFolder}/omnibus/spec:/home/dependabot/dependabot-core/omnibus/spec",
+
+    "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
+  ],
+
+  // Use 'settings' to set *default* container specific settings.json values on container create.
+  // You can edit these settings after create using File > Preferences > Settings > Remote.
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash",
+    "solargraph.useBundler": true,
+    "ruby.useBundler": true,
+    "ruby.useLanguageServer": true,
+    "ruby.lint": {
+      "rubocop": {
+        "useBundler": true,
+        "lint": true
+      },
+      "reek": {
+        "useBundler": true
+      }
+    },
+    "ruby.format": "rubocop",
+    "[ruby]": {
+      "editor.defaultFormatter": "misogi.ruby-rubocop"
+    }
+  },
+
+  // Uncomment the next line if you want to publish any ports.
+  // "appPort": [],
+
+  // Uncomment the next line to run commands after the container is created.
+  // "postCreateCommand": "ruby --version"
+
+  "extensions": [
+		"rebornix.ruby",
+		"castwide.solargraph",
+		"misogi.ruby-rubocop",
+		"groksrc.ruby",
+		"hoovercj.ruby-linter",
+		"miguel-savignano.ruby-symbols"
+  ]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,11 @@
 
   "runArgs": [
     "-u", "dependabot",
+    "-e", "LOCAL_GITHUB_ACCESS_TOKEN=${env:LOCAL_GITHUB_ACCESS_TOKEN}",
+    "-e", "LOCAL_CONFIG_VARIABLES=${env:LOCAL_CONFIG_VARIABLES}",
 
     "-v", "${localWorkspaceFolder}/.vscode:/home/dependabot/dependabot-core/.vscode",
+    "-v", "${localWorkspaceFolder}/.vscode-server:/home/dependabot/.vscode-server",
     "-v", "${localWorkspaceFolder}/.gitignore:/home/dependabot/dependabot-core/.gitignore",
     "-v", "${localWorkspaceFolder}/.rubocop.yml:/home/dependabot/dependabot-core/.rubocop.yml",
     "-v", "${localWorkspaceFolder}/bin:/home/dependabot/dependabot-core/bin",

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ vendor
 /npm_and_yarn/helpers/node_modules
 /npm_and_yarn/helpers/install-dir
 /dry-run
+**/bin/helper

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ vendor
 .DS_Store
 *.pyc
 *git.store
-.vscode/
+/.vscode/
+/.vscode-server/
+/.vscode-server-insiders/
 .byebug_history
 /terraform/helpers/install-dir
 /go_modules/helpers/install-dir

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,18 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"rebornix.ruby",
+		"castwide.solargraph",
+		"misogi.ruby-rubocop",
+		"groksrc.ruby",
+		"hoovercj.ruby-linter",
+		"miguel-savignano.ruby-symbols",
+		"ms-vscode-remote.remote-containers"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,9 +11,6 @@
       "program": "${workspaceRoot}/bin/dry-run.rb",
       "cwd": "${workspaceRoot}",
       "useBundler": true,
-      "env": {
-        "LOCAL_GITHUB_ACCESS_TOKEN": ""
-      },
       "args": [
         "${input:package_manager}",
         "${input:repository}"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,9 @@
       "program": "${workspaceRoot}/bin/dry-run.rb",
       "cwd": "${workspaceRoot}",
       "useBundler": true,
+      "env": {
+        "LOCAL_GITHUB_ACCESS_TOKEN": ""
+      },
       "args": [
         "${input:package_manager}",
         "${input:repository}"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,51 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug dry run",
+      "type": "Ruby",
+      "request": "launch",
+      "program": "${workspaceRoot}/bin/dry-run.rb",
+      "cwd": "${workspaceRoot}",
+      "useBundler": true,
+      "args": [
+        "${input:package_manager}",
+        "${input:repository}"
+      ]
+    }
+  ],
+  "inputs": [
+    {
+      "type": "pickString",
+      "id": "package_manager",
+      "description": "What type of package manager do you want to debug?",
+      "options": [
+        "bundler",
+        "cargo",
+        "composer",
+        "dep",
+        "docker",
+        "elm",
+        "go_modules",
+        "gradle",
+        "hex",
+        "maven",
+        "npm_and_yarn",
+        "nuget",
+        "pip",
+        "submodules",
+        "terraform"
+      ],
+      "default": "go_modules"
+    },
+    {
+      "type": "promptString",
+      "id": "repository",
+      "description": "Enter the name of the repository to scan.",
+      "default": "zonedb/zonedb"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "Dockerfile.*": "dockerfile"
+  }
+}

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -91,3 +91,10 @@ RUN GREEN='\033[0;32m'; NC='\033[0m'; \
 RUN cd omnibus && bundle install
 # Make omnibus gems available to bundler in root directory
 RUN echo 'eval_gemfile File.join(File.dirname(__FILE__), "omnibus/Gemfile")' > Gemfile
+
+# Create directory for volume containing VS Code extensions, to avoid reinstalling on image rebuilds
+RUN mkdir -p ~/.vscode-server ~/.vscode-server-insiders
+
+# Declare pass-thru environment variables used for debugging
+ENV LOCAL_GITHUB_ACCESS_TOKEN "" \
+    LOCAL_CONFIG_VARIABLES ""

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,92 +1,93 @@
 FROM dependabot/dependabot-core
 
+# Temporarily switch to root user in order to install packages
+USER root
+
+# Add debugging tools
 RUN apt-get update && apt-get install -y vim strace ltrace gdb
 
-RUN useradd -m dependabot
-RUN chown -R dependabot:dependabot \
+# This Dockerfile adds a non-root 'dependabot' user. However, for Linux,
+# this user's GID/UID must match your local user UID/GID to avoid permission issues
+# with bind mounts. Update USER_UID / USER_GID if yours is not 1000.
+# USER_UID should be the value of $UID from the host environment and
+# USER_GID the value of `id -g`.
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+ARG USERNAME=dependabot
+
+RUN groupadd -o --gid "${USER_GID}" "${USERNAME}" && \
+    useradd --uid "${USER_UID}" --gid "${USER_GID}" -m "${USERNAME}"
+RUN chown -R "${USERNAME}":"${USERNAME}" \
   /usr/local/.pyenv \
   /opt/go/gopath \
   /opt/rust/
-USER dependabot
+USER $USERNAME
+
+ARG CODE_DIR=/home/$USERNAME/dependabot-core
 
 RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/master/vimrc-vanilla.vim && \
     echo 'export PS1="[dependabot-core-dev] \w \[$(tput setaf 4)\]$ \[$(tput sgr 0)\]"' >> ~/.bashrc
 
-RUN mkdir -p /home/dependabot/dependabot-core/common/lib/dependabot
-WORKDIR /home/dependabot/dependabot-core
+RUN mkdir -p ${CODE_DIR}/common/lib/dependabot
+WORKDIR ${CODE_DIR}
 
-ENV BUNDLE_PATH="/home/dependabot/.bundle" \
-    BUNDLE_BIN=".bundle/binstubs" \
-    PATH=".bundle/binstubs:$PATH"
+ENV BUNDLE_PATH="/home/$USERNAME/.bundle" \
+    BUNDLE_BIN=".bundle/binstubs"
+ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
 
-COPY common/Gemfile common/dependabot-common.gemspec /home/dependabot/dependabot-core/common/
-COPY common/lib/dependabot/version.rb /home/dependabot/dependabot-core/common/lib/dependabot/
+COPY common/Gemfile common/dependabot-common.gemspec ${CODE_DIR}/common/
+COPY common/lib/dependabot/version.rb ${CODE_DIR}/common/lib/dependabot/
 RUN cd common && bundle install
 
-RUN mkdir -p /home/dependabot/dependabot-core/terraform
-COPY terraform/Gemfile terraform/dependabot-terraform.gemspec /home/dependabot/dependabot-core/terraform/
-RUN cd terraform && bundle install
+RUN mkdir -p ${CODE_DIR}/bundler \
+             ${CODE_DIR}/cargo \
+             ${CODE_DIR}/composer \
+             ${CODE_DIR}/dep \
+             ${CODE_DIR}/docker \
+             ${CODE_DIR}/elm \
+             ${CODE_DIR}/git_submodules \
+             ${CODE_DIR}/github_actions \
+             ${CODE_DIR}/go_modules \
+             ${CODE_DIR}/gradle \
+             ${CODE_DIR}/hex \
+             ${CODE_DIR}/maven \
+             ${CODE_DIR}/npm_and_yarn \
+             ${CODE_DIR}/nuget \
+             ${CODE_DIR}/omnibus \
+             ${CODE_DIR}/python \
+             ${CODE_DIR}/terraform
 
-RUN mkdir -p /home/dependabot/dependabot-core/elm
-COPY elm/Gemfile elm/dependabot-elm.gemspec /home/dependabot/dependabot-core/elm/
-RUN cd elm && bundle install
+COPY bundler/Gemfile bundler/dependabot-bundler.gemspec ${CODE_DIR}/bundler/
+COPY cargo/Gemfile cargo/dependabot-cargo.gemspec ${CODE_DIR}/cargo/
+COPY composer/Gemfile composer/dependabot-composer.gemspec ${CODE_DIR}/composer/
+COPY dep/Gemfile dep/dependabot-dep.gemspec ${CODE_DIR}/dep/
+COPY docker/Gemfile docker/dependabot-docker.gemspec ${CODE_DIR}/docker/
+COPY elm/Gemfile elm/dependabot-elm.gemspec ${CODE_DIR}/elm/
+COPY git_submodules/Gemfile git_submodules/dependabot-git_submodules.gemspec ${CODE_DIR}/git_submodules/
+COPY github_actions/Gemfile github_actions/dependabot-github_actions.gemspec ${CODE_DIR}/github_actions/
+COPY go_modules/Gemfile go_modules/dependabot-go_modules.gemspec ${CODE_DIR}/go_modules/
+COPY gradle/Gemfile gradle/dependabot-gradle.gemspec ${CODE_DIR}/gradle/
+COPY hex/Gemfile hex/dependabot-hex.gemspec ${CODE_DIR}/hex/
+COPY maven/Gemfile maven/dependabot-maven.gemspec ${CODE_DIR}/maven/
+COPY npm_and_yarn/Gemfile npm_and_yarn/dependabot-npm_and_yarn.gemspec ${CODE_DIR}/npm_and_yarn/
+COPY nuget/Gemfile nuget/dependabot-nuget.gemspec ${CODE_DIR}/nuget/
+COPY omnibus/Gemfile omnibus/dependabot-omnibus.gemspec ${CODE_DIR}/omnibus/
+COPY python/Gemfile python/dependabot-python.gemspec ${CODE_DIR}/python/
+COPY terraform/Gemfile terraform/dependabot-terraform.gemspec ${CODE_DIR}/terraform/
 
-RUN mkdir -p /home/dependabot/dependabot-core/docker
-COPY docker/Gemfile docker/dependabot-docker.gemspec /home/dependabot/dependabot-core/docker/
-RUN cd docker && bundle install
+RUN GREEN='\033[0;32m'; NC='\033[0m'; \
+    for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
+                   -not -path "${CODE_DIR}/omnibus/Gemfile" \
+                   -not -path "${CODE_DIR}/common/Gemfile" \
+                   -name 'Gemfile' | xargs dirname`; do \
+      echo && \
+      echo "---------------------------------------------------------------------------" && \
+      echo "Installing gems for ${GREEN}$(realpath --relative-to=${CODE_DIR} $d)${NC}..." && \
+      echo "---------------------------------------------------------------------------" && \
+      cd $d && bundle install; \
+    done
 
-RUN mkdir -p /home/dependabot/dependabot-core/git_submodules
-COPY git_submodules/Gemfile git_submodules/dependabot-git_submodules.gemspec /home/dependabot/dependabot-core/git_submodules/
-RUN cd git_submodules && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/github_actions
-COPY github_actions/Gemfile github_actions/dependabot-github_actions.gemspec /home/dependabot/dependabot-core/github_actions/
-RUN cd github_actions && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/python
-COPY python/Gemfile python/dependabot-python.gemspec /home/dependabot/dependabot-core/python/
-RUN cd python && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/nuget
-COPY nuget/Gemfile nuget/dependabot-nuget.gemspec /home/dependabot/dependabot-core/nuget/
-RUN cd nuget && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/maven
-COPY maven/Gemfile maven/dependabot-maven.gemspec /home/dependabot/dependabot-core/maven/
-RUN cd maven && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/gradle
-COPY gradle/Gemfile gradle/dependabot-gradle.gemspec /home/dependabot/dependabot-core/gradle/
-RUN cd gradle && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/hex
-COPY hex/Gemfile hex/dependabot-hex.gemspec /home/dependabot/dependabot-core/hex/
-RUN cd hex && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/cargo
-COPY cargo/Gemfile cargo/dependabot-cargo.gemspec /home/dependabot/dependabot-core/cargo/
-RUN cd cargo && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/dep
-COPY dep/Gemfile dep/dependabot-dep.gemspec /home/dependabot/dependabot-core/dep/
-RUN cd dep && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/go_modules
-COPY go_modules/Gemfile go_modules/dependabot-go_modules.gemspec /home/dependabot/dependabot-core/go_modules/
-RUN cd go_modules && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/npm_and_yarn
-COPY npm_and_yarn/Gemfile npm_and_yarn/dependabot-npm_and_yarn.gemspec /home/dependabot/dependabot-core/npm_and_yarn/
-RUN cd npm_and_yarn && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/composer
-COPY composer/Gemfile composer/dependabot-composer.gemspec /home/dependabot/dependabot-core/composer/
-RUN cd composer && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/bundler
-COPY bundler/Gemfile bundler/dependabot-bundler.gemspec /home/dependabot/dependabot-core/bundler/
-RUN cd bundler && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/omnibus
-COPY omnibus/Gemfile omnibus/dependabot-omnibus.gemspec /home/dependabot/dependabot-core/omnibus/
 RUN cd omnibus && bundle install
+# Make omnibus gems available to bundler in root directory
+RUN echo 'eval_gemfile File.join(File.dirname(__FILE__), "omnibus/Gemfile")' > Gemfile

--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ $ bin/dry-run.rb go_modules rsc/quote
 ...
 ```
 
+## Debugging with Visual Studio Code and Docker
+
+There's built-in support for leveraging Visual Studio Code's [ability for
+debugging](https://code.visualstudio.com/docs/remote/containers) inside a Docker container.
+After installing the recommended [`Remote - Containers` extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers),
+simply press `Ctrl+Shift+P` (`⇧⌘P` on macOS) and select `Remote-Containers: Reopen in Container`.
+You can also access the dropdown by clicking on the green button in the bottom-left corner of the editor.
+If the development Docker image isn't present on your machine, it will be built automatically.
+Once that's finished, start the `Debug Dry Run` configuration `(F5)` and you'll be prompted
+to select a package manager and a repository to perform a dry run on.
+Feel free to place breakpoints on the code.
+
 ## Releasing
 
 Triggering the jobs that will push the new gems is done by following the steps below.

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -29,7 +29,7 @@ fi
 
 build_image() {
   echo "$(tput setaf 2)=> building image from $DOCKERFILE$(tput sgr0)"
-  docker build -t "$IMAGE_NAME" -f "$DOCKERFILE" .
+  docker build --build-arg "USER_UID=$UID" --build-arg "USER_GID=$(id -g)" -t "$IMAGE_NAME" -f "$DOCKERFILE" .
 }
 
 IMAGE_ID=$(docker inspect --type=image -f '{{.Id}}' "$IMAGE_NAME" 2> /dev/null || true)

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -108,7 +108,7 @@ unless ENV["LOCAL_GITHUB_ACCESS_TOKEN"].to_s.strip.empty?
   }
 end
 
-if ENV["LOCAL_CONFIG_VARIABLES"]
+unless ENV["LOCAL_CONFIG_VARIABLES"].to_s.strip.empty?
   # For example:
   # "[{\"type\":\"npm_registry\",\"registry\":\"registry.npmjs.org\",\"token\":\"123\"}]"
   $options[:credentials].concat(JSON.parse(ENV["LOCAL_CONFIG_VARIABLES"]))

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -99,7 +99,7 @@ $options = {
   commit: nil
 }
 
-if ENV["LOCAL_GITHUB_ACCESS_TOKEN"]
+unless ENV["LOCAL_GITHUB_ACCESS_TOKEN"].to_s.strip.empty?
   $options[:credentials] << {
     "type" => "git_source",
     "host" => "github.com",

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -20,6 +20,12 @@ gem "dependabot-nuget", path: "../nuget"
 gem "dependabot-python", path: "../python"
 gem "dependabot-terraform", path: "../terraform"
 
-gem "rubocop"
+gem "rubocop", group: :development
+
+# Visual Studio Code integration
+gem "debase", group: :development
+gem "reek", group: :development
+gem "ruby-debug-ide", group: :development
+gem "solargraph", group: :development
 
 gemspec


### PR DESCRIPTION
### Summary

This PR adds support in Dependabot for [Visual Studio Remote Development feature](https://code.visualstudio.com/docs/remote/containers), allowing devs to debug the app within the Docker development image. When starting a dry run debugging session, VS Code prompts for the package manager and a repo name.
See the [updated README](https://github.com/dependabot/dependabot-core/pull/1442/files#diff-04c6e90faac2675aa89e2176d2eec7d8) for usage instructions.

### Implementation

Debugging gems were added to `omnibus/Gemfile` in the `:development` group, which are then leveraged by the config in the new `.devcontainer/devcontainer.json` and `.vscode/launch.json` files.
The new `.vscode/extensions.json` file takes care of recommending the correct plugins for debugging with Ruby and supporting Remote Development.
The new `.devcontainer/devcontainer.json` also passes some settings through to the VS Code server running within the development container.

I also simplified `Dockerfile.development` so that it'll contain about half the Docker layers as before while keeping exactly the same logic. I ended up making a more complete PR for that in #1444 that I hope to get merged before this one.

Tested on Ubuntu 18.04 and macOS 10.14.6.

### Flow

> ![image](https://user-images.githubusercontent.com/138074/66690263-37abdf80-ec8f-11e9-85bc-40b68e6d9fbf.png)
> Visual Studio automatically building development container with VS Code server support

> ![image](https://user-images.githubusercontent.com/138074/66690283-62963380-ec8f-11e9-80c3-2afcbab67672.png)
> Pressing F5 to debug project

> ![image](https://user-images.githubusercontent.com/138074/66690299-907b7800-ec8f-11e9-8d4e-53bd0a873845.png)
> Stopping in a debug breakpoint and watching variables inside the Docker container

Enjoy!