### PR TITLE
Mount dry-run folder in docker dev shell

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -140,6 +140,7 @@ docker run --rm -ti \
   -v "$(pwd)/omnibus/dependabot-omnibus.gemspec:$CODE_DIR/omnibus/dependabot-omnibus.gemspec" \
   -v "$(pwd)/omnibus/lib:$CODE_DIR/omnibus/lib" \
   -v "$(pwd)/omnibus/spec:$CODE_DIR/omnibus/spec" \
+  -v "$(pwd)/dry-run:$CODE_DIR/dry-run" \
   "${DOCKER_OPTS[@]}" \
   --cap-add=SYS_PTRACE \
   "$IMAGE_NAME" "${CONTAINER_ARGS[@]}"


### PR DESCRIPTION
This makes it easier to run the dry-run script in docker and make
changes to the dependencies etc we're running the script against.