### PR TITLE
Split regex to fix hang in mention sanitizer

### DIFF
--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
             "```@not-a-mention``` ````"
           end
 
-          pending "sanitizes the text without touching the code fence" do
+          it "sanitizes the text without touching the code fence" do
             expect(sanitize_links_and_mentions).to eq(
               "Take a look at this code: ```` @not-a-mention "\
               "```@not-a-mention``` ````"
@@ -134,7 +134,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
               "```@not-a-mention``` ```` This is a @mention!"
             end
 
-            pending "sanitizes the text without touching the code fence" do
+            it "sanitizes the text without touching the code fence" do
               expect(sanitize_links_and_mentions).to eq(
                 "Take a look at this code: ```` @not-a-mention "\
                 "```@not-a-mention``` ```` "\


### PR DESCRIPTION
This PR undoes https://github.com/dependabot/dependabot-core/pull/1500 by fixing the underlying issue with the regular expression. For some reason, using the `|` operator in a regular expression causes the performance to drop significantly. Fortunately for our needs, it's straightforward to split the expression and perform the candidate selection in Ruby. The time needed to run the test added in #1500 goes from 5-7 seconds on my MBP, to 0.00282 seconds.