### PR TITLE
Refactor `sanitize_mentions` method

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -65,7 +65,7 @@ module Dependabot
 
               until scan.eos?
                 line = scan.scan_until(mention_regex) ||
-                        scan.scan_until(EOS_REGEX)
+                       scan.scan_until(EOS_REGEX)
                 mention = line.match(mention_regex)&.to_s
                 text_node = CommonMarker::Node.new(:text)
 
@@ -75,7 +75,7 @@ module Dependabot
                   link_node = CommonMarker::Node.new(:link)
                   text_node = CommonMarker::Node.new(:text)
                   link_node.url = "https://github.com/#{mention.tr('@', '')}"
-                  text_node.string_content = "#{mention}"
+                  text_node.string_content = mention.to_s
                   link_node.append_child(text_node)
                   nodes << link_node
                 else

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
       it "sanitizes the text" do
         expect(sanitize_links_and_mentions).
           to eq("<p>Great work <a href=\"https://github.com/greysteil\">"\
-            "@​greysteil</a>!</p>\n")
+            "@greysteil</a>!</p>\n")
       end
 
       context "that includes a dash" do
@@ -31,7 +31,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         it "sanitizes the text" do
           expect(sanitize_links_and_mentions).to eq(
             "<p>Great work <a href=\"https://github.com/greysteil-work\">"\
-            "@​greysteil-work</a>!</p>\n"
+            "@greysteil-work</a>!</p>\n"
           )
         end
       end
@@ -47,7 +47,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         it "sanitizes the text" do
           expect(sanitize_links_and_mentions).to eq(
             "<p>The team (by <a href=\"https://github.com/greysteil\">"\
-            "@​greysteil</a>) etc.</p>\n"
+            "@greysteil</a>) etc.</p>\n"
           )
         end
       end
@@ -57,7 +57,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
         it "sanitizes the text with zero width space" do
           expect(sanitize_links_and_mentions).to eq(
-            "<p>[@​hmarr]</p>\n"
+            "<p>[<a href=\"https://github.com/hmarr\">@hmarr</a>]</p>\n"
           )
         end
       end
@@ -76,7 +76,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         let(:text) { fixture("changelogs", "sentry.md") }
         it do
           is_expected.to include(
-            "<a href=\"https://github.com/halkeye\">@​halkeye</a>"
+            "<a href=\"https://github.com/halkeye\">@halkeye</a>"
           )
         end
       end
@@ -102,9 +102,9 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
           it "sanitizes the text" do
             expect(sanitize_links_and_mentions).to eq(
-              "<p><a href=\"https://github.com/greysteil\">@​greysteil</a> "\
+              "<p><a href=\"https://github.com/greysteil\">@greysteil</a> "\
               "wrote this:</p>\n<pre><code> @model ||= 123\n</code></pre>\n<p>"\
-              "Review by <a href=\"https://github.com/hmarr\">@​hmarr</a>!"\
+              "Review by <a href=\"https://github.com/hmarr\">@hmarr</a>!"\
               "</p>\n"
             )
           end
@@ -118,9 +118,9 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
           it "sanitizes the mention" do
             expect(sanitize_links_and_mentions).to eq(
               "<p><code>@command</code>\nThanks to "\
-              "<a href=\"https://github.com/feelepxyz\">@​feelepxyz</a>"\
+              "<a href=\"https://github.com/feelepxyz\">@feelepxyz</a>"\
               "<code>@other</code> <a href=\"https://github.com/escape\">"\
-              "@​escape</a></p>\n"
+              "@escape</a></p>\n"
             )
           end
         end
@@ -131,7 +131,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
           it "sanitizes the mention" do
             expect(sanitize_links_and_mentions).to eq(
               "<p><code>@command </code>\n<code> @test</code> "\
-              "<a href=\"https://github.com/feelepxyz\">@​feelepxyz</a></p>\n"
+              "<a href=\"https://github.com/feelepxyz\">@feelepxyz</a></p>\n"
             )
           end
         end
@@ -171,8 +171,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
           it "sanitizes the mention" do
             expect(sanitize_links_and_mentions).to eq(
               "<p><code>@command </code></p>\n<pre><code> @test~~~ "\
-              "[@&amp;#8203;feelepxyz](https://github.com/feelepxyz)\n</code>"\
-              "</pre>\n"
+              "@feelepxyz\n</code></pre>\n"
             )
           end
         end
@@ -182,8 +181,9 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
           it "sanitizes the mention" do
             expect(sanitize_links_and_mentions).to eq(
-              "<p><a href=\"https://github.com/command\">@​command</a> ``` "\
-              "<a href=\"https://github.com/feelepxyz\">@​feelepxyz</a></p>\n"
+              "<p><a href=\"https://github.com/command\">@command</a>@command "\
+              "``` <a href=\"https://github.com/feelepxyz\">"\
+              "@feelepxyz</a></p>\n"
             )
           end
         end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1098,10 +1098,11 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 "<blockquote>\n"\
                 "<h2>v1.6.0</h2>\n"\
                 "<p>Mad props to <a href=\"https://github.com/greysteil\">"\
-                "@​greysteil</a> and <a href=\"https://github.com/hmarr\">"\
-                "@​hmarr</a> for the @angular/scope work - see "\
-                "<a href=\"https://github.com/gocardless/business/blob/HEAD/"\
-                "CHANGELOG.md\">changelog</a>.</p>\n"\
+                "@greysteil</a> and <a href=\"https://github.com/hmarr\">"\
+                "<a href=\"https://github.com/hmarr\">@hmarr</a></a> for the "\
+                "@angular/scope work - see <a href=\"https://github.com/"\
+                "gocardless/business/blob/HEAD/CHANGELOG.md\">changelog</a>."\
+                "</p>\n"\
                 "</blockquote>\n"\
                 "</details>\n"\
                 "#{commits_details(base: 'v1.5.0', head: 'v1.6.0')}"\


### PR DESCRIPTION
Similar to https://github.com/dependabot/dependabot-core/pull/1558, we are refactoring this method to use the [commonmarker ](https://github.com/gjtorikian/commonmarker) gem.