### PR TITLE
Refactor `sanitize_links` method

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-codecommit", "~> 1.28"
   spec.add_dependency "aws-sdk-ecr", "~> 1.5"
   spec.add_dependency "bundler", ">= 1.16", "< 3.0.0"
+  spec.add_dependency "commonmarker", "~> 0.20.1"
   spec.add_dependency "docker_registry2", "~> 1.7", ">= 1.7.1"
   spec.add_dependency "excon", "~> 0.66"
   spec.add_dependency "gitlab", "4.12"

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -292,7 +292,7 @@ module Dependabot
         end
 
         dependencies.map do |dep|
-          msg = "\n\nUpdates `#{dep.display_name}` from "\
+          msg = "\nUpdates `#{dep.display_name}` from "\
                 "#{previous_version(dep)} to #{new_version(dep)}"
 
           if vulnerabilities_fixed[dep.name]&.one?
@@ -314,7 +314,7 @@ module Dependabot
         msg += commits_cascade(dep)
         msg += maintainer_changes_cascade(dep)
         msg += "\n<br />" unless msg == ""
-        sanitize_links_and_mentions(msg)
+        "\n" + sanitize_links_and_mentions(msg)
       end
 
       def vulnerabilities_cascade(dep)
@@ -438,9 +438,9 @@ module Dependabot
         if source.provider == ("azure" || "codecommit")
           "\n\##{summary}\n\n#{body}"
         else
-          msg = "\n<details>\n<summary>#{summary}</summary>\n\n"
+          msg = "<details>\n<summary>#{summary}</summary>\n\n"
           msg += body
-          msg + "</details>"
+          msg + "</details>\n"
         end
       end
 

--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -67,7 +67,7 @@ module Dependabot
                last_match.post_match.chars.first == "]"
               sanitized_mention
             else
-              "[#{mention}]"\
+              "[#{sanitized_mention}]"\
               "(https://github.com/#{mention.tr('@', '')})"
             end
           end

--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -74,11 +74,11 @@ module Dependabot
         end
 
         def sanitize_links(text)
-          doc = CommonMarker.render_doc(
-            text,
-            :DEFAULT,
-            %i(table tasklist strikethrough autolink tagfilter)
-          )
+          # We rely on GitHub to do the HTML sanitization
+          options = %i(UNSAFE GITHUB_PRE_LANG FULL_INFO_STRING)
+          extensions = %i(table tasklist strikethrough autolink tagfilter)
+
+          doc = CommonMarker.render_doc(text, :LIBERAL_HTML_TAG, extensions)
 
           doc.walk do |node|
             if node.type == :link && node.url.match?(GITHUB_REF_REGEX)
@@ -99,7 +99,7 @@ module Dependabot
             end
           end
 
-          doc.to_html
+          doc.to_html(options, extensions)
         end
       end
     end

--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -48,11 +48,11 @@ module Dependabot
             delimiter = line.match(CODEBLOCK_REGEX)&.to_s
             unless delimiter && lines.count { |l| l.include?(delimiter) }.odd?
               line = sanitize_mentions(line)
-              line = sanitize_links(line)
             end
             lines << line
           end
-          lines.join
+
+          sanitize_links(lines.join)
         end
 
         private
@@ -63,12 +63,11 @@ module Dependabot
 
             last_match = Regexp.last_match
 
-            sanitized_mention = mention.gsub("@", "@&#8203;")
             if last_match.pre_match.chars.last == "[" &&
                last_match.post_match.chars.first == "]"
-              sanitized_mention
+              next mention
             else
-              "[#{sanitized_mention}]"\
+              "[#{mention}]"\
               "(https://github.com/#{mention.tr('@', '')})"
             end
           end

--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -75,19 +75,28 @@ module Dependabot
         end
 
         def sanitize_links(text)
-          doc = CommonMarker.render_doc(text, :DEFAULT, [:table, :tasklist, :strikethrough, :autolink, :tagfilter])
+          doc = CommonMarker.render_doc(
+            text,
+            :DEFAULT,
+            %i(table tasklist strikethrough autolink tagfilter)
+          )
 
           doc.walk do |node|
             if node.type == :link && node.url.match?(GITHUB_REF_REGEX)
               node.each do |subnode|
-                if subnode.type == :text && last_match = subnode.string_content.match(GITHUB_REF_REGEX)
+                last_match = subnode.string_content.match(GITHUB_REF_REGEX)
+                if subnode.type == :text && last_match
                   number = last_match.named_captures.fetch("number")
                   repo = last_match.named_captures.fetch("repo")
                   subnode.string_content = "#{repo}##{number}"
                 end
+
+                next
               end
 
-              node.url = node.url.gsub("github.com", github_redirection_service || "github.com")
+              node.url = node.url.gsub(
+                "github.com", github_redirection_service || "github.com"
+              )
             end
           end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
       context "that appears in single tick code quotes" do
         let(:text) { "Great work `@greysteil`!" }
-        it { is_expected.to eq(text) }
+        it { is_expected.to eq("<p>Great work <code>@greysteil</code>!</p>\n") }
       end
 
       context "that appears in double tick code quotes" do

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
       it "sanitizes the text" do
         expect(sanitize_links_and_mentions).
           to eq("<p>Great work <a href=\"https://github.com/greysteil\">"\
-            "@greysteil</a>!</p>\n")
+            "@​greysteil</a>!</p>\n")
       end
 
       context "that includes a dash" do
@@ -31,7 +31,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         it "sanitizes the text" do
           expect(sanitize_links_and_mentions).to eq(
             "<p>Great work <a href=\"https://github.com/greysteil-work\">"\
-            "@greysteil-work</a>!</p>\n"
+            "@​greysteil-work</a>!</p>\n"
           )
         end
       end
@@ -47,7 +47,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         it "sanitizes the text" do
           expect(sanitize_links_and_mentions).to eq(
             "<p>The team (by <a href=\"https://github.com/greysteil\">"\
-            "@greysteil</a>) etc.</p>\n"
+            "@​greysteil</a>) etc.</p>\n"
           )
         end
       end
@@ -66,7 +66,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         let(:text) { fixture("changelogs", "sentry.md") }
         it do
           is_expected.to include(
-            "<a href=\"https://github.com/halkeye\">@halkeye</a>"
+            "<a href=\"https://github.com/halkeye\">@​halkeye</a>"
           )
         end
       end
@@ -92,9 +92,10 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
           it "sanitizes the text" do
             expect(sanitize_links_and_mentions).to eq(
-              "<p><a href=\"https://github.com/greysteil\">@greysteil</a> "\
+              "<p><a href=\"https://github.com/greysteil\">@​greysteil</a> "\
               "wrote this:</p>\n<pre><code> @model ||= 123\n</code></pre>\n<p>"\
-              "Review by <a href=\"https://github.com/hmarr\">@hmarr</a>!</p>\n"
+              "Review by <a href=\"https://github.com/hmarr\">@​hmarr</a>!"\
+              "</p>\n"
             )
           end
         end
@@ -107,9 +108,9 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
           it "sanitizes the mention" do
             expect(sanitize_links_and_mentions).to eq(
               "<p><code>@command</code>\nThanks to "\
-              "<a href=\"https://github.com/feelepxyz\">@feelepxyz</a>"\
+              "<a href=\"https://github.com/feelepxyz\">@​feelepxyz</a>"\
               "<code>@other</code> <a href=\"https://github.com/escape\">"\
-              "@escape</a></p>\n"
+              "@​escape</a></p>\n"
             )
           end
         end
@@ -120,7 +121,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
           it "sanitizes the mention" do
             expect(sanitize_links_and_mentions).to eq(
               "<p><code>@command </code>\n<code> @test</code> "\
-              "<a href=\"https://github.com/feelepxyz\">@feelepxyz</a></p>\n"
+              "<a href=\"https://github.com/feelepxyz\">@​feelepxyz</a></p>\n"
             )
           end
         end
@@ -160,7 +161,8 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
           it "sanitizes the mention" do
             expect(sanitize_links_and_mentions).to eq(
               "<p><code>@command </code></p>\n<pre><code> @test~~~ "\
-              "[@feelepxyz](https://github.com/feelepxyz)\n</code></pre>\n"
+              "[@&amp;#8203;feelepxyz](https://github.com/feelepxyz)\n</code>"\
+              "</pre>\n"
             )
           end
         end
@@ -170,8 +172,8 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
           it "sanitizes the mention" do
             expect(sanitize_links_and_mentions).to eq(
-              "<p><a href=\"https://github.com/command\">@command</a> ``` "\
-              "<a href=\"https://github.com/feelepxyz\">@feelepxyz</a></p>\n"
+              "<p><a href=\"https://github.com/command\">@​command</a> ``` "\
+              "<a href=\"https://github.com/feelepxyz\">@​feelepxyz</a></p>\n"
             )
           end
         end

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         end
       end
 
+      context "that is in square brackets" do
+        let(:text) { "[@hmarr]" }
+
+        it "sanitizes the text with zero width space" do
+          expect(sanitize_links_and_mentions).to eq(
+            "<p>[@​hmarr]</p>\n"
+          )
+        end
+      end
+
       context "that appears in single tick code quotes" do
         let(:text) { "Great work `@greysteil`!" }
         it { is_expected.to eq("<p>Great work <code>@greysteil</code>!</p>\n") }
@@ -207,6 +217,32 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         is_expected.to eq(
           "<p>Check out <a href=\"https://github-redirect.com/my/repo/"\
           "issues/5\">my/repo#5</a></p>\n"
+        )
+      end
+    end
+
+    context "with a GitHub pull request link" do
+      let(:text) do
+        "https://github.com/rust-num/num-traits/pull/144"
+      end
+
+      it do
+        is_expected.to eq(
+          "<p><a href=\"https://github-redirect.com/rust-num/num-traits/"\
+          "pull/144\">rust-num/num-traits#144</a></p>\n"
+        )
+      end
+    end
+
+    context "with a GitHub repo settings link link" do
+      let(:text) do
+        "https://github.com/rust-num/num-traits/settings"
+      end
+
+      it do
+        is_expected.to eq(
+          "<p><a href=\"https://github.com/rust-num/num-traits/settings\">"\
+          "https://github.com/rust-num/num-traits/settings</a></p>\n"
         )
       end
     end

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -202,6 +202,20 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
       end
     end
 
+    context "with a markdown footer" do
+      let(:text) do
+        "- [Updated the `libm` dependency to 0.2][144].\n"\
+        "[144]: https://github.com/rust-num/num-traits/pull/144"
+      end
+
+      it do
+        is_expected.to eq(
+          "- [Updated the `libm` dependency to 0.2][144].\n"\
+          "[144]: https://github-redirect.com/rust-num/num-traits/pull/144"
+        )
+      end
+    end
+
     context "with a changelog that doesn't need sanitizing" do
       let(:text) { fixture("changelogs", "jsdom.md") }
       let(:github_redirection_service) { "github.com" }

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -71,30 +71,38 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
   # rubocop:disable Metrics/MethodLength
   def commits_details(base:, head:)
     "<details>\n"\
-    "<summary>Commits</summary>\n\n"\
-    "- [`26f4887`](https://github.com/gocardless/business/commit/"\
-    "26f4887ec647493f044836363537e329d9d213aa) Bump version to v1.4.0\n"\
-    "- [`7abe4c2`](https://github.com/gocardless/business/commit/"\
-    "7abe4c2dc0161904c40c221a48999d12995fbea7) "\
-    "[Fix [#9](https://github-redirect.dependabot.com/"\
-    "gocardless/business/issues/9)] Allow custom calendars\n"\
-    "- [`1c72c35`](https://github.com/gocardless/business/commit/"\
-    "1c72c35ff2aa9d7ce0403d7fd4aa010d94723076) Allow custom calendars\n"\
-    "- [`5555535`](https://github.com/gocardless/business/commit/"\
-    "5555535ff2aa9d7ce0403d7fd4aa010d94723076) \n"\
-    "- [`0bfb8c3`](https://github.com/gocardless/business/commit/"\
-    "0bfb8c3f0d2701abf9248185beeb8adf643374f6) Spacing: [my/repo#5]"\
-    "(https://github-redirect.dependabot.com/my/repo/pull/5)\n"\
-    "- [`a5970da`](https://github.com/gocardless/business/commit/"\
-    "a5970daf0b824e4c3974e57474b6cf9e39a11d0f) "\
-    "Merge pull request [#8](https://github-redirect.dependabot.com/"\
-    "gocardless/business/issues/8) from gocardless/rename-sepa-to-ecb\n"\
-    "- [`d2eb29b`](https://github.com/gocardless/business/commit/"\
-    "d2eb29beda934c14220146c82f830de2edd63a25) "\
-    "[12](https://github-redirect.dependabot.com/gocardless/business/"\
-    "issues/12) Remove \_SEPA_ calendar (replaced by TARGET)\n"\
-    "- See full diff in [compare view](https://github.com/gocardless/business/"\
-    "compare/#{base}...#{head})\n"\
+    "<summary>Commits</summary>\n"\
+    "<ul>\n"\
+    "<li><a href=\"https://github.com/gocardless/business/commit/"\
+    "26f4887ec647493f044836363537e329d9d213aa\"><code>26f4887</code></a> "\
+    "Bump version to v1.4.0</li>\n"\
+    "<li><a href=\"https://github.com/gocardless/business/commit/"\
+    "7abe4c2dc0161904c40c221a48999d12995fbea7\"><code>7abe4c2</code></a> "\
+    "[Fix <a href=\"https://github-redirect.dependabot.com/gocardless/"\
+    "business/issues/9\">#9</a>] Allow custom calendars</li>\n"\
+    "<li><a href=\"https://github.com/gocardless/business/commit/"\
+    "1c72c35ff2aa9d7ce0403d7fd4aa010d94723076\"><code>1c72c35</code></a> "\
+    "Allow custom calendars</li>\n"\
+    "<li><a href=\"https://github.com/gocardless/business/commit/"\
+    "5555535ff2aa9d7ce0403d7fd4aa010d94723076\"><code>5555535</code>"\
+    "</a></li>\n"\
+    "<li><a href=\"https://github.com/gocardless/business/commit/"\
+    "0bfb8c3f0d2701abf9248185beeb8adf643374f6\"><code>0bfb8c3</code></a> "\
+    "Spacing: <a href=\"https://github-redirect.dependabot.com/my/repo/"\
+    "pull/5\">my/repo#5</a></li>\n"\
+    "<li><a href=\"https://github.com/gocardless/business/commit/"\
+    "a5970daf0b824e4c3974e57474b6cf9e39a11d0f\"><code>a5970da</code></a> "\
+    "Merge pull request <a href=\"https://github-redirect.dependabot.com/"\
+    "gocardless/business/issues/8\">#8</a> "\
+    "from gocardless/rename-sepa-to-ecb</li>\n"\
+    "<li><a href=\"https://github.com/gocardless/business/commit/"\
+    "d2eb29beda934c14220146c82f830de2edd63a25\"><code>d2eb29b</code></a> "\
+    "<a href=\"https://github-redirect.dependabot.com/gocardless/business/"\
+    "issues/12\">12</a> Remove <em>SEPA</em> "\
+    "calendar (replaced by TARGET)</li>\n"\
+    "<li>See full diff in <a href=\"https://github.com/gocardless/business/"\
+    "compare/#{base}...#{head}\">compare view</a></li>\n"\
+    "</ul>\n"\
     "</details>\n"
   end
   # rubocop:enable Metrics/MethodLength
@@ -676,15 +684,19 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             "Bumps [business](https://github.com/gocardless/business) "\
             "from 1.4.0 to 1.5.0.\n"\
             "<details>\n"\
-            "<summary>Changelog</summary>\n\n"\
-            "*Sourced from [business's changelog](https://github.com/"\
-            "gocardless/business/blob/master/CHANGELOG.md).*\n\n"\
-            "> ## 1.5.0 - June 2, 2015\n"\
-            "> \n"\
-            "> - Add 2016 holiday definitions\n"\
+            "<summary>Changelog</summary>\n"\
+            "<p><em>Sourced from <a href=\"https://github.com/gocardless/"\
+            "business/blob/master/CHANGELOG.md\">"\
+            "business's changelog</a>.</em></p>\n"\
+            "<blockquote>\n"\
+            "<h2>1.5.0 - June 2, 2015</h2>\n"\
+            "<ul>\n"\
+            "<li>Add 2016 holiday definitions</li>\n"\
+            "</ul>\n"\
+            "</blockquote>\n"\
             "</details>\n"\
             "#{commits_details(base: 'v1.4.0', head: 'v1.5.0')}"\
-            "<br />"
+            "<br />\n"
           )
       end
 
@@ -699,15 +711,19 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               "Bumps [business](https://github.com/gocardless/business) "\
               "from 1.4.0 to 1.5.0.\n"\
               "<details>\n"\
-              "<summary>Changelog</summary>\n\n"\
-              "*Sourced from [business's changelog](https://github.com/"\
-              "gocardless/business/blob/master/CHANGELOG.md).*\n\n"\
-              "> ## 1.5.0 - June 2, 2015\n"\
-              "> \n"\
-              "> - Add 2016 holiday definitions\n"\
+              "<summary>Changelog</summary>\n"\
+              "<p><em>Sourced from <a href=\"https://github.com/gocardless/"\
+              "business/blob/master/CHANGELOG.md\">"\
+              "business's changelog</a>.</em></p>\n"\
+              "<blockquote>\n"\
+              "<h2>1.5.0 - June 2, 2015</h2>\n"\
+              "<ul>\n"\
+              "<li>Add 2016 holiday definitions</li>\n"\
+              "</ul>\n"\
+              "</blockquote>\n"\
               "</details>\n"\
               "#{commits}"\
-              "<br />"
+              "<br />\n"
             )
         end
       end
@@ -729,17 +745,21 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               "Bumps [business](https://github.com/gocardless/business) "\
               "from 1.4.0 to 1.5.0.\n"\
               "<details>\n"\
-              "<summary>Changelog</summary>\n\n"\
-              "*Sourced from [business's changelog](https://github.com/"\
-              "gocardless/business/blob/master/CHANGELOG.md).*\n\n"\
-              "> ## 1.5.0 - June 2, 2015\n"\
-              "> \n"\
-              "> - Add 2016 holiday definitions\n"\
-              "> - See [holiday-deps](https://github.com/gocardless/"\
-              "business/blob/master/holiday/README.md)\n"\
+              "<summary>Changelog</summary>\n"\
+              "<p><em>Sourced from <a href=\"https://github.com/gocardless/"\
+              "business/blob/master/CHANGELOG.md\">"\
+              "business's changelog</a>.</em></p>\n"\
+              "<blockquote>\n"\
+              "<h2>1.5.0 - June 2, 2015</h2>\n"\
+              "<ul>\n"\
+              "<li>Add 2016 holiday definitions</li>\n"\
+              "<li>See <a href=\"https://github.com/gocardless/business/blob/"\
+              "master/holiday/README.md\">holiday-deps</a></li>\n"\
+              "</ul>\n"\
+              "</blockquote>\n"\
               "</details>\n"\
               "#{commits_details(base: 'v1.4.0', head: 'v1.5.0')}"\
-              "<br />"
+              "<br />\n"
             )
         end
       end
@@ -807,7 +827,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             "Bumps [business](https://github.com/gocardless/business) "\
             "from `2468a02` to `cff701b`.\n"\
             "#{commits_details}"\
-            "<br />"
+            "<br />\n"
           )
         end
 
@@ -825,15 +845,19 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 "Bumps [business](https://github.com/gocardless/business) "\
                 "from v1.0.0 to v1.1.0.\n"\
                 "<details>\n"\
-                "<summary>Changelog</summary>\n\n"\
-                "*Sourced from [business's changelog](https://github.com/"\
-                "gocardless/business/blob/master/CHANGELOG.md).*\n\n"\
-                "> ## 1.1.0 - September 30, 2014\n"\
-                "> \n"\
-                "> - Add 2015 holiday definitions\n"\
+                "<summary>Changelog</summary>\n"\
+                "<p><em>Sourced from <a href=\"https://github.com/gocardless/"\
+                "business/blob/master/CHANGELOG.md\">"\
+                "business's changelog</a>.</em></p>\n"\
+                "<blockquote>\n"\
+                "<h2>1.1.0 - September 30, 2014</h2>\n"\
+                "<ul>\n"\
+                "<li>Add 2015 holiday definitions</li>\n"\
+                "</ul>\n"\
+                "</blockquote>\n"\
                 "</details>\n"\
                 "#{commits_details}"\
-                "<br />"
+                "<br />\n"
               )
           end
 
@@ -859,15 +883,19 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                   "Bumps [business](https://github.com/gocardless/business) "\
                   "from v1.0.0 to v1.1.0.\n"\
                   "<details>\n"\
-                  "<summary>Changelog</summary>\n\n"\
-                  "*Sourced from [business's changelog](https://github.com/"\
-                  "gocardless/business/blob/master/CHANGELOG.md).*\n\n"\
-                  "> ## 1.1.0 - September 30, 2014\n"\
-                  "> \n"\
-                  "> - Add 2015 holiday definitions\n"\
+                  "<summary>Changelog</summary>\n"\
+                  "<p><em>Sourced from <a href=\"https://github.com/"\
+                  "gocardless/business/blob/master/CHANGELOG.md\">"\
+                  "business's changelog</a>.</em></p>\n"\
+                  "<blockquote>\n"\
+                  "<h2>1.1.0 - September 30, 2014</h2>\n"\
+                  "<ul>\n"\
+                  "<li>Add 2015 holiday definitions</li>\n"\
+                  "</ul>\n"\
+                  "</blockquote>\n"\
                   "</details>\n"\
                   "#{commits_details}"\
-                  "<br />"
+                  "<br />\n"
                 )
             end
           end
@@ -929,40 +957,40 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               "from `2468a02` to 1.5.0. This release includes the previously "\
               "tagged commit.\n"\
               "<details>\n"\
-              "<summary>Changelog</summary>\n\n"\
-              "*Sourced from [business's changelog](https://github.com/"\
-              "gocardless/business/blob/master/CHANGELOG.md).*\n\n"\
-              "> ## 1.5.0 - June 2, 2015\n"\
-              "> \n"\
-              "> - Add 2016 holiday definitions\n"\
-              "> \n"\
-              "> ## 1.4.0 - December 24, 2014\n"\
-              "> \n"\
-              "> - Add support for custom calendar load paths\n"\
-              "> - Remove the 'sepa' calendar\n"\
-              "> \n"\
-              "> \n"\
-              "> ## 1.3.0 - December 2, 2014\n"\
-              "> \n"\
-              "> - Add `Calendar#previous_business_day`\n"\
-              "> \n"\
-              "> \n"\
-              "> ## 1.2.0 - November 15, 2014\n"\
-              "> \n"\
-              "> - Add TARGET calendar\n"\
-              "> \n"\
-              "> \n"\
-              "> ## 1.1.0 - September 30, 2014\n"\
-              "> \n"\
-              "> - Add 2015 holiday definitions\n"\
-              "> \n"\
-              "> \n"\
-              "> ## 1.0.0 - June 11, 2014\n"\
-              "> \n"\
-              "> - Initial public release\n"\
+              "<summary>Changelog</summary>\n"\
+              "<p><em>Sourced from <a href=\"https://github.com/gocardless/"\
+              "business/blob/master/CHANGELOG.md\">"\
+              "business's changelog</a>.</em></p>\n"\
+              "<blockquote>\n"\
+              "<h2>1.5.0 - June 2, 2015</h2>\n"\
+              "<ul>\n"\
+              "<li>Add 2016 holiday definitions</li>\n"\
+              "</ul>\n"\
+              "<h2>1.4.0 - December 24, 2014</h2>\n"\
+              "<ul>\n"\
+              "<li>Add support for custom calendar load paths</li>\n"\
+              "<li>Remove the 'sepa' calendar</li>\n"\
+              "</ul>\n"\
+              "<h2>1.3.0 - December 2, 2014</h2>\n"\
+              "<ul>\n"\
+              "<li>Add <code>Calendar#previous_business_day</code></li>\n"\
+              "</ul>\n"\
+              "<h2>1.2.0 - November 15, 2014</h2>\n"\
+              "<ul>\n"\
+              "<li>Add TARGET calendar</li>\n"\
+              "</ul>\n"\
+              "<h2>1.1.0 - September 30, 2014</h2>\n"\
+              "<ul>\n"\
+              "<li>Add 2015 holiday definitions</li>\n"\
+              "</ul>\n"\
+              "<h2>1.0.0 - June 11, 2014</h2>\n"\
+              "<ul>\n"\
+              "<li>Initial public release</li>\n"\
+              "</ul>\n"\
+              "</blockquote>\n"\
               "</details>\n"\
               "#{commits_details}"\
-              "<br />"
+              "<br />\n"
             )
         end
 
@@ -1011,7 +1039,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               "Bumps [business](https://github.com/gocardless/business) from "\
               "1.4.0 to 1.5.0.\n"\
               "#{commits_details(base: 'v1.4.0', head: 'v1.5.0')}"\
-              "<br />"
+              "<br />\n"
             )
         end
 
@@ -1065,18 +1093,20 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 "from 1.5.0 to 1.6.0.\n"\
                 "<details>\n"\
                 "<summary>Release notes</summary>\n"\
-                "\n"\
-                "*Sourced from [business's releases](https://github.com/"\
-                "gocardless/business/releases).*\n\n"\
-                "> ## v1.6.0\n"\
-                "> Mad props to [@&#8203;greysteil](https://github.com/"\
-                "greysteil) and [@&#8203;hmarr](https://github.com/hmarr) "\
-                "for the @angular/scope work - see [changelog]"\
-                "(https://github.com/gocardless/business/blob/HEAD/"\
-                "CHANGELOG.md).\n"\
+                "<p><em>Sourced from <a href=\"https://github.com/gocardless/"\
+                "business/releases\">business's releases</a>.</em></p>\n"\
+                "<blockquote>\n"\
+                "<h2>v1.6.0</h2>\n"\
+                "<p>Mad props to <a href=\"https://github.com/greysteil\">"\
+                "[@greysteil](https://github.com/greysteil)</a> and "\
+                "<a href=\"https://github.com/hmarr\">[@hmarr]"\
+                "(https://github.com/hmarr)</a> for the @angular/scope work - "\
+                "see <a href=\"https://github.com/gocardless/business/blob/"\
+                "HEAD/CHANGELOG.md\">changelog</a>.</p>\n"\
+                "</blockquote>\n"\
                 "</details>\n"\
                 "#{commits_details(base: 'v1.5.0', head: 'v1.6.0')}"\
-                "<br />"
+                "<br />\n"
               )
           end
         end
@@ -1220,9 +1250,11 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
         it "has the right text" do
           expect(pr_message).to include(
-            "<summary>Maintainer changes</summary>\n\n"\
-            "Maintainer change\n"\
-            "</details>"
+            "<details>\n"\
+            "<summary>Maintainer changes</summary>\n"\
+            "<p>Maintainer change</p>\n"\
+            "</details>\n"\
+            "<br />"
           )
         end
       end
@@ -1294,33 +1326,43 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             to eq(
               "Bumps [business](https://github.com/gocardless/business) "\
               "and [statesman](https://github.com/gocardless/statesman). "\
-              "These dependencies needed to be updated together.\n\n"\
+              "These dependencies needed to be updated together.\n"\
               "Updates `business` from 1.4.0 to 1.5.0\n"\
               "<details>\n"\
-              "<summary>Changelog</summary>\n\n"\
-              "*Sourced from [business's changelog](https://github.com/"\
-              "gocardless/business/blob/master/CHANGELOG.md).*\n\n"\
-              "> ## 1.5.0 - June 2, 2015\n"\
-              "> \n"\
-              "> - Add 2016 holiday definitions\n"\
+              "<summary>Changelog</summary>\n"\
+              "<p><em>Sourced from <a href=\"https://github.com/gocardless/"\
+              "business/blob/master/CHANGELOG.md\">"\
+              "business's changelog</a>.</em></p>\n"\
+              "<blockquote>\n"\
+              "<h2>1.5.0 - June 2, 2015</h2>\n"\
+              "<ul>\n"\
+              "<li>Add 2016 holiday definitions</li>\n"\
+              "</ul>\n"\
+              "</blockquote>\n"\
               "</details>\n"\
               "#{commits_details(base: 'v1.4.0', head: 'v1.5.0')}"\
               "<br />\n\n"\
               "Updates `statesman` from 1.6.0 to 1.7.0\n"\
               "<details>\n"\
-              "<summary>Changelog</summary>\n\n"\
-              "*Sourced from [statesman's changelog](https://github.com/"\
-              "gocardless/statesman/blob/master/CHANGELOG.md).*\n\n"\
-              "> ## 1.7.0 - January 18, 2017\n"\
-              "> \n"\
-              "> - Add 2018-2027 BACS holiday defintions\n"\
+              "<summary>Changelog</summary>\n"\
+              "<p><em>Sourced from <a href=\"https://github.com/gocardless/"\
+              "statesman/blob/master/CHANGELOG.md\">"\
+              "statesman's changelog</a>.</em></p>\n"\
+              "<blockquote>\n"\
+              "<h2>1.7.0 - January 18, 2017</h2>\n"\
+              "<ul>\n"\
+              "<li>Add 2018-2027 BACS holiday defintions</li>\n"\
+              "</ul>\n"\
+              "</blockquote>\n"\
               "</details>\n"\
               "<details>\n"\
-              "<summary>Commits</summary>\n\n"\
-              "- See full diff in [compare view](https://github.com/gocardless"\
-              "/statesman/commits)\n"\
+              "<summary>Commits</summary>\n"\
+              "<ul>\n"\
+              "<li>See full diff in <a href=\"https://github.com/gocardless/"\
+              "statesman/commits\">compare view</a></li>\n"\
+              "</ul>\n"\
               "</details>\n"\
-              "<br />"
+              "<br />\n"
             )
         end
 
@@ -1407,15 +1449,19 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             "[business](https://github.com/gocardless/business) "\
             "to permit the latest version.\n"\
             "<details>\n"\
-            "<summary>Changelog</summary>\n\n"\
-            "*Sourced from [business's changelog](https://github.com/"\
-            "gocardless/business/blob/master/CHANGELOG.md).*\n\n"\
-            "> ## 1.5.0 - June 2, 2015\n"\
-            "> \n"\
-            "> - Add 2016 holiday definitions\n"\
+            "<summary>Changelog</summary>\n"\
+            "<p><em>Sourced from "\
+            "<a href=\"https://github.com/gocardless/business/blob/master/"\
+            "CHANGELOG.md\">business's changelog</a>.</em></p>\n"\
+            "<blockquote>\n"\
+            "<h2>1.5.0 - June 2, 2015</h2>\n"\
+            "<ul>\n"\
+            "<li>Add 2016 holiday definitions</li>\n"\
+            "</ul>\n"\
+            "</blockquote>\n"\
             "</details>\n"\
             "#{commits_details(base: 'v1.4.0', head: 'v1.5.0')}"\
-            "<br />"
+            "<br />\n"
           )
       end
 
@@ -1487,33 +1533,43 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               "Updates the requirements on "\
               "[business](https://github.com/gocardless/business) "\
               "and [statesman](https://github.com/gocardless/statesman) "\
-              "to permit the latest version.\n\n"\
+              "to permit the latest version.\n"\
               "Updates `business` from 1.4.0 to 1.5.0\n"\
               "<details>\n"\
-              "<summary>Changelog</summary>\n\n"\
-              "*Sourced from [business's changelog](https://github.com/"\
-              "gocardless/business/blob/master/CHANGELOG.md).*\n\n"\
-              "> ## 1.5.0 - June 2, 2015\n"\
-              "> \n"\
-              "> - Add 2016 holiday definitions\n"\
+              "<summary>Changelog</summary>\n"\
+              "<p><em>Sourced from <a href=\"https://github.com/gocardless/"\
+              "business/blob/master/CHANGELOG.md\">"\
+              "business's changelog</a>.</em></p>\n"\
+              "<blockquote>\n"\
+              "<h2>1.5.0 - June 2, 2015</h2>\n"\
+              "<ul>\n"\
+              "<li>Add 2016 holiday definitions</li>\n"\
+              "</ul>\n"\
+              "</blockquote>\n"\
               "</details>\n"\
               "#{commits_details(base: 'v1.4.0', head: 'v1.5.0')}"\
               "<br />\n\n"\
               "Updates `statesman` from 1.6.0 to 1.7.0\n"\
               "<details>\n"\
-              "<summary>Changelog</summary>\n\n"\
-              "*Sourced from [statesman's changelog](https://github.com/"\
-              "gocardless/statesman/blob/master/CHANGELOG.md).*\n\n"\
-              "> ## 1.7.0 - January 18, 2017\n"\
-              "> \n"\
-              "> - Add 2018-2027 BACS holiday defintions\n"\
+              "<summary>Changelog</summary>\n"\
+              "<p><em>Sourced from <a href=\"https://github.com/gocardless/"\
+              "statesman/blob/master/CHANGELOG.md\">"\
+              "statesman's changelog</a>.</em></p>\n"\
+              "<blockquote>\n"\
+              "<h2>1.7.0 - January 18, 2017</h2>\n"\
+              "<ul>\n"\
+              "<li>Add 2018-2027 BACS holiday defintions</li>\n"\
+              "</ul>\n"\
+              "</blockquote>\n"\
               "</details>\n"\
               "<details>\n"\
-              "<summary>Commits</summary>\n\n"\
-              "- See full diff in [compare view](https://github.com/gocardless"\
-              "/statesman/commits)\n"\
+              "<summary>Commits</summary>\n"\
+              "<ul>\n"\
+              "<li>See full diff in <a href=\"https://github.com/gocardless/"\
+              "statesman/commits\">compare view</a></li>\n"\
+              "</ul>\n"\
               "</details>\n"\
-              "<br />"
+              "<br />\n"
             )
         end
       end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1098,11 +1098,10 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 "<blockquote>\n"\
                 "<h2>v1.6.0</h2>\n"\
                 "<p>Mad props to <a href=\"https://github.com/greysteil\">"\
-                "[@greysteil](https://github.com/greysteil)</a> and "\
-                "<a href=\"https://github.com/hmarr\">@​hmarr</a> for the "\
-                "@angular/scope work - see <a href=\"https://github.com/"\
-                "gocardless/business/blob/HEAD/CHANGELOG.md\">"\
-                "changelog</a>.</p>\n"\
+                "@​greysteil</a> and <a href=\"https://github.com/hmarr\">"\
+                "@​hmarr</a> for the @angular/scope work - see "\
+                "<a href=\"https://github.com/gocardless/business/blob/HEAD/"\
+                "CHANGELOG.md\">changelog</a>.</p>\n"\
                 "</blockquote>\n"\
                 "</details>\n"\
                 "#{commits_details(base: 'v1.5.0', head: 'v1.6.0')}"\

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1099,10 +1099,10 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 "<h2>v1.6.0</h2>\n"\
                 "<p>Mad props to <a href=\"https://github.com/greysteil\">"\
                 "[@greysteil](https://github.com/greysteil)</a> and "\
-                "<a href=\"https://github.com/hmarr\">[@hmarr]"\
-                "(https://github.com/hmarr)</a> for the @angular/scope work - "\
-                "see <a href=\"https://github.com/gocardless/business/blob/"\
-                "HEAD/CHANGELOG.md\">changelog</a>.</p>\n"\
+                "<a href=\"https://github.com/hmarr\">@​hmarr</a> for the "\
+                "@angular/scope work - see <a href=\"https://github.com/"\
+                "gocardless/business/blob/HEAD/CHANGELOG.md\">"\
+                "changelog</a>.</p>\n"\
                 "</blockquote>\n"\
                 "</details>\n"\
                 "#{commits_details(base: 'v1.5.0', head: 'v1.6.0')}"\

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1132,14 +1132,14 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               "Bumps [business](https://github.com/gocardless/business) "\
               "from 1.4.0 to 1.5.0. **This update includes a security fix.**\n"\
               "<details>\n"\
-              "<summary>Vulnerabilities fixed</summary>\n\n"\
-              "> **Serious vulnerability**\n"\
-              "> A vulnerability that allows arbitrary code\n"\
-              "> execution.\n"\
-              "> \n"\
-              "> Patched versions: > 1.5.0\n"\
-              "> Unaffected versions: none\n"\
-              "\n"\
+              "<summary>Vulnerabilities fixed</summary>\n"\
+              "<blockquote>\n"\
+              "<p><strong>Serious vulnerability</strong>\n"\
+              "A vulnerability that allows arbitrary code\n"\
+              "execution.</p>\n"\
+              "<p>Patched versions: &gt; 1.5.0\n"\
+              "Unaffected versions: none</p>\n"\
+              "</blockquote>\n"\
               "</details>\n"
             )
         end
@@ -1197,46 +1197,48 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         it "has the right text" do
           expect(pr_message).
             to start_with(
-              "Bumps [business](https://github.com/gocardless/business) "\
-              "from 0.9.0 to 1.5.0.\n"\
+              "Bumps [business](https://github.com/gocardless/business) from "\
+              "0.9.0 to 1.5.0.\n"\
               "<details>\n"\
-              "<summary>Changelog</summary>\n\n"\
-              "*Sourced from [business's changelog](https://github.com/"\
-              "gocardless/business/blob/master/CHANGELOG.md).*\n\n"\
-              "> ## 1.5.0 - June 2, 2015\n"\
-              "> \n"\
-              "> - Add 2016 holiday definitions\n"\
-              "> \n"\
-              "> ## 1.4.0 - December 24, 2014\n"\
-              "> \n"\
-              "> - Add support for custom calendar load paths\n"\
-              "> - Remove the 'sepa' calendar\n"\
-              "> \n"\
-              "> \n"\
-              "> ## 1.3.0 - December 2, 2014\n"\
-              "> \n"\
-              "> - Add `Calendar#previous_business_day`\n"\
-              "> \n"\
-              "> \n"\
-              "> ## 1.2.0 - November 15, 2014\n"\
-              "> \n"\
-              "> - Add TARGET calendar\n"\
-              "> \n"\
-              "> \n"\
-              "> ## 1.1.0 - September 30, 2014\n"\
-              "> \n"\
-              "> - Add 2015 holiday definitions\n"\
-              "> \n"\
-              "> \n"\
-              "> ## 1.0.0 - June 11, 2014\n"\
-              "> \n"\
-              "> - Initial public release\n"\
+              "<summary>Changelog</summary>\n"\
+              "<p><em>Sourced from <a href=\"https://github.com/gocardless/"\
+              "business/blob/master/CHANGELOG.md\">business's changelog</a>."\
+              "</em></p>\n"\
+              "<blockquote>\n"\
+              "<h2>1.5.0 - June 2, 2015</h2>\n"\
+              "<ul>\n"\
+              "<li>Add 2016 holiday definitions</li>\n"\
+              "</ul>\n"\
+              "<h2>1.4.0 - December 24, 2014</h2>\n"\
+              "<ul>\n"\
+              "<li>Add support for custom calendar load paths</li>\n"\
+              "<li>Remove the 'sepa' calendar</li>\n"\
+              "</ul>\n"\
+              "<h2>1.3.0 - December 2, 2014</h2>\n"\
+              "<ul>\n"\
+              "<li>Add <code>Calendar#previous_business_day</code></li>\n"\
+              "</ul>\n"\
+              "<h2>1.2.0 - November 15, 2014</h2>\n"\
+              "<ul>\n"\
+              "<li>Add TARGET calendar</li>\n"\
+              "</ul>\n"\
+              "<h2>1.1.0 - September 30, 2014</h2>\n"\
+              "<ul>\n"\
+              "<li>Add 2015 holiday definitions</li>\n"\
+              "</ul>\n"\
+              "<h2>1.0.0 - June 11, 2014</h2>\n"\
+              "<ul>\n"\
+              "<li>Initial public release</li>\n"\
+              "</ul>\n"\
+              "</blockquote>\n"\
               "</details>\n"\
               "<details>\n"\
-              "<summary>Upgrade guide</summary>\n\n"\
-              "*Sourced from [business's upgrade guide](https://github.com/"\
-              "gocardless/business/blob/master/UPGRADE.md).*\n\n"\
-              "> UPGRADE GUIDE FROM 2.x to 3.0\n"
+              "<summary>Upgrade guide</summary>\n"\
+              "<p><em>Sourced from <a href=\"https://github.com/gocardless/"\
+              "business/blob/master/UPGRADE.md\">business's upgrade guide</a>."\
+              "</em></p>\n"\
+              "<blockquote>\n"\
+              "<h1>UPGRADE GUIDE FROM 2.x to 3.0</h1>"
             )
         end
       end
@@ -1426,7 +1428,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           it "has the right intro" do
             expect(pr_message).
               to start_with(
-                "Bumps `springframework.version` from 1.4.0 to 1.5.0.\n\n"
+                "Bumps `springframework.version` from 1.4.0 to 1.5.0.\n"
               )
           end
         end

--- a/common/spec/fixtures/changelogs/jsdom.html
+++ b/common/spec/fixtures/changelogs/jsdom.html
@@ -1,0 +1,23 @@
+<h2>15.2.0</h2>
+<ul>
+<li>Set <code>canvas</code> as an optional ``peerDependency`, which apparently helps with Yarn PnP support.</li>
+</ul>
+<h2>15.1.1</h2>
+<ul>
+<li>Moved the <code>nonce</code> property from <code>HTMLScriptElement</code> and <code>HTMLStyleElement</code> to <code>HTMLElement</code>. Note that it is still just a simple reflection of the attribute, and has not been updated for the rest of the changes in <a href="https://github-redirect.com/whatwg/html/pull/2373">whatwg/html#2373</a>.</li>
+</ul>
+<h2>15.1.0</h2>
+<ul>
+<li>Added the <code>Headers</code> class from the Fetch standard.</li>
+<li>Added the <code>element.translate</code> getter and setter.</li>
+<li>Fixed synchronous <code>XMLHttpRequest</code> on the newly-released Node.js v12.</li>
+<li>Fixed <code>form.elements</code> to exclude <code>&lt;input type=&quot;image&quot;&gt;</code> elements.</li>
+<li>Fixed event path iteration in shadow DOM cases, following spec fixes at <a href="https://github-redirect.com/whatwg/dom/pull/686">whatwg/dom#686</a> and <a href="https://github-redirect.com/whatwg/dom/pull/750">whatwg/dom#750</a>.</li>
+<li>Fixed <code>pattern=&quot;&quot;</code> form control validation to apply the given regular expression to the whole string. (kontomondo)</li>
+</ul>
+<h2>15.0.0</h2>
+<p>Several potentially-breaking changes, each of them fairly unlikely to actually break anything:</p>
+<ul>
+<li><code>JSDOM.fromFile()</code> now treats <code>.xht</code> files as <code>application/xhtml+xml</code>, the same as it does for <code>.xhtml</code> and <code>.xml</code>. Previously, it would treat them as <code>text/html</code>.</li>
+<li>When using the <code>Blob</code> or <code>File</code> constructor with the <code>endings: &quot;native&quot;</code> option, jsdom will now convert line endings to <code>\n</code> on all operating systems, for consistency. Previously, on Windows, it would convert line endings to <code>\r\n</code>.</li>
+</ul>


### PR DESCRIPTION
We had a bug reported where we weren't sanitizing the markdown footer in changelogs.  As @feelepxyz and I dove into fixing this, we realized a refactor of the `sanitize_links` method was in order.  Not only does it fix the bug, but it makes for a cleaner and more resilient method.