### PR TITLE
Fix for nuget v2 responses that don't specify a base

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -11,7 +11,7 @@ module Dependabot
     class UpdateChecker
       class RepositoryFinder
         DEFAULT_REPOSITORY_URL = "https://api.nuget.org/v3/index.json"
-        ATOM_NAMESPACE = "http://www.w3.org/2007/app"
+        ATOM_PUB_NAMESPACE = "http://www.w3.org/2007/app"
 
         def initialize(dependency:, credentials:, config_files: [])
           @dependency  = dependency
@@ -94,7 +94,8 @@ module Dependabot
 
         def build_v2_url(response, repo_details)
           doc = Nokogiri::XML(response.body)
-          return unless doc.root.namespace&.href&.casecmp(ATOM_NAMESPACE)&.zero?
+          return unless doc.root.namespace&.href&.casecmp(ATOM_PUB_NAMESPACE)&.
+                        zero?
 
           doc.remove_namespaces!
           base_url = doc.at_xpath("service")&.attributes&.

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RepositoryFinder do
         end
       end
 
-      context "that doesn't have base url" do
+      context "that has no base url in v2 API response" do
         let(:config_file_fixture_name) { "with_v2_endpoints.config" }
 
         before do

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -367,6 +367,93 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RepositoryFinder do
           )
         end
       end
+
+      context "that doesn't have base url" do
+        let(:config_file_fixture_name) { "with_v2_endpoints.config" }
+
+        before do
+          v2_repo_urls = %w(
+            https://www.nuget.org/api/v2/
+            https://www.myget.org/F/azure-appservice/api/v2
+            https://www.myget.org/F/azure-appservice-staging/api/v2
+            https://www.myget.org/F/fusemandistfeed/api/v2
+            https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/
+          )
+
+          v2_repo_urls.each do |repo_url|
+            stub_request(:get, repo_url).
+              to_return(
+                status: 200,
+                body: fixture("nuget_responses", "v2_no_base.xml")
+              )
+          end
+
+          url = "https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json"
+          stub_request(:get, url).
+            to_return(
+              status: 200,
+              body: fixture("nuget_responses", "myget_base.json")
+            )
+        end
+
+        it "gets the right URLs" do
+          expect(dependency_urls).to match_array(
+            [{
+              repository_url:
+                "https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json",
+              versions_url:
+                "https://www.myget.org/F/exceptionless/api/v3/" \
+                "flatcontainer/microsoft.extensions.dependencymodel/index.json",
+              search_url:
+                "https://www.myget.org/F/exceptionless/api/v3/"\
+                "query?q=microsoft.extensions.dependencymodel&prerelease=true",
+              auth_header: {},
+              repository_type: "v3"
+            }, {
+              repository_url: "https://www.nuget.org/api/v2/",
+              versions_url:
+                "https://www.nuget.org/api/v2/FindPackagesById()?id="\
+                "'Microsoft.Extensions.DependencyModel'",
+              auth_header: {},
+              repository_type: "v2"
+            }, {
+              repository_url: "https://www.myget.org/F/azure-appservice/api/v2",
+              versions_url:
+                "https://www.myget.org/F/azure-appservice/api/v2/"\
+                "FindPackagesById()?id="\
+                "'Microsoft.Extensions.DependencyModel'",
+              auth_header: {},
+              repository_type: "v2"
+            }, {
+              repository_url:
+                "https://www.myget.org/F/azure-appservice-staging/api/v2",
+              versions_url:
+                "https://www.myget.org/F/azure-appservice-staging/api/v2/"\
+                "FindPackagesById()?id="\
+                "'Microsoft.Extensions.DependencyModel'",
+              auth_header: {},
+              repository_type: "v2"
+            }, {
+              repository_url: "https://www.myget.org/F/fusemandistfeed/api/v2",
+              versions_url:
+                "https://www.myget.org/F/fusemandistfeed/api/v2/"\
+                "FindPackagesById()?id="\
+                "'Microsoft.Extensions.DependencyModel'",
+              auth_header: {},
+              repository_type: "v2"
+            }, {
+              repository_url:
+                "https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/",
+              versions_url:
+                "https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/"\
+                "FindPackagesById()?id="\
+                "'Microsoft.Extensions.DependencyModel'",
+              auth_header: {},
+              repository_type: "v2"
+            }]
+          )
+        end
+      end
     end
   end
 end

--- a/nuget/spec/fixtures/nuget_responses/v2_no_base.xml
+++ b/nuget/spec/fixtures/nuget_responses/v2_no_base.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service xmlns="http://www.w3.org/2007/app">
+    <workspace>
+        <title xmlns="http://www.w3.org/2005/Atom">Default</title>
+        <collection href="Packages">
+            <title xmlns="http://www.w3.org/2005/Atom">Packages</title>
+        </collection>
+    </workspace>
+</service>


### PR DESCRIPTION
Some v2 nuget endpoints return no `base` attribute in the `service` node of the response, such as Inedo's [ProGet ](https://inedo.com/proget) like so:

```
<?xml version="1.0" encoding="utf-8"?>
<service xmlns="http://www.w3.org/2007/app">
    <workspace>
        <title xmlns="http://www.w3.org/2005/Atom">Default</title>
        <collection href="Packages">
            <title xmlns="http://www.w3.org/2005/Atom">Packages</title>
        </collection>
    </workspace>
</service>
```

Dependabot's [current behavior](https://github.com/dependabot/dependabot-core/commit/c54d31c628eedb6c5d28e48b0642dac4cbfe6704) results in such sources not being added to the list of `dependency_urls` that are probed for updates. 

This fix uses the `repo_details` `url` in the case where a `base` url is not returned by the v2 api.

Further conversation with @feelepxyz here: https://github.com/dependabot/dependabot-core/commit/c54d31c628eedb6c5d28e48b0642dac4cbfe6704