### PR TITLE
Gradle: Skip name property if already present

### DIFF
--- a/gradle/lib/dependabot/gradle/file_parser/property_value_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/property_value_finder.rb
@@ -81,11 +81,14 @@ module Dependabot
             declaration_string = Regexp.last_match.to_s.strip
             captures = Regexp.last_match.named_captures
             name = captures.fetch("name").sub(/^ext\./, "")
-            properties[name] = {
-              value: captures.fetch("value"),
-              declaration_string: declaration_string,
-              file: buildfile.name
-            }
+
+            unless properties.key?(name)
+              properties[name] = {
+                value: captures.fetch("value"),
+                declaration_string: declaration_string,
+                file: buildfile.name
+              }
+            end
           end
 
           properties

--- a/gradle/spec/dependabot/gradle/file_parser/property_value_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser/property_value_finder_spec.rb
@@ -64,6 +64,15 @@ RSpec.describe Dependabot::Gradle::FileParser::PropertyValueFinder do
             its([:declaration_string]) do
               is_expected.to eq("buildToolsVersion = '27.0.3'")
             end
+
+            context "and the property name has already been set" do
+              let(:buildfile_fixture_name) { "duplicate_property_name.gradle" }
+              let(:property_name) { "spek_version" }
+              its([:value]) { is_expected.to eq("2.0.6") }
+              its([:declaration_string]) do
+                is_expected.to eq("spek_version = '2.0.6'")
+              end
+            end
           end
 
           context "and the property is preceded by a comment" do

--- a/gradle/spec/fixtures/buildfiles/duplicate_property_name.gradle
+++ b/gradle/spec/fixtures/buildfiles/duplicate_property_name.gradle
@@ -1,0 +1,47 @@
+buildscript {
+    ext {
+        kotlin_version = '1.3.50'
+        spek_version = '2.0.6'
+    }
+
+    repositories {
+        mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
+    }
+
+    dependencies {
+        classpath "com.gradle.publish:plugin-publish-plugin:$publish_version"
+    }
+}
+
+configurations {
+    dependabot
+}
+
+dependencies {
+    dependabot "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    dependabot "org.spekframework.spek2:spek-dsl-jvm:$spek_version"
+}
+
+task removeRepo(type: Delete) {
+    delete gradle.ext.repo
+}
+
+[
+    'spek',
+].each {
+    def generateHardCodedDependencies = project.task('generateHardCodedDependencies', group: 'build') {
+        doLast {
+            def folder = new File("${project.projectDir}/src/main/groovy/ch/dependabot/gradle/$projectName/generated")
+            mkdir folder
+            new File(folder, "Dependencies.groovy").text =
+                """package ch.dependabot.gradle.${projectName}.generated
+                |
+                |class Dependencies {
+                |   public static final spek_version = '$project.spek_version'
+                |}
+                """.stripMargin('|')
+        }
+    }
+    project.compileGroovy.dependsOn generateHardCodedDependencies
+}


### PR DESCRIPTION
In this [issue](https://github.com/dependabot/feedback/issues/698), the user had some variable names in code that matched the property name of the dependency.  When Dependabot parsed the `gradle.build` file, it would pick up the variable name, replacing the version value of the property with the variable name.  This caused Dependabot to skip over the dependency, as it didn't see it as valid.