### PR TITLE
Nuget: Handle version requirements with prefix

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/requirements_updater.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/requirements_updater.rb
@@ -12,8 +12,6 @@ module Dependabot
   module Nuget
     class UpdateChecker
       class RequirementsUpdater
-        VERSION_REGEX = /[0-9a-zA-Z]+(?:\.[a-zA-Z0-9\-]+)*/.freeze
-
         def initialize(requirements:, latest_version:, source_details:)
           @requirements = requirements
           @source_details = source_details
@@ -36,9 +34,13 @@ module Dependabot
               if req.fetch(:requirement).include?("*")
                 update_wildcard_requirement(req.fetch(:requirement))
               else
-                # Since range requirements are excluded by the line above we
-                # can just do a `gsub` on anything that looks like a version
-                req[:requirement].gsub(VERSION_REGEX, latest_version.to_s)
+                # Since range requirements are excluded by the line above we can
+                # replace anything that looks like a version with the new
+                # version
+                req[:requirement].sub(
+                  /#{Nuget::Version::VERSION_PATTERN}/,
+                  latest_version.to_s
+                )
               end
 
             next req if new_req == req.fetch(:requirement)

--- a/nuget/spec/dependabot/nuget/update_checker/requirements_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/requirements_updater_spec.rb
@@ -63,6 +63,16 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RequirementsUpdater do
         its([:requirement]) { is_expected.to eq("[23.6-jre]") }
       end
 
+      context "and a suffixed requirement was previously specified" do
+        let(:latest_version) do
+          version_class.new("3.0.0-beta4.20210.2+38fe3493")
+        end
+        let(:csproj_req_string) { "3.0.0-beta4.20207.4+07df2f07" }
+        its([:requirement]) do
+          is_expected.to eq("3.0.0-beta4.20210.2+38fe3493")
+        end
+      end
+
       context "and a wildcard requirement was previously specified" do
         let(:csproj_req_string) { "22.*" }
         its([:requirement]) { is_expected.to eq("23.*") }


### PR DESCRIPTION
Changed `gsub` to `sub`. I don't think it makes sense to `gsub` as there
shouldn't be multiple of the same version in the requirement.

Fixes https://github.com/dependabot/feedback/issues/906