### PR TITLE
business-1.18.0

### DIFF
--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -893,7 +893,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
             let(:requirements) do
               [{
                 file: "Gemfile",
-                requirement: "~> 1.17.0",
+                requirement: "~> 1.18.0",
                 groups: [],
                 source: {
                   type: "git",
@@ -912,7 +912,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
                 }
               }]
             end
-            its(:content) { is_expected.to include "business (~> 1.17.0)!" }
+            its(:content) { is_expected.to include "business (~> 1.18.0)!" }
           end
         end
       end

--- a/bundler/spec/fixtures/ruby/gemfiles/git_source_with_version
+++ b/bundler/spec/fixtures/ruby/gemfiles/git_source_with_version
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem "business", "~> 1.0.0", git: "https://github.com/gocardless/business"
+gem "business", "~> 1.0.0", git: "https://github.com/gocardless/business", ref: "b12c186"


### PR DESCRIPTION
https://github.com/gocardless/business/releases/tag/v1.18.0

This breaks a bundler test that expects the latest version.
This is a blind patch w/o much consideration for what the test is doing.