### PR TITLE
docker-dev-shell: rebuild core

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -28,6 +28,8 @@ if [ "$HELP" = "true" ]; then
 fi
 
 build_image() {
+  echo "$(tput setaf 2)=> building image from Dockerfile$(tput sgr0)"
+  docker build -t dependabot/dependabot-core .
   echo "$(tput setaf 2)=> building image from $DOCKERFILE$(tput sgr0)"
   docker build --build-arg "USER_UID=$UID" --build-arg "USER_GID=$(id -g)" -t "$IMAGE_NAME" -f "$DOCKERFILE" .
 }


### PR DESCRIPTION
I expected `git pull && bin/docker-dev-shell --rebuild` to provide me with a suitable sandbox for development.
Since `Dockerfile.development` references `dependabot/dependabot-core:latest`, changes to helpers aren't included unless I manually rebuild.

This PR updates `bin/docker-dev-shell` to rebuild `dependabot/dependabot-core:latest` whenever the developer shell image is being rebuilt.
Thanks to docker's layer cache, this costs `<1s` if there's no work to be done. Worth it to trivialize synchronizing the dev sandbox.