### PR TITLE
Python extras fix

### DIFF
--- a/python/helpers/lib/parser.py
+++ b/python/helpers/lib/parser.py
@@ -59,7 +59,7 @@ def parse_requirements(directory):
                     "markers": str(install_req.markers) or None,
                     "file": rel_path,
                     "requirement": str(install_req.specifier) or None,
-                    "extras": list(install_req.extras)
+                    "extras": sorted(list(install_req.extras))
                 })
         except Exception as e:
             print(json.dumps({ "error": repr(e) }))
@@ -87,7 +87,7 @@ def parse_setup(directory):
                 "file": "setup.py",
                 "requirement": str(install_req.specifier) or None,
                 "requirement_type": req_type,
-                "extras": list(install_req.extras)
+                "extras": sorted(list(install_req.extras))
             })
 
         def setup(*args, **kwargs):

--- a/python/helpers/lib/parser.py
+++ b/python/helpers/lib/parser.py
@@ -58,7 +58,8 @@ def parse_requirements(directory):
                     "version": version_from_install_req(install_req),
                     "markers": str(install_req.markers) or None,
                     "file": rel_path,
-                    "requirement": str(install_req.specifier) or None
+                    "requirement": str(install_req.specifier) or None,
+                    "extras": list(install_req.extras)
                 })
         except Exception as e:
             print(json.dumps({ "error": repr(e) }))
@@ -85,7 +86,8 @@ def parse_setup(directory):
                 "markers": str(install_req.markers) or None,
                 "file": "setup.py",
                 "requirement": str(install_req.specifier) or None,
-                "requirement_type": req_type
+                "requirement_type": req_type,
+                "extras": list(install_req.extras)
             })
 
         def setup(*args, **kwargs):

--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -92,7 +92,7 @@ module Dependabot
 
           dependencies <<
             Dependency.new(
-              name: normalised_name(dep["name"]),
+              name: normalised_name(dep["name"], dep["extras"]),
               version: dep["version"]&.include?("*") ? nil : dep["version"],
               requirements: requirements,
               package_manager: "pip"
@@ -192,8 +192,8 @@ module Dependabot
           join
       end
 
-      def normalised_name(name)
-        NameNormaliser.normalise(name)
+      def normalised_name(name, extras = [])
+        NameNormaliser.normalise_including_extras(name, extras)
       end
 
       def check_required_files

--- a/python/lib/dependabot/python/file_parser/setup_file_parser.rb
+++ b/python/lib/dependabot/python/file_parser/setup_file_parser.rb
@@ -37,7 +37,7 @@ module Dependabot
 
             dependencies <<
               Dependency.new(
-                name: normalised_name(dep["name"]),
+                name: normalised_name(dep["name"], dep["extras"]),
                 version: dep["version"]&.include?("*") ? nil : dep["version"],
                 requirements: [{
                   requirement: dep["requirement"],
@@ -164,8 +164,8 @@ module Dependabot
           0
         end
 
-        def normalised_name(name)
-          NameNormaliser.normalise(name)
+        def normalised_name(name, extras)
+          NameNormaliser.normalise_including_extras(name, extras)
         end
 
         def setup_file

--- a/python/lib/dependabot/python/file_updater/requirement_replacer.rb
+++ b/python/lib/dependabot/python/file_updater/requirement_replacer.rb
@@ -14,7 +14,7 @@ module Dependabot
         def initialize(content:, dependency_name:, old_requirement:,
                        new_requirement:, new_hash_version: nil)
           @content          = content
-          @dependency_name  = dependency_name
+          @dependency_name  = normalise(dependency_name)
           @old_requirement  = old_requirement
           @new_requirement  = new_requirement
           @new_hash_version = new_hash_version

--- a/python/lib/dependabot/python/name_normaliser.rb
+++ b/python/lib/dependabot/python/name_normaliser.rb
@@ -4,7 +4,15 @@ module Dependabot
   module Python
     module NameNormaliser
       def self.normalise(name)
-        name.downcase.gsub(/[-_.]+/, "-")
+        extras_regex = /\[.+\]/
+        name.downcase.gsub(/[-_.]+/, "-").gsub(extras_regex, "")
+      end
+
+      def self.normalise_including_extras(name, extras)
+        normalised_name = normalise(name)
+        return normalised_name if extras.empty?
+
+        normalised_name + "[" + extras.join(",") + "]"
       end
     end
   end

--- a/python/spec/dependabot/python/file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Dependabot::Python::FileParser do
   describe "parse" do
     subject(:dependencies) { parser.parse }
 
-    its(:length) { is_expected.to eq(3) }
+    its(:length) { is_expected.to eq(4) }
 
     context "with a version specified" do
       describe "the first dependency" do
@@ -62,7 +62,7 @@ RSpec.describe Dependabot::Python::FileParser do
         )
       end
 
-      its(:length) { is_expected.to eq(3) }
+      its(:length) { is_expected.to eq(4) }
     end
 
     context "with jinja templates" do
@@ -158,7 +158,10 @@ RSpec.describe Dependabot::Python::FileParser do
 
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
-          expect(dependency.name).to eq("psycopg2")
+          expect(dependency.name).to start_with("psycopg2[")
+          expect(dependency.name).to end_with("]")
+          expect(dependency.name).to include("foo")
+          expect(dependency.name).to include("bar")
           expect(dependency.version).to eq("2.6.1")
           expect(dependency.requirements).to eq(
             [{
@@ -390,7 +393,7 @@ RSpec.describe Dependabot::Python::FileParser do
         )
       end
 
-      its(:length) { is_expected.to eq(3) }
+      its(:length) { is_expected.to eq(4) }
 
       describe "the first dependency" do
         subject(:dependency) { dependencies.first }
@@ -420,7 +423,7 @@ RSpec.describe Dependabot::Python::FileParser do
         )
       end
 
-      its(:length) { is_expected.to eq(3) }
+      its(:length) { is_expected.to eq(4) }
 
       describe "the first dependency" do
         subject(:dependency) { dependencies.first }
@@ -450,7 +453,7 @@ RSpec.describe Dependabot::Python::FileParser do
         )
       end
 
-      its(:length) { is_expected.to eq(3) }
+      its(:length) { is_expected.to eq(4) }
 
       describe "the first dependency" do
         subject(:dependency) { dependencies.first }
@@ -661,7 +664,7 @@ RSpec.describe Dependabot::Python::FileParser do
         )
       end
 
-      its(:length) { is_expected.to eq(4) }
+      its(:length) { is_expected.to eq(5) }
 
       it "has the right details" do
         expect(dependencies).to match_array(
@@ -672,6 +675,17 @@ RSpec.describe Dependabot::Python::FileParser do
               requirements: [{
                 requirement: "==2.4.1",
                 file: "requirements.txt",
+                groups: ["dependencies"],
+                source: nil
+              }],
+              package_manager: "pip"
+            ),
+            Dependabot::Dependency.new(
+              name: "aiocache[redis]",
+              version: "0.10.0",
+              requirements: [{
+                requirement: "==0.10.0",
+                file: "more_requirements.txt",
                 groups: ["dependencies"],
                 source: nil
               }],
@@ -912,12 +926,12 @@ RSpec.describe Dependabot::Python::FileParser do
 
         describe "a dependency with extras" do
           subject(:dependency) do
-            dependencies.find { |d| d.name == "requests" }
+            dependencies.find { |d| d.name == "requests[security]" }
           end
 
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
-            expect(dependency.name).to eq("requests")
+            expect(dependency.name).to eq("requests[security]")
             expect(dependency.version).to be_nil
             expect(dependency.requirements).to eq(
               [{
@@ -1036,7 +1050,7 @@ RSpec.describe Dependabot::Python::FileParser do
           )
         end
 
-        its(:length) { is_expected.to eq(4) }
+        its(:length) { is_expected.to eq(5) }
 
         describe "the first dependency" do
           subject(:dependency) { dependencies.first }
@@ -1125,7 +1139,7 @@ RSpec.describe Dependabot::Python::FileParser do
           )
         end
 
-        its(:length) { is_expected.to eq(4) }
+        its(:length) { is_expected.to eq(5) }
 
         describe "the first dependency" do
           subject(:dependency) { dependencies.first }

--- a/python/spec/dependabot/python/file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser_spec.rb
@@ -158,10 +158,7 @@ RSpec.describe Dependabot::Python::FileParser do
 
         it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
-          expect(dependency.name).to start_with("psycopg2[")
-          expect(dependency.name).to end_with("]")
-          expect(dependency.name).to include("foo")
-          expect(dependency.name).to include("bar")
+          expect(dependency.name).to eq("psycopg2[bar,foo]")
           expect(dependency.version).to eq("2.6.1")
           expect(dependency.requirements).to eq(
             [{

--- a/python/spec/dependabot/python/file_updater/requirement_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/requirement_file_updater_spec.rb
@@ -68,6 +68,8 @@ RSpec.describe Dependabot::Python::FileUpdater::RequirementFileUpdater do
 
       its(:content) { is_expected.to include "psycopg2==2.8.1\n" }
       its(:content) { is_expected.to include "luigi==2.2.0\n" }
+      # extras are preserved
+      its(:content) { is_expected.to include "aiocache[redis]==0.10.0\n" }
 
       context "when only the minor version is specified" do
         let(:requirements_fixture_name) { "minor_version_specified.txt" }

--- a/python/spec/dependabot/python/file_updater/setup_file_sanitizer_spec.rb
+++ b/python/spec/dependabot/python/file_updater/setup_file_sanitizer_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe Dependabot::Python::FileUpdater::SetupFileSanitizer do
       )
     end
 
+    context "for a setup.py including a dependency with extras" do
+      let(:setup_file_fixture_name) { "extras.py" }
+      it "extracts the install_requires and conserves extras" do
+        expect(sanitized_content).to eq(
+          "from setuptools import setup\n\n"\
+          'setup(name="sanitized-package",version="0.0.1",'\
+          'install_requires=["requests[security]==2.12.*",'\
+          '"scipy==0.18.1","scikit-learn==0.18.1"],'\
+          "extras_require={})"
+        )
+      end
+    end
+
     context "for a setup.py using pbr" do
       let(:setup_file_fixture_name) { "with_pbr.py" }
       let(:setup_cfg) do

--- a/python/spec/fixtures/requirements/version_specified.txt
+++ b/python/spec/fixtures/requirements/version_specified.txt
@@ -1,3 +1,4 @@
 psycopg2==2.6.1
 luigi==2.2.0
 pytest==3.4.0
+aiocache[redis]==0.10.0


### PR DESCRIPTION
This fixes an issue with a setup.py + requirements.txt setup where extras (defined in square brackets as part of a dependency name) are ignored and therefore lost in the parsing stage (i.e. https://github.com/dependabot/dependabot-core/issues/1517). Now we keep the information with the dependency for as long as we can and switch between including it in the name and not as appropriate.