### PR TITLE
Fix hanging regex in LinkAndMentionSanitizer

### DIFF
--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -7,8 +7,9 @@ require "dependabot/pull_request_creator/message_builder/"\
 namespace = Dependabot::PullRequestCreator::MessageBuilder
 RSpec.describe namespace::LinkAndMentionSanitizer do
   subject(:sanitizer) do
-    described_class.new(github_redirection_service: "github-redirect.com")
+    described_class.new(github_redirection_service: github_redirection_service)
   end
+  let(:github_redirection_service) { "github-redirect.com" }
 
   describe "#sanitize_links_and_mentions" do
     subject(:sanitize_links_and_mentions) do
@@ -120,7 +121,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
             "```@not-a-mention``` ````"
           end
 
-          it "sanitizes the text without touching the code fence" do
+          pending "sanitizes the text without touching the code fence" do
             expect(sanitize_links_and_mentions).to eq(
               "Take a look at this code: ```` @not-a-mention "\
               "```@not-a-mention``` ````"
@@ -133,7 +134,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
               "```@not-a-mention``` ```` This is a @mention!"
             end
 
-            it "sanitizes the text without touching the code fence" do
+            pending "sanitizes the text without touching the code fence" do
               expect(sanitize_links_and_mentions).to eq(
                 "Take a look at this code: ```` @not-a-mention "\
                 "```@not-a-mention``` ```` "\
@@ -198,6 +199,15 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         is_expected.to eq(
           "Check out [my/repo#5](https://github-redirect.com/my/repo/issues/5)"
         )
+      end
+    end
+
+    context "with a changelog that doesn't need sanitizing" do
+      let(:text) { fixture("changelogs", "jsdom.md") }
+      let(:github_redirection_service) { "github.com" }
+
+      it "doesn't freeze when parsing the changelog" do
+        is_expected.to eq(text)
       end
     end
   end

--- a/common/spec/fixtures/changelogs/jsdom.md
+++ b/common/spec/fixtures/changelogs/jsdom.md
@@ -1,0 +1,23 @@
+## 15.2.0
+
+* Set `canvas` as an optional ``peerDependency`, which apparently helps with Yarn PnP support.
+
+## 15.1.1
+
+* Moved the `nonce` property from `HTMLScriptElement` and `HTMLStyleElement` to `HTMLElement`. Note that it is still just a simple reflection of the attribute, and has not been updated for the rest of the changes in [whatwg/html#2373](https://github.com/whatwg/html/pull/2373).
+
+## 15.1.0
+
+* Added the `Headers` class from the Fetch standard.
+* Added the `element.translate` getter and setter.
+* Fixed synchronous `XMLHttpRequest` on the newly-released Node.js v12.
+* Fixed `form.elements` to exclude `<input type="image">` elements.
+* Fixed event path iteration in shadow DOM cases, following spec fixes at [whatwg/dom#686](https://github.com/whatwg/dom/pull/686) and [whatwg/dom#750](https://github.com/whatwg/dom/pull/750).
+* Fixed `pattern=""` form control validation to apply the given regular expression to the whole string. (kontomondo)
+
+## 15.0.0
+
+Several potentially-breaking changes, each of them fairly unlikely to actually break anything:
+
+* `JSDOM.fromFile()` now treats `.xht` files as `application/xhtml+xml`, the same as it does for `.xhtml` and `.xml`. Previously, it would treat them as `text/html`.
+* When using the `Blob` or `File` constructor with the `endings: "native"` option, jsdom will now convert line endings to `\n` on all operating systems, for consistency. Previously, on Windows, it would convert line endings to `\r\n`.


### PR DESCRIPTION
It seems that this commit introduced a regex pattern that would hang
indefinitely on some changelogs:
https://github.com/dependabot/dependabot-core/commit/ddf6a3ed55fda4a4247338a4ed95d2304726607b

Temporarily rollback the changes until we have a better fix in place. We
should probably switch to a legit markdown parser instead of rolling our
own.