### PR TITLE
Decompress gzipped http responses

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -122,7 +122,9 @@ module Dependabot
     # rubocop:enable Metrics/MethodLength
 
     def self.excon_middleware
-      Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower]
+      Excon.defaults[:middlewares] +
+        [Excon::Middleware::Decompress] +
+        [Excon::Middleware::RedirectFollower]
     end
 
     def self.excon_defaults


### PR DESCRIPTION
Seems we don't decompress gzipped responses in dependabot-core but we do
in the proxy which blocks debugging using the dry run script.