### PR TITLE
Codecommit: Create client without credentials

### DIFF
--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -26,11 +26,16 @@ module Dependabot
 
       def initialize(source, credentials)
         @source = source
-        @cc_client = Aws::CodeCommit::Client.new(
-          access_key_id: credentials&.fetch("username"),
-          secret_access_key: credentials&.fetch("password"),
-          region: credentials&.fetch("region")
-        )
+        @cc_client =
+          if credentials
+            Aws::CodeCommit::Client.new(
+              access_key_id: credentials.fetch("username"),
+              secret_access_key: credentials.fetch("password"),
+              region: credentials.fetch("region")
+            )
+          else
+            Aws::CodeCommit::Client.new
+          end
       end
 
       def fetch_commit(repo, branch)

--- a/common/spec/dependabot/clients/codecommit_spec.rb
+++ b/common/spec/dependabot/clients/codecommit_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe Dependabot::Clients::CodeCommit do
       specify { expect { subject }.to_not raise_error }
 
       it { is_expected.to eq("9c8376e9b2e943c2c72fac4b239876f377f0305a") }
+
+      context "without credentials" do
+        let(:credentials) { [] }
+        before { ENV["AWS_REGION"] = "us-east-1" }
+
+        it { is_expected.to eq("9c8376e9b2e943c2c72fac4b239876f377f0305a") }
+      end
     end
 
     context "when the target branch does not exist" do


### PR DESCRIPTION
Create `Aws::CodeCommit::Client` without any credentials if no
`git_source` credentials are provided. The client will default to using
AWS environment variables.

Fixes: https://github.com/dependabot/dependabot-core/pull/1399