### PR TITLE
[feature]Add Support for Semver Build Identifier in Maven

### DIFF
--- a/maven/lib/dependabot/maven/version.rb
+++ b/maven/lib/dependabot/maven/version.rb
@@ -28,7 +28,7 @@ module Dependabot
       VERSION_PATTERN =
         "[0-9a-zA-Z]+"\
         '(?>\.[0-9a-zA-Z]*)*'\
-        '([_-][0-9A-Za-z_-]*(\.[0-9A-Za-z_-]*)*)?'
+        '([_\-\+][0-9A-Za-z_-]*(\.[0-9A-Za-z_-]*)*)?'
       ANCHORED_VERSION_PATTERN = /\A\s*(#{VERSION_PATTERN})?\s*\z/.freeze
 
       def self.correct?(version)
@@ -132,7 +132,7 @@ module Dependabot
       end
 
       def split_into_prefixed_tokens(version)
-        ".#{version}".split(/(?=[\-\.])/)
+        ".#{version}".split(/(?=[\-\.\+])/)
       end
 
       def pad_for_comparison(prefixed_tokens, other_prefixed_tokens)

--- a/maven/spec/dependabot/maven/version_spec.rb
+++ b/maven/spec/dependabot/maven/version_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe Dependabot::Maven::Version do
       it { is_expected.to eq("1.0.0") }
     end
 
+    context "with a + separated build number" do
+      let(:version_string) { "1.0.0+100" }
+      it { is_expected.to eq("1.0.0+100") }
+    end
+
+    context "with a + separated alphanumeric build identifier" do
+      let(:version_string) { "1.0.0+build1" }
+      it { is_expected.to eq("1.0.0+build1") }
+    end
+
     context "with a dot-specified prerelease" do
       let(:version_string) { "1.0.0.pre1" }
       it { is_expected.to eq("1.0.0.pre1") }
@@ -81,7 +91,7 @@ RSpec.describe Dependabot::Maven::Version do
     context "with a post-release" do
       let(:version_string) { "1.0.0.sp7" }
       it { is_expected.to eq(false) }
-    end
+    end    
   end
 
   describe "#<=>" do

--- a/maven/spec/dependabot/maven/version_spec.rb
+++ b/maven/spec/dependabot/maven/version_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Dependabot::Maven::Version do
     context "with a post-release" do
       let(:version_string) { "1.0.0.sp7" }
       it { is_expected.to eq(false) }
-    end    
+    end
   end
 
   describe "#<=>" do


### PR DESCRIPTION
[Semver allows for build identifiers prefixed with a `+`](https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions).  Currently, dependabot does not supports this.  This PR adds support.

Example: `1.0.0+100` or `1.0.0+build1`