### PR TITLE
Enable updates against codecommit hosted repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,14 @@ ENV RUSTUP_HOME=/opt/rust \
     PATH="${PATH}:/opt/rust/bin"
 RUN export CARGO_HOME=/opt/rust ; curl https://sh.rustup.rs -sSf | sh -s -- -y
 
+### CODECOMMIT
+
+# install the awscli and configure git to use the codecommit credential-helper
+RUN apt-get update \
+    && apt-get install -y awscli \
+    && git config --global credential.'https://git-codecommit.us-east-1.amazonaws.com'.helper '!aws codecommit credential-helper $@' \
+    && git config --global credential.'https://git-codecommit.us-east-1.amazonaws.com'.UseHttpPath true \
+
 
 ### NEW NATIVE HELPERS
 

--- a/common/lib/dependabot/git_metadata_fetcher.rb
+++ b/common/lib/dependabot/git_metadata_fetcher.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require "open3"
 require "excon"
 require "dependabot/errors"
+require "dependabot/shared_helpers"
 
 module Dependabot
   class GitMetadataFetcher
-    KNOWN_HOSTS = /github\.com|bitbucket\.org|gitlab.com/i.freeze
+    KNOWN_HOSTS = /github\.com|bitbucket\.org|amazonaws\.com|gitlab.com/i.freeze
 
     def initialize(url:, credentials:)
       @url = url
@@ -50,7 +52,13 @@ module Dependabot
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
     def fetch_upload_pack_for(uri)
-      response = fetch_raw_upload_pack_for(uri)
+      response =
+        if uri.match?(/git\-codecommit/i && /\.amazonaws\.com/i)
+          fetch_raw_codecommit_upload_pack_for(uri)
+        else
+          fetch_raw_upload_pack_for(uri)
+        end
+
       return response.body if response.status == 200
 
       unless uri.match?(KNOWN_HOSTS)
@@ -85,10 +93,43 @@ module Dependabot
     def fetch_raw_upload_pack_for(uri)
       url = service_pack_uri(uri)
       url = url.rpartition("@").tap { |a| a.first.gsub!("@", "%40") }.join
+
       Excon.get(
         url,
         idempotent: true,
         **excon_defaults
+      )
+    end
+
+    def fetch_raw_codecommit_upload_pack_for(uri)
+      status = 200
+      url = uri + ".git"
+      command = "git ls-remote #{url}"
+
+      start = Time.now
+      # the git-upload-pack service endpoint isn't exposed in codecommit so
+      # the git-upload-pack has to be queried via git directly
+      stdout, stderr, process = Open3.capture3(
+        { "PATH" => ENV["PATH"] },
+        command
+      )
+      time_taken = Time.now - start
+
+      # package the command error like a HTTP response so upstream error
+      # handling remains unchanged
+      unless process.success?
+        status = 500
+        stdout = {
+            message: stderr,
+            command: command,
+            time_taken: time_taken,
+            process_exit_value: process.to_s
+          }
+      end
+
+      OpenStruct.new(
+        body: stdout,
+        status: status
       )
     end
 

--- a/common/spec/dependabot/git_metadata_fetcher_spec.rb
+++ b/common/spec/dependabot/git_metadata_fetcher_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Dependabot::GitMetadataFetcher do
     subject(:tags) { checker.tags }
 
     before do
-      stub_request(:get, service_pack_url).
+      stub_request(:get, service_pack_uri).
         to_return(
           status: 200,
           body: fixture("git", "upload_packs", upload_pack_fixture),
@@ -34,7 +34,7 @@ RSpec.describe Dependabot::GitMetadataFetcher do
     end
 
     context "with source code hosted on GitHub" do
-      let(:service_pack_url) do
+      let(:service_pack_uri) do
         "https://github.com/gocardless/business.git/info/refs"\
         "?service=git-upload-pack"
       end
@@ -61,7 +61,7 @@ RSpec.describe Dependabot::GitMetadataFetcher do
       end
 
       context "but GitHub returns a 404" do
-        before { stub_request(:get, service_pack_url).to_return(status: 404) }
+        before { stub_request(:get, service_pack_uri).to_return(status: 404) }
 
         it "raises a helpful error" do
           expect { tags }.
@@ -70,7 +70,7 @@ RSpec.describe Dependabot::GitMetadataFetcher do
       end
 
       context "but GitHub returns a 401" do
-        before { stub_request(:get, service_pack_url).to_return(status: 401) }
+        before { stub_request(:get, service_pack_uri).to_return(status: 401) }
 
         it "raises a helpful error" do
           expect { tags }.
@@ -79,7 +79,7 @@ RSpec.describe Dependabot::GitMetadataFetcher do
       end
 
       context "but GitHub returns a 500" do
-        before { stub_request(:get, service_pack_url).to_return(status: 500) }
+        before { stub_request(:get, service_pack_uri).to_return(status: 500) }
 
         it "raises a helpful error" do
           expect { tags }.to raise_error(Octokit::InternalServerError)
@@ -142,7 +142,7 @@ RSpec.describe Dependabot::GitMetadataFetcher do
 
     context "with source code not hosted on GitHub" do
       let(:url) { "https://bitbucket.org/gocardless/business" }
-      let(:service_pack_url) do
+      let(:service_pack_uri) do
         "https://bitbucket.org/gocardless/business.git/info/refs"\
         "?service=git-upload-pack"
       end
@@ -154,7 +154,7 @@ RSpec.describe Dependabot::GitMetadataFetcher do
 
     context "with source code hosted on a HTTP host" do
       let(:url) { "http://bitbucket.org/gocardless/business" }
-      let(:service_pack_url) do
+      let(:service_pack_uri) do
         "http://bitbucket.org/gocardless/business.git/info/refs"\
         "?service=git-upload-pack"
       end
@@ -169,7 +169,7 @@ RSpec.describe Dependabot::GitMetadataFetcher do
     subject(:ref_names) { checker.ref_names }
 
     before do
-      stub_request(:get, service_pack_url).
+      stub_request(:get, service_pack_uri).
         to_return(
           status: 200,
           body: fixture("git", "upload_packs", upload_pack_fixture),
@@ -180,7 +180,7 @@ RSpec.describe Dependabot::GitMetadataFetcher do
     end
 
     context "with source code hosted on GitHub" do
-      let(:service_pack_url) do
+      let(:service_pack_uri) do
         "https://github.com/gocardless/business.git/info/refs"\
         "?service=git-upload-pack"
       end
@@ -197,7 +197,7 @@ RSpec.describe Dependabot::GitMetadataFetcher do
       end
 
       context "but GitHub returns a 404" do
-        before { stub_request(:get, service_pack_url).to_return(status: 404) }
+        before { stub_request(:get, service_pack_uri).to_return(status: 404) }
 
         it "raises a helpful error" do
           expect { ref_names }.
@@ -212,7 +212,7 @@ RSpec.describe Dependabot::GitMetadataFetcher do
     let(:ref) { "v1.0.0" }
 
     before do
-      stub_request(:get, service_pack_url).
+      stub_request(:get, service_pack_uri).
         to_return(
           status: 200,
           body: fixture("git", "upload_packs", upload_pack_fixture),
@@ -222,7 +222,7 @@ RSpec.describe Dependabot::GitMetadataFetcher do
         )
     end
 
-    let(:service_pack_url) do
+    let(:service_pack_uri) do
       "https://github.com/gocardless/business.git/info/refs"\
       "?service=git-upload-pack"
     end


### PR DESCRIPTION
Title says it all. 

Hoping this approach isn't too much of a hack.. 

I had to add `awscli` and update the `git` config of the base docker image in order to enable `git` operations against codecommit repositories. I tried to avoid this approach and query the cc api directly, but unfortunately it doesn't look like the `/info/refs?service=git-upload-pack` endpoint is exposed in a way where it is directly accessible.  Thankfully `git ls-remote <cc_repo_url>` returns the `git-upload-pack` without issue.

Obligatory I'm not a ruby dev, but I started to work on updated tests for this. Long story short, I'm struggling with mocking out the results of `Open3.capture3()`.  

It _feels_ like it should be simple[(ish)](https://stackoverflow.com/a/50152544/12031185) but given the amount of time I've wasted on it I'm thinking there's either a simpler approach to testing cc specifics here that I'm just not seeing, or what I've added needs a refactor. Any guidance on how to approach writing updated tests would be most appreciated. 