### PR TITLE
Maven: Change logic to check if a version is released

### DIFF
--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -60,9 +60,6 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
     "https://repo.maven.apache.org/maven2/"\
     "com/google/guava/guava/23.6-jre/guava-23.6-jre.jar"
   end
-  let(:maven_central_version_files) do
-    fixture("maven_central_version_files", "guava-23.6.html")
-  end
 
   before do
     stub_request(:get, maven_central_metadata_url).
@@ -79,17 +76,20 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
     end
 
     context "when the latest version hasn't actually been released" do
-      let(:maven_central_version_files) do
-        fixture("maven_central_version_files", "guava-23.6-no-jar.html")
+      let(:maven_central_version_files_url) do
+        "https://repo.maven.apache.org/maven2/"\
+        "com/google/guava/guava/23.6-jre/guava-23.6-jre.jar"
       end
-      let(:old_maven_central_version_files) do
-        fixture("maven_central_version_files", "guava-23.5.html")
+      let(:old_maven_central_version_files_url) do
+        "https://repo.maven.apache.org/maven2/"\
+        "com/google/guava/guava/23.5-jre/guava-23.5-jre.jar"
       end
+
       before do
-        stub_request(
-          :get,
-          maven_central_version_files_url.gsub("23.6", "23.5")
-        ).to_return(status: 200, body: old_maven_central_version_files)
+        stub_request(:head, maven_central_version_files_url).
+          to_return(status: 404)
+        stub_request(:head, old_maven_central_version_files_url).
+          to_return(status: 200)
       end
 
       its([:version]) { is_expected.to eq(version_class.new("23.5-jre")) }
@@ -329,19 +329,20 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
     end
 
     context "when the lowest version hasn't actually been released" do
-      let(:maven_central_version_files) do
-        fixture("maven_central_version_files", "guava-23.6-no-jar.html").
-          gsub("23.6-jre", "20.0")
+      let(:maven_central_version_files_url) do
+        "https://repo.maven.apache.org/maven2/"\
+        "com/google/guava/guava/20.0/guava-20.0.jar"
       end
-      let(:next_maven_central_version_files) do
-        fixture("maven_central_version_files", "guava-23.6.html").
-          gsub("23.6-jre", "21.0")
+      let(:next_maven_central_version_files_url) do
+        "https://repo.maven.apache.org/maven2/"\
+        "com/google/guava/guava/21.0/guava-21.0.jar"
       end
+
       before do
-        stub_request(
-          :get,
-          maven_central_version_files_url.gsub("20.0", "21.0")
-        ).to_return(status: 200, body: next_maven_central_version_files)
+        stub_request(:head, maven_central_version_files_url).
+          to_return(status: 404)
+        stub_request(:head, next_maven_central_version_files_url).
+          to_return(status: 200)
       end
 
       its([:version]) { is_expected.to eq(version_class.new("21.0")) }

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
   end
   let(:maven_central_version_files_url) do
     "https://repo.maven.apache.org/maven2/"\
-    "com/google/guava/guava/23.6-jre/"
+    "com/google/guava/guava/23.6-jre/guava-23.6-jre.jar"
   end
   let(:maven_central_version_files) do
     fixture("maven_central_version_files", "guava-23.6.html")
@@ -67,8 +67,8 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
   before do
     stub_request(:get, maven_central_metadata_url).
       to_return(status: 200, body: maven_central_releases)
-    stub_request(:get, maven_central_version_files_url).
-      to_return(status: 200, body: maven_central_version_files)
+    stub_request(:head, maven_central_version_files_url).
+      to_return(status: 200)
   end
 
   describe "#latest_version_details" do
@@ -99,7 +99,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       let(:dependency_version) { "23.0-rc1-android" }
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
-        "com/google/guava/guava/23.7-rc1-android/"
+        "com/google/guava/guava/23.7-rc1-android/guava-23.7-rc1-android.jar"
       end
       let(:maven_central_version_files) do
         fixture("maven_central_version_files", "guava-23.7.html")
@@ -119,7 +119,8 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       end
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
-        "commons-collections/commons-collections/3.2.2/"
+        "commons-collections/commons-collections/3.2.2/"\
+        "commons-collections-3.2.2.jar"
       end
       let(:maven_central_releases) do
         fixture("maven_central_metadata", "with_date_releases.xml")
@@ -137,7 +138,8 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
         let(:dependency_version) { "20030418" }
         let(:maven_central_version_files_url) do
           "https://repo.maven.apache.org/maven2/"\
-          "commons-collections/commons-collections/20040616/"
+          "commons-collections/commons-collections/20040616/"\
+          "commons-collections-20040616.jar"
         end
         let(:maven_central_version_files) do
           fixture(
@@ -154,7 +156,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       let(:dependency_version) { "17.0" }
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
-        "com/google/guava/guava/22.0/"
+        "com/google/guava/guava/22.0/guava-22.0.jar"
       end
       let(:maven_central_version_files) do
         fixture("maven_central_version_files", "guava-22.0.html")
@@ -166,7 +168,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       let(:dependency_version) { "RELEASE802" }
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
-        "com/google/guava/guava/23.0/"
+        "com/google/guava/guava/23.0/guava-23.0.jar"
       end
       let(:maven_central_version_files) do
         fixture("maven_central_version_files", "guava-23.0.html")
@@ -247,7 +249,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
 
       let(:scala_tools_version_files_url) do
         "http://scala-tools.org/repo-releases/"\
-        "com/google/guava/guava/23.6-jre/"
+        "com/google/guava/guava/23.6-jre/guava-23.6-jre.jar"
       end
 
       let(:jboss_metadata_url) do
@@ -262,12 +264,12 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
 
       let(:jboss_plugins_version_files_url) do
         "http://plugin-repository.jboss.org/maven2/"\
-        "com/google/guava/guava/23.6-jre/"
+        "com/google/guava/guava/23.6-jre/guava-23.6-jre.jar"
       end
 
       let(:jboss_version_files_url) do
         "http://repository.jboss.org/maven2/"\
-        "com/google/guava/guava/23.6-jre/"
+        "com/google/guava/guava/23.6-jre/guava-23.6-jre.jar"
       end
 
       before do
@@ -282,14 +284,14 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
           )
         stub_request(:get, jboss_plugins_metadata_url).
           to_return(status: 404, body: "")
-        stub_request(:get, maven_central_version_files_url).
-          to_return(status: 404, body: "")
-        stub_request(:get, scala_tools_version_files_url).
-          to_return(status: 404, body: "")
-        stub_request(:get, jboss_plugins_version_files_url).
-          to_return(status: 404, body: "")
-        stub_request(:get, jboss_version_files_url).
-          to_return(status: 200, body: maven_central_version_files)
+        stub_request(:head, maven_central_version_files_url).
+          to_return(status: 404)
+        stub_request(:head, scala_tools_version_files_url).
+          to_return(status: 404)
+        stub_request(:head, jboss_plugins_version_files_url).
+          to_return(status: 404)
+        stub_request(:head, jboss_version_files_url).
+          to_return(status: 200)
       end
 
       its([:version]) { is_expected.to eq(version_class.new("23.6-jre")) }
@@ -314,7 +316,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
     end
     let(:maven_central_version_files_url) do
       "https://repo.maven.apache.org/maven2/"\
-      "com/google/guava/guava/20.0/"
+      "com/google/guava/guava/20.0/guava-20.0.jar"
     end
     let(:maven_central_version_files) do
       fixture("maven_central_version_files", "guava-23.6.html").

--- a/maven/spec/dependabot/maven/update_checker_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker_spec.rb
@@ -542,7 +542,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
       end
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
-        "org/springframework/spring-beans/23.6-jre/"
+        "org/springframework/spring-beans/23.6-jre/spring-beans-23.6-jre.jar"
       end
       let(:maven_central_version_files) do
         fixture("maven_central_version_files", "spring-beans-23.6.html")
@@ -556,7 +556,8 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
           source: nil,
           metadata: {
             property_name: "springframework.version",
-            property_source: "pom.xml"
+            property_source: "pom.xml",
+            packaging_type: "jar"
           }
         }]
       end
@@ -612,7 +613,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
       end
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
-        "org/springframework/spring-beans/23.6-jre/"
+        "org/springframework/spring-beans/23.6-jre/spring-beans-23.6-jre.jar"
       end
       let(:maven_central_version_files) do
         fixture("maven_central_version_files", "spring-beans-23.6.html")

--- a/maven/spec/dependabot/maven/update_checker_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker_spec.rb
@@ -63,12 +63,8 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
 
   let(:maven_central_version_files_url) do
     "https://repo.maven.apache.org/maven2/"\
-    "com/google/guava/guava/23.6-jre/"
+    "com/google/guava/guava/23.6-jre/guava-23.6-jre.jar"
   end
-
-  # let(:maven_central_version_files) do
-  #   fixture("maven_central_version_files", "guava-23.6.html")
-  # end
 
   before do
     stub_request(:get, maven_central_metadata_url).
@@ -97,7 +93,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
       let(:dependency_version) { "23.0-rc1-android" }
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
-        "com/google/guava/guava/23.7-rc1-android/"
+        "com/google/guava/guava/23.7-rc1-android/guava-23.7-rc1-android.jar"
       end
       let(:maven_central_version_files) do
         fixture("maven_central_version_files", "guava-23.7.html")
@@ -118,7 +114,8 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
       end
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
-        "commons-collections/commons-collections/3.2.2/"
+        "commons-collections/commons-collections/3.2.2/"\
+        "commons-collections-3.2.2.jar"
       end
       let(:maven_central_version_files) do
         fixture(
@@ -133,7 +130,8 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
         let(:dependency_version) { "20030418" }
         let(:maven_central_version_files_url) do
           "https://repo.maven.apache.org/maven2/"\
-          "commons-collections/commons-collections/20040616/"
+          "commons-collections/commons-collections/20040616/"\
+          "commons-collections-20040616.jar"
         end
         let(:maven_central_version_files) do
           fixture(
@@ -150,7 +148,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
       let(:dependency_version) { "RELEASE802" }
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
-        "com/google/guava/guava/23.0/"
+        "com/google/guava/guava/23.0/guava-23.0.jar"
       end
       let(:maven_central_version_files) do
         fixture("maven_central_version_files", "guava-23.0.html")
@@ -166,7 +164,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
       end
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
-        "org/springframework/spring-beans/23.0/"
+        "org/springframework/spring-beans/23.0/spring-beans-23.0.jar"
       end
       let(:maven_central_version_files) do
         fixture("maven_central_version_files", "spring-beans-23.0.html")
@@ -176,6 +174,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
           file: "pom.xml",
           requirement: "4.3.12.RELEASE",
           groups: [],
+          metadata: { packaging_type: "jar" },
           source: nil
         }]
       end
@@ -203,7 +202,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
       end
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
-        "org/springframework/spring-beans/23.0/"
+        "org/springframework/spring-beans/23.0/spring-beans-23.0.jar"
       end
       let(:maven_central_version_files) do
         fixture("maven_central_version_files", "spring-beans-23.0.html")
@@ -222,7 +221,8 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
       let(:metadata) do
         {
           property_name: "springframework.version",
-          property_source: "pom.xml"
+          property_source: "pom.xml",
+          packaging_type: "jar"
         }
       end
 
@@ -253,7 +253,8 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
         end
         let(:maven_central_version_files_url) do
           "https://repo.maven.apache.org/maven2/"\
-          "org/apache/maven/plugins/maven-javadoc-plugin/23.0/"
+          "org/apache/maven/plugins/maven-javadoc-plugin/23.0/"\
+          "maven-javadoc-plugin-23.0.jar"
         end
         let(:maven_central_version_files) do
           fixture(
@@ -299,11 +300,13 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
               file: "pom.xml",
               requirement: "3.0.0-M1",
               groups: [],
+              metadata: { packaging_type: "jar" },
               source: nil
             }, {
               file: "pom.xml",
               requirement: nil,
               groups: [],
+              metadata: { packaging_type: "jar" },
               source: nil
             }]
           end
@@ -362,11 +365,13 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
             requirement: "23.0-jre",
             file: "pom.xml",
             groups: [],
+            metadata: { packaging_type: "jar" },
             source: nil
           }, {
             requirement: nil,
             file: "util/pom.xml",
             groups: [],
+            metadata: { packaging_type: "jar" },
             source: nil
           }]
         end
@@ -382,6 +387,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
             requirement: "2.5.6",
             file: "legacy/some-spring-project/pom.xml",
             groups: [],
+            metadata: { packaging_type: "jar" },
             source: nil
           }]
         end
@@ -393,7 +399,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
         end
         let(:maven_central_version_files_url) do
           "https://repo.maven.apache.org/maven2/"\
-          "org/springframework/spring-aop/23.0/"
+          "org/springframework/spring-aop/23.0/spring-aop-23.0.jar"
         end
         let(:maven_central_version_files) do
           fixture(
@@ -424,7 +430,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
       end
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
-        "com/google/guava/guava/20.0/"
+        "com/google/guava/guava/20.0/guava-20.0.jar"
       end
       let(:maven_central_version_files) do
         fixture("maven_central_version_files", "guava-23.6.html").
@@ -454,6 +460,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
             file: "pom.xml",
             requirement: "23.6-jre",
             groups: [],
+            metadata: { packaging_type: "jar" },
             source: {
               type: "maven_repo",
               url: "https://repo.maven.apache.org/maven2"
@@ -475,7 +482,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
       end
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
-        "com/google/guava/guava/20.0/"
+        "com/google/guava/guava/20.0/guava-20.0.jar"
       end
       let(:maven_central_version_files) do
         fixture("maven_central_version_files", "guava-23.6.html").
@@ -498,6 +505,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
               file: "pom.xml",
               requirement: "20.0",
               groups: [],
+              metadata: { packaging_type: "jar" },
               source: {
                 type: "maven_repo",
                 url: "https://repo.maven.apache.org/maven2"

--- a/maven/spec/dependabot/maven/update_checker_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker_spec.rb
@@ -29,7 +29,13 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
     )
   end
   let(:dependency_requirements) do
-    [{ file: "pom.xml", requirement: "23.3-jre", groups: [], source: nil }]
+    [{
+      file: "pom.xml",
+      requirement: "23.3-jre",
+      groups: [],
+      metadata: { packaging_type: "jar" },
+      source: nil
+    }]
   end
   let(:dependency_name) { "com.google.guava:guava" }
   let(:dependency_version) { "23.3-jre" }
@@ -59,15 +65,16 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
     "https://repo.maven.apache.org/maven2/"\
     "com/google/guava/guava/23.6-jre/"
   end
-  let(:maven_central_version_files) do
-    fixture("maven_central_version_files", "guava-23.6.html")
-  end
+
+  # let(:maven_central_version_files) do
+  #   fixture("maven_central_version_files", "guava-23.6.html")
+  # end
 
   before do
     stub_request(:get, maven_central_metadata_url).
       to_return(status: 200, body: maven_central_releases)
-    stub_request(:get, maven_central_version_files_url).
-      to_return(status: 200, body: maven_central_version_files)
+    stub_request(:head, maven_central_version_files_url).
+      to_return(status: 200)
   end
   let(:pom) do
     Dependabot::DependencyFile.new(name: "pom.xml", content: pom_body)


### PR DESCRIPTION
Previously, we parsed an HTML page looking for the name of a dependency to be present.  This was causing failures with Nexus repositories that were returning a non-browsable page.  This PR changes the logic to instead check the headers to see if the dependency exists.

Fixes https://github.com/dependabot/feedback/issues/746