### PR TITLE
Dependabot::AllVersionsIgnored

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker.rb
+++ b/bundler/lib/dependabot/bundler/update_checker.rb
@@ -167,6 +167,7 @@ module Dependabot
               unprepared_dependency_files: dependency_files,
               credentials: credentials,
               ignored_versions: ignored_versions,
+              raise_on_ignored: raise_on_ignored,
               replacement_git_pin: tag
             ).latest_resolvable_version_details
             true
@@ -348,6 +349,7 @@ module Dependabot
               unprepared_dependency_files: dependency_files,
               credentials: credentials,
               ignored_versions: ignored_versions,
+              raise_on_ignored: raise_on_ignored,
               remove_git_source: remove_git_source,
               unlock_requirement: unlock_requirement,
               latest_allowable_version: latest_version
@@ -369,6 +371,7 @@ module Dependabot
               dependency_files: prepared_dependency_files,
               credentials: credentials,
               ignored_versions: ignored_versions,
+              raise_on_ignored: raise_on_ignored,
               security_advisories: security_advisories
             )
           end

--- a/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
@@ -25,6 +25,7 @@ module Dependabot
 
         def initialize(dependency:, unprepared_dependency_files:,
                        credentials:, ignored_versions:,
+                       raise_on_ignored: false,
                        replacement_git_pin: nil, remove_git_source: false,
                        unlock_requirement: true,
                        latest_allowable_version: nil)
@@ -32,6 +33,7 @@ module Dependabot
           @unprepared_dependency_files = unprepared_dependency_files
           @credentials                 = credentials
           @ignored_versions            = ignored_versions
+          @raise_on_ignored            = raise_on_ignored
           @replacement_git_pin         = replacement_git_pin
           @remove_git_source           = remove_git_source
           @unlock_requirement          = unlock_requirement
@@ -270,6 +272,7 @@ module Dependabot
               dependency_files: dependency_files,
               credentials: credentials,
               ignored_versions: ignored_versions,
+              raise_on_ignored: @raise_on_ignored,
               security_advisories: []
             ).latest_version_details
         end

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       dependency: dependency,
       dependency_files: dependency_files,
       ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored,
       security_advisories: security_advisories,
       credentials: [{
         "type" => "git_source",
@@ -23,6 +24,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
   end
   let(:dependency_files) { [gemfile, lockfile] }
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
 
   let(:dependency) do
@@ -142,6 +144,21 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       context "when the user is ignoring the latest version" do
         let(:ignored_versions) { [">= 1.5.0.a, < 1.6"] }
         its([:version]) { is_expected.to eq(Gem::Version.new("1.4.0")) }
+      end
+
+      context "when the user has ignored all versions" do
+        let(:ignored_versions) { [">= 0"] }
+
+        it "returns nil" do
+          expect(subject).to be_nil
+        end
+
+        context "raise_on_ignored" do
+          let(:raise_on_ignored) { true }
+          it "raises an error" do
+            expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+          end
+        end
       end
 
       context "with a prerelease version specified" do

--- a/cargo/lib/dependabot/cargo/update_checker.rb
+++ b/cargo/lib/dependabot/cargo/update_checker.rb
@@ -109,6 +109,7 @@ module Dependabot
           dependency_files: dependency_files,
           credentials: credentials,
           ignored_versions: ignored_versions,
+          raise_on_ignored: raise_on_ignored,
           security_advisories: security_advisories
         )
       end

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -8,11 +8,13 @@ module Dependabot
     class UpdateChecker
       class LatestVersionFinder
         def initialize(dependency:, dependency_files:, credentials:,
-                       ignored_versions:, security_advisories:)
+                       ignored_versions:, raise_on_ignored: false,
+                       security_advisories:)
           @dependency          = dependency
           @dependency_files    = dependency_files
           @credentials         = credentials
           @ignored_versions    = ignored_versions
+          @raise_on_ignored    = raise_on_ignored
           @security_advisories = security_advisories
         end
 
@@ -39,8 +41,8 @@ module Dependabot
         def fetch_lowest_security_fix_version
           versions = available_versions
           versions = filter_prerelease_versions(versions)
-          versions = filter_ignored_versions(versions)
           versions = filter_vulnerable_versions(versions)
+          versions = filter_ignored_versions(versions)
           versions = filter_lower_versions(versions)
           versions.min
         end
@@ -52,8 +54,13 @@ module Dependabot
         end
 
         def filter_ignored_versions(versions_array)
-          versions_array.
-            reject { |v| ignore_reqs.any? { |r| r.satisfied_by?(v) } }
+          filtered = versions_array.
+                     reject { |v| ignore_reqs.any? { |r| r.satisfied_by?(v) } }
+          if @raise_on_ignored && filtered.empty? && versions_array.any?
+            raise Dependabot::AllVersionsIgnored
+          end
+
+          filtered
         end
 
         def filter_vulnerable_versions(versions_array)

--- a/cargo/spec/dependabot/cargo/update_checker/latest_version_finder_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/latest_version_finder_spec.rb
@@ -19,11 +19,13 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::LatestVersionFinder do
       dependency_files: dependency_files,
       credentials: credentials,
       ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored,
       security_advisories: security_advisories
     )
   end
 
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
   let(:credentials) do
     [{
@@ -148,6 +150,20 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::LatestVersionFinder do
     context "when the lowest version is being ignored" do
       let(:ignored_versions) { [">= 0.1.18, < 0.1.20"] }
       it { is_expected.to eq(Gem::Version.new("0.1.20")) }
+    end
+
+    context "when all versions are being ignored" do
+      let(:ignored_versions) { [">= 0"] }
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "raises an error" do
+          expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
     end
 
     context "when the lowest fixed version is a pre-release" do

--- a/cargo/spec/dependabot/cargo/update_checker_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker_spec.rb
@@ -22,11 +22,13 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
       dependency_files: dependency_files,
       credentials: credentials,
       ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored,
       security_advisories: security_advisories
     )
   end
 
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
   let(:credentials) do
     [{
@@ -199,6 +201,14 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
     context "when the latest version is being ignored" do
       let(:ignored_versions) { [">= 0.1.40, < 2.0"] }
       it { is_expected.to eq(Gem::Version.new("0.1.39")) }
+    end
+
+    context "when all versions are being ignored" do
+      let(:ignored_versions) { [">= 0"] }
+      let(:raise_on_ignored) { true }
+      it "raises an error" do
+        expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+      end
     end
 
     context "with a git dependency" do

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -25,7 +25,7 @@ module Dependabot
   class OutOfMemory < DependabotError; end
 
   #####################
-  # Repo leval errors #
+  # Repo level errors #
   #####################
 
   class BranchNotFound < DependabotError
@@ -191,4 +191,7 @@ module Dependabot
       super(msg)
     end
   end
+
+  # Raised by UpdateChecker if all candidate updates are ignored
+  class AllVersionsIgnored < DependabotError; end
 end

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -8,17 +8,19 @@ module Dependabot
   module UpdateCheckers
     class Base
       attr_reader :dependency, :dependency_files, :credentials,
-                  :ignored_versions, :security_advisories,
-                  :requirements_update_strategy
+                  :ignored_versions, :raise_on_ignored,
+                  :security_advisories, :requirements_update_strategy
 
       def initialize(dependency:, dependency_files:, credentials:,
-                     ignored_versions: [], security_advisories: [],
+                     ignored_versions: [], raise_on_ignored: false,
+                     security_advisories: [],
                      requirements_update_strategy: nil)
         @dependency = dependency
         @dependency_files = dependency_files
         @credentials = credentials
         @requirements_update_strategy = requirements_update_strategy
         @ignored_versions = ignored_versions
+        @raise_on_ignored = raise_on_ignored
         @security_advisories = security_advisories
       end
 

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Dependabot::GitCommitChecker do
     described_class.new(
       dependency: dependency,
       credentials: credentials,
-      ignored_versions: ignored_versions
+      ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored
     )
   end
 
@@ -22,6 +23,7 @@ RSpec.describe Dependabot::GitCommitChecker do
     )
   end
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
 
   let(:requirements) do
     [{ file: "Gemfile", requirement: ">= 0", groups: [], source: source }]
@@ -921,6 +923,20 @@ RSpec.describe Dependabot::GitCommitChecker do
         context "and an ignore condition" do
           let(:ignored_versions) { [">= 1.12.0"] }
           its([:tag]) { is_expected.to eq("v1.11.1") }
+        end
+
+        context "all versions ignored" do
+          let(:ignored_versions) { [">= 0"] }
+          it "returns nil" do
+            expect(subject).to be_nil
+          end
+
+          context "raise_on_ignored" do
+            let(:raise_on_ignored) { true }
+            it "raises an error" do
+              expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+            end
+          end
         end
 
         context "and a ref prefixed with tags/" do

--- a/composer/lib/dependabot/composer/update_checker.rb
+++ b/composer/lib/dependabot/composer/update_checker.rb
@@ -97,6 +97,7 @@ module Dependabot
           dependency_files: dependency_files,
           credentials: credentials,
           ignored_versions: ignored_versions,
+          raise_on_ignored: raise_on_ignored,
           security_advisories: security_advisories
         )
       end
@@ -166,7 +167,8 @@ module Dependabot
         @git_commit_checker ||= Dependabot::GitCommitChecker.new(
           dependency: dependency,
           credentials: credentials,
-          ignored_versions: ignored_versions
+          ignored_versions: ignored_versions,
+          raise_on_ignored: raise_on_ignored
         )
       end
     end

--- a/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
       dependency_files: files,
       credentials: credentials,
       ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored,
       security_advisories: security_advisories
     )
   end
@@ -25,6 +26,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
     )
   end
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
   let(:dependency_name) { "monolog/monolog" }
   let(:dependency_version) { "1.0.1" }
@@ -78,6 +80,20 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
     context "when the user is ignoring the latest version" do
       let(:ignored_versions) { [">= 1.22.0.a, < 1.23"] }
       it { is_expected.to eq(Gem::Version.new("1.21.0")) }
+    end
+
+    context "when the user is ignoring all versions" do
+      let(:ignored_versions) { [">= 0"] }
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "raises an error" do
+          expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
     end
 
     context "when using a pre-release" do

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
 
     context "when the user is ignoring all versions" do
       let(:ignored_versions) { [">= 0"] }
-      it "returns nil" do
-        expect(subject).to be_nil
+      it "returns latest_resolvable_version" do
+        expect(subject).to eq(Gem::Version.new("1.17.0"))
       end
 
       context "raise_on_ignored" do

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
       dependency_files: files,
       credentials: credentials,
       ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored,
       security_advisories: security_advisories
     )
   end
@@ -28,6 +29,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     )
   end
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
   let(:dependency_name) { "monolog/monolog" }
   let(:dependency_version) { "1.0.1" }
@@ -83,6 +85,20 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     context "when the user is ignoring the latest version" do
       let(:ignored_versions) { [">= 1.22.0.a, < 1.23"] }
       it { is_expected.to eq(Gem::Version.new("1.21.0")) }
+    end
+
+    context "when the user is ignoring all versions" do
+      let(:ignored_versions) { [">= 0"] }
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "raises an error" do
+          expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
     end
 
     context "when packagist returns an empty array" do

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       dependency: dependency,
       dependency_files: [],
       credentials: credentials,
-      ignored_versions: ignored_versions
+      ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored
     )
   end
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:credentials) do
     [{
       "type" => "git_source",
@@ -171,6 +173,18 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     context "when the latest version is being ignored" do
       let(:ignored_versions) { [">= 17.10"] }
       it { is_expected.to eq("17.04") }
+    end
+
+    context "when all versions are being ignored" do
+      let(:ignored_versions) { [">= 0"] }
+      it { is_expected.to eq("17.04") }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "raises an error" do
+          expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
     end
 
     context "when there are also date-like versions" do

--- a/elm/lib/dependabot/elm/update_checker.rb
+++ b/elm/lib/dependabot/elm/update_checker.rb
@@ -79,8 +79,14 @@ module Dependabot
       end
 
       def candidate_versions
-        all_versions.
-          reject { |v| ignore_reqs.any? { |r| r.satisfied_by?(v) } }
+        filtered = all_versions.
+                   reject { |v| ignore_reqs.any? { |r| r.satisfied_by?(v) } }
+
+        if @raise_on_ignored && filtered.empty? && all_versions.any?
+          raise AllVersionsIgnored
+        end
+
+        filtered
       end
 
       def all_versions

--- a/elm/spec/dependabot/elm/update_checker_spec.rb
+++ b/elm/spec/dependabot/elm/update_checker_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Dependabot::Elm::UpdateChecker do
       dependency: dependency,
       dependency_files: dependency_files,
       credentials: credentials,
-      ignored_versions: ignored_versions
+      ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored
     )
   end
   let(:dependency_files) { [elm_package] }
@@ -22,6 +23,7 @@ RSpec.describe Dependabot::Elm::UpdateChecker do
   let(:directory) { "/" }
   let(:credentials) { nil }
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
 
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -151,6 +153,20 @@ RSpec.describe Dependabot::Elm::UpdateChecker do
     context "when the latest version is being ignored" do
       let(:ignored_versions) { [">= 5.0.0"] }
       it { is_expected.to eq(Dependabot::Elm::Version.new("4.0.5")) }
+    end
+
+    context "when all versions are being ignored" do
+      let(:ignored_versions) { [">= 0"] }
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "raises an error" do
+          expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
     end
   end
 end

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -133,7 +133,8 @@ module Dependabot
         @git_commit_checker ||= Dependabot::GitCommitChecker.new(
           dependency: dependency,
           credentials: credentials,
-          ignored_versions: ignored_versions
+          ignored_versions: ignored_versions,
+          raise_on_ignored: raise_on_ignored
         )
       end
     end

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       dependency: dependency,
       dependency_files: [],
       credentials: credentials,
-      ignored_versions: ignored_versions
+      ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored
     )
   end
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:credentials) do
     [{
       "type" => "git_source",
@@ -142,6 +144,20 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       context "and the latest version is being ignored" do
         let(:ignored_versions) { [">= 1.1.0"] }
         it { is_expected.to eq("fc9ff49b90869a686df00e922af871c12215986a") }
+      end
+
+      context "and all versions are being ignored" do
+        let(:ignored_versions) { [">= 0"] }
+        it "returns nil" do
+          expect(subject).to be_nil
+        end
+
+        context "raise_on_ignored" do
+          let(:raise_on_ignored) { true }
+          it "raises an error" do
+            expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+          end
+        end
       end
     end
 

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -125,7 +125,8 @@ module Dependabot
           GitCommitChecker.new(
             dependency: dependency,
             credentials: credentials,
-            ignored_versions: ignored_versions
+            ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored,
           )
       end
     end

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -126,7 +126,7 @@ module Dependabot
             dependency: dependency,
             credentials: credentials,
             ignored_versions: ignored_versions,
-            raise_on_ignored: raise_on_ignored,
+            raise_on_ignored: raise_on_ignored
           )
       end
     end

--- a/gradle/lib/dependabot/gradle/update_checker.rb
+++ b/gradle/lib/dependabot/gradle/update_checker.rb
@@ -117,6 +117,7 @@ module Dependabot
             dependency_files: dependency_files,
             credentials: credentials,
             ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored,
             security_advisories: security_advisories
           )
       end
@@ -128,7 +129,8 @@ module Dependabot
             dependency_files: dependency_files,
             credentials: credentials,
             target_version_details: latest_version_details,
-            ignored_versions: ignored_versions
+            ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored
           )
       end
 

--- a/gradle/lib/dependabot/gradle/update_checker/multi_dependency_updater.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/multi_dependency_updater.rb
@@ -11,13 +11,15 @@ module Dependabot
         require_relative "requirements_updater"
 
         def initialize(dependency:, dependency_files:, credentials:,
-                       target_version_details:, ignored_versions:)
+                       target_version_details:, ignored_versions:,
+                       raise_on_ignored: false)
           @dependency       = dependency
           @dependency_files = dependency_files
           @credentials      = credentials
           @target_version   = target_version_details&.fetch(:version)
           @source_url       = target_version_details&.fetch(:source_url)
           @ignored_versions = ignored_versions
+          @raise_on_ignored = raise_on_ignored
         end
 
         def update_possible?
@@ -30,6 +32,7 @@ module Dependabot
                 dependency_files: dependency_files,
                 credentials: credentials,
                 ignored_versions: ignored_versions,
+                raise_on_ignored: @raise_on_ignored,
                 security_advisories: []
               ).versions.
                 map { |v| v.fetch(:version) }.

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -16,11 +16,13 @@ module Dependabot
         TYPE_SUFFICES = %w(jre android java).freeze
 
         def initialize(dependency:, dependency_files:, credentials:,
-                       ignored_versions:, security_advisories:)
+                       ignored_versions:, raise_on_ignored: false,
+                       security_advisories:)
           @dependency          = dependency
           @dependency_files    = dependency_files
           @credentials         = credentials
           @ignored_versions    = ignored_versions
+          @raise_on_ignored    = raise_on_ignored
           @security_advisories = security_advisories
           @forbidden_urls      = []
         end
@@ -42,8 +44,8 @@ module Dependabot
           possible_versions = filter_prereleases(possible_versions)
           possible_versions = filter_date_based_versions(possible_versions)
           possible_versions = filter_version_types(possible_versions)
-          possible_versions = filter_ignored_versions(possible_versions)
           possible_versions = filter_vulnerable_versions(possible_versions)
+          possible_versions = filter_ignored_versions(possible_versions)
           possible_versions = filter_lower_versions(possible_versions)
 
           possible_versions.first
@@ -92,16 +94,20 @@ module Dependabot
         end
 
         def filter_ignored_versions(possible_versions)
-          versions_array = possible_versions
+          filtered = possible_versions
 
           ignored_versions.each do |req|
             ignore_req = Gradle::Requirement.new(req.split(","))
-            versions_array =
-              versions_array.
+            filtered =
+              filtered.
               reject { |v| ignore_req.satisfied_by?(v.fetch(:version)) }
           end
 
-          versions_array
+          if @raise_on_ignored && filtered.empty? && possible_versions.any?
+            raise AllVersionsIgnored
+          end
+
+          filtered
         end
 
         def filter_vulnerable_versions(possible_versions)

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
       dependency_files: dependency_files,
       credentials: credentials,
       ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored,
       security_advisories: security_advisories
     )
   end
   let(:version_class) { Dependabot::Gradle::Version }
   let(:credentials) { [] }
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
 
   let(:dependency) do
@@ -117,6 +119,21 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
       let(:ignored_versions) { [">= 23.0, < 24"] }
       let(:dependency_version) { "17.0" }
       its([:version]) { is_expected.to eq(version_class.new("22.0")) }
+    end
+
+    context "when the user has asked to ignore all versions" do
+      let(:ignored_versions) { [">= 0"] }
+      let(:dependency_version) { "17.0" }
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "raises an error" do
+          expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
     end
 
     context "when the current version isn't normal" do

--- a/gradle/spec/dependabot/gradle/update_checker_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker_spec.rb
@@ -367,6 +367,7 @@ RSpec.describe Dependabot::Gradle::UpdateChecker do
             dependency_files: dependency_files,
             credentials: credentials,
             ignored_versions: [],
+            raise_on_ignored: false,
             target_version_details: {
               version: version_class.new("23.0"),
               source_url: "https://repo.maven.apache.org/maven2"
@@ -432,6 +433,7 @@ RSpec.describe Dependabot::Gradle::UpdateChecker do
             dependency_files: dependency_files,
             credentials: credentials,
             ignored_versions: [],
+            raise_on_ignored: false,
             target_version_details: {
               version: version_class.new("23.0"),
               source_url: "https://jcenter.bintray.com"
@@ -492,6 +494,7 @@ RSpec.describe Dependabot::Gradle::UpdateChecker do
             dependency_files: dependency_files,
             credentials: credentials,
             ignored_versions: [],
+            raise_on_ignored: false,
             target_version_details: {
               version: version_class.new("23.0"),
               source_url: "https://repo.maven.apache.org/maven2"

--- a/hex/lib/dependabot/hex/update_checker.rb
+++ b/hex/lib/dependabot/hex/update_checker.rb
@@ -219,10 +219,16 @@ module Dependabot
               map { |release| version_class.new(release["version"]) }
 
             versions.reject!(&:prerelease?) unless wants_prerelease?
-            versions.reject! do |v|
+
+            filtered = versions.reject do |v|
               ignore_reqs.any? { |r| r.satisfied_by?(v) }
             end
-            versions.max
+
+            if @raise_on_ignored && filtered.empty? && versions.any?
+              raise AllVersionsIgnored
+            end
+
+            filtered.max
           end
       end
 

--- a/hex/spec/dependabot/hex/update_checker_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
       dependency: dependency,
       dependency_files: files,
       credentials: credentials,
-      ignored_versions: ignored_versions
+      ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored
     )
   end
 
@@ -28,6 +29,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
     }]
   end
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:dependency) do
     Dependabot::Dependency.new(
       name: dependency_name,
@@ -96,6 +98,18 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
     context "when the user is ignoring the latest version" do
       let(:ignored_versions) { [">= 1.3.0.a, < 2.0"] }
       it { is_expected.to eq(Gem::Version.new("1.2.6")) }
+    end
+
+    context "when the user is ignoring all versions" do
+      let(:ignored_versions) { [">= 0, < 99"] }
+      it { is_expected.to eq(Gem::Version.new("1.3.5")) }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "raises an error" do
+          expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
     end
 
     context "when the dependency doesn't have a requirement" do

--- a/maven/lib/dependabot/maven/update_checker.rb
+++ b/maven/lib/dependabot/maven/update_checker.rb
@@ -117,6 +117,7 @@ module Dependabot
             dependency_files: dependency_files,
             credentials: credentials,
             ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored,
             security_advisories: security_advisories
           )
       end

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -14,11 +14,13 @@ module Dependabot
         TYPE_SUFFICES = %w(jre android java).freeze
 
         def initialize(dependency:, dependency_files:, credentials:,
-                       ignored_versions:, security_advisories:)
+                       ignored_versions:, security_advisories:,
+                       raise_on_ignored: false)
           @dependency          = dependency
           @dependency_files    = dependency_files
           @credentials         = credentials
           @ignored_versions    = ignored_versions
+          @raise_on_ignored    = raise_on_ignored
           @security_advisories = security_advisories
           @forbidden_urls      = []
         end
@@ -40,8 +42,8 @@ module Dependabot
           possible_versions = filter_prereleases(possible_versions)
           possible_versions = filter_date_based_versions(possible_versions)
           possible_versions = filter_version_types(possible_versions)
-          possible_versions = filter_ignored_versions(possible_versions)
           possible_versions = filter_vulnerable_versions(possible_versions)
+          possible_versions = filter_ignored_versions(possible_versions)
           possible_versions = filter_lower_versions(possible_versions)
 
           possible_versions.find { |v| released?(v.fetch(:version)) }
@@ -89,16 +91,20 @@ module Dependabot
         end
 
         def filter_ignored_versions(possible_versions)
-          versions_array = possible_versions
+          filtered = possible_versions
 
           ignored_versions.each do |req|
             ignore_req = Maven::Requirement.new(req.split(","))
-            versions_array =
-              versions_array.
+            filtered =
+              filtered.
               reject { |v| ignore_req.satisfied_by?(v.fetch(:version)) }
           end
 
-          versions_array
+          if @raise_on_ignored && filtered.empty? && possible_versions.any?
+            raise AllVersionsIgnored
+          end
+
+          filtered
         end
 
         def filter_vulnerable_versions(possible_versions)

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       dependency_files: dependency_files,
       credentials: credentials,
       ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored,
       security_advisories: security_advisories
     )
   end
   let(:version_class) { Dependabot::Maven::Version }
   let(:credentials) { [] }
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
 
   let(:dependency) do
@@ -346,6 +348,21 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       end
 
       its([:version]) { is_expected.to eq(version_class.new("21.0")) }
+    end
+
+    context "when the user has ignored all versions" do
+      let(:ignored_versions) { [">= 17.0, < 24"] }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "raises an error" do
+          expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
     end
   end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -307,7 +307,9 @@ module Dependabot
         @git_commit_checker ||=
           GitCommitChecker.new(
             dependency: dependency,
-            credentials: credentials
+            credentials: credentials,
+            ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored
           )
       end
     end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -205,6 +205,7 @@ module Dependabot
             credentials: credentials,
             dependency_files: dependency_files,
             ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored,
             security_advisories: security_advisories
           )
       end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -61,7 +61,7 @@ module Dependabot
           versions_array =
             if specified_dist_tag_requirement?
               [version_from_dist_tags].compact
-            else possible_versions(false)
+            else possible_versions(filter_ignored: false)
             end
 
           secure_versions = filter_vulnerable_versions(versions_array)
@@ -83,17 +83,17 @@ module Dependabot
           end
         end
 
-        def possible_versions_with_details(ignore = true)
+        def possible_versions_with_details(filter_ignored: true)
           versions = possible_previous_versions_with_details.
                      reject { |_, details| details["deprecated"] }
 
-          return filter_ignored_versions(versions) if ignore
+          return filter_ignored_versions(versions) if filter_ignored
 
           versions
         end
 
-        def possible_versions(ignore = true)
-          possible_versions_with_details(ignore).map(&:first)
+        def possible_versions(filter_ignored: true)
+          possible_versions_with_details(filter_ignored).map(&:first)
         end
 
         private

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -93,7 +93,8 @@ module Dependabot
         end
 
         def possible_versions(filter_ignored: true)
-          possible_versions_with_details(filter_ignored).map(&:first)
+          possible_versions_with_details(filter_ignored: filter_ignored).
+            map(&:first)
         end
 
         private

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -415,6 +415,7 @@ module Dependabot
 
         # TODO: Remove need for me
         def git_dependency?
+          # ignored_version/raise_on_ignored are irrelevant.
           GitCommitChecker.new(
             dependency: dependency,
             credentials: credentials

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -364,6 +364,7 @@ module Dependabot
         end
 
         def git_dependency?(dep)
+          # ignored_version/raise_on_ignored are irrelevant.
           GitCommitChecker.
             new(dependency: dep, credentials: credentials).
             git_dependency?

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
@@ -953,6 +953,21 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
         end
       end
     end
+
+    context "when the user has ignored all but vulnerable versions" do
+      # 1.1.0 is not ignored, but it is vulnerable
+      let(:ignored_versions) { ["> 0, < 1.1.0", "> 1.2.0, < 99"] }
+
+      it { is_expected.to be_nil }
+
+      context "with raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+
+        it "raises exception" do
+          expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
+    end
   end
 
   describe "#possible_versions" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
@@ -24,10 +24,12 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
       dependency_files: dependency_files,
       credentials: credentials,
       ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored,
       security_advisories: security_advisories
     )
   end
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
   let(:dependency_files) { [package_json] }
   let(:package_json) do
@@ -936,6 +938,20 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
           to_return(status: 200)
       end
       it { is_expected.to eq(Gem::Version.new("1.5.1")) }
+    end
+
+    context "when the user has ignored all versions" do
+      let(:ignored_versions) { [">= 0, < 99"] }
+
+      it { is_expected.to be_nil }
+
+      context "with raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+
+        it "raises exception" do
+          expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
     end
   end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -195,6 +195,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         credentials: credentials,
         dependency_files: dependency_files,
         ignored_versions: ignored_versions,
+        raise_on_ignored: false,
         security_advisories: security_advisories
       ).and_call_original
 
@@ -506,6 +507,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           credentials: credentials,
           dependency_files: dependency_files,
           ignored_versions: ignored_versions,
+          raise_on_ignored: false,
           security_advisories: security_advisories
         ).and_call_original
 

--- a/nuget/lib/dependabot/nuget/update_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker.rb
@@ -95,6 +95,7 @@ module Dependabot
             dependency_files: dependency_files,
             credentials: credentials,
             ignored_versions: ignored_versions,
+            raise_on_ignored: @raise_on_ignored,
             security_advisories: security_advisories
           )
       end
@@ -106,7 +107,8 @@ module Dependabot
             dependency_files: dependency_files,
             target_version_details: latest_version_details,
             credentials: credentials,
-            ignored_versions: ignored_versions
+            ignored_versions: ignored_versions,
+            raise_on_ignored: @raise_on_ignored
           )
       end
 

--- a/nuget/lib/dependabot/nuget/update_checker/property_updater.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/property_updater.rb
@@ -11,11 +11,13 @@ module Dependabot
         require_relative "requirements_updater"
 
         def initialize(dependency:, dependency_files:, credentials:,
-                       target_version_details:, ignored_versions:)
+                       target_version_details:, ignored_versions:,
+                       raise_on_ignored: false)
           @dependency       = dependency
           @dependency_files = dependency_files
           @credentials      = credentials
           @ignored_versions = ignored_versions
+          @raise_on_ignored = raise_on_ignored
           @target_version   = target_version_details&.fetch(:version)
           @source_details   = target_version_details&.
                               slice(:nuspec_url, :repo_url, :source_url)
@@ -31,6 +33,7 @@ module Dependabot
                 dependency_files: dependency_files,
                 credentials: credentials,
                 ignored_versions: ignored_versions,
+                raise_on_ignored: @raise_on_ignored,
                 security_advisories: []
               ).versions.map { |v| v.fetch(:version) }
 

--- a/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
       dependency_files: dependency_files,
       credentials: credentials,
       ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored,
       security_advisories: security_advisories
     )
   end
@@ -45,6 +46,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
     }]
   end
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
 
   let(:nuget_versions_url) do
@@ -102,6 +104,20 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
     context "when the user is ignoring the latest version" do
       let(:ignored_versions) { [">= 2.a, < 3.0.0"] }
       its([:version]) { is_expected.to eq(version_class.new("1.1.2")) }
+    end
+
+    context "when the user has ignored all versions" do
+      let(:ignored_versions) { ["> 0"] }
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "raises an error" do
+          expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
     end
 
     context "with a custom repo in a nuget.config file" do

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -195,6 +195,7 @@ module Dependabot
           dependency_files: dependency_files,
           credentials: credentials,
           ignored_versions: ignored_versions,
+          raise_on_ignored: @raise_on_ignored,
           security_advisories: security_advisories
         )
       end
@@ -262,6 +263,7 @@ module Dependabot
           dependency_files: dependency_files,
           credentials: credentials,
           ignored_versions: ignored_versions,
+          raise_on_ignored: @raise_on_ignored,
           security_advisories: security_advisories
         )
       end

--- a/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
@@ -9,11 +9,13 @@ module Dependabot
     class UpdateChecker
       class PipVersionResolver
         def initialize(dependency:, dependency_files:, credentials:,
-                       ignored_versions:, security_advisories:)
+                       ignored_versions:, raise_on_ignored: false,
+                       security_advisories:)
           @dependency          = dependency
           @dependency_files    = dependency_files
           @credentials         = credentials
           @ignored_versions    = ignored_versions
+          @raise_on_ignored    = raise_on_ignored
           @security_advisories = security_advisories
         end
 
@@ -42,6 +44,7 @@ module Dependabot
             dependency_files: dependency_files,
             credentials: credentials,
             ignored_versions: ignored_versions,
+            raise_on_ignored: @raise_on_ignored,
             security_advisories: security_advisories
           )
         end

--- a/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
       dependency_files: dependency_files,
       credentials: credentials,
       ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored,
       security_advisories: security_advisories
     )
   end
@@ -31,6 +32,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
     }]
   end
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
   let(:dependency_files) { [requirements_file] }
   let(:pipfile) do
@@ -582,6 +584,20 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
         fixture("pypi", "pypi_simple_response_yanked.html")
       end
       it { is_expected.to eq(Gem::Version.new("2.2.0")) }
+    end
+
+    context "when the user has ignored all versions" do
+      let(:ignored_versions) { ["> 0"] }
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "raises an error" do
+          expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
     end
 
     context "when the PyPI response includes data-requires-python entries" do

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
       dependency_files: dependency_files,
       credentials: credentials,
       ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored,
       security_advisories: security_advisories
     )
   end
@@ -32,6 +33,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
     }]
   end
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
   let(:dependency_files) { [requirements_file] }
   let(:pipfile) do
@@ -106,6 +108,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
           dependency_files: dependency_files,
           credentials: credentials,
           ignored_versions: ignored_versions,
+          raise_on_ignored: raise_on_ignored,
           security_advisories: security_advisories
         ).and_call_original
       expect(checker.latest_version).to eq(Gem::Version.new("2.6.0"))
@@ -372,6 +375,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
             dependency_files: dependency_files,
             credentials: credentials,
             ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored,
             security_advisories: security_advisories
           ).and_call_original
         expect(checker.latest_resolvable_version_with_no_unlock).

--- a/terraform/lib/dependabot/terraform/update_checker.rb
+++ b/terraform/lib/dependabot/terraform/update_checker.rb
@@ -185,6 +185,7 @@ module Dependabot
             dependency: dependency,
             credentials: credentials,
             ignored_versions: ignored_versions,
+            raise_on_ignored: raise_on_ignored,
             requirement_class: Requirement,
             version_class: Version
           )


### PR DESCRIPTION
This PR:
- Introduces a new error type to `dependabot-common`: `AllVersionsIgnored`
- Introduces a new constructor argument to `UpdateChecker`: `raise_on_ignored`
- Modifies package ecosystems to raise `AllVersionsIgnored` if `raise_on_ignored`, and the provided `ignored_versions` result in a non-empty list of candidate versions all being ignored.
   - [x] bundler
   - [x] cargo
   - [x] composer
   - [x] ~dep~ WONTFIX
   - [x] docker
   - [x] elm
   - [x] ~git_submodules~ UNUSED
   - [x] github_actions
   - [x] go_modules
   - [x] gradle
   - [x] hex
   - [x] maven
   - [x] npm_and_yarn
   - [x] nuget
   - [x] python
   - [x] terraform

The intent is to use `UpdateChecker.raise_on_ignored` to improve Dependabot's handling of security updates. If we're invoking Dependabot to resolve a security alert and resolution fails because of ignored versions, we'd like to prompt the user to reconsider ignored versions.