### PR TITLE
[Python] Add parsing of environment markers

### DIFF
--- a/python/lib/dependabot/python/requirement_parser.rb
+++ b/python/lib/dependabot/python/requirement_parser.rb
@@ -13,11 +13,25 @@ module Dependabot
       HASH = /--hash=(?<algorithm>.*?):(?<hash>.*?)(?=\s|$)/.freeze
       REQUIREMENTS = /#{REQUIREMENT}(\s*,\s*\\?\s*#{REQUIREMENT})*/.freeze
       HASHES = /#{HASH}(\s*\\?\s*#{HASH})*/.freeze
+      MARKER_OP = /\s*(#{COMPARISON}|(\s*in)|(\s*not\s*in))/.freeze
+      PYTHON_STR_C =
+        %r{[a-zA-Z0-9\s\(\)\.\{\}\-_\*#:;/\?\[\]!~`@\$%\^&=\+\|<>]}.freeze
+      PYTHON_STR = /('(#{PYTHON_STR_C}|")*'|"(#{PYTHON_STR_C}|')*")/.freeze
+      ENV_VAR =
+        /python_version|python_full_version|os_name|sys_platform|
+         platform_release|platform_system|platform_version|platform_machine|
+         platform_python_implementation|implementation_name|
+         implementation_version/.freeze
+      MARKER_VAR = /\s*(#{ENV_VAR}|#{PYTHON_STR})/.freeze
+      MARKER_EXPR_ONE = /#{MARKER_VAR}#{MARKER_OP}#{MARKER_VAR}/.freeze
+      MARKER_EXPR =
+        /(#{MARKER_EXPR_ONE}|\(\s*|\s*\)|\s+and\s+|\s+or\s+)+/.freeze
 
       INSTALL_REQ_WITH_REQUIREMENT =
         /\s*\\?\s*(?<name>#{NAME})
           \s*\\?\s*(\[\s*(?<extras>#{EXTRA}(\s*,\s*#{EXTRA})*)\s*\])?
           \s*\\?\s*\(?(?<requirements>#{REQUIREMENTS})\)?
+          \s*\\?\s*(;\s*(?<markers>#{MARKER_EXPR}))?
           \s*\\?\s*(?<hashes>#{HASHES})?
           \s*#*\s*(?<comment>.+)?
         /x.freeze
@@ -25,6 +39,7 @@ module Dependabot
       INSTALL_REQ_WITHOUT_REQUIREMENT =
         /^\s*\\?\s*(?<name>#{NAME})
           \s*\\?\s*(\[\s*(?<extras>#{EXTRA}(\s*,\s*#{EXTRA})*)\s*\])?
+          \s*\\?\s*(;\s*(?<markers>#{MARKER_EXPR}))?
           \s*\\?\s*(?<hashes>#{HASHES})?
           \s*#*\s*(?<comment>.+)?$
         /x.freeze
@@ -33,6 +48,7 @@ module Dependabot
         /^\s*\\?\s*(?<name>#{NAME})
           \s*\\?\s*(\[\s*(?<extras>#{EXTRA}(\s*,\s*#{EXTRA})*)\s*\])?
           \s*\\?\s*\(?(?<requirements>#{REQUIREMENTS})?\)?
+          \s*\\?\s*(;\s*(?<markers>#{MARKER_EXPR}))?
           \s*\\?\s*(?<hashes>#{HASHES})?
           \s*(\#+\s*(?<comment>.*))?$
         /x.freeze

--- a/python/spec/dependabot/python/file_updater/requirement_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/requirement_file_updater_spec.rb
@@ -201,6 +201,20 @@ RSpec.describe Dependabot::Python::FileUpdater::RequirementFileUpdater do
           end
         end
 
+        context "with markers and linebreaks" do
+          let(:requirements_fixture_name) { "markers_and_hashes_multiline.txt" }
+
+          its(:content) do
+            is_expected.to eq(
+              "pytest==3.3.1 ; python_version=='2.7' \\\n"\
+              "    --hash=sha256:ae4a2d0bae1098bbe938ecd6c20a526d5d47a94dc4"\
+              "2ad7331c9ad06d0efe4962 \\\n"\
+              "    --hash=sha256:cf8436dc59d8695346fcd3ab296de46425ecab00d6"\
+              "4096cebe79fb51ecb2eb93\n"
+            )
+          end
+        end
+
         context "with a single hash" do
           let(:requirements_fixture_name) { "hashes_single.txt" }
           let(:dependency) do

--- a/python/spec/fixtures/requirements/markers_and_hashes_multiline.txt
+++ b/python/spec/fixtures/requirements/markers_and_hashes_multiline.txt
@@ -1,0 +1,3 @@
+pytest==3.2.3 ; python_version=='2.7' \
+    --hash=sha256:81a25f36a97da3313e1125fce9e7bbbba565bc7fec3c5beb14c262ddab238ac1 \
+    --hash=sha256:27fa6617efc2869d3e969a3e75ec060375bfb28831ade8b5cdd68da3a741dc3c


### PR DESCRIPTION
Hashes are ignored when environment markers are present because the regex used for parsing doesn't take into account environment markers.
Adding them to the regex allow proper parsing of hashes when environment markers are present.
RegExp inspired from https://www.python.org/dev/peps/pep-0508

Fix #1587 