### PR TITLE
Support multiple poetry versions

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -3,7 +3,7 @@ pip-tools==4.3.0
 hashin==0.14.6
 pipenv==2018.11.26
 pipfile==0.0.2
-poetry==0.12.17
+poetry==1.0.0
 
 # Some dependencies will only install if Cython is present
 Cython==0.29.14


### PR DESCRIPTION
Install poetry 0.12.17 for pre-1.0.0 lock files.
In the case that a poetry.lock file is discovered with a
metadata.hashes entry, we should use poetry 0.12.17 to update
the lockfile in order to preserve version compatibility. Otherwise
assume that the user wants to use the latest poetry version (1.0.0
at this time).

This attempts to tackle #1571. There are a few issues with this PR, but this is to get the discussion started. I'd like to add tests to confirm it works as expected, however I'm not a ruby/rspec expert so I'd need some help. I think that most of the tests in `python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb` could be executed both under 0.12.7 and 1.0.0, which would require creating a separate set of fixtures for each version.

One thing I'd like to discuss is where the downgrading logic should go. In my tests, it seems it will do the downgrade when it checks the first package. I think however that it would make sense to execute the downgrade before that, however I'm unsure where that place is. I put the code there simply because it was the path where the crash was occurring and all the information necessary was there. There's also a bit of code about installing a version of python that may not have been installed yet and installing the requirements (poetry amongst them), so I thought it was not too bad.