### PR TITLE
Cargo: Handle virtual manifests /w workspace glob

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -173,6 +173,8 @@ module Dependabot
             FileUtils.mkdir_p(Pathname.new(path).dirname)
             File.write(file.name, prepared_manifest_content(file))
 
+            next if virtual_manifest?(file)
+
             FileUtils.mkdir_p(File.join(dir, "src"))
             File.write(File.join(dir, "src/lib.rs"), dummy_app_content)
             File.write(File.join(dir, "src/main.rs"), dummy_app_content)
@@ -367,6 +369,10 @@ module Dependabot
         def toolchain
           @toolchain ||=
             dependency_files.find { |f| f.name == "rust-toolchain" }
+        end
+
+        def virtual_manifest?(file)
+          !file.content.include?("[package]")
         end
       end
     end

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -340,6 +340,8 @@ module Dependabot
             FileUtils.mkdir_p(dir)
             File.write(file.name, sanitized_manifest_content(file.content))
 
+            next if virtual_manifest?(file)
+
             FileUtils.mkdir_p(File.join(dir, "src"))
             File.write(File.join(dir, "src/lib.rs"), dummy_app_content)
             File.write(File.join(dir, "src/main.rs"), dummy_app_content)
@@ -413,6 +415,13 @@ module Dependabot
             dependency: dependency,
             credentials: credentials
           ).git_dependency?
+        end
+
+        # When the package table is not present in a workspace manifest, it is
+        # called a virtual manifest: https://doc.rust-lang.org/cargo/reference/
+        # manifest.html#virtual-manifest
+        def virtual_manifest?(file)
+          !file.content.include?("[package]")
         end
 
         def version_class

--- a/cargo/spec/dependabot/cargo/file_parser_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_parser_spec.rb
@@ -286,19 +286,19 @@ RSpec.describe Dependabot::Cargo::FileParser do
           end
           let(:workspace_child) do
             Dependabot::DependencyFile.new(
-              name: "lib/sub_crate/Cargo.toml",
+              name: "src/sub_crate/Cargo.toml",
               content: fixture("manifests", "workspace_child")
             )
           end
           let(:workspace_child2) do
             Dependabot::DependencyFile.new(
-              name: "lib/sub_crate2/Cargo.toml",
+              name: "src/sub_crate2/Cargo.toml",
               content: workspace_child2_body
             )
           end
           let(:workspace_child3) do
             Dependabot::DependencyFile.new(
-              name: "lib/sub_crate3/Cargo.toml",
+              name: "src/sub_crate3/Cargo.toml",
               content: workspace_child2_body
             )
           end
@@ -323,7 +323,7 @@ RSpec.describe Dependabot::Cargo::FileParser do
                 expect(dependency.requirements).to eq(
                   [{
                     requirement: "=0.4.0",
-                    file: "lib/sub_crate/Cargo.toml",
+                    file: "src/sub_crate/Cargo.toml",
                     groups: ["dependencies"],
                     source: nil
                   }]
@@ -342,13 +342,13 @@ RSpec.describe Dependabot::Cargo::FileParser do
                   [
                     {
                       requirement: nil,
-                      file: "lib/sub_crate2/Cargo.toml",
+                      file: "src/sub_crate2/Cargo.toml",
                       groups: ["dependencies"],
                       source: { type: "path" }
                     },
                     {
                       requirement: nil,
-                      file: "lib/sub_crate3/Cargo.toml",
+                      file: "src/sub_crate3/Cargo.toml",
                       groups: ["dependencies"],
                       source: { type: "path" }
                     }

--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -379,6 +379,52 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
           )
         end
       end
+
+      context "when there's a virtual workspace" do
+        let(:manifest_fixture_name) { "virtual_workspace_root" }
+        let(:lockfile_fixture_name) { "virtual_workspace" }
+        let(:dependency_files) do
+          [manifest, lockfile, workspace_child]
+        end
+        let(:workspace_child) do
+          Dependabot::DependencyFile.new(
+            name: "src/sub_crate/Cargo.toml",
+            content: fixture("manifests", "workspace_child")
+          )
+        end
+
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "log",
+            version: "0.4.1",
+            requirements: [{
+              requirement: "=0.4.1",
+              file: "src/sub_crate/Cargo.toml",
+              groups: ["dependencies"],
+              source: nil
+            }],
+            previous_version: "0.4.0",
+            previous_requirements: [{
+              requirement: "=0.4.0",
+              file: "src/sub_crate/Cargo.toml",
+              groups: ["dependencies"],
+              source: nil
+            }],
+            package_manager: "cargo"
+          )
+        end
+
+        it "updates the dependency version in the lockfile" do
+          expect(updated_lockfile_content).
+            to include(%(name = "log"\nversion = "0.4.1"))
+          expect(updated_lockfile_content).to include(
+            "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
+          )
+          expect(updated_lockfile_content).to_not include(
+            "b3a89a0c46ba789b8a247d4c567aed4d7c68e624672d238b45cc3ec20dc9f940"
+          )
+        end
+      end
     end
   end
 end

--- a/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
@@ -402,6 +402,34 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
       end
     end
 
+    context "when there's a virtual workspace" do
+      let(:manifest_fixture_name) { "virtual_workspace_root" }
+      let(:lockfile_fixture_name) { "virtual_workspace" }
+      let(:unprepared_dependency_files) do
+        [manifest, lockfile, workspace_child]
+      end
+      let(:workspace_child) do
+        Dependabot::DependencyFile.new(
+          name: "src/sub_crate/Cargo.toml",
+          content: fixture("manifests", "workspace_child")
+        )
+      end
+
+      let(:dependency_name) { "log" }
+      let(:dependency_version) { "0.4.0" }
+      let(:string_req) { "2.0" }
+      let(:requirements) do
+        [{
+          requirement: "=0.4.0",
+          file: "src/sub_crate/Cargo.toml",
+          groups: ["dependencies"],
+          source: nil
+        }]
+      end
+
+      it { is_expected.to be >= Gem::Version.new("0.4.4") }
+    end
+
     context "when there is a workspace" do
       let(:unprepared_dependency_files) do
         [manifest, lockfile, workspace_child]

--- a/cargo/spec/fixtures/manifests/virtual_workspace_root
+++ b/cargo/spec/fixtures/manifests/virtual_workspace_root
@@ -1,2 +1,2 @@
 [workspace]
-members = ["./packages/*"]
+members = ["src/*"]


### PR DESCRIPTION
Add a check to only write dummy target files if the manifest isn't a
virtual manifest (without `[package]` table).

When writing temporary manifest files we add a dummy `src/lib.rs` and
`src/main.rs` to satisfy Cargo's checks for a target src file.

If the top-level manifest is a virtual manifest (which doesn't require a
target lib/main file) and it has a workspace glob set to `src/*` Cargo
will attempt to read the dummy file as a directory failing to find
`src/lib.rs/Cargo.toml` as a result.

## TODO
- [x] Add tests