### PR TITLE
Add notices about slow response times to README and Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+<!-- Please search existing issues to avoid creating duplicates. -->
+
 <!-- The Dependabot team is currently at reduced capacity, because of this our
 response times on issues will be slower than we'd like. -->
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+<!-- The Dependabot team is currently at reduced capacity, because of this our
+response times on issues will be slower than we'd like. -->
+
+**Describe the bug**
+A clear and concise description of what the bug may be.
+
+**Package ecosystem**: <!-- bundler, docker, npm.. etc -->
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**PR, Issue or logs**
+If applicable, add links to public PR's or Issues that Dependabot opened, and/or
+paste in any related logs.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Report a bug in Dependabot to help us fix it
 title: ''
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: "\U0001F41B Bug report"
 about: Report a bug in Dependabot to help us fix it
 title: ''
 labels: bug

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -12,14 +12,16 @@ assignees: ''
 <!-- The Dependabot team is currently at reduced capacity, because of this our
 response times on issues will be slower than we'd like. -->
 
-**Describe the bug**
-A clear and concise description of what the bug may be.
+<!-- The more information you can provide, the easier it will be to reproduce the issue and find a fix -->
 
-**Package ecosystem**: <!-- bundler, docker, npm.. etc -->
-
-**Expected behavior**
-A clear and concise description of what you expected to happen.
-
-**PR, Issue or logs**
-If applicable, add links to public PR's or Issues that Dependabot opened, and/or
-paste in any related logs.
+**Package manage/ecosystem**
+<!-- ruby:bundler, javascript, docker.. etc -->
+**Manifest contents prior to update**
+<!-- If applicable, link to package.json, Gemfile.. etc -->
+**Updated dependency**
+<!-- If applicable, the dependency name and to and from versions -->
+**What you expected to see, versus what you actually saw**
+<!-- A clear and concise description of what you expected to happen -->
+**Images of the diff or a link to the PR, issue or logs**
+<!-- If applicable, add links to public PR's or Issues that Dependabot opened, and/or
+paste in any related logs -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest features or enhancements
+about: Suggest an idea for Dependabot
 title: ''
 labels: enhancements
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+<!-- Please search existing issues to avoid creating duplicates. -->
+
 <!-- The Dependabot team is currently at reduced capacity, because of this our
 response times on issues will be slower than we'd like. -->
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: "\U0001F680 Feature request"
 about: Suggest an idea for Dependabot
 title: ''
 labels: enhancements

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -12,6 +12,4 @@ assignees: ''
 <!-- The Dependabot team is currently at reduced capacity, because of this our
 response times on issues will be slower than we'd like. -->
 
-**Describe the feature**
-A clear and concise description of the feature you would like Dependabot to
-support.
+<!-- Describe the feature you'd like. -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest features or enhancements
+title: ''
+labels: enhancements
+assignees: ''
+
+---
+
+<!-- The Dependabot team is currently at reduced capacity, because of this our
+response times on issues will be slower than we'd like. -->
+
+**Describe the feature**
+A clear and concise description of the feature you would like Dependabot to
+support.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ If you want to host your own automated dependency update bot then this repo
 should give you the tools you need. A reference implementation is available
 [here][dependabot-script].
 
+## Issue / contribution response times
+
+Currently the Dependabot team is at reduced capacity, because of this our
+response times on issues and contributions will be slower than we'd like.
+
 ## What's in this repo?
 
 Dependabot Core is a collection of packages for automating dependency updating


### PR DESCRIPTION
Unfortunately we're not able to respond as quickly to feedback as we'd
like, let's inform users of this.