### PR TITLE
Always use exact dependencies label if one exists

### DIFF
--- a/common/spec/dependabot/pull_request_creator/labeler_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/labeler_spec.rb
@@ -472,6 +472,12 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
         it { is_expected.to eq(["Dependency: Gems"]) }
       end
 
+      context "when a default and custom dependencies label exists" do
+        let(:labels_fixture_name) { "labels_with_custom_and_default.json" }
+
+        it { is_expected.to eq(["dependencies"]) }
+      end
+
       context "when asking for custom labels" do
         let(:custom_labels) { ["wontfix"] }
         it { is_expected.to eq(["wontfix"]) }

--- a/common/spec/fixtures/github/labels_with_custom_and_default.json
+++ b/common/spec/fixtures/github/labels_with_custom_and_default.json
@@ -1,0 +1,65 @@
+[
+  {
+      "id": 618335045,
+      "url": "https://api.github.com/repos/dependabot/dependabot-core/labels/bug",
+      "name": "bug",
+      "color": "ee0701",
+      "default": true
+  },
+  {
+      "id": 675690998,
+      "url": "https://api.github.com/repos/dependabot/dependabot-core/labels/dependency-gems",
+      "name": "Dependency: Gems",
+      "color": "0366d6",
+      "default": false
+  },
+  {
+    "id": 675690998,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/labels/dependencies-app",
+    "name": "dependencies-app",
+    "color": "0466d6",
+    "default": false
+},
+  {
+      "id": 618335046,
+      "url": "https://api.github.com/repos/dependabot/dependabot-core/labels/duplicate",
+      "name": "duplicate",
+      "color": "cccccc",
+      "default": true
+  },
+  {
+      "id": 618335047,
+      "url": "https://api.github.com/repos/dependabot/dependabot-core/labels/enhancement",
+      "name": "enhancement",
+      "color": "84b6eb",
+      "default": true
+  },
+  {
+      "id": 618335048,
+      "url": "https://api.github.com/repos/dependabot/dependabot-core/labels/help%20wanted",
+      "name": "dependencies",
+      "color": "0366d6",
+      "default": true
+  },
+  {
+      "id": 618335049,
+      "url": "https://api.github.com/repos/dependabot/dependabot-core/labels/invalid",
+      "name": "invalid",
+      "color": "e6e6e6",
+      "default": true
+  },
+  {
+      "id": 618335050,
+      "url": "https://api.github.com/repos/dependabot/dependabot-core/labels/question",
+      "name": "question",
+      "color": "cc317c",
+      "default": true
+  },
+  {
+      "id": 618335051,
+      "url": "https://api.github.com/repos/dependabot/dependabot-core/labels/wontfix",
+      "name": "wontfix",
+      "color": "ffffff",
+      "default": true
+  }
+]


### PR DESCRIPTION
Fixes https://github.com/dependabot/feedback/issues/846

This change makes sure an existing label named `dependencies` is always
used as the default over one that matches `*dependenc.`.

When a repo label exists that matches `*dependenc.` Dependabot will pick
and use that as the default label (unless you specifcy default/custom
labels).