### PR TITLE
Support attributes in maven properties.

### DIFF
--- a/maven/lib/dependabot/maven/file_updater/property_value_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater/property_value_updater.rb
@@ -24,12 +24,22 @@ module Dependabot
           filename = declaration_details.fetch(:file)
 
           pom_to_update = dependency_files.find { |f| f.name == filename }
-          updated_content = pom_to_update.content.sub(
-            %r{<#{Regexp.quote(node.name)}>
-               \s*#{Regexp.quote(node.content)}\s*
-               </#{Regexp.quote(node.name)}>}xm,
-            "<#{node.name}>#{updated_value}</#{node.name}>"
-          )
+          property_re = %r{<#{Regexp.quote(node.name)}>
+            \s*#{Regexp.quote(node.content)}\s*
+            </#{Regexp.quote(node.name)}>}xm
+          property_text = node.to_s
+          if pom_to_update.content =~ property_re
+            updated_content = pom_to_update.content.sub(
+              property_re,
+              "<#{node.name}>#{updated_value}</#{node.name}>"
+            )
+          elsif pom_to_update.content.include? property_text
+            node.content = updated_value
+            updated_content = pom_to_update.content.sub(
+              property_text,
+              node.to_s
+            )
+          end
 
           updated_pomfiles = dependency_files.dup
           updated_pomfiles[updated_pomfiles.index(pom_to_update)] =

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -421,6 +421,48 @@ RSpec.describe Dependabot::Maven::FileUpdater do
             to include(%(<project xmlns="http://maven.apache.org/POM/4.0.0"\n))
         end
 
+        context "with an attribute" do
+          let(:pom_body) do
+            fixture("poms", "property_pom_single_attribute.xml")
+          end
+          let(:dependencies) do
+            [
+              Dependabot::Dependency.new(
+                name: "org.springframework:spring-beans",
+                version: "5.0.0.RELEASE",
+                requirements: [{
+                  file: "pom.xml",
+                  requirement: "5.0.0.RELEASE",
+                  groups: [],
+                  source: nil,
+                  metadata: {
+                    property_name: "springframework.version",
+                    packaging_type: "jar"
+                  }
+                }],
+                previous_requirements: [{
+                  file: "pom.xml",
+                  requirement: "4.3.12.RELEASE.1",
+                  groups: [],
+                  source: nil,
+                  metadata: {
+                    property_name: "springframework.version",
+                    packaging_type: "jar"
+                  }
+                }],
+                package_manager: "maven"
+              )
+            ]
+          end
+
+          it "updates the version in the POM" do
+            expect(updated_pom_file.content).
+              to include("<springframework.version attribute=\"value\">5.0.0.")
+            expect(updated_pom_file.content).
+              to include("<version>${springframework.version}</version>")
+          end
+        end
+
         context "with a suffix" do
           let(:pom_body) do
             fixture("poms", "property_pom_single_suffix.xml")

--- a/maven/spec/fixtures/poms/property_pom_single_attribute.xml
+++ b/maven/spec/fixtures/poms/property_pom_single_attribute.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.dependabot</groupId>
+  <artifactId>basic-pom</artifactId>
+  <version>0.0.1-RELEASE</version>
+  <name>Dependabot Basic POM</name>
+
+  <packaging>pom</packaging>
+
+  <properties>
+    <springframework.version attribute="value">4.3.12.RELEASE</springframework.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <version>${springframework.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.3</version>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
Because we update the properties via string substitution instead of editing the dom with nokogiri we can fail to update valid POMs that don't don't match what we expect, for example POMs where properties have attributes.

This will result in no substitution being performed, which then triggers an assertion:

```
uri@MacBook-Pro-108 ~/g/d/dependabot-core> bin/dry-run.rb maven canva/canva --dir parent
=> fetching dependency files
=> dumping fetched dependency files: ./dry-run/canva/canva/parent
=> parsing dependency files
=> updating 192 dependencies
=== com.google.googlejavaformat:google-java-format (1.5)
 => checking for updates
 => latest version from registry is 1.7
 => latest resolvable version is 1.7
 => requirements to unlock: own
 => requirements update strategy: 
 => updating com.google.googlejavaformat:google-java-format from 1.5 to 1.7
Traceback (most recent call last):
	4: from bin/dry-run.rb:401:in `<main>'
	3: from bin/dry-run.rb:401:in `each'
	2: from bin/dry-run.rb:445:in `block in <main>'
	1: from bin/dry-run.rb:395:in `generate_dependency_files_for'
/Users/uri/github/dependabot/dependabot-core/maven/lib/dependabot/maven/file_updater.rb:34:in `updated_dependency_files': No files changed! (RuntimeError)
```

This PR adds support for properties with attributes, though it still uses string substitution, so it will still fail if the properties are not formatted as expected, for example if they're broken over multiple lines. To stay backwards compatible as much as possible it will still attempt to substitute using the regular expression first, and still fall back to not performing any substitution if neither the regular expression or the node matches.