### PR TITLE
Cleaner branch names

### DIFF
--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -27,7 +27,11 @@ module Dependabot
               elsif dependencies.count > 1 && updating_a_dependency_set?
                 dependency_set.fetch(:group)
               else
-                dependencies.map(&:name).join("-and-").tr(":", "-").tr("@", "")
+                dependencies.
+                  map(&:name).
+                  join("-and-").
+                  tr(":[]", "-").
+                  tr("@", "")
               end
 
             dep = dependencies.first
@@ -42,6 +46,7 @@ module Dependabot
           end
 
         branch_name = File.join(prefixes, @name).
+                      gsub(/-+/, "-").
                       gsub(%r{/\.}, "/dot-").
                       gsub(%r{/\.}, "/dot-")
 

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -45,13 +45,8 @@ module Dependabot
             end
           end
 
-        branch_name = File.join(prefixes, @name).
-                      gsub(/-+/, "-").
-                      gsub(%r{/\.}, "/dot-").
-                      gsub(%r{/\.}, "/dot-")
-
         # Some users need branch names without slashes
-        branch_name.gsub("/", separator)
+        sanitize_ref(File.join(prefixes, @name).gsub("/", separator))
       end
 
       # rubocop:enable Metrics/PerceivedComplexity
@@ -118,8 +113,7 @@ module Dependabot
           gsub(">", "gt-").
           gsub("<", "lt-").
           gsub("*", "star").
-          gsub(",", "-and-").
-          sub(/\.$/, "")
+          gsub(",", "-and-")
       end
 
       def new_version(dependency)
@@ -173,6 +167,23 @@ module Dependabot
 
       def requirements_changed?(dependency)
         (dependency.requirements - dependency.previous_requirements).any?
+      end
+
+      def sanitize_ref(ref)
+        # This isn't a complete implementation of git's ref validation, but it
+        # covers most cases that crop up. Its list of allowed charactersr is a
+        # bit stricter than git's, but that's for cosmetic reasons.
+        ref.
+          # Remove forbidden characters (those not already replaced elsewhere)
+          gsub(%r{[^A-Za-z0-9/\-_.(){}]}, "").
+          # Slashes can't be followed by periods
+          gsub(%r{/\.}, "/dot-").
+          # Two or more sequential periods are forbidden
+          gsub(/\.+/, ".").
+          # Two or more sequential slashes are forbidden
+          gsub(%r{/+}, "/").
+          # Trailing periods are forbidden
+          sub(/\.$/, "")
       end
     end
   end

--- a/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
@@ -290,6 +290,23 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
       end
     end
 
+    context "with square brackets in the name" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "werkzeug[watchdog]",
+          version: "0.16.0",
+          previous_version: "0.15.0",
+          package_manager: "pip",
+          requirements: []
+        )
+      end
+
+      it "replaces the brackets with hyphens" do
+        expect(new_branch_name).
+          to eq("dependabot/pip/werkzeug-watchdog-0.16.0")
+      end
+    end
+
     context "with a requirement only" do
       let(:previous_version) { nil }
       let(:requirements) do

--- a/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
@@ -303,7 +303,24 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
 
       it "replaces the brackets with hyphens" do
         expect(new_branch_name).
-          to eq("dependabot/pip/werkzeug-watchdog-0.16.0")
+          to eq("dependabot/pip/werkzeug-watchdog--0.16.0")
+      end
+    end
+
+    context "with an invalid control character name" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "werk\1zeug",
+          version: "0.16.0",
+          previous_version: "0.15.0",
+          package_manager: "pip",
+          requirements: []
+        )
+      end
+
+      it "strips the invalid character" do
+        expect(new_branch_name).
+          to eq("dependabot/pip/werkzeug-0.16.0")
       end
     end
 


### PR DESCRIPTION
Looks like we're trying to put `[` characters in branch names, which are being rejected. Git's ref [validation logic](https://github.com/libgit2/libgit2/blob/559751714b23f63ead726e9a773be8b07e3551ae/src/refs.c#L898-L956) is quite complex so I didn't go all the way, but this should get us closer to fully-normalising the branch names we generate.