### PR TITLE
fix: Fix version types in gradle to allow matching postfixed version types

### DIFF
--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -263,13 +263,17 @@ module Dependabot
         def matches_dependency_version_type?(comparison_version)
           return true unless dependency.version
 
-          current_type =
-            TYPE_SUFFICES.
-            find { |t| dependency.version.split(/[.\-]/).include?(t) }
+          current_type = dependency.version.split(/[.\-]/).
+                         find do |type|
+                           TYPE_SUFFICES.
+                             find { |s| type.include?(s) }
+                         end
 
-          version_type =
-            TYPE_SUFFICES.
-            find { |t| comparison_version.to_s.split(/[.\-]/).include?(t) }
+          version_type = comparison_version.to_s.split(/[.\-]/).
+                         find do |type|
+                           TYPE_SUFFICES.
+                             find { |s| type.include?(s) }
+                         end
 
           current_type == version_type
         end

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -83,6 +83,36 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
       end
     end
 
+    context "when the user has asked for a version type and it's available" do
+      let(:dependency_name) { "com.thoughtworks.xstream:xstream" }
+      let(:dependency_version) { "1.4.11.1" }
+
+      let(:maven_central_metadata_url) do
+        "https://repo.maven.apache.org/maven2/"\
+        "com/thoughtworks/xstream/xstream/maven-metadata.xml"
+      end
+      let(:maven_central_releases) do
+        fixture("maven_central_metadata", "with_version_type_releases.xml")
+      end
+      let(:dependency_version) { "1.4.11-java7" }
+      its([:version]) { is_expected.to eq(version_class.new("1.4.12-java7")) }
+    end
+
+    context "when a version type is available that wasn't requested" do
+      let(:dependency_name) { "com.thoughtworks.xstream:xstream" }
+      let(:dependency_version) { "1.4.11.1" }
+
+      let(:maven_central_metadata_url) do
+        "https://repo.maven.apache.org/maven2/"\
+        "com/thoughtworks/xstream/xstream/maven-metadata.xml"
+      end
+      let(:maven_central_releases) do
+        fixture("maven_central_metadata", "with_version_type_releases.xml")
+      end
+      let(:dependency_version) { "1.4.11.1" }
+      its([:version]) { is_expected.to eq(version_class.new("1.4.12")) }
+    end
+
     context "when the user has asked to ignore a major version" do
       let(:ignored_versions) { [">= 23.0, < 24"] }
       let(:dependency_version) { "17.0" }

--- a/gradle/spec/fixtures/maven_central_metadata/with_version_type_releases.xml
+++ b/gradle/spec/fixtures/maven_central_metadata/with_version_type_releases.xml
@@ -1,0 +1,17 @@
+<metadata>
+  <groupId>com.thoughtworks.xstream</groupId>
+  <artifactId>xstream</artifactId>
+  <versioning>
+    <latest>1.4.12-java11</latest>
+    <release>1.4.12-java11</release>
+    <versions>
+      <version>1.4.11</version>
+      <version>1.4.11-java7</version>
+      <version>1.4.11.1</version>
+      <version>1.4.12</version>
+      <version>1.4.12-java7</version>
+      <version>1.4.12-java11</version>
+    </versions>
+    <lastUpdated>20200412215547</lastUpdated>
+  </versioning>
+</metadata>

--- a/gradle/spec/fixtures/poms/with_version_type_releases.xml
+++ b/gradle/spec/fixtures/poms/with_version_type_releases.xml
@@ -1,0 +1,17 @@
+<metadata>
+  <groupId>com.thoughtworks.xstream</groupId>
+  <artifactId>xstream</artifactId>
+  <versioning>
+    <latest>1.4.12-java11</latest>
+    <release>1.4.12-java11</release>
+    <versions>
+      <version>1.4.11</version>
+      <version>1.4.11-java7</version>
+      <version>1.4.11.1</version>
+      <version>1.4.12</version>
+      <version>1.4.12-java7</version>
+      <version>1.4.12-java11</version>
+    </versions>
+    <lastUpdated>20200412215547</lastUpdated>
+  </versioning>
+</metadata>


### PR DESCRIPTION
Fixes a bug in Gradle that would not match version types when additional context is provided.

For example: com.thoughtworks.xtream:xstream:1.4.11-java7

Now, the system will obey the version type that the user provides, maintaining the correct version types for future upgrades.
