### PR TITLE
go_modules: multiline `go` output matching

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -135,16 +135,16 @@ module Dependabot
         end
       end
 
-      GIT_ERROR_REGEX = /go: .*: git fetch .*: exit status 128/.freeze
+      GIT_ERROR_REGEX = /go: .*: git fetch .*: exit status 128/m.freeze
       def handle_parser_error(path, stderr)
         case stderr
-        when /go: .*: unknown revision/
+        when /go: .*: unknown revision/m
           line = stderr.lines.grep(/unknown revision/).first
           raise Dependabot::DependencyFileNotResolvable, line.strip
-        when /go: .*: unrecognized import path/
+        when /go: .*: unrecognized import path/m
           line = stderr.lines.grep(/unrecognized import/).first
           raise Dependabot::DependencyFileNotResolvable, line.strip
-        when /go: errors parsing go.mod/
+        when /go: errors parsing go.mod/m
           msg = stderr.gsub(path.to_s, "").strip
           raise Dependabot::DependencyFileNotParseable.new(go_mod.path, msg)
         when GIT_ERROR_REGEX

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -156,7 +156,9 @@ RSpec.describe Dependabot::GoModules::FileParser do
 
       it "raises the correct error" do
         expect { parser.parse }.
-          to raise_error(Dependabot::DependencyFileNotResolvable)
+          to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
+            expect(error.message).to include("hmarr/404")
+          end
       end
     end
 

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -150,6 +150,16 @@ RSpec.describe Dependabot::GoModules::FileParser do
       end
     end
 
+    describe "a non-existing transitive dependency" do
+      # go.mod references repo with bad go.mod, a broken transitive dependency
+      let(:go_mod_fixture_name) { "parent_module.mod" }
+
+      it "raises the correct error" do
+        expect { parser.parse }.
+          to raise_error(Dependabot::DependencyFileNotResolvable)
+      end
+    end
+
     describe "a dependency at a non-existent version" do
       let(:go_mod_content) do
         go_mod = fixture("go_mods", go_mod_fixture_name)

--- a/go_modules/spec/fixtures/go_mods/parent_module.mod
+++ b/go_modules/spec/fixtures/go_mods/parent_module.mod
@@ -1,0 +1,7 @@
+module github.com/dependabot/vgotestparent
+
+go 1.12
+
+require (
+  github.com/dependabot/vgotest v1.0.0
+)


### PR DESCRIPTION
This PR updates the regular expressions used to parse `go` command output to handle errors encountered processing transitive dependencies.

When go encounters an error resolving a direct dependency, it outputs an error like:
```
go: github.com/hmarr/404@v1.4.0: reading github.com/hmarr/404/go.mod at revision v1.4.0: unknown revision v1.4.0
```

When go resolves a direct dependency, then fails resolving a transitive dependency-of-a-dependency, it outputs an error like:
```
go: github.com/dependabot/vgotest@v1.0.0 requires
	github.com/hmarr/404@v1.0.0: reading github.com/hmarr/404/go.mod at revision v1.0.0: unknown revision v1.0.0
```

That `\n\t` breaks dependabot's regexp, which is used to detect and retry on ephemeral errors (e.g. a 502 from a remote).
This results in a `DependencyFileNotParseable` being raised, which is incorrect if a valid `go.mod` was parsed with a problematic remote.

As observed https://github.com/dependabot/feedback/issues/938