### PR TITLE
Pass all the assignees to gitlab merge request creator

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler", ">= 1.16", "< 3.0.0"
   spec.add_dependency "docker_registry2", "~> 1.7", ">= 1.7.1"
   spec.add_dependency "excon", "~> 0.66"
-  spec.add_dependency "gitlab", "~> 4.9"
+  spec.add_dependency "gitlab", "~> 4.12"
   spec.add_dependency "nokogiri", "~> 1.8"
   spec.add_dependency "octokit", "~> 4.6"
   spec.add_dependency "pandoc-ruby", "~> 2.0"

--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -126,7 +126,7 @@ module Dependabot
         author_details: author_details,
         labeler: labeler,
         approvers: reviewers,
-        assignee: assignees&.first,
+        assignees: assignees,
         milestone: milestone
       )
     end

--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -9,12 +9,12 @@ module Dependabot
     class Gitlab
       attr_reader :source, :branch_name, :base_commit, :credentials,
                   :files, :pr_description, :pr_name, :commit_message,
-                  :author_details, :labeler, :approvers, :assignee,
+                  :author_details, :labeler, :approvers, :assignees,
                   :milestone
 
       def initialize(source:, branch_name:, base_commit:, credentials:,
                      files:, commit_message:, pr_description:, pr_name:,
-                     author_details:, labeler:, approvers:, assignee:,
+                     author_details:, labeler:, approvers:, assignees:,
                      milestone:)
         @source         = source
         @branch_name    = branch_name
@@ -27,7 +27,7 @@ module Dependabot
         @author_details = author_details
         @labeler        = labeler
         @approvers      = approvers
-        @assignee       = assignee
+        @assignees      = assignees
         @milestone      = milestone
       end
 
@@ -140,7 +140,7 @@ module Dependabot
           target_branch: source.branch || default_branch,
           description: pr_description,
           remove_source_branch: true,
-          assignee_id: assignee,
+          assignee_ids: assignees,
           labels: labeler.labels_for_pr.join(","),
           milestone_id: milestone
         )

--- a/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
       author_details: author_details,
       labeler: labeler,
       approvers: approvers,
-      assignee: assignee,
+      assignees: assignees,
       milestone: milestone
     )
   end
@@ -43,7 +43,7 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
   let(:pr_name) { "PR name" }
   let(:author_details) { nil }
   let(:approvers) { nil }
-  let(:assignee) { nil }
+  let(:assignees) { nil }
   let(:milestone) { nil }
   let(:labeler) do
     Dependabot::PullRequestCreator::Labeler.new(

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Dependabot::PullRequestCreator do
             author_details: author_details,
             labeler: instance_of(described_class::Labeler),
             approvers: reviewers,
-            assignee: nil,
+            assignees: nil,
             milestone: milestone
           ).and_return(dummy_creator)
         expect(dummy_creator).to receive(:create)


### PR DESCRIPTION
Gitlab API supports creating merge requests with multiple assignees for a while now.

* Pass all the assignees to merge request creator
* Bump ruby gitlab gem version