### PR TITLE
go 1.13.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" >> /etc/ap
 ### GO
 
 # Install Go and dep
-RUN curl https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz | tar -xz -C /opt \
+RUN curl https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz | tar -xz -C /opt \
     && wget -O /opt/go/bin/dep https://github.com/golang/dep/releases/download/v0.5.4/dep-linux-amd64 \
     && chmod +x /opt/go/bin/dep \
     && mkdir /opt/go/gopath

--- a/go_modules/helpers/go.mod
+++ b/go_modules/helpers/go.mod
@@ -1,5 +1,7 @@
 module github.com/dependabot/dependabot-core/go_modules/helpers
 
+go 1.13
+
 require (
 	github.com/Masterminds/vcs v1.13.1
 	github.com/dependabot/dependabot-core/go_modules/helpers/updater v0.0.0


### PR DESCRIPTION
- Keep the golang version to the latest (v1.13.4)
- Add golang version specifier to `go.mod`