### PR TITLE
Fix Semver Build Identifier Support

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -323,7 +323,7 @@ def update_checker_for(dependency)
     credentials: $options[:credentials],
     requirements_update_strategy: $options[:requirements_update_strategy],
     ignored_versions: ignore_conditions_for(dependency),
-    security_advisories: security_advisories_for(dependency),
+    security_advisories: security_advisories_for(dependency)
   )
 end
 

--- a/common/spec/dependabot/clients/github_with_retries_spec.rb
+++ b/common/spec/dependabot/clients/github_with_retries_spec.rb
@@ -17,11 +17,9 @@ RSpec.describe Dependabot::Clients::GithubWithRetries do
           with(headers: { "Authorization" => "token my-token" }).
           to_return(
             { status: 502, headers: { "content-type" => "application/json" } },
-            {
-              status: 200,
-              body: fixture("github", "gemfile_content.json"),
-              headers: { "content-type" => "application/json" }
-            }
+            status: 200,
+            body: fixture("github", "gemfile_content.json"),
+            headers: { "content-type" => "application/json" }
           )
       end
 

--- a/common/spec/dependabot/clients/gitlab_with_retries_spec.rb
+++ b/common/spec/dependabot/clients/gitlab_with_retries_spec.rb
@@ -21,11 +21,9 @@ RSpec.describe Dependabot::Clients::GitlabWithRetries do
         stub_request(:get, "#{repo_url}/files/important_path.json?ref=sha").
           to_return(
             { status: 502, headers: { "content-type" => "application/json" } },
-            {
-              status: 200,
-              body: fixture("github", "gemfile_content.json"),
-              headers: { "content-type" => "application/json" }
-            }
+            status: 200,
+            body: fixture("github", "gemfile_content.json"),
+            headers: { "content-type" => "application/json" }
           )
       end
 

--- a/hex/lib/dependabot/hex/update_checker/requirements_updater.rb
+++ b/hex/lib/dependabot/hex/update_checker/requirements_updater.rb
@@ -32,7 +32,7 @@ module Dependabot
         private
 
         attr_reader :requirements, :latest_resolvable_version, :updated_source
-        # rubocop:disable PerceivedComplexity
+        # rubocop:disable Metrics/PerceivedComplexity
         def updated_mixfile_requirement(req)
           req = update_source(req)
           return req unless latest_resolvable_version && req[:requirement]
@@ -60,7 +60,7 @@ module Dependabot
           req.merge(requirement: new_requirement)
         end
 
-        # rubocop:enable PerceivedComplexity
+        # rubocop:enable Metrics/PerceivedComplexity
 
         def update_source(requirement_hash)
           # Only git sources ever need to be updated. Anything else should be

--- a/maven/lib/dependabot/maven/version.rb
+++ b/maven/lib/dependabot/maven/version.rb
@@ -14,7 +14,8 @@ module Dependabot
       NULL_VALUES = %w(0 final ga).freeze
       PREFIXED_TOKEN_HIERARCHY = {
         "." => { qualifier: 1, number: 4 },
-        "-" => { qualifier: 2, number: 3 }
+        "-" => { qualifier: 2, number: 3 },
+        "+" => { qualifier: 3, number: 2 }
       }.freeze
       NAMED_QUALIFIERS_HIERARCHY = {
         "a" => 1, "alpha"     => 1,

--- a/maven/spec/dependabot/maven/version_spec.rb
+++ b/maven/spec/dependabot/maven/version_spec.rb
@@ -157,6 +157,26 @@ RSpec.describe Dependabot::Maven::Version do
         it { is_expected.to eq(1) }
       end
 
+      describe "with a + separated alphanumeric build identifier" do
+        context "that is equal" do
+          let(:version_string) { "9.0.0+100" }
+          let(:other_version) { described_class.new("9.0.0+100") }
+          it { is_expected.to eq(0) }
+        end
+
+        context "that is greater" do
+          let(:version_string) { "9.0.0+102" }
+          let(:other_version) { described_class.new("9.0.0+101") }
+          it { is_expected.to eq(1) }
+        end
+
+        context "that is less than" do
+          let(:version_string) { "9.0.0+100" }
+          let(:other_version) { described_class.new("9.0.0+101") }
+          it { is_expected.to eq(-1) }
+        end
+      end
+
       describe "from the spec" do
         context "number padding" do
           let(:version) { described_class.new("1") }


### PR DESCRIPTION
The version comparison logic was broken in the Maven Version.rb file.  The `PREFIXED_TOKEN_HIERARCHY` did not list `+` as a valid key.  The Maven documentation site listed did not provide any guidance on how to handle `+` so I chose some sane values for `qualifier` and `number`.
I added some tests to test comparison with plus signs.  Please let me know if additional testing is needed.