### PR TITLE
NPM and Yarn: Fetch tarball path dependencies

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -125,7 +125,12 @@ module Dependabot
 
         path_dependency_details(fetched_files).each do |name, path|
           path = path.gsub(PATH_DEPENDENCY_CLEAN_REGEX, "")
-          filename = File.join(path, "package.json")
+          filename = path
+          # NPM/Yarn support loading path dependencies from tarballs:
+          # https://docs.npmjs.com/cli/pack.html
+          unless filename.end_with?(".tgz")
+            filename = File.join(filename, "package.json")
+          end
           cleaned_name = Pathname.new(filename).cleanpath.to_path
           next if fetched_files.map(&:name).include?(cleaned_name)
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -390,6 +390,48 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
       end
     end
 
+    context "with a tarball path dependency" do
+      before do
+        stub_request(:get, File.join(url, "package.json?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "package_json_with_tarball_path.json"),
+            headers: json_header
+          )
+        stub_request(:get, "https://api.github.com/repos/gocardless/bump/"\
+                           "contents/deps/etag.tgz?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 403,
+            body: fixture("github", "file_too_large.json"),
+            headers: json_header
+          )
+        stub_request(:get, "https://api.github.com/repos/gocardless/bump/"\
+                            "contents/deps?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "contents_js_tarball.json"),
+            headers: json_header
+          )
+        stub_request(:get, "https://api.github.com/repos/gocardless/bump/git/"\
+                           "blobs/2393602fac96cfe31d64f89476014124b4a13b85").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "blob_js_tarball.json"),
+            headers: json_header
+          )
+      end
+
+      it "fetches the tarball path dependency" do
+        expect(file_fetcher_instance.files.map(&:name)).to eq(
+          ["package.json", "package-lock.json", "deps/etag.tgz"]
+        )
+      end
+    end
+
     context "that has an unfetchable path" do
       before do
         stub_request(:get, File.join(url, "deps/etag/package.json?ref=sha")).

--- a/npm_and_yarn/spec/fixtures/github/blob_js_tarball.json
+++ b/npm_and_yarn/spec/fixtures/github/blob_js_tarball.json
@@ -1,0 +1,7 @@
+{
+  "content": "Q29udGVudCBvZiB0aGUgYmxvYg==\n",
+  "encoding": "base64",
+  "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/2393602fac96cfe31d64f89476014124b4a13b85",
+  "sha": "2393602fac96cfe31d64f89476014124b4a13b85",
+  "size": 19
+}

--- a/npm_and_yarn/spec/fixtures/github/contents_js_tarball.json
+++ b/npm_and_yarn/spec/fixtures/github/contents_js_tarball.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "etag.tgz",
+    "path": "deps/etag.tgz",
+    "sha": "2393602fac96cfe31d64f89476014124b4a13b85",
+    "size": 19,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/.deps/etag.tgz?ref=master",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/blob/master/.deps/etag.tgz",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/blobs/2393602fac96cfe31d64f89476014124b4a13b85",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/master/.deps/etag.tgz",
+    "type": "file"
+  }
+]

--- a/npm_and_yarn/spec/fixtures/github/file_too_large.json
+++ b/npm_and_yarn/spec/fixtures/github/file_too_large.json
@@ -1,0 +1,11 @@
+{
+  "message": "This API returns blobs up to 1 MB in size. The requested blob is too large to fetch via the API, but you can use the Git Data API to request blobs up to 100 MB in size.",
+  "errors": [
+      {
+          "resource": "Blob",
+          "field": "data",
+          "code": "too_large"
+      }
+  ],
+  "documentation_url": "https://developer.github.com/v3/repos/contents/#get-contents"
+}

--- a/npm_and_yarn/spec/fixtures/github/package_json_with_tarball_path.json
+++ b/npm_and_yarn/spec/fixtures/github/package_json_with_tarball_path.json
@@ -1,0 +1,18 @@
+{
+  "name": "package.json",
+  "path": "package.json",
+  "sha": "5c7b3419e0056515122b981f1566ebe22c208251",
+  "size": 594,
+  "url": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+  "html_url": "https://github.com/gocardless/bump/blob/master/package.json",
+  "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+  "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/package.json?token=ABMwe0apDiKCctWHnEHnszRBAebVHjQnks5WJWD9wA%3D%3D",
+  "type": "file",
+  "content": "ewogICJuYW1lIjogImJ1bXAtdGVzdCIsCiAgInZlcnNpb24iOiAiMC4wLjEiLAogICJkZXNjcmlwdGlvbiI6ICIiLAogICJkZXBlbmRlbmNpZXMiOiB7CiAgICAibG9kYXNoIjogIl4xLjMuMSIsCiAgICAiY2hhbGsiOiAiMC40LjAiLAogICAgInN0b3B3b3JkcyI6ICIwLjAuMSIKICB9LAogICJkZXZEZXBlbmRlbmNpZXMiOiB7CiAgICAiZXRhZyI6ICJmaWxlOi4vZGVwcy9ldGFnLnRneiIsCiAgICAiY29yZG92YS1wbHVnaW4tZ2VvbG9jYXRpb24iOiB7CiAgICAgICJHRU9MT0NBVElPTl9VU0FHRV9ERVNDUklQVElPTiI6ICJUbyBsb2NhdGUgeW91IgogICAgfQogIH0KfQo=",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+    "git": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+    "html": "https://github.com/gocardless/bump/blob/master/package.json"
+  }
+}


### PR DESCRIPTION
Fetch tarballed path dependencies in the file fetcher.

https://docs.npmjs.com/cli/pack.html

Fixes: https://github.com/dependabot/feedback/issues/757