### PR TITLE
Correctly mark requirements as not up to date

### DIFF
--- a/common/spec/dependabot/update_checkers/base_spec.rb
+++ b/common/spec/dependabot/update_checkers/base_spec.rb
@@ -162,9 +162,9 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
         [{ file: "Gemfile", requirement: "~> 1", groups: [], source: nil }]
       end
 
-      context "that already permits the latest version" do
+      context "when the requirement is out of date" do
         let(:updated_requirements) { requirements }
-        it { is_expected.to be_truthy }
+        it { is_expected.to be_falsy }
       end
 
       context "that doesn't yet permit the latest version" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -64,6 +64,29 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
   end
   let(:dependency_version) { "1.0.0" }
 
+  describe "#up_to_date?", :vcr do
+    context "with no lockfile" do
+      let(:manifest_fixture_name) { "peer_dependency_typescript.json" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "typescript",
+          version: nil,
+          requirements: [{
+            requirement: "3.7",
+            file: "package.json",
+            groups: [],
+            source: nil
+          }],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      it "returns false when there is a newer version available" do
+        expect(checker.up_to_date?).to be_falsy
+      end
+    end
+  end
+
   describe "#can_update?" do
     subject { checker.can_update?(requirements_to_unlock: :own) }
 

--- a/npm_and_yarn/spec/fixtures/package_files/peer_dependency_typescript.json
+++ b/npm_and_yarn/spec/fixtures/package_files/peer_dependency_typescript.json
@@ -1,0 +1,23 @@
+{
+    "name": "test",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/waltfy/PROTO_TEST.git"
+    },
+    "author": "",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/waltfy/PROTO_TEST/issues"
+    },
+    "homepage": "https://github.com/waltfy/PROTO_TEST#readme",
+    "dependencies": {
+	"@angular/compiler-cli": "^9.0.0",
+	"typescript": "3.7"
+    }
+}


### PR DESCRIPTION
Previously when we knew that a newer version was available in the
registry, we didn't correctly mark the dependency as out of date.

`UpdateChecker#requirements_up_to_date?` was first checking if any
dependencies were actually updated, but this check is already happening
in `#can_update_requirements?`, and this was causing us to miss cases
when a new version was _available_ but not possible to update.

Concretely this means that we show a better error when these updates
fail, previously we would mark them as no update needed and now we mark
them as no update possible.