### PR TITLE
Ensures codecommit client actually creates a commit before opening a PR

### DIFF
--- a/common/lib/dependabot/pull_request_creator/codecommit.rb
+++ b/common/lib/dependabot/pull_request_creator/codecommit.rb
@@ -50,6 +50,8 @@ module Dependabot
         branch = create_or_get_branch(base_commit)
         return unless branch
 
+        create_commit
+
         pull_request = codecommit_client_for_source.create_pull_request(
           pr_name,
           branch_name,


### PR DESCRIPTION
Currently, dependabot will happily open a PR against a codecommit repo that requires updates, but fails to actually include the updated file and associated commit in the PR.. this should fix that.