### PR TITLE
Fix Elixir support for new mix.lock format

### DIFF
--- a/hex/README.md
+++ b/hex/README.md
@@ -16,6 +16,7 @@ Elixir support for [`dependabot-core`][core-repo].
 
 3. Run tests
    ```
+   $ export DEPENDABOT_NATIVE_HELPERS_PATH=$PWD/helpers/install-dir
    $ bundle exec rspec spec
    ```
 

--- a/hex/helpers/build
+++ b/hex/helpers/build
@@ -8,14 +8,20 @@ if [ -z "$install_dir" ]; then
   exit 1
 fi
 
+mkdir -p $install_dir
+
 mix local.hex --force
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
-cp -r \
-  "$helpers_dir/lib" \
-  "$helpers_dir/mix.exs" \
-  "$helpers_dir/mix.lock" \
-  "$install_dir"
+
+case `uname` in
+  'Darwin') CP_OPTS='-R' ;;
+  *) CP_OPTS='-r' ;;
+esac
+
+cp $CP_OPTS "$helpers_dir/lib" $install_dir
+cp $CP_OPTS "$helpers_dir/mix.exs" $install_dir
+cp $CP_OPTS "$helpers_dir/mix.lock" $install_dir
 
 cd "$install_dir"
 mix deps.get

--- a/hex/helpers/lib/parse_deps.exs
+++ b/hex/helpers/lib/parse_deps.exs
@@ -69,6 +69,9 @@ defmodule Parser do
   defp parse_lock({:git, repo_url, checksum, opts}),
     do: {nil, checksum, git_source(repo_url, opts)}
 
+  defp parse_lock({:hex, _app, version, checksum, _managers, _dependencies, _source, _outer_checksum}),
+    do: {version, checksum, nil}
+
   defp parse_lock({:hex, _app, version, checksum, _managers, _dependencies, _source}),
     do: {version, checksum, nil}
 

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -274,6 +274,13 @@ RSpec.describe Dependabot::Hex::FileParser do
       end
     end
 
+    context "with hex v0.20.2+" do
+      let(:mixfile_fixture_name) { "minor_version" }
+      let(:lockfile_fixture_name) { "hex_version_0_20_2" }
+
+      its(:length) { is_expected.to eq(2) }
+    end
+
     context "with an old elixir version" do
       let(:mixfile_fixture_name) { "old_elixir" }
       let(:lockfile_fixture_name) { "old_elixir" }

--- a/hex/spec/fixtures/lockfiles/hex_version_0_20_2
+++ b/hex/spec/fixtures/lockfiles/hex_version_0_20_2
@@ -1,0 +1,7 @@
+%{
+  "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm", "6cbe761d6a0ca5a31a0931bf4c63204bceb64538e664a8ecf784a9a6f3b875f1"},
+  "phoenix": {:hex, :phoenix, "1.2.5", "dbc45a5f8fb522aaa815b003f2d5598bc45e23102ae3e265768848ab23eafcb7", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.3 or ~> 1.2.4 or ~> 1.1.8 or ~> 1.0.5", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm", "53141e3226ccc4abbf141961699aeefb7048fb129c64825215e4ceb18c03e938"},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.1.2", "496c303bdf1b2e98a9d26e89af5bba3ab487ba3a3735f74bf1f4064d2a845a3e", [:mix], [], "hexpm", "1f13f9f0f3e769a667a6b6828d29dec37497a082d195cc52dbef401a9b69bf38"},
+  "plug": {:hex, :plug, "1.3.6", "bcdf94ac0f4bc3b804bdbdbde37ebf598bd7ed2bfa5106ed1ab5984a09b7e75f", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm", "3f2f20bddfb606afe53fa3920d562e9b5c0f6f64052f0575c7522d0e8b15817d"},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm", "519bc209e4433961284174c497c8524c001e285b79bdf80212b47a1f898084cc"},
+}


### PR DESCRIPTION
Hello,

Recently hex was updated and new mix.lock file format is not supported by Dependabot. I prepared a fix for that. It also fixes #1675 