### PR TITLE
Add parameter to decompress gzip responses in middleware

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -122,7 +122,10 @@ module Dependabot
     # rubocop:enable Metrics/MethodLength
 
     def self.excon_middleware
-      Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower]
+      Excon.defaults[:middlewares] + [
+        Excon::Middleware::RedirectFollower,
+        Excon::Middleware::Decompress
+      ]
     end
 
     def self.excon_defaults


### PR DESCRIPTION
Fixes https://github.com/dependabot/dependabot-core/pull/1483

It seems a recent upgrade to Excon changed its default behavior of automatically decompressing gzipped responses.  This fix adds that parameter into dependabot-core to restore the desired behavior.

Paired w/@greysteil