### PR TITLE
Simplify Dockerfiles and fix permission issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,37 @@
-/.bundle
-/.git
-/tmp/
-/helpers
-/spec
-gitignored
+# Start by removing everything from the context
+*
+
+# Add back helpers
+!composer/helpers
+!dep/helpers
+!go_modules/helpers
+go_modules/helpers/install-dir
+!hex/helpers
+!npm_and_yarn/helpers
+npm_and_yarn/helpers/install-dir
+npm_and_yarn/helpers/node_modules
+!python/helpers
+!terraform/helpers
+terraform/helpers/install-dir
+
+# Add Gemfiles and gemspec files
+!*/Gemfile
+!common/dependabot-common.gemspec
+!common/lib/dependabot/version.rb
+!bundler/dependabot-bundler.gemspec
+!cargo/dependabot-cargo.gemspec
+!composer/dependabot-composer.gemspec
+!dep/dependabot-dep.gemspec
+!docker/dependabot-docker.gemspec
+!elm/dependabot-elm.gemspec
+!git_submodules/dependabot-git_submodules.gemspec
+!github_actions/dependabot-github_actions.gemspec
+!go_modules/dependabot-go_modules.gemspec
+!gradle/dependabot-gradle.gemspec
+!hex/dependabot-hex.gemspec
+!maven/dependabot-maven.gemspec
+!npm_and_yarn/dependabot-npm_and_yarn.gemspec
+!nuget/dependabot-nuget.gemspec
+!omnibus/dependabot-omnibus.gemspec
+!python/dependabot-python.gemspec
+!terraform/dependabot-terraform.gemspec

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update \
       libxmlsec1-dev \
       libgeos-dev \
       python3-enchant \
+    && rm -rf /var/lib/apt/lists/* \
     && locale-gen en_US.UTF-8
 
 
@@ -56,7 +57,8 @@ ENV BUNDLE_SILENCE_ROOT_WARNING=1
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3173AA6 \
     && echo "deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu bionic main" > /etc/apt/sources.list.d/brightbox.list \
     && apt-get update \
-    && apt-get install -y ruby2.6 ruby2.6-dev \
+    && apt-get install -y --no-install-recommends ruby2.6 ruby2.6-dev \
+    && rm -rf /var/lib/apt/lists/* \
     && gem update --system 3.0.3 \
     && gem install bundler -v 1.17.3 --no-document
 
@@ -77,10 +79,11 @@ RUN git clone https://github.com/pyenv/pyenv.git /usr/local/.pyenv \
 
 # Install Node 10.0 and Yarn
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
-    && apt-get install -y nodejs \
+    && apt-get install -y --no-install-recommends nodejs \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-    && apt-get update && apt-get install -y yarn
+    && apt-get update && apt-get install -y --no-install-recommends yarn \
+    && rm -rf /var/lib/apt/lists/*
 
 
 ### ELM
@@ -102,7 +105,8 @@ RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" >> /etc/ap
     && echo "deb-src http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" >> /etc/apt/sources.list.d/ondrej-php.list \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C \
     && apt-get update \
-    && apt-get install -y php7.3 php7.3-cli php7.3-xml php7.3-json php7.3-zip php7.3-mbstring php7.3-intl php7.3-common php7.3-gettext php7.3-curl php7.3-bcmath php7.3-gmp php7.3-imagick php7.3-gd php7.3-redis php7.3-soap php7.3-ldap php7.3-memcached php7.3-sqlite3 php7.3-apcu php7.3-tidy php7.3-mongodb php7.3-zmq php7.3-mysql php7.3-imap php7.3-geoip \
+    && apt-get install -y --no-install-recommends php7.3 php7.3-cli php7.3-xml php7.3-json php7.3-zip php7.3-mbstring php7.3-intl php7.3-common php7.3-gettext php7.3-curl php7.3-bcmath php7.3-gmp php7.3-imagick php7.3-gd php7.3-redis php7.3-soap php7.3-ldap php7.3-memcached php7.3-sqlite3 php7.3-apcu php7.3-tidy php7.3-mongodb php7.3-zmq php7.3-mysql php7.3-imap php7.3-geoip \
+    && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer
 
@@ -124,7 +128,8 @@ ENV PATH="$PATH:/usr/local/elixir/bin"
 RUN wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
     && dpkg -i erlang-solutions_1.0_all.deb \
     && apt-get update \
-    && apt-get install -y esl-erlang \
+    && apt-get install -y --no-install-recommends esl-erlang \
+    && rm -rf /var/lib/apt/lists/* \
     && wget https://github.com/elixir-lang/elixir/releases/download/v1.9.1/Precompiled.zip \
     && unzip -d /usr/local/elixir -x Precompiled.zip \
     && rm -f Precompiled.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ RUN wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
 # Install Rust 1.37.0
 ENV RUSTUP_HOME=/opt/rust \
     PATH="${PATH}:/opt/rust/bin"
-RUN export CARGO_HOME=/opt/rust ; curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN export CARGO_HOME=/opt/rust; curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 
 ### NEW NATIVE HELPERS

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,122 +1,58 @@
 FROM dependabot/dependabot-core
 
-RUN useradd -m dependabot
-RUN chown -R dependabot:dependabot /usr/local/.pyenv /opt/go/gopath
-USER dependabot
+ARG USERNAME=dependabot
 
-RUN mkdir -p /home/dependabot/dependabot-core/common/lib/dependabot
-WORKDIR /home/dependabot/dependabot-core
+RUN useradd -m "${USERNAME}"
+RUN chown -R ${USERNAME}:${USERNAME} \
+  /usr/local/.pyenv \
+  /opt/go/gopath
+USER $USERNAME
 
-ENV BUNDLE_PATH="/home/dependabot/.bundle" \
-    BUNDLE_BIN=".bundle/binstubs" \
-    PATH=".bundle/binstubs:$PATH:/home/dependabot/.bundle/bin"
+ARG CODE_DIR=/home/$USERNAME/dependabot-core
+
+RUN mkdir -p ${CODE_DIR}
+WORKDIR ${CODE_DIR}
+
+ENV BUNDLE_PATH="/home/$USERNAME/.bundle" \
+    BUNDLE_BIN=".bundle/binstubs"
+ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
 
 RUN gem install --user rake
 
-COPY common/Gemfile common/dependabot-common.gemspec /home/dependabot/dependabot-core/common/
-COPY common/lib/dependabot/version.rb /home/dependabot/dependabot-core/common/lib/dependabot/
+COPY --chown=dependabot common/Gemfile common/dependabot-common.gemspec common/
+COPY --chown=dependabot common/lib/dependabot/version.rb common/lib/dependabot/
 RUN cd common && bundle install
 
-RUN mkdir -p /home/dependabot/dependabot-core/terraform
-COPY terraform/Gemfile \
-     terraform/dependabot-terraform.gemspec \
-     /home/dependabot/dependabot-core/terraform/
-RUN cd terraform && bundle install
+COPY --chown=dependabot bundler/Gemfile bundler/dependabot-bundler.gemspec ${CODE_DIR}/bundler/
+COPY --chown=dependabot cargo/Gemfile cargo/dependabot-cargo.gemspec ${CODE_DIR}/cargo/
+COPY --chown=dependabot composer/Gemfile composer/dependabot-composer.gemspec ${CODE_DIR}/composer/
+COPY --chown=dependabot dep/Gemfile dep/dependabot-dep.gemspec ${CODE_DIR}/dep/
+COPY --chown=dependabot docker/Gemfile docker/dependabot-docker.gemspec ${CODE_DIR}/docker/
+COPY --chown=dependabot elm/Gemfile elm/dependabot-elm.gemspec ${CODE_DIR}/elm/
+COPY --chown=dependabot git_submodules/Gemfile git_submodules/dependabot-git_submodules.gemspec ${CODE_DIR}/git_submodules/
+COPY --chown=dependabot github_actions/Gemfile github_actions/dependabot-github_actions.gemspec ${CODE_DIR}/github_actions/
+COPY --chown=dependabot go_modules/Gemfile go_modules/dependabot-go_modules.gemspec ${CODE_DIR}/go_modules/
+COPY --chown=dependabot gradle/Gemfile gradle/dependabot-gradle.gemspec ${CODE_DIR}/gradle/
+COPY --chown=dependabot hex/Gemfile hex/dependabot-hex.gemspec ${CODE_DIR}/hex/
+COPY --chown=dependabot maven/Gemfile maven/dependabot-maven.gemspec ${CODE_DIR}/maven/
+COPY --chown=dependabot npm_and_yarn/Gemfile npm_and_yarn/dependabot-npm_and_yarn.gemspec ${CODE_DIR}/npm_and_yarn/
+COPY --chown=dependabot nuget/Gemfile nuget/dependabot-nuget.gemspec ${CODE_DIR}/nuget/
+COPY --chown=dependabot omnibus/Gemfile omnibus/dependabot-omnibus.gemspec ${CODE_DIR}/omnibus/
+COPY --chown=dependabot python/Gemfile python/dependabot-python.gemspec ${CODE_DIR}/python/
+COPY --chown=dependabot terraform/Gemfile terraform/dependabot-terraform.gemspec ${CODE_DIR}/terraform/
 
-RUN mkdir -p /home/dependabot/dependabot-core/elm
-COPY elm/Gemfile \
-     elm/dependabot-elm.gemspec \
-     /home/dependabot/dependabot-core/elm/
-RUN cd elm && bundle install
+RUN GREEN='\033[0;32m'; NC='\033[0m'; \
+    for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
+                   -not -path "${CODE_DIR}/omnibus/Gemfile" \
+                   -not -path "${CODE_DIR}/common/Gemfile" \
+                   -name 'Gemfile' | xargs dirname`; do \
+      echo && \
+      echo "---------------------------------------------------------------------------" && \
+      echo "Installing gems for ${GREEN}$(realpath --relative-to=${CODE_DIR} $d)${NC}..." && \
+      echo "---------------------------------------------------------------------------" && \
+      cd $d && bundle install; \
+    done
 
-RUN mkdir -p /home/dependabot/dependabot-core/python
-COPY python/Gemfile \
-     python/dependabot-python.gemspec \
-     /home/dependabot/dependabot-core/python/
-RUN cd python && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/docker
-COPY docker/Gemfile \
-     docker/dependabot-docker.gemspec \
-     /home/dependabot/dependabot-core/docker/
-RUN cd docker && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/git_submodules
-COPY git_submodules/Gemfile \
-     git_submodules/dependabot-git_submodules.gemspec \
-     /home/dependabot/dependabot-core/git_submodules/
-RUN cd git_submodules && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/github_actions
-COPY github_actions/Gemfile \
-     github_actions/dependabot-github_actions.gemspec \
-     /home/dependabot/dependabot-core/github_actions/
-RUN cd github_actions && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/maven
-COPY maven/Gemfile \
-     maven/dependabot-maven.gemspec \
-     /home/dependabot/dependabot-core/maven/
-RUN cd maven && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/gradle
-COPY gradle/Gemfile \
-     gradle/dependabot-gradle.gemspec \
-     /home/dependabot/dependabot-core/gradle/
-RUN cd gradle && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/hex
-COPY hex/Gemfile \
-     hex/dependabot-hex.gemspec \
-     /home/dependabot/dependabot-core/hex/
-RUN cd hex && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/nuget
-COPY nuget/Gemfile \
-     nuget/dependabot-nuget.gemspec \
-     /home/dependabot/dependabot-core/nuget/
-RUN cd nuget && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/composer
-COPY composer/Gemfile \
-     composer/dependabot-composer.gemspec \
-     /home/dependabot/dependabot-core/composer/
-RUN cd composer && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/cargo
-COPY cargo/Gemfile \
-     cargo/dependabot-cargo.gemspec \
-     /home/dependabot/dependabot-core/cargo/
-RUN cd cargo && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/dep
-COPY dep/Gemfile \
-     dep/dependabot-dep.gemspec \
-     /home/dependabot/dependabot-core/dep/
-RUN cd dep && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/go_modules
-COPY go_modules/Gemfile \
-     go_modules/dependabot-go_modules.gemspec \
-     /home/dependabot/dependabot-core/go_modules/
-RUN cd go_modules && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/npm_and_yarn
-COPY npm_and_yarn/Gemfile \
-     npm_and_yarn/dependabot-npm_and_yarn.gemspec \
-     /home/dependabot/dependabot-core/npm_and_yarn/
-RUN cd npm_and_yarn && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/bundler
-COPY bundler/Gemfile \
-     bundler/dependabot-bundler.gemspec \
-     /home/dependabot/dependabot-core/bundler/
-RUN cd bundler && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/omnibus
-COPY omnibus/Gemfile \
-     omnibus/dependabot-omnibus.gemspec \
-     /home/dependabot/dependabot-core/omnibus/
 RUN cd omnibus && bundle install
 
-COPY --chown=dependabot . /home/dependabot/dependabot-core/
+COPY --chown=dependabot . ${CODE_DIR}/

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,62 +1,17 @@
-FROM dependabot/dependabot-core
+FROM dependabot/dependabot-core AS build
 
-# Temporarily switch to root user in order to install packages
-USER root
-
-# Add debugging tools
-RUN apt-get update && apt-get install -y vim strace ltrace gdb
-
-# This Dockerfile adds a non-root 'dependabot' user. However, for Linux,
-# this user's GID/UID must match your local user UID/GID to avoid permission issues
-# with bind mounts. Update USER_UID / USER_GID if yours is not 1000.
-# USER_UID should be the value of $UID from the host environment and
-# USER_GID the value of `id -g`.
-# See https://aka.ms/vscode-remote/containers/non-root-user for details.
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
 ARG USERNAME=dependabot
-
-RUN groupadd -o --gid "${USER_GID}" "${USERNAME}" && \
-    useradd --uid "${USER_UID}" --gid "${USER_GID}" -m "${USERNAME}"
-RUN chown -R "${USERNAME}":"${USERNAME}" \
-  /usr/local/.pyenv \
-  /opt/go/gopath \
-  /opt/rust/
-USER $USERNAME
-
 ARG CODE_DIR=/home/$USERNAME/dependabot-core
-
-RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/master/vimrc-vanilla.vim && \
-    echo 'export PS1="[dependabot-core-dev] \w \[$(tput setaf 4)\]$ \[$(tput sgr 0)\]"' >> ~/.bashrc
-
-RUN mkdir -p ${CODE_DIR}/common/lib/dependabot
-WORKDIR ${CODE_DIR}
 
 ENV BUNDLE_PATH="/home/$USERNAME/.bundle" \
     BUNDLE_BIN=".bundle/binstubs"
-ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
+
+RUN mkdir -p ${CODE_DIR}
+WORKDIR ${CODE_DIR}
 
 COPY common/Gemfile common/dependabot-common.gemspec ${CODE_DIR}/common/
 COPY common/lib/dependabot/version.rb ${CODE_DIR}/common/lib/dependabot/
 RUN cd common && bundle install
-
-RUN mkdir -p ${CODE_DIR}/bundler \
-             ${CODE_DIR}/cargo \
-             ${CODE_DIR}/composer \
-             ${CODE_DIR}/dep \
-             ${CODE_DIR}/docker \
-             ${CODE_DIR}/elm \
-             ${CODE_DIR}/git_submodules \
-             ${CODE_DIR}/github_actions \
-             ${CODE_DIR}/go_modules \
-             ${CODE_DIR}/gradle \
-             ${CODE_DIR}/hex \
-             ${CODE_DIR}/maven \
-             ${CODE_DIR}/npm_and_yarn \
-             ${CODE_DIR}/nuget \
-             ${CODE_DIR}/omnibus \
-             ${CODE_DIR}/python \
-             ${CODE_DIR}/terraform
 
 COPY bundler/Gemfile bundler/dependabot-bundler.gemspec ${CODE_DIR}/bundler/
 COPY cargo/Gemfile cargo/dependabot-cargo.gemspec ${CODE_DIR}/cargo/
@@ -89,6 +44,50 @@ RUN GREEN='\033[0;32m'; NC='\033[0m'; \
     done
 
 RUN cd omnibus && bundle install
+
+#--------------------------------------------------------------
+
+FROM dependabot/dependabot-core
+
+# Temporarily switch to root user in order to install packages
+USER root
+
+# Add debugging tools
+RUN apt-get update && apt-get install -y vim strace ltrace gdb
+
+# This Dockerfile adds a non-root 'dependabot' user. However, for Linux,
+# this user's GID/UID must match your local user UID/GID to avoid permission issues
+# with bind mounts. Update USER_UID / USER_GID if yours is not 1000.
+# USER_UID should be the value of $UID from the host environment and
+# USER_GID the value of `id -g`.
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+ARG USERNAME=dependabot
+
+RUN groupadd -o --gid "${USER_GID}" "${USERNAME}" && \
+    useradd --uid "${USER_UID}" --gid "${USER_GID}" -m "${USERNAME}"
+RUN chown -R "${USERNAME}":"${USERNAME}" \
+  /usr/local/.pyenv \
+  /opt/go/gopath \
+  /opt/rust/
+USER $USERNAME
+
+RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/master/vimrc-vanilla.vim && \
+    echo 'export PS1="[dependabot-core-dev] \w \[$(tput setaf 4)\]$ \[$(tput sgr 0)\]"' >> ~/.bashrc
+
+ARG CODE_DIR=/home/$USERNAME/dependabot-core
+
+RUN mkdir -p ${CODE_DIR}
+WORKDIR ${CODE_DIR}
+
+ENV BUNDLE_PATH="/home/$USERNAME/.bundle" \
+    BUNDLE_BIN=".bundle/binstubs"
+ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
+
+COPY --from=build --chown=${USERNAME}:${USERNAME} ${CODE_DIR}/ .
+COPY --from=build --chown=${USERNAME}:${USERNAME} ${BUNDLE_PATH}/ ${BUNDLE_PATH}
+
 # Make omnibus gems available to bundler in root directory
 RUN echo 'eval_gemfile File.join(File.dirname(__FILE__), "omnibus/Gemfile")' > Gemfile
 

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -67,11 +67,11 @@ ARG USER_GID=$USER_UID
 ARG USERNAME=dependabot
 
 RUN groupadd -o --gid "${USER_GID}" "${USERNAME}" && \
-    useradd --uid "${USER_UID}" --gid "${USER_GID}" -m "${USERNAME}"
-RUN chown -R "${USERNAME}":"${USERNAME}" \
-  /usr/local/.pyenv \
-  /opt/go/gopath \
-  /opt/rust/
+    useradd --uid "${USER_UID}" --gid "${USER_GID}" -m "${USERNAME}" && \
+    chown -R ${USER_UID}:${USER_GID} \
+          /usr/local/.pyenv \
+          /opt/go/gopath \
+          /opt/rust/
 USER $USERNAME
 
 RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/master/vimrc-vanilla.vim && \
@@ -86,8 +86,8 @@ ENV BUNDLE_PATH="/home/$USERNAME/.bundle" \
     BUNDLE_BIN=".bundle/binstubs"
 ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
 
-COPY --from=build --chown=${USERNAME}:${USERNAME} ${CODE_DIR}/ .
-COPY --from=build --chown=${USERNAME}:${USERNAME} ${BUNDLE_PATH}/ ${BUNDLE_PATH}
+COPY --from=build --chown=${USER_UID}:${USER_GID} ${CODE_DIR}/ .
+COPY --from=build --chown=${USER_UID}:${USER_GID} ${BUNDLE_PATH}/ ${BUNDLE_PATH}
 
 # Make omnibus gems available to bundler in root directory
 RUN echo 'eval_gemfile File.join(File.dirname(__FILE__), "omnibus/Gemfile")' > Gemfile

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -53,7 +53,8 @@ FROM dependabot/dependabot-core
 USER root
 
 # Add debugging tools
-RUN apt-get update && apt-get install -y vim strace ltrace gdb
+RUN apt-get update && apt-get install -y --no-install-recommends vim strace ltrace gdb && \
+    rm -rf /var/lib/apt/lists/*
 
 # This Dockerfile adds a non-root 'dependabot' user. However, for Linux,
 # this user's GID/UID must match your local user UID/GID to avoid permission issues

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -62,84 +62,33 @@ if [ "$#" -gt "0" ]; then
   CONTAINER_ARGS=("$@")
 fi
 
+function add_volume() {
+  local fname=$1
+  local dir=$2
+  local target=$3
+  if [ -e "$dir/$fname" ]; then
+    echo "-v" "$dir/$fname:$target/$fname"
+  fi
+}
+
 echo "$(tput setaf 2)=> running docker development shell$(tput sgr0)"
 CODE_DIR="/home/dependabot/dependabot-core"
+VOLUME_ARGS=()
+# Search for Gemfiles in any 2nd-level folders, and add volumes linking relevant files
+for gemfile in $PWD/*/Gemfile; do
+  pm_dir="$(dirname $gemfile)"
+  dirname="$(basename $pm_dir)"
+  target="$CODE_DIR/$dirname"
+  VOLUME_ARGS+=( $(add_volume 'Gemfile' $pm_dir $target)
+                 $(add_volume "dependabot-$dirname.gemspec" $pm_dir $target)
+                 $(add_volume 'lib' $pm_dir $target)
+                 $(add_volume 'spec' $pm_dir $target) )
+done
 docker run --rm -ti \
-  -v "$(pwd)/.rubocop.yml:$CODE_DIR/.rubocop.yml" \
-  -v "$(pwd)/bin:$CODE_DIR/bin" \
-  -v "$(pwd)/common/Gemfile:$CODE_DIR/common/Gemfile" \
-  -v "$(pwd)/common/dependabot-common.gemspec:$CODE_DIR/common/dependabot-common.gemspec" \
-  -v "$(pwd)/common/bin:$CODE_DIR/common/bin" \
-  -v "$(pwd)/common/lib:$CODE_DIR/common/lib" \
-  -v "$(pwd)/common/spec:$CODE_DIR/common/spec" \
-  -v "$(pwd)/terraform/Gemfile:$CODE_DIR/terraform/Gemfile" \
-  -v "$(pwd)/terraform/dependabot-terraform.gemspec:$CODE_DIR/terraform/dependabot-terraform.gemspec" \
-  -v "$(pwd)/terraform/lib:$CODE_DIR/terraform/lib" \
-  -v "$(pwd)/terraform/spec:$CODE_DIR/terraform/spec" \
-  -v "$(pwd)/elm/Gemfile:$CODE_DIR/elm/Gemfile" \
-  -v "$(pwd)/elm/dependabot-elm.gemspec:$CODE_DIR/elm/dependabot-elm.gemspec" \
-  -v "$(pwd)/elm/lib:$CODE_DIR/elm/lib" \
-  -v "$(pwd)/elm/spec:$CODE_DIR/elm/spec" \
-  -v "$(pwd)/docker/Gemfile:$CODE_DIR/docker/Gemfile" \
-  -v "$(pwd)/docker/dependabot-docker.gemspec:$CODE_DIR/docker/dependabot-docker.gemspec" \
-  -v "$(pwd)/docker/lib:$CODE_DIR/docker/lib" \
-  -v "$(pwd)/docker/spec:$CODE_DIR/docker/spec" \
-  -v "$(pwd)/git_submodules/Gemfile:$CODE_DIR/git_submodules/Gemfile" \
-  -v "$(pwd)/git_submodules/dependabot-git_submodules.gemspec:$CODE_DIR/git_submodules/dependabot-core.gemspec" \
-  -v "$(pwd)/git_submodules/lib:$CODE_DIR/git_submodules/lib" \
-  -v "$(pwd)/git_submodules/spec:$CODE_DIR/git_submodules/spec" \
-  -v "$(pwd)/github_actions/Gemfile:$CODE_DIR/github_actions/Gemfile" \
-  -v "$(pwd)/github_actions/dependabot-github_actions.gemspec:$CODE_DIR/github_actions/dependabot-core.gemspec" \
-  -v "$(pwd)/github_actions/lib:$CODE_DIR/github_actions/lib" \
-  -v "$(pwd)/github_actions/spec:$CODE_DIR/github_actions/spec" \
-  -v "$(pwd)/python/Gemfile:$CODE_DIR/python/Gemfile" \
-  -v "$(pwd)/python/dependabot-python.gemspec:$CODE_DIR/python/dependabot-python.gemspec" \
-  -v "$(pwd)/python/lib:$CODE_DIR/python/lib" \
-  -v "$(pwd)/python/spec:$CODE_DIR/python/spec" \
-  -v "$(pwd)/nuget/Gemfile:$CODE_DIR/nuget/Gemfile" \
-  -v "$(pwd)/nuget/dependabot-nuget.gemspec:$CODE_DIR/nuget/dependabot-core.gemspec" \
-  -v "$(pwd)/nuget/lib:$CODE_DIR/nuget/lib" \
-  -v "$(pwd)/nuget/spec:$CODE_DIR/nuget/spec" \
-  -v "$(pwd)/maven/Gemfile:$CODE_DIR/maven/Gemfile" \
-  -v "$(pwd)/maven/dependabot-maven.gemspec:$CODE_DIR/maven/dependabot-core.gemspec" \
-  -v "$(pwd)/maven/lib:$CODE_DIR/maven/lib" \
-  -v "$(pwd)/maven/spec:$CODE_DIR/maven/spec" \
-  -v "$(pwd)/gradle/Gemfile:$CODE_DIR/gradle/Gemfile" \
-  -v "$(pwd)/gradle/dependabot-gradle.gemspec:$CODE_DIR/gradle/dependabot-gradle.gemspec" \
-  -v "$(pwd)/gradle/lib:$CODE_DIR/gradle/lib" \
-  -v "$(pwd)/gradle/spec:$CODE_DIR/gradle/spec" \
-  -v "$(pwd)/hex/Gemfile:$CODE_DIR/hex/Gemfile" \
-  -v "$(pwd)/hex/dependabot-hex.gemspec:$CODE_DIR/hex/dependabot-hex.gemspec" \
-  -v "$(pwd)/hex/lib:$CODE_DIR/hex/lib" \
-  -v "$(pwd)/hex/spec:$CODE_DIR/hex/spec" \
-  -v "$(pwd)/cargo/Gemfile:$CODE_DIR/cargo/Gemfile" \
-  -v "$(pwd)/cargo/dependabot-cargo.gemspec:$CODE_DIR/cargo/dependabot-core.gemspec" \
-  -v "$(pwd)/cargo/lib:$CODE_DIR/cargo/lib" \
-  -v "$(pwd)/cargo/spec:$CODE_DIR/cargo/spec" \
-  -v "$(pwd)/dep/Gemfile:$CODE_DIR/dep/Gemfile" \
-  -v "$(pwd)/dep/dependabot-dep.gemspec:$CODE_DIR/dep/dependabot-dep.gemspec" \
-  -v "$(pwd)/dep/lib:$CODE_DIR/dep/lib" \
-  -v "$(pwd)/dep/spec:$CODE_DIR/dep/spec" \
-  -v "$(pwd)/go_modules/Gemfile:$CODE_DIR/go_modules/Gemfile" \
-  -v "$(pwd)/go_modules/dependabot-go_modules.gemspec:$CODE_DIR/go_modules/dependabot-go_modules.gemspec" \
-  -v "$(pwd)/go_modules/lib:$CODE_DIR/go_modules/lib" \
-  -v "$(pwd)/go_modules/spec:$CODE_DIR/go_modules/spec" \
-  -v "$(pwd)/npm_and_yarn/Gemfile:$CODE_DIR/npm_and_yarn/Gemfile" \
-  -v "$(pwd)/npm_and_yarn/dependabot-npm_and_yarn.gemspec:$CODE_DIR/npm_and_yarn/dependabot-npm_and_yarn.gemspec" \
-  -v "$(pwd)/npm_and_yarn/lib:$CODE_DIR/npm_and_yarn/lib" \
-  -v "$(pwd)/npm_and_yarn/spec:$CODE_DIR/npm_and_yarn/spec" \
-  -v "$(pwd)/composer/Gemfile:$CODE_DIR/composer/Gemfile" \
-  -v "$(pwd)/composer/dependabot-composer.gemspec:$CODE_DIR/composer/dependabot-composer.gemspec" \
-  -v "$(pwd)/composer/lib:$CODE_DIR/composer/lib" \
-  -v "$(pwd)/composer/spec:$CODE_DIR/composer/spec" \
-  -v "$(pwd)/bundler/Gemfile:$CODE_DIR/bundler/Gemfile" \
-  -v "$(pwd)/bundler/dependabot-bundler.gemspec:$CODE_DIR/bundler/dependabot-bundler.gemspec" \
-  -v "$(pwd)/bundler/lib:$CODE_DIR/bundler/lib" \
-  -v "$(pwd)/bundler/spec:$CODE_DIR/bundler/spec" \
-  -v "$(pwd)/omnibus/Gemfile:$CODE_DIR/omnibus/Gemfile" \
-  -v "$(pwd)/omnibus/dependabot-omnibus.gemspec:$CODE_DIR/omnibus/dependabot-omnibus.gemspec" \
-  -v "$(pwd)/omnibus/lib:$CODE_DIR/omnibus/lib" \
-  -v "$(pwd)/omnibus/spec:$CODE_DIR/omnibus/spec" \
+  -v "$PWD/.rubocop.yml:$CODE_DIR/.rubocop.yml" \
+  -v "$PWD/bin:$CODE_DIR/bin" \
+  -v "$PWD/common/bin:$CODE_DIR/common/bin" \
+  "${VOLUME_ARGS[@]}" \
   "${DOCKER_OPTS[@]}" \
   --cap-add=SYS_PTRACE \
   "$IMAGE_NAME" "${CONTAINER_ARGS[@]}"


### PR DESCRIPTION
This PR addresses the following issues with Dockerfiles:
- Dockerfile (down from 3.57GB to 3.43GB - total savings of 140MB):
  - cleans up local apt cache before creating a new layer, to avoid storing unnecessary data (tip: [fromlatest.io](https://www.fromlatest.io/#/) is a nice little service that scans Dockerfiles for easy optimizations);
- Dockerfile.development/Dockerfile.ci (total savings of ~260MB):
  - removes a lot of duplication (identical blocks of code for each package manager) in the creation of volumes (let me know if that's intentional though and we're being explicit, - e.g. [here](https://github.com/dependabot/dependabot-core/blob/b8acc040e4015f8ecb3e773b4cdc3f3454a209be/Dockerfile#L156-L162) - and I can revert those changes).
  - cleans up local apt cache before creating a new layer, to avoid storing unnecessary data (saves ~40MB);
  - uses an additional `build` stage to perform the bundle installs (saves ~90MB);
  - reduces the size of the context sent to Docker daemon from 50+ MB to 600 KB by using positive filtering in `.dockerignore` instead of negative filtering.
  - reduces the number of layers in the image by ~20;
  - fixes the following permissions issues on Linux hosts:
    - when passing `-u dependabot` to `docker build`, the active user didn't have root permissions so wouldn't be able to successfully install apt packages;
    - the volume mapping was done with the UID of the Dockerfile's `dependabot` user, which might have a different UID than on the host system. This is evident when your UID is not `1000`.

  Without any change in logic, the size of the development image went down from 5.53GB to 5.27GB.

To further simplify things and get rid of the `mkdir -p` instructions, I've had to use `--chown` in the `COPY` instructions. However, these are not supported in Windows hosts. I don't know if Windows is supported as a host for development. If that's the case, I can revert that part of the PR.

I wasn't able to pass `--chown=$USERNAME` in Dockerfile.ci, I imagine it's because the CI server is running an older version of Docker which doesn't do variable substitution for values in `--chown`.