### PR TITLE
Go Modules: Stop trying to update indirect deps

### DIFF
--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -11,6 +11,13 @@ module Dependabot
   module GoModules
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       def latest_resolvable_version
+        # We don't yet support updating indirect dependencies for go_modules
+        #
+        # To update indirect dependencies we'll need to promote the indirect
+        # dependency to the go.mod file forcing the resolver to pick this
+        # version (possibly as # indirect)
+        return dependency.version unless dependency.top_level?
+
         @latest_resolvable_version ||=
           version_class.new(find_latest_resolvable_version.gsub(/^v/, ""))
       end

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -97,13 +97,9 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
       expect(latest_resolvable_version).to_not eq("1.2.0-pre2")
     end
 
-    context "for libraries" do
+    context "doesn't update indirect dependencies (not supported)" do
       let(:requirements) { [] }
-
-      it "updates the version" do
-        expect(latest_resolvable_version).
-          to eq(Dependabot::GoModules::Version.new("1.1.0"))
-      end
+      it { is_expected.to eq(dependency.version) }
     end
 
     it "updates v2+ modules"
@@ -132,6 +128,5 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
     end
 
     it "doesn't update Git SHAs not on master to newer commits to master"
-    # TODO: sub-dependencies?
   end
 end


### PR DESCRIPTION
We don't yet support updating indirect dependencies for Go Modules.

Currently we attempt to update the indirect dependency but raise in the
file updater because no files where changed.

To update indirect dependencies we'll need to promote the indirect
dependency to the go.mod file forcing the resolver to pick this version.