### PR TITLE
Respect HTTP scheme for git dependencies

### DIFF
--- a/common/lib/dependabot/git_metadata_fetcher.rb
+++ b/common/lib/dependabot/git_metadata_fetcher.rb
@@ -156,10 +156,7 @@ module Dependabot
       cred = credentials.select { |c| c["type"] == "git_source" }.
              find { |c| bare_uri.start_with?(c["host"]) }
 
-      scheme =
-        if uri.match?(%r{^http://}) then "http"
-        else "https"
-        end
+      scheme = scheme_for_uri(uri)
 
       if bare_uri.match?(%r{[^/]+:[^/]+@})
         # URI already has authentication details
@@ -171,6 +168,14 @@ module Dependabot
       else
         # No credentials, so just return the http(s) URI
         "#{scheme}://#{bare_uri}"
+      end
+    end
+
+    def scheme_for_uri(uri)
+      if uri.match?(%r{^http://})
+        "http"
+      else
+        "https"
       end
     end
 

--- a/common/lib/dependabot/git_metadata_fetcher.rb
+++ b/common/lib/dependabot/git_metadata_fetcher.rb
@@ -156,16 +156,21 @@ module Dependabot
       cred = credentials.select { |c| c["type"] == "git_source" }.
              find { |c| bare_uri.start_with?(c["host"]) }
 
+      scheme =
+        if uri.match?(%r{^http://}) then "http"
+        else "https"
+        end
+
       if bare_uri.match?(%r{[^/]+:[^/]+@})
         # URI already has authentication details
-        "https://#{bare_uri}"
+        "#{scheme}://#{bare_uri}"
       elsif cred&.fetch("username", nil) && cred&.fetch("password", nil)
         # URI doesn't have authentication details, but we have credentials
         auth_string = "#{cred.fetch('username')}:#{cred.fetch('password')}"
-        "https://#{auth_string}@#{bare_uri}"
+        "#{scheme}://#{auth_string}@#{bare_uri}"
       else
-        # No credentials, so just return the https URI
-        "https://#{bare_uri}"
+        # No credentials, so just return the http(s) URI
+        "#{scheme}://#{bare_uri}"
       end
     end
 

--- a/common/spec/dependabot/git_metadata_fetcher_spec.rb
+++ b/common/spec/dependabot/git_metadata_fetcher_spec.rb
@@ -151,6 +151,18 @@ RSpec.describe Dependabot::GitMetadataFetcher do
 
       its(:count) { is_expected.to eq(14) }
     end
+
+    context "with source code hosted on a non-HTTP host" do
+      let(:url) { "http://bitbucket.org/gocardless/business" }
+      let(:service_pack_url) do
+        "http://bitbucket.org/gocardless/business.git/info/refs"\
+        "?service=git-upload-pack"
+      end
+
+      let(:upload_pack_fixture) { "business" }
+
+      its(:count) { is_expected.to eq(14) }
+    end
   end
 
   describe "#ref_names" do

--- a/common/spec/dependabot/git_metadata_fetcher_spec.rb
+++ b/common/spec/dependabot/git_metadata_fetcher_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Dependabot::GitMetadataFetcher do
       its(:count) { is_expected.to eq(14) }
     end
 
-    context "with source code hosted on a non-HTTP host" do
+    context "with source code hosted on a HTTP host" do
       let(:url) { "http://bitbucket.org/gocardless/business" }
       let(:service_pack_url) do
         "http://bitbucket.org/gocardless/business.git/info/refs"\


### PR DESCRIPTION
Even in these modern ages I do have this gem in a git repository that
does not support HTTPS (yet). Currently the uri_with_auth always adds
"https://", which makes the service pack URI invalid. This change makes
sure it uses `http` if and only if the original scheme is HTTP.