### PR TITLE
Fix Python version finder with name extras

### DIFF
--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -230,7 +230,7 @@ module Dependabot
         end
 
         def name_regex
-          parts = dependency.name.split(/[\s_.-]/).map { |n| Regexp.quote(n) }
+          parts = normalised_name.split(/[\s_.-]/).map { |n| Regexp.quote(n) }
           /#{parts.join("[\s_.-]")}/i
         end
 

--- a/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
@@ -172,6 +172,12 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
       end
     end
 
+    context "when the dependency name includes extras" do
+      let(:dependency_name) { "luigi[toml]" }
+
+      it { is_expected.to eq(Gem::Version.new("2.6.0")) }
+    end
+
     context "when the user's current version is a pre-release" do
       let(:dependency_version) { "2.6.0a1" }
       let(:dependency_requirements) do


### PR DESCRIPTION
When a dependency includes extras (dep[extra]) in the name we should
strip these out when building a valid name regex.