### PR TITLE
IAM role and AWS cred file support for Docker bumps

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -115,6 +115,7 @@ CODE_DIR="/home/dependabot/dependabot-core"
 touch .core-bash_history
 mkdir -p dry-run tmp
 docker run --rm -ti \
+  -v "$HOME/.aws:$CODE_DIR/../.aws" \
   -v "$(pwd)/.core-bash_history:/home/dependabot/.bash_history" \
   -v "$(pwd)/.rubocop.yml:$CODE_DIR/.rubocop.yml" \
   -v "$(pwd)/bin:$CODE_DIR/bin" \


### PR DESCRIPTION
The AWS SDK has built-in default behaviour for credential finding. Therefore, if we just don't force the client to accept a custom-made credentials object, it will execute down that chain to find credentials. This means that this change will allow for developers to get AWS access for Docker ECR bumping by providing credentials via:
1. Environment variables
2. .aws/credentials files
3. Instance roles (IAM)

In order to not break the existing flow, this is an option that has to be opted into -- though ideally, I think it should probably be the default. WDYT?