### PR TITLE
Handle unauthorized pushes to protected branches

### DIFF
--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -162,7 +162,10 @@ module Dependabot
         return nil if e.message.match?(/Reference does not exist/i)
         return nil if e.message.match?(/Reference cannot be updated/i)
 
-        raise BranchProtected if e.message.match?(/force\-push to a protected/i)
+        if e.message.match?(/force\-push to a protected/i) ||
+           e.message.match?(/not authorized to push/i)
+          raise BranchProtected
+        end
 
         raise
       end

--- a/common/spec/dependabot/pull_request_updater/github_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/github_spec.rb
@@ -501,5 +501,23 @@ RSpec.describe Dependabot::PullRequestUpdater::Github do
           to raise_error(Dependabot::PullRequestUpdater::BranchProtected)
       end
     end
+
+    context "when unauthorized to push to a protected branch" do
+      before do
+        stub_request(
+          :patch,
+          "#{watched_repo_url}/git/refs/heads/#{branch_name}"
+        ).to_return(
+          status: 422,
+          body: fixture("github", "unauthorized_push_protected_branch.json"),
+          headers: json_header
+        )
+      end
+
+      it "raises a helpful error" do
+        expect { updater.update }.
+          to raise_error(Dependabot::PullRequestUpdater::BranchProtected)
+      end
+    end
   end
 end

--- a/common/spec/fixtures/github/unauthorized_push_protected_branch.json
+++ b/common/spec/fixtures/github/unauthorized_push_protected_branch.json
@@ -1,0 +1,4 @@
+{
+  "message": "You're not authorized to push to this branch. Visit https://help.github.com/articles/about-protected-branches/ for more information.",
+  "documentation_url": "https://help.github.com/articles/about-protected-branches"
+}


### PR DESCRIPTION

When you restrict who can push to protected branches a different error
message is returned compared to pushing to a branch that only disables
force-pushes.