### PR TITLE
Future proof Hex lock parsing

### DIFF
--- a/hex/helpers/lib/parse_deps.exs
+++ b/hex/helpers/lib/parse_deps.exs
@@ -69,14 +69,12 @@ defmodule Parser do
   defp parse_lock({:git, repo_url, checksum, opts}),
     do: {nil, checksum, git_source(repo_url, opts)}
 
-  defp parse_lock({:hex, _app, version, checksum, _managers, _dependencies, _source, _outer_checksum}),
-    do: {version, checksum, nil}
+  defp parse_lock(tuple) when elem(tuple, 0) == 0 do
+    destructure [:hex, _app, version, _old_checksum, _managers, _deps, _repo, checksum],
+                Tuple.to_list(tuple)
 
-  defp parse_lock({:hex, _app, version, checksum, _managers, _dependencies, _source}),
-    do: {version, checksum, nil}
-
-  defp parse_lock({:hex, _app, version, checksum, _managers, _dependencies}),
-    do: {version, checksum, nil}
+    {version, checksum, nil}
+  end
 
   defp normalise_requirement(req) do
     req

--- a/hex/helpers/lib/parse_deps.exs
+++ b/hex/helpers/lib/parse_deps.exs
@@ -69,7 +69,7 @@ defmodule Parser do
   defp parse_lock({:git, repo_url, checksum, opts}),
     do: {nil, checksum, git_source(repo_url, opts)}
 
-  defp parse_lock(tuple) when elem(tuple, 0) == 0 do
+  defp parse_lock(tuple) when elem(tuple, 0) == :hex do
     destructure [:hex, _app, version, _old_checksum, _managers, _deps, _repo, checksum],
                 Tuple.to_list(tuple)
 

--- a/hex/spec/fixtures/lockfiles/hex_version_0_20_2
+++ b/hex/spec/fixtures/lockfiles/hex_version_0_20_2
@@ -4,4 +4,5 @@
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.1.2", "496c303bdf1b2e98a9d26e89af5bba3ab487ba3a3735f74bf1f4064d2a845a3e", [:mix], [], "hexpm", "1f13f9f0f3e769a667a6b6828d29dec37497a082d195cc52dbef401a9b69bf38"},
   "plug": {:hex, :plug, "1.3.6", "bcdf94ac0f4bc3b804bdbdbde37ebf598bd7ed2bfa5106ed1ab5984a09b7e75f", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm", "3f2f20bddfb606afe53fa3920d562e9b5c0f6f64052f0575c7522d0e8b15817d"},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm", "519bc209e4433961284174c497c8524c001e285b79bdf80212b47a1f898084cc"},
+  "package": {:hex, :package, "1.2.3", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm", "519bc209e4433961284174c497c8524c001e285b79bdf80212b47a1f898084cc", "FUTUREPROOF"},
 }


### PR DESCRIPTION
Hex may add more lock entries in the future, make sure to only parse the
ones we know about now.

From https://github.com/dependabot/dependabot-core/pull/1680/files#r376408834.