### PR TITLE
go modules: remove unnecessary requirements

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -2,7 +2,6 @@
 
 require "dependabot/shared_helpers"
 require "dependabot/errors"
-require "dependabot/go_modules/file_parser"
 require "dependabot/go_modules/file_updater"
 require "dependabot/go_modules/native_helpers"
 

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -25,8 +25,6 @@ module Dependabot
           /go: ([^@\s]+)(?:@[^\s]+)?: .* declares its path as: ([\S]*)/m
         ].freeze
 
-        attr_reader :dependencies, :go_mod, :go_sum, :credentials
-
         def initialize(dependencies:, go_mod:, go_sum:, credentials:)
           @dependencies = dependencies
           @go_mod = go_mod
@@ -43,6 +41,8 @@ module Dependabot
         end
 
         private
+
+        attr_reader :dependencies, :go_mod, :go_sum, :credentials
 
         def updated_files
           @updated_files ||= update_files

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -125,7 +125,8 @@ module Dependabot
           _, stderr, status = Open3.capture3(ENVIRONMENT, "go get -d")
           handle_subprocess_error(stderr) unless status.success?
 
-          { go_mod: File.read("go.mod"), go_sum: File.read("go.sum") }
+          updated_go_sum = go_sum ? File.read("go.sum") : nil
+          { go_mod: File.read("go.mod"), go_sum: updated_go_sum }
         end
 
         def parse_manifest_requirements(go_mod_content)

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -49,6 +49,7 @@ module Dependabot
           @updated_files ||= update_files
         end
 
+        # rubocop:disable Metrics/AbcSize
         def update_files
           substitutions = replace_directive_substitutions(go_mod.content)
           clean_go_mod = substitute_all(go_mod.content, substitutions)
@@ -86,6 +87,7 @@ module Dependabot
 
           { go_mod: output_go_mod, go_sum: regenerated_files[:go_sum] }
         end
+        # rubocop:enable Metrics/AbcSize
 
         def update_go_mod(go_mod_content, dependencies)
           File.write("go.mod", go_mod_content)
@@ -247,15 +249,16 @@ module Dependabot
           # This is an approximation - we're not correctly populating `source`
           # for instance, but it's only to plug the requirement into the
           # `update_go_mod` method so this mapping doesn't need to be perfect
+          dep_req = {
+            file: "go.mod",
+            requirement: req["Version"],
+            groups: [],
+            source: nil
+          }
           Dependency.new(
             name: req["Path"],
             version: req["Version"],
-            requirements: req["Indirect"] ? [] : [{
-              file: "go.mod",
-              requirement: req["Version"],
-              groups: [],
-              source: nil
-            }],
+            requirements: req["Indirect"] ? [] : [dep_req],
             package_manager: "go_modules"
           )
         end

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -2,6 +2,7 @@
 
 require "dependabot/shared_helpers"
 require "dependabot/errors"
+require "dependabot/go_modules/file_parser"
 require "dependabot/go_modules/file_updater"
 require "dependabot/go_modules/native_helpers"
 
@@ -9,6 +10,24 @@ module Dependabot
   module GoModules
     class FileUpdater
       class GoModUpdater
+        # Turn off the module proxy for now, as it's causing issues with
+        # private git dependencies
+        ENVIRONMENT = { "GOPRIVATE" => "*" }.freeze
+
+        RESOLVABILITY_ERROR_REGEXES = [
+          /go: .*: git fetch .*: exit status 128/.freeze,
+          /verifying .*: checksum mismatch/.freeze,
+          /build .*: cannot find module providing package/.freeze
+        ].freeze
+
+        MODULE_PATH_MISMATCH_REGEXES = [
+          /go: ([^@\s]+)(?:@[^\s]+)?: .* has non-.* module path "(.*)" at/,
+          /go: ([^@\s]+)(?:@[^\s]+)?: .* unexpected module path "(.*)"/,
+          /go: ([^@\s]+)(?:@[^\s]+)?: .* declares its path as: ([\S]*)/m
+        ].freeze
+
+        attr_reader :dependencies, :go_mod, :go_sum, :credentials
+
         def initialize(dependencies:, go_mod:, go_sum:, credentials:)
           @dependencies = dependencies
           @go_mod = go_mod
@@ -17,96 +36,157 @@ module Dependabot
         end
 
         def updated_go_mod_content
-          # Turn off the module proxy for now, as it's causing issues with
-          # private git dependencies
-          env = { "GOPRIVATE" => "*" }
-
-          @updated_go_mod_content ||=
-            SharedHelpers.in_a_temporary_directory do
-              SharedHelpers.with_git_configured(credentials: credentials) do
-                File.write("go.mod", go_mod.content)
-
-                deps = dependencies.map do |dep|
-                  {
-                    name: dep.name,
-                    version: "v" + dep.version.sub(/^v/i, ""),
-                    indirect: dep.requirements.empty?
-                  }
-                end
-
-                SharedHelpers.run_helper_subprocess(
-                  command: NativeHelpers.helper_path,
-                  env: env,
-                  function: "updateDependencyFile",
-                  args: { dependencies: deps }
-                )
-              end
-            end
+          updated_files[:go_mod]
         end
 
         def updated_go_sum_content
-          return nil unless go_sum
-
-          # This needs to be run separately so we don't nest subprocess calls
-          prepared_go_mod_content
-
-          @updated_go_sum_content ||=
-            SharedHelpers.in_a_temporary_directory do
-              SharedHelpers.with_git_configured(credentials: credentials) do
-                # Create a fake empty module for each local module so that
-                # `go get -d` works, even if some modules have been `replace`d
-                # with a local module that we don't have access to.
-                local_replacements.each do |_, stub_path|
-                  Dir.mkdir(stub_path) unless Dir.exist?(stub_path)
-                  FileUtils.touch(File.join(stub_path, "go.mod"))
-                end
-
-                File.write("go.mod", prepared_go_mod_content)
-                File.write("go.sum", go_sum.content)
-                File.write("main.go", dummy_main_go)
-
-                # Turn off the module proxy for now, as it's causing issues
-                # with private git dependencies
-                env = { "GOPRIVATE" => "*" }
-
-                _, stderr, status = Open3.capture3(env, "go get -d")
-                unless status.success?
-                  handle_subprocess_error(go_sum.path, stderr)
-                end
-
-                File.read("go.sum")
-              end
-            end
+          updated_files[:go_sum]
         end
 
         private
 
-        RESOLVABILITY_ERROR_REGEXES = [
-          /go: .*: git fetch .*: exit status 128/.freeze,
-          /verifying .*: checksum mismatch/.freeze,
-          /build .*: cannot find module providing package/.freeze
-        ].freeze
-        MODULE_PATH_MISMATCH_REGEXES = [
-          /go: ([^@\s]+)(?:@[^\s]+)?: .* has non-.* module path "(.*)" at/,
-          /go: ([^@\s]+)(?:@[^\s]+)?: .* unexpected module path "(.*)"/,
-          /go: ([^@\s]+)(?:@[^\s]+)?: .* declares its path as: ([\S]*)/m
-        ].freeze
+        def updated_files
+          @updated_files ||= update_files
+        end
 
-        def local_replacements
-          @local_replacements ||=
+        def update_files
+          substitutions = replace_directive_substitutions(go_mod.content)
+          clean_go_mod = substitute_all(go_mod.content, substitutions)
+
+          original_manifest_requirements = in_temp_dir(substitutions) do
+            parse_manifest_requirements(go_mod.content)
+          end
+
+          updated_go_mod = in_temp_dir(substitutions) do
+            update_go_mod(clean_go_mod, dependencies)
+          end
+
+          regenerated_files = in_temp_dir(substitutions) do
+            run_go_get(updated_go_mod, go_sum)
+          end
+
+          updated_manifest_requirements = in_temp_dir(substitutions) do
+            parse_manifest_requirements(regenerated_files[:go_mod])
+          end
+
+          original_reqs = original_manifest_requirements.map { |r| r["Path"] }
+          updated_reqs = updated_manifest_requirements.map { |r| r["Path"] }
+          reqs_to_remove = original_reqs - updated_reqs
+
+          output_go_mod = in_temp_dir(substitutions) do
+            remove_requirements(go_mod.content, reqs_to_remove)
+          end
+
+          output_go_mod = in_temp_dir(substitutions) do
+            deps = updated_manifest_requirements.map do |req|
+              requirement_to_dependency_obj(req)
+            end
+            update_go_mod(output_go_mod, deps)
+          end
+
+          { go_mod: output_go_mod, go_sum: regenerated_files[:go_sum] }
+        end
+
+        def update_go_mod(go_mod_content, dependencies)
+          File.write("go.mod", go_mod_content)
+
+          deps = dependencies.map do |dep|
+            {
+              name: dep.name,
+              version: "v" + dep.version.sub(/^v/i, ""),
+              indirect: dep.requirements.empty?
+            }
+          end
+
+          SharedHelpers.run_helper_subprocess(
+            command: NativeHelpers.helper_path,
+            env: ENVIRONMENT,
+            function: "updateDependencyFile",
+            args: { dependencies: deps }
+          )
+        end
+
+        def run_go_get(go_mod_content, go_sum)
+          File.write("go.mod", go_mod_content)
+          File.write("go.sum", go_sum.content) if go_sum
+          File.write("main.go", dummy_main_go)
+
+          _, stderr, status = Open3.capture3(ENVIRONMENT, "go get -d")
+          handle_subprocess_error(stderr) unless status.success?
+
+          { go_mod: File.read("go.mod"), go_sum: File.read("go.sum") }
+        end
+
+        def parse_manifest_requirements(go_mod_content)
+          File.write("go.mod", go_mod_content)
+
+          command = "go mod edit -json"
+          stdout, stderr, status = Open3.capture3(ENVIRONMENT, command)
+          handle_subprocess_error(stderr) unless status.success?
+
+          JSON.parse(stdout)["Require"] || []
+        end
+
+        def remove_requirements(go_mod_content, requirement_paths)
+          File.write("go.mod", go_mod_content)
+
+          requirement_paths.each do |path|
+            escaped_path = Shellwords.escape(path)
+            command = "go mod edit -droprequire #{escaped_path}"
+            _, stderr, status = Open3.capture3(ENVIRONMENT, command)
+            handle_subprocess_error(stderr) unless status.success?
+          end
+
+          File.read("go.mod")
+        end
+
+        def add_requirements(go_mod_content, requirements)
+          File.write("go.mod", go_mod_content)
+
+          requirements.each do |r|
+            escaped_req = Shellwords.escape("#{r['Path']}@#{r['Version']}")
+            command = "go mod edit -require #{escaped_req}"
+            _, stderr, status = Open3.capture3(ENVIRONMENT, command)
+            handle_subprocess_error(stderr) unless status.success?
+          end
+
+          File.read("go.mod")
+        end
+
+        def in_temp_dir(stub_paths, &block)
+          SharedHelpers.in_a_temporary_directory do
+            SharedHelpers.with_git_configured(credentials: credentials) do
+              # Create a fake empty module for each local module so that
+              # `go get -d` works, even if some modules have been `replace`d
+              # with a local module that we don't have access to.
+              stub_paths.each do |stub_path|
+                Dir.mkdir(stub_path) unless Dir.exist?(stub_path)
+                FileUtils.touch(File.join(stub_path, "go.mod"))
+              end
+
+              block.call
+            end
+          end
+        end
+
+        # Given a go.mod file, find all `replace` directives pointing to a path
+        # on the local filesystem, and return an array of pairs mapping the
+        # original path to a hash of the path.
+        #
+        # This lets us substitute all parts of the go.mod that are dependent on
+        # the layout of the filesystem with a structure we can reproduce (i.e.
+        # no paths such as ../../../foo), run the Go tooling, then reverse the
+        # process afterwards.
+        def replace_directive_substitutions(go_mod_content)
+          @replace_directive_substitutions ||=
             SharedHelpers.in_a_temporary_directory do |path|
-              File.write("go.mod", go_mod.content)
+              File.write("go.mod", go_mod_content)
 
               # Parse the go.mod to get a JSON representation of the replace
               # directives
               command = "go mod edit -json"
-
-              # Turn off the module proxy for now, as it's causing issues with
-              # private git dependencies
-              env = { "GOPRIVATE" => "*" }
-
-              stdout, stderr, status = Open3.capture3(env, command)
-              handle_parser_error(path, stderr) unless status.success?
+              stdout, stderr, status = Open3.capture3(ENVIRONMENT, command)
+              handle_subprocess_error(path, stderr) unless status.success?
 
               # Find all the local replacements, and return them with a stub
               # path we can use in their place. Using generated paths is safer
@@ -120,14 +200,15 @@ module Dependabot
             end
         end
 
-        def prepared_go_mod_content
-          content = updated_go_mod_content
-          local_replacements.reduce(content) do |body, (path, stub_path)|
-            body.sub(path, stub_path)
+        def substitute_all(file, substitutions)
+          substitutions.reduce(file) do |text, (a, b)|
+            text.sub(a, b)
           end
         end
 
-        def handle_subprocess_error(path, stderr)
+        def handle_subprocess_error(stderr)
+          stderr = stderr.gsub(Dir.getwd, "")
+
           error_regex = RESOLVABILITY_ERROR_REGEXES.find { |r| stderr =~ r }
           if error_regex
             lines = stderr.lines.drop_while { |l| error_regex !~ l }
@@ -141,7 +222,7 @@ module Dependabot
               new(go_mod.path, match[1], match[2])
           end
 
-          msg = stderr.gsub(path.to_s, "").lines.last(10).join.strip
+          msg = stderr.lines.last(10).join.strip
           raise Dependabot::DependencyFileNotParseable.new(go_mod.path, msg)
         end
 
@@ -156,13 +237,28 @@ module Dependabot
           # good to switch back to `main` so we can surface more errors.
           lines = ["package dummypkg", "import ("]
           dependencies.each do |dep|
-            lines << "_ \"#{dep.name}\""
+            lines << "_ \"#{dep.name}\"" unless dep.requirements.empty?
           end
           lines << ")"
           lines.join("\n")
         end
 
-        attr_reader :dependencies, :go_mod, :go_sum, :credentials
+        def requirement_to_dependency_obj(req)
+          # This is an approximation - we're not correctly populating `source`
+          # for instance, but it's only to plug the requirement into the
+          # `update_go_mod` method so this mapping doesn't need to be perfect
+          Dependency.new(
+            name: req["Path"],
+            version: req["Version"],
+            requirements: req["Indirect"] ? [] : [{
+              file: "go.mod",
+              requirement: req["Version"],
+              groups: [],
+              source: nil
+            }],
+            package_manager: "go_modules"
+          )
+        end
       end
     end
   end

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -62,7 +62,7 @@ module Dependabot
             update_go_mod(clean_go_mod, dependencies)
           end
 
-          # Then run `go get` to pick up other changes to the file cuased by
+          # Then run `go get` to pick up other changes to the file caused by
           # the upgrade
           regenerated_files = in_temp_dir(stub_dirs) do
             run_go_get(updated_go_mod, go_sum)

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -213,6 +213,12 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
             end
           end
         end
+
+        context "without a go.sum" do
+          it "doesn't return a go.sum" do
+            expect(updater.updated_go_sum_content).to be_nil
+          end
+        end
       end
 
       context "when it has become indirect" do

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -78,6 +78,15 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
 
         it { is_expected.to include(%(rsc.io/quote v1.5.2\n)) }
 
+        context "when a replace directive is present" do
+          let(:go_mod_body) do
+            fixture("go_mods", go_mod_fixture_name) +
+              "\nreplace github.com/fatih/Color => ../../../../../../foo"
+          end
+
+          it { is_expected.to include(%(rsc.io/quote v1.5.2\n)) }
+        end
+
         context "for a go 1.11 go.mod" do
           let(:go_mod_body) do
             fixture("go_mods", go_mod_fixture_name).sub(/go 1.12/, "")

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
       requirements: requirements,
       previous_version: dependency_previous_version,
       previous_requirements: previous_requirements,
-      package_manager: "dep"
+      package_manager: "go_modules"
     )
   end
 

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -253,5 +253,30 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
         end
       end
     end
+
+    context "for an upgraded indirect dependency" do
+      let(:go_mod_fixture_name) { "upgraded_indirect_dependency.mod" }
+      let(:dependency_name) { "github.com/gorilla/csrf" }
+      let(:dependency_version) { "v1.7.0" }
+      let(:dependency_previous_version) { "v1.6.2" }
+      let(:requirements) do
+        [{
+          file: "go.mod",
+          requirement: "v1.7.0",
+          groups: [],
+          source: {
+            type: "default",
+            source: "github.com/gorilla/csrf"
+          }
+        }]
+      end
+      let(:previous_requirements) do
+        [requirements.first.merge(requirement: "1.6.2")]
+      end
+
+      it do
+        is_expected.to_not include("github.com/pkg/errors")
+      end
+    end
   end
 end

--- a/go_modules/spec/fixtures/go_mods/upgraded_indirect_dependency.mod
+++ b/go_modules/spec/fixtures/go_mods/upgraded_indirect_dependency.mod
@@ -1,0 +1,15 @@
+module foo
+
+go 1.12
+
+// gorilla/csrf v1.6.2 depends on pkg/errors v0.8.0, but here we've upgraded 
+// it to v0.8.1
+//
+// gorilla/csrf v1.7.0 depends on pkg/errors v0.9.1, so if we upgrade it to
+// that version, we no longer need pkg/errors to appear in this file as MVS
+// will select v0.9.1 over v0.8.1
+
+require (
+	github.com/gorilla/csrf v1.6.2
+	github.com/pkg/errors v0.8.1 // indirect
+)


### PR DESCRIPTION
Fixes an issue in our Go modules support where we'd fail to remove lines from the go.mod that because unnecessary due to a Dependabot version update.

Reviewer notes:
- To understand the problem this solves, it may be beneficial to start with the first commit, which adds a failing test.
- Reorganizes a bit of code (class constants, attr_reader), which creates some visual noise in the diff. Sorry about that.

Previously, we'd:
1. Add the new dependency versions to the go.mod
2. If a go.sum was present, run `go get` to update the go.sum

Sometimes the new dependency requirement should change other entries in the go.mod. For instance, say we use dependency x@v1, which depends on y@v1. We upgrade y to v2 manually in the go.mod, which promotes y@v2 to the go.mod. Dependabot kicks in and then updates x to v2, which includes a dependency on y@v2, meaning the go.mod entry for y@v2 is no longer necessary (according to MVS).

With the previous algorithm, we wouldn't update the go.mod correspondingly.

Now, we:
1. Add the new dependency versions to the go.mod
2. Run `go get` to produce a regenerated go.sum and go.mod
3. Figure out all the differences in `require`s between the new go.mod and the input go.mod
4. Update the original go.mod to reflect all these changes

This change also introduces an imperative `update_files` method, which walks through this process, and hopefully is easier to follow than the prior implementation.