### PR TITLE
Fix Gitlab api types to match GitHub

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -212,9 +212,11 @@ module Dependabot
         gitlab_client.
           repo_tree(repo, path: path, ref_name: commit, per_page: 100).
           map do |file|
+            # GitLab API essentially returns the output from `git ls-tree`
             type = case file.type
                    when "blob" then "file"
                    when "tree" then "dir"
+                   when "commit" then "submodule"
                    else file.fetch("type")
                    end
 


### PR DESCRIPTION
In #1484  was reported a bug when trying to update `docker` dependencies using Gitlab.

At least with Gitlab 12, when a submodule is present the type returned is "commit".

Due to my practically nonexistent skills in Ruby I could't create any tests. I think there is no coverage for the `_gitlab_repo_contents` method and couldn't find any example to work with.