### PR TITLE
Adds reverse_markdown to the codecommit client

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pandoc-ruby", "~> 2.0"
   spec.add_dependency "parseconfig", "~> 1.0"
   spec.add_dependency "parser", "~> 2.5"
+  spec.add_dependency "reverse_markdown", "~> 2.0"
   spec.add_dependency "toml-rb", ">= 1.1.2", "< 3.0"
 
   spec.add_development_dependency "byebug", "~> 11.0"

--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dependabot/shared_helpers"
+require "reverse_markdown"
 
 module Dependabot
   module Clients
@@ -184,7 +185,10 @@ module Dependabot
                               pr_description)
         cc_client.create_pull_request(
           title: pr_name,
-          description: pr_description,
+          description: ReverseMarkdown.convert(
+            pr_description,
+            github_flavored: true
+          ),
           targets: [
             repository_name: source.unscoped_repo,
             source_reference: target_branch,


### PR DESCRIPTION
Unfortunately, codecommit doesn't support html rendering in PR details, making the resulting PR detail block difficult to read. This PR ensures that codecommit dependabot PR details are provided as markdown. 

without reverse_markdown: 
<img width="1139" alt="without_reverse_markdown" src="https://user-images.githubusercontent.com/29389186/75734070-ed221280-5cc4-11ea-99c2-673cb4ae9281.png">

with reverse_markdown: 
<img width="864" alt="with_reverse_markdown" src="https://user-images.githubusercontent.com/29389186/75734075-f0b59980-5cc4-11ea-909f-cda210401683.png">
