### PR TITLE
Don't pass empty array to update approvers gitlab method

### DIFF
--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -157,8 +157,8 @@ module Dependabot
         gitlab_client_for_source.edit_merge_request_approvers(
           source.repo,
           merge_request.iid,
-          approver_ids: approvers_hash[:approvers] || [],
-          approver_group_ids: approvers_hash[:group_approvers] || []
+          approver_ids: approvers_hash[:approvers],
+          approver_group_ids: approvers_hash[:group_approvers]
         )
       end
 


### PR DESCRIPTION
Gitlab api doesn't allow passing empty array for `approver_ids` or `approver_group_ids`. This leads to situation, when passing in approvers hash without `approver_group_ids`, request will fail with invalid approver_group_ids error.

Instead, if one of the 2 is not passed, it should be left as `nil`.