### PR TITLE
python: upgrade to poetry ^1.0.0

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -94,6 +94,8 @@ docker run --rm -ti \
   -v "$(pwd)/github_actions/spec:$CODE_DIR/github_actions/spec" \
   -v "$(pwd)/python/Gemfile:$CODE_DIR/python/Gemfile" \
   -v "$(pwd)/python/dependabot-python.gemspec:$CODE_DIR/python/dependabot-python.gemspec" \
+  -v "$(pwd)/python/helpers:/opt/python" \
+  -v "$(pwd)/python/helpers:/opt/python/helpers" \
   -v "$(pwd)/python/lib:$CODE_DIR/python/lib" \
   -v "$(pwd)/python/spec:$CODE_DIR/python/spec" \
   -v "$(pwd)/nuget/Gemfile:$CODE_DIR/nuget/Gemfile" \

--- a/python/helpers/lib/hasher.py
+++ b/python/helpers/lib/hasher.py
@@ -2,6 +2,7 @@ import hashin
 import json
 import pipfile
 from poetry.poetry import Poetry
+from poetry.factory import Factory
 
 def get_dependency_hash(dependency_name, dependency_version, algorithm):
     hashes = hashin.get_package_hashes(
@@ -18,6 +19,6 @@ def get_pipfile_hash(directory):
     return json.dumps({ "result": p.hash })
 
 def get_pyproject_hash(directory):
-    p = Poetry.create(directory)
+    p = Factory().create_poetry(directory)
 
     return json.dumps({ "result": p.locker._get_content_hash() })

--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -3,7 +3,7 @@ pip-tools==4.5.1
 hashin==0.14.6
 pipenv==2018.11.26
 pipfile==0.0.2
-poetry==0.12.17
+poetry==1.0.5
 
 # Some dependencies will only install if Cython is present
 Cython==0.29.15

--- a/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
         )
       end
 
-      pending "updates the lockfile successfully" do
+      it "updates the lockfile successfully" do
         updated_lockfile = updated_files.find { |f| f.name == "pyproject.lock" }
 
         lockfile_obj = TomlRB.parse(updated_lockfile.content)

--- a/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe namespace::PoetryVersionResolver do
       let(:pyproject_fixture_name) { "python_2.toml" }
       let(:lockfile_fixture_name) { "python_2.lock" }
 
-      pending "resolves version" do
+      it "resolves version" do
         is_expected.to eq(Gem::Version.new("2.18.4"))
       end
     end


### PR DESCRIPTION
Upgrades Dependabot to using Poetry v1. This is backwards compatible with existing lockfiles, while supporting the new lockfile features introduced in v1.

This is based on #1710, but also:
- upgrades `python/helpers` test fixtures
- changes tests fixed by the upgrade from `pending -> it`