### PR TITLE
Composer: Do not include #sha if the source.reference is unkown

### DIFF
--- a/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
@@ -307,7 +307,11 @@ module Dependabot
                            find { |d| d["name"] == name }&.
                            dig("source", "reference")
               updated_req_parts = req.split(" ")
-              updated_req_parts[0] = updated_req_parts[0] + "##{commit_sha}"
+
+              unless commit_sha.to_s.empty?
+                updated_req_parts[0] = updated_req_parts[0] + "##{commit_sha}"
+              end
+
               json[keys[:manifest]][name] = updated_req_parts.join(" ")
             end
           end

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -8,6 +8,8 @@ require "dependabot/composer/version"
 require "dependabot/composer/requirement"
 require "dependabot/composer/native_helpers"
 require "dependabot/composer/file_parser"
+
+# rubocop:disable Metrics/ClassLength
 module Dependabot
   module Composer
     class UpdateChecker
@@ -483,3 +485,4 @@ module Dependabot
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -156,7 +156,11 @@ module Dependabot
                            find { |d| d["name"] == name }&.
                            dig("source", "reference")
               updated_req_parts = req.split(" ")
-              updated_req_parts[0] = updated_req_parts[0] + "##{commit_sha}"
+
+              unless commit_sha.to_s.empty?
+                updated_req_parts[0] = updated_req_parts[0] + "##{commit_sha}"
+              end
+
               json[keys[:manifest]][name] = updated_req_parts.join(" ")
             end
           end


### PR DESCRIPTION
When a package is installed that does not provide any files, the composer.lock file does not include the source.reference attribute. For example, the Roave/SecurityAdvisories package is a depency-blocker that only provides meta-data.

However, the composer.lock that is generated still append the hash as a seperator plus an empty commit-sha. This results in an incorrect packagename. The version-check then fails, but this failure is not picked up and thus it seems everything is up-to-date.

By checking the commit-sha before appending the hash, the generated composer.lock is no longer invalid and solves this problem.