### PR TITLE
#1231: Create .npmrc file in the current working directory

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -365,7 +365,9 @@ module Dependabot
         def write_temporary_dependency_files(lockfile_name,
                                              update_package_json: true)
           write_lockfiles(lockfile_name)
-          File.write(".npmrc", npmrc_content)
+
+          dir = Pathname.new(lockfile_name).dirname
+          File.write(File.join(dir, ".npmrc"), npmrc_content)
 
           package_files.each do |file|
             path = file.name


### PR DESCRIPTION
Many moons later, after quite some investigation and unfortunately after @keirlawson left the team, we managed to find out what the issue was and add a fix.

Basically what is/was happening is that in the absence of a `.npmrc` file (our default case in most repositories) dependabot creates a temporary one at runtime but it always creates it in the root folder of the project rather than in the working directory where the `package.json` is located and where the `npm:update` command is run which, in some cases, like in our setup, could be in subfolders.

I hope it helps.