### PR TITLE
Fix Dockerfile.development syntax error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,6 @@
     "-e", "LOCAL_CONFIG_VARIABLES=${env:LOCAL_CONFIG_VARIABLES}",
 
     "-v", "${localWorkspaceFolder}/.vscode:/home/dependabot/dependabot-core/.vscode",
-    "-v", "${localWorkspaceFolder}/.vscode-server:/home/dependabot/.vscode-server",
     "-v", "${localWorkspaceFolder}/.gitignore:/home/dependabot/dependabot-core/.gitignore",
     "-v", "${localWorkspaceFolder}/.rubocop.yml:/home/dependabot/dependabot-core/.rubocop.yml",
     "-v", "${localWorkspaceFolder}/bin:/home/dependabot/dependabot-core/bin",

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -96,5 +96,5 @@ RUN echo 'eval_gemfile File.join(File.dirname(__FILE__), "omnibus/Gemfile")' > G
 RUN mkdir -p ~/.vscode-server ~/.vscode-server-insiders
 
 # Declare pass-thru environment variables used for debugging
-ENV LOCAL_GITHUB_ACCESS_TOKEN "" \
-    LOCAL_CONFIG_VARIABLES ""
+ENV LOCAL_GITHUB_ACCESS_TOKEN="" \
+    LOCAL_CONFIG_VARIABLES=""


### PR DESCRIPTION
This PR fixes a syntax error introduced in a7dafb5b5a75dc6d011eca93146176023967cac2, causing `LOCAL_GITHUB_ACCESS_TOKEN` to be initialized with a bogus value, instead of empty. It looks like the empty quotes are ignored by Docker, causing `LOCAL_CONFIG_VARIABLES` to become the value of `LOCAL_GITHUB_ACCESS_TOKEN`.

Note: for some reason, [this context](https://github.com/dependabot/dependabot-core/blob/master/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb#L1838-L1856) seems to be failing, even on `master` and older releases. Most likely something in the CI is non-deterministic, since a7dafb5b5a75dc6d011eca93146176023967cac2 recently passed in [CI](https://circleci.com/gh/dependabot/dependabot-core/12615).