### PR TITLE
Gradle: Add support for properties set as defaults

### DIFF
--- a/gradle/lib/dependabot/gradle/file_parser/property_value_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/property_value_finder.rb
@@ -6,16 +6,19 @@ module Dependabot
   module Gradle
     class FileParser
       class PropertyValueFinder
+        # rubocop:disable Layout/LineLength
+        PROPERTY_DECLARATION_AS_DEFAULTS_REGEX =
+          /(?:\s*(?:project\.findProperty\(\s*['"][^\s]+['"]\s*\)\s*\?|project\.hasProperty\(\s*['"][^\s]+['"]\s*\)\s*\?\s*project\.getProperty\(\s*['"][^\s]+['"]\s*\)\s*):)?/.freeze
+
         SINGLE_PROPERTY_DECLARATION_REGEX =
-          /(?:^|\s+|ext.)(?<name>[^\s=]+)\s*=\s*['"](?<value>[^\s]+)['"]/.
-          freeze
+          /(?:^|\s+|ext.)(?<name>[^\s=]+)\s*=#{PROPERTY_DECLARATION_AS_DEFAULTS_REGEX}\s*['"](?<value>[^\s]+)['"]/.freeze
 
         MULTI_PROPERTY_DECLARATION_REGEX =
-          /(?:^|\s+|ext.)(?<namespace>[^\s=]+)\s*=\s*\[(?<values>[^\]]+)\]/m.
-          freeze
+          /(?:^|\s+|ext.)(?<namespace>[^\s=]+)\s*=\s*\[(?<values>[^\]]+)\]/m.freeze
 
         NAMESPACED_DECLARATION_REGEX =
-          /(?:^|\s+)(?<name>[^\s:]+)\s*:\s*['"](?<value>[^\s]+)['"]\s*/.freeze
+          /(?:^|\s+)(?<name>[^\s:]+)\s*:#{PROPERTY_DECLARATION_AS_DEFAULTS_REGEX}\s*['"](?<value>[^\s]+)['"]\s*/.freeze
+        # rubocop:enable Layout/LineLength
 
         def initialize(dependency_files:)
           @dependency_files = dependency_files

--- a/gradle/lib/dependabot/gradle/file_parser/property_value_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/property_value_finder.rb
@@ -7,8 +7,19 @@ module Dependabot
     class FileParser
       class PropertyValueFinder
         # rubocop:disable Layout/LineLength
+        QUOTED_VALUE_REGEX =
+          /\s*['"][^\s]+['"]\s*/.freeze
+
+        # project.findProperty('property') ?:
+        FIND_PROPERTY_REGEX =
+          /\s*project\.findProperty\(#{QUOTED_VALUE_REGEX}\)\s*\?:/.freeze
+
+        # project.hasProperty('property') ? project.getProperty('property') :
+        HAS_PROPERTY_REGEX =
+          /\s*project\.hasProperty\(#{QUOTED_VALUE_REGEX}\)\s*\?\s*project\.getProperty\(#{QUOTED_VALUE_REGEX}\)\s*:/.freeze
+
         PROPERTY_DECLARATION_AS_DEFAULTS_REGEX =
-          /(?:\s*(?:project\.findProperty\(\s*['"][^\s]+['"]\s*\)\s*\?|project\.hasProperty\(\s*['"][^\s]+['"]\s*\)\s*\?\s*project\.getProperty\(\s*['"][^\s]+['"]\s*\)\s*):)?/.freeze
+          /(?:#{FIND_PROPERTY_REGEX}|#{HAS_PROPERTY_REGEX})?/.freeze
 
         SINGLE_PROPERTY_DECLARATION_REGEX =
           /(?:^|\s+|ext.)(?<name>[^\s=]+)\s*=#{PROPERTY_DECLARATION_AS_DEFAULTS_REGEX}\s*['"](?<value>[^\s]+)['"]/.freeze

--- a/gradle/spec/dependabot/gradle/file_parser/property_value_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser/property_value_finder_spec.rb
@@ -86,6 +86,26 @@ RSpec.describe Dependabot::Gradle::FileParser::PropertyValueFinder do
             end
           end
 
+          context "and the property is using findProperty syntax" do
+            let(:property_name) { "findPropertyVersion" }
+            its([:value]) { is_expected.to eq("27.1.1") }
+            its([:declaration_string]) do
+              # rubocop:disable Layout/LineLength
+              is_expected.to eq("findPropertyVersion = project.findProperty('findPropertyVersion') ?: '27.1.1'")
+              # rubocop:enable Layout/LineLength
+            end
+          end
+
+          context "and the property is using hasProperty syntax" do
+            let(:property_name) { "hasPropertyVersion" }
+            its([:value]) { is_expected.to eq("27.1.1") }
+            its([:declaration_string]) do
+              # rubocop:disable Layout/LineLength
+              is_expected.to eq("hasPropertyVersion = project.hasProperty('hasPropertyVersion') ? project.getProperty('hasPropertyVersion') :'27.1.1'")
+              # rubocop:enable Layout/LineLength
+            end
+          end
+
           context "and the property is commented out" do
             let(:property_name) { "commentedVersion" }
             it { is_expected.to be_nil }
@@ -98,6 +118,25 @@ RSpec.describe Dependabot::Gradle::FileParser::PropertyValueFinder do
             its([:value]) { is_expected.to eq("3.12.1") }
             its([:declaration_string]) do
               is_expected.to eq("okhttp                 : '3.12.1'")
+            end
+            context "and the property is using findProperty syntax" do
+              let(:property_name) { "findPropertyVersion" }
+              its([:value]) { is_expected.to eq("1.0.0") }
+              its([:declaration_string]) do
+                # rubocop:disable Layout/LineLength
+                is_expected.to eq("findPropertyVersion = project.findProperty('findPropertyVersion') ?: '1.0.0'")
+                # rubocop:enable Layout/LineLength
+              end
+            end
+
+            context "and the property is using hasProperty syntax" do
+              let(:property_name) { "hasPropertyVersion" }
+              its([:value]) { is_expected.to eq("1.0.0") }
+              its([:declaration_string]) do
+                # rubocop:disable Layout/LineLength
+                is_expected.to eq("hasPropertyVersion = project.hasProperty('hasPropertyVersion') ? project.getProperty('hasPropertyVersion') :'1.0.0'")
+                # rubocop:enable Layout/LineLength
+              end
             end
           end
         end

--- a/gradle/spec/dependabot/gradle/file_parser/property_value_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser/property_value_finder_spec.rb
@@ -120,21 +120,21 @@ RSpec.describe Dependabot::Gradle::FileParser::PropertyValueFinder do
               is_expected.to eq("okhttp                 : '3.12.1'")
             end
             context "and the property is using findProperty syntax" do
-              let(:property_name) { "findPropertyVersion" }
+              let(:property_name) { "versions.findPropertyVersion" }
               its([:value]) { is_expected.to eq("1.0.0") }
               its([:declaration_string]) do
                 # rubocop:disable Layout/LineLength
-                is_expected.to eq("findPropertyVersion = project.findProperty('findPropertyVersion') ?: '1.0.0'")
+                is_expected.to eq("findPropertyVersion    : project.findProperty('findPropertyVersion') ?: '1.0.0'")
                 # rubocop:enable Layout/LineLength
               end
             end
 
             context "and the property is using hasProperty syntax" do
-              let(:property_name) { "hasPropertyVersion" }
+              let(:property_name) { "versions.hasPropertyVersion" }
               its([:value]) { is_expected.to eq("1.0.0") }
               its([:declaration_string]) do
                 # rubocop:disable Layout/LineLength
-                is_expected.to eq("hasPropertyVersion = project.hasProperty('hasPropertyVersion') ? project.getProperty('hasPropertyVersion') :'1.0.0'")
+                is_expected.to eq("hasPropertyVersion     : project.hasProperty('hasPropertyVersion') ? project.getProperty('hasPropertyVersion') :'1.0.0'")
                 # rubocop:enable Layout/LineLength
               end
             end

--- a/gradle/spec/fixtures/buildfiles/properties.gradle
+++ b/gradle/spec/fixtures/buildfiles/properties.gradle
@@ -19,4 +19,8 @@ ext {
     supportVersion = '27.1.1'
 
     // commentedVersion = '27.1.1'
+
+    findPropertyVersion = project.findProperty('findPropertyVersion') ?: '27.1.1'
+
+    hasPropertyVersion = project.hasProperty('hasPropertyVersion') ? project.getProperty('hasPropertyVersion') :'27.1.1'
 }

--- a/gradle/spec/fixtures/buildfiles/properties_namespaced.gradle
+++ b/gradle/spec/fixtures/buildfiles/properties_namespaced.gradle
@@ -34,8 +34,8 @@ ext.versions = [
         screengrab             : '1.2.0',
         deviceAnimationRule    : '0.0.2',
 
-        findPropertyVersion = project.findProperty('findPropertyVersion') ?: '1.0.0'
-        hasPropertyVersion = project.hasProperty('hasPropertyVersion') ? project.getProperty('hasPropertyVersion') :'1.0.0'
+        findPropertyVersion    : project.findProperty('findPropertyVersion') ?: '1.0.0',
+        hasPropertyVersion     : project.hasProperty('hasPropertyVersion') ? project.getProperty('hasPropertyVersion') :'1.0.0',
 ]
 
 ext.gradlePlugins = [

--- a/gradle/spec/fixtures/buildfiles/properties_namespaced.gradle
+++ b/gradle/spec/fixtures/buildfiles/properties_namespaced.gradle
@@ -33,6 +33,9 @@ ext.versions = [
         testRunner             : '1.0.2',
         screengrab             : '1.2.0',
         deviceAnimationRule    : '0.0.2',
+
+        findPropertyVersion = project.findProperty('findPropertyVersion') ?: '1.0.0'
+        hasPropertyVersion = project.hasProperty('hasPropertyVersion') ? project.getProperty('hasPropertyVersion') :'1.0.0'
 ]
 
 ext.gradlePlugins = [


### PR DESCRIPTION
Extract properties set as defaults, supports both the findProperty and hasProperty syntax styles:

```
findPropertyVersion = project.findProperty('findPropertyVersion') ?: '1.0.0'
hasPropertyVersion = project.hasProperty('hasPropertyVersion') ? project.getProperty('hasPropertyVersion') :'1.0.0'
```