### PR TITLE
JS: Fix unfetchable tarball path deps ∞ loop

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -138,7 +138,8 @@ module Dependabot
             file = fetch_file_from_host(filename, fetch_submodules: true)
             package_json_files << file
           rescue Dependabot::DependencyFileNotFound
-            unfetchable_deps << [name, path]
+            # Unfetchable tarballs should not be re-fetched as a package
+            unfetchable_deps << [name, path] unless path.end_with?(".tgz")
           end
         end
 


### PR DESCRIPTION
Fixes a regression introduced by
https://github.com/dependabot/dependabot-core/commit/6fa27f79834e2ed7a84e7d2565492115854b13f8

When a path dependency is a tarball it shouldn't be fetched as a
package (appending/package.json to the end assuming it's a directory).

Commit #6fa27f79834e2ed7a84e7d2565492115854b13f8 only handled the
initial fetch but not the retry which caused an infinite retry loop as
the path dependency was re-fetched with path.tgz/package.json after each
time it wasn't found as path.tgz.