### PR TITLE
Sanitize Dir.chdir calls in gemspecs

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/gemspec_sanitizer.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/gemspec_sanitizer.rb
@@ -159,7 +159,15 @@ module Dependabot
             return false unless node.children.first&.type == :lvar
             return false unless node.children[1] == :files=
 
-            node.children[2]&.type == :send
+            node_dynamically_lists_files?(node.children[2])
+          end
+
+          def node_dynamically_lists_files?(node)
+            return false unless node.is_a?(Parser::AST::Node)
+
+            return true if node.type == :send
+
+            node.type == :block && node.children.first&.type == :send
           end
 
           def node_assigns_require_paths?(node)

--- a/bundler/spec/dependabot/bundler/file_updater/gemspec_sanitizer_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/gemspec_sanitizer_spec.rb
@@ -241,6 +241,13 @@ RSpec.describe Dependabot::Bundler::FileUpdater::GemspecSanitizer do
         it { is_expected.to eq("Spec.new { |s| s.files = [] }") }
       end
 
+      context "with an assignment to a method call with a block (Dir.chdir)" do
+        let(:content) do
+          'Spec.new { |s| s.files = Dir.chdir("path") { `ls`.split("\n") } }'
+        end
+        it { is_expected.to eq("Spec.new { |s| s.files = [] }") }
+      end
+
       context "with an assignment to Dir[..]" do
         let(:content) { fixture("ruby", "gemspecs", "example") }
         it { is_expected.to include("spec.files        = []") }


### PR DESCRIPTION
Gems generated by `bundle gem` dynamically generate their `spec.files` by shelling out to `git ls-files`, inside a `Dir.chdir` block ([see here](
https://github.com/rubygems/rubygems/blob/9cfc95d9d9eeede71884a25ade8851b7ab722011/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt#L25-L27)).

Dependabot was unable to update our dependencies because of this call.

```
There was an error while loading `our-private-project.gemspec`: No such file or directory @ dir_chdir
```

Currently, gemspec sanitization replaces dynamic `files` assignment with an empty array by searching for an AST node that looks like this:

```
s(:send,
  s(:lvar, :spec), :files=,
  s(:send, ...))
```

However, because `Dir.chdir` receives a [literal block](https://github.com/whitequark/parser/blob/68c21e247fde370fae7640fdc3bb6323b03fa8b7/doc/AST_FORMAT.md#passing-a-literal-block), the offending AST node looks like this instead:

```
s(:send,
  s(:lvar, :spec), :files=,
  s(:block,
    s(:send, ...),
    ...))
```

This PR adds a check to sanitize these types of dynamic `files` assignments as well.