### PR TITLE
Handle protected branches enforcing linear history

### DIFF
--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -163,7 +163,8 @@ module Dependabot
         return nil if e.message.match?(/Reference cannot be updated/i)
 
         if e.message.match?(/force\-push to a protected/i) ||
-           e.message.match?(/not authorized to push/i)
+           e.message.match?(/not authorized to push/i) ||
+           e.message.match?(/must not contain merge commits/)
           raise BranchProtected
         end
 

--- a/common/spec/dependabot/pull_request_updater/github_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/github_spec.rb
@@ -519,5 +519,23 @@ RSpec.describe Dependabot::PullRequestUpdater::Github do
           to raise_error(Dependabot::PullRequestUpdater::BranchProtected)
       end
     end
+
+    context "when pushing to a protected branch enforcing linear history" do
+      before do
+        stub_request(
+          :patch,
+          "#{watched_repo_url}/git/refs/heads/#{branch_name}"
+        ).to_return(
+          status: 422,
+          body: fixture("github", "linear_history_protected_branch.json"),
+          headers: json_header
+        )
+      end
+
+      it "raises a helpful error" do
+        expect { updater.update }.
+          to raise_error(Dependabot::PullRequestUpdater::BranchProtected)
+      end
+    end
   end
 end

--- a/common/spec/fixtures/github/linear_history_protected_branch.json
+++ b/common/spec/fixtures/github/linear_history_protected_branch.json
@@ -1,0 +1,4 @@
+{
+  "message": "This branch must not contain merge commits. // See: https://help.github.com/articles/about-protected-branches",
+  "documentation_url": "https://help.github.com/articles/about-protected-branches"
+}


### PR DESCRIPTION
You can enforce linear history for a protected branch preventing any
merge commits to be pushed to the branch, this currently prevents the
pull request from being updated. I'm not entirely sure where we're
creating a merge commit but might be because we're creating a new commit
and force pushing and this is the first rule that gets tripped up in
github.

<img width="686" alt="Screen Shot 2020-05-18 at 15 03 45" src="https://user-images.githubusercontent.com/20165/82222140-cadd7f80-9918-11ea-9c96-dbbf1e920cb5.png">

`BranchProtected` is rescued in dependabot api resulting in a comment on
the pull request explaining why the update failed.