### PR TITLE
Fix go modules package manager (was set to dep)

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -61,7 +61,7 @@ module Dependabot
           name: details["Path"],
           version: version,
           requirements: details["Indirect"] ? [] : reqs,
-          package_manager: "dep"
+          package_manager: "go_modules"
         )
       end
 

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe Dependabot::GoModules::FileParser do
 
       its(:length) { is_expected.to eq(3) }
 
+      it "sets the package manager" do
+        expect(dependencies.first.package_manager).to eq("go_modules")
+      end
+
       describe "a dependency that uses go modules" do
         subject(:dependency) do
           dependencies.find { |d| d.name == "rsc.io/quote" }

--- a/go_modules/spec/dependabot/go_modules/metadata_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/metadata_finder_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Dependabot::GoModules::MetadataFinder do
       name: dependency_name,
       version: "2.1.0",
       requirements: requirements,
-      package_manager: "dep"
+      package_manager: "go_modules"
     )
   end
   let(:requirements) do


### PR DESCRIPTION
This discrepancy caused the `SecurityAdvisory` class to fail when
comparing a `dep` version with a `go_modules` version:
https://github.com/dependabot/dependabot-core/blob/master/common/lib/dependabot/security_advisory.rb#L22

We have some code paths that fetch the version class from the dependencies
package manager and some fetch it from the [job package manager](https://github.com/dependabot/dependabot-updater/blob/master/lib/dependabot/updater.rb#L351). 