### PR TITLE
Support Jina templates in requirements files

### DIFF
--- a/python/helpers/lib/parser.py
+++ b/python/helpers/lib/parser.py
@@ -2,17 +2,28 @@ from itertools import chain
 import glob
 import io
 import json
+import optparse
 import os.path
 import re
 
 import setuptools
 import pip._internal.req.req_file
 from pip._internal.download import PipSession
+from pip._internal.models.format_control import FormatControl
 from pip._internal.req.constructors import install_req_from_line
+
+JINJA_DELIMITER_IGNORE_REGEX = r"({{(.*?)}})|({%[-]?(.*?)%})|({#(.*?)#})"
 
 def parse_requirements(directory):
     # Parse the requirements.txt
     requirement_packages = []
+    parser_options = optparse.Values(
+            {
+                "skip_requirements_regex": JINJA_DELIMITER_IGNORE_REGEX,
+                "isolated_mode": False,
+                "format_control": FormatControl(),
+            }
+        )
 
     requirement_files = glob.glob(os.path.join(directory, '*.txt')) \
                         + glob.glob(os.path.join(directory, '**', '*.txt'))
@@ -28,6 +39,7 @@ def parse_requirements(directory):
         try:
             requirements = pip._internal.req.req_file.parse_requirements(
                 reqs_file,
+                options=parser_options,
                 session=PipSession()
             )
             for install_req in requirements:

--- a/python/helpers/lib/parser.py
+++ b/python/helpers/lib/parser.py
@@ -20,6 +20,9 @@ def parse_requirements(directory):
     parser_options = optparse.Values(
             {
                 "skip_requirements_regex": JINJA_DELIMITER_IGNORE_REGEX,
+                # pip._internal assumes parse_requirements will be called from
+                # CLI, which sets default values. When passing parser options,
+                # need to explicitly set those defaults.
                 "isolated_mode": False,
                 "format_control": FormatControl(),
             }

--- a/python/spec/dependabot/python/file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser_spec.rb
@@ -65,6 +65,29 @@ RSpec.describe Dependabot::Python::FileParser do
       its(:length) { is_expected.to eq(3) }
     end
 
+    context "with jinja templates" do
+      let(:requirements_fixture_name) { "jinja_requirements.txt" }
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+
+        it "has the right details" do
+          dependency = dependencies.first
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("psycopg2")
+          expect(dependency.version).to eq("2.6.1")
+        end
+      end
+
+      describe "the second dependency" do
+        subject(:dependency) { dependencies[1] }
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("gunicorn")
+          expect(dependency.version).to eq("20.0.2")
+        end
+      end
+    end
+
     context "with comments" do
       let(:requirements_fixture_name) { "comments.txt" }
       its(:length) { is_expected.to eq(2) }

--- a/python/spec/dependabot/python/file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser_spec.rb
@@ -67,24 +67,17 @@ RSpec.describe Dependabot::Python::FileParser do
 
     context "with jinja templates" do
       let(:requirements_fixture_name) { "jinja_requirements.txt" }
+
       describe "the first dependency" do
         subject(:dependency) { dependencies.first }
-
-        it "has the right details" do
-          dependency = dependencies.first
-          expect(dependency).to be_a(Dependabot::Dependency)
-          expect(dependency.name).to eq("psycopg2")
-          expect(dependency.version).to eq("2.6.1")
-        end
+        its(:name) { is_expected.to eq("psycopg2") }
+        its(:version) { is_expected.to eq("2.6.1") }
       end
 
       describe "the second dependency" do
-        subject(:dependency) { dependencies[1] }
-        it "has the right details" do
-          expect(dependency).to be_a(Dependabot::Dependency)
-          expect(dependency.name).to eq("gunicorn")
-          expect(dependency.version).to eq("20.0.2")
-        end
+        subject(:dependency) { dependencies.last }
+        its(:name) { is_expected.to eq("gunicorn") }
+        its(:version) { is_expected.to eq("20.0.2") }
       end
     end
 

--- a/python/spec/dependabot/python/requirement_parser_spec.rb
+++ b/python/spec/dependabot/python/requirement_parser_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Dependabot::Python::RequirementParser do
 
     context "with a Jinja template" do
       let(:line) { "{{ cookiecutter.package_name }}" }
+
       it { is_expected.to be_nil }
     end
 
@@ -89,6 +90,7 @@ RSpec.describe Dependabot::Python::RequirementParser do
           "{% if cookiecutter.include_package == 'y' %} luigi==0.1.0 "\
           "{% endif %}"
         end
+
         its([:name]) { is_expected.to eq "luigi" }
         its([:requirements]) do
           is_expected.to eq [{ comparison: "==", version: "0.1.0" }]

--- a/python/spec/dependabot/python/requirement_parser_spec.rb
+++ b/python/spec/dependabot/python/requirement_parser_spec.rb
@@ -52,6 +52,11 @@ RSpec.describe Dependabot::Python::RequirementParser do
       it { is_expected.to be_nil }
     end
 
+    context "with a Jinja template" do
+      let(:line) { "{{ cookiecutter.package_name }}" }
+      it { is_expected.to be_nil }
+    end
+
     context "with no specification" do
       let(:line) { "luigi" }
       it { is_expected.to be_nil }
@@ -73,6 +78,17 @@ RSpec.describe Dependabot::Python::RequirementParser do
 
       context "with a comment" do
         let(:line) { "luigi==0.1.0 # some comment" }
+        its([:name]) { is_expected.to eq "luigi" }
+        its([:requirements]) do
+          is_expected.to eq [{ comparison: "==", version: "0.1.0" }]
+        end
+      end
+
+      context "with an optional Jinja dependency" do
+        let(:line) do
+          "{% if cookiecutter.include_package == 'y' %} luigi==0.1.0 "\
+          "{% endif %}"
+        end
         its([:name]) { is_expected.to eq "luigi" }
         its([:requirements]) do
           is_expected.to eq [{ comparison: "==", version: "0.1.0" }]

--- a/python/spec/fixtures/requirements/jinja_requirements.txt
+++ b/python/spec/fixtures/requirements/jinja_requirements.txt
@@ -1,0 +1,5 @@
+{%- if cookiecutter.foo == "y" %}
+psycopg2==2.6.1
+{%- endif %}
+gunicorn==20.0.2
+{{ cookiecutter.another_dependency }}


### PR DESCRIPTION
Closes https://github.com/dependabot/feedback/issues/769.

When parsing python requirements files, ignore Jinja delimiters (e.g. `{{ }}`, `{% %}`, etc.). This provides the ability to update dependencies that are part of a [cookiecutter](https://github.com/cookiecutter/cookiecutter) project.