### PR TITLE
Improve PR descriptions for non-github PR's

### DIFF
--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -897,6 +897,33 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             end
           end
         end
+
+        context "from GitLab" do
+          let(:source) do
+            Dependabot::Source.new(provider: "gitlab", repo: "gocardless/bump")
+          end
+
+          it "does not sanitize github links" do
+            expect(pr_message).not_to include(github_redirection_service)
+          end
+        end
+
+        context "from codecommit" do
+          let(:source) do
+            Dependabot::Source.new(
+              provider: "codecommit",
+              repo: "gocardless/bump"
+            )
+          end
+
+          it "does not include detail tags" do
+            expect(pr_message).not_to include("<details>")
+          end
+
+          it "does not include br tags" do
+            expect(pr_message).not_to include("<br />")
+          end
+        end
       end
 
       context "switching from a SHA-1 version to a release" do


### PR DESCRIPTION
We do not need to sanitize github links when creating PR's outside of
GitHub.

Some providers don't support HTML rendering, this change correctly
respects that.

Fixes https://github.com/dependabot/dependabot-core/pull/1715