### PR TITLE
Added support for <PackageVersion> elements for MSBuild projects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,21 @@
 {
   "files.associations": {
     "Dockerfile.*": "dockerfile"
-  }
+  },
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#1f6fd0",
+    "activityBar.activeBorder": "#ee90bb",
+    "activityBar.background": "#1f6fd0",
+    "activityBar.foreground": "#e7e7e7",
+    "activityBar.inactiveForeground": "#e7e7e799",
+    "activityBarBadge.background": "#ee90bb",
+    "activityBarBadge.foreground": "#15202b",
+    "tab.activeBorder": "#1f6fd0",
+    "titleBar.activeBackground": "#1857a4",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.border": "#1857a4",
+    "titleBar.inactiveBackground": "#1857a499",
+    "titleBar.inactiveForeground": "#e7e7e799"
+  },
+  "peacock.remoteColor": "#1857a4"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,21 +1,5 @@
 {
   "files.associations": {
     "Dockerfile.*": "dockerfile"
-  },
-  "workbench.colorCustomizations": {
-    "activityBar.activeBackground": "#1f6fd0",
-    "activityBar.activeBorder": "#ee90bb",
-    "activityBar.background": "#1f6fd0",
-    "activityBar.foreground": "#e7e7e7",
-    "activityBar.inactiveForeground": "#e7e7e799",
-    "activityBarBadge.background": "#ee90bb",
-    "activityBarBadge.foreground": "#15202b",
-    "tab.activeBorder": "#1f6fd0",
-    "titleBar.activeBackground": "#1857a4",
-    "titleBar.activeForeground": "#e7e7e7",
-    "titleBar.border": "#1857a4",
-    "titleBar.inactiveBackground": "#1857a499",
-    "titleBar.inactiveForeground": "#e7e7e799"
-  },
-  "peacock.remoteColor": "#1857a4"
+  }
 }

--- a/nuget/lib/dependabot/nuget/file_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher.rb
@@ -117,6 +117,8 @@ module Dependabot
           possible_paths += [
             "Directory.Build.props",
             "Directory.build.props",
+            "Directory.Packages.props",
+            "Directory.packages.props",
             "Directory.Build.targets",
             "Directory.build.targets"
           ]
@@ -137,6 +139,8 @@ module Dependabot
         [
           Pathname.new(base + "/Directory.Build.props").cleanpath.to_path,
           Pathname.new(base + "/Directory.build.props").cleanpath.to_path,
+          Pathname.new(base + "/Directory.Packages.props").cleanpath.to_path,
+          Pathname.new(base + "/Directory.packages.props").cleanpath.to_path,
           Pathname.new(base + "/Directory.Build.targets").cleanpath.to_path,
           Pathname.new(base + "/Directory.build.targets").cleanpath.to_path
         ]

--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -16,6 +16,7 @@ module Dependabot
 
         DEPENDENCY_SELECTOR = "ItemGroup > PackageReference, "\
                               "ItemGroup > GlobalPackageReference, "\
+                              "ItemGroup > PackageVersion, "\
                               "ItemGroup > Dependency, "\
                               "ItemGroup > DevelopmentDependency"
 

--- a/nuget/lib/dependabot/nuget/file_updater/project_file_declaration_finder.rb
+++ b/nuget/lib/dependabot/nuget/file_updater/project_file_declaration_finder.rb
@@ -13,6 +13,8 @@ module Dependabot
             <PackageReference [^>]*?[^/]>.*?</PackageReference>|
             <GlobalPackageReference [^>]*?/>|
             <GlobalPackageReference [^>]*?[^/]>.*?</GlobalPackageReference>|
+            <PackageVersion [^>]*?/>|
+            <PackageVersion [^>]*?[^/]>.*?</PackageVersion>|
             <Dependency [^>]*?/>|
             <Dependency [^>]*?[^/]>.*?</Dependency>|
             <DevelopmentDependency [^>]*?/>|

--- a/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_fetcher_spec.rb
@@ -53,6 +53,9 @@ RSpec.describe Dependabot::Nuget::FileFetcher do
       stub_request(:get, File.join(url, "Directory.Build.props?ref=sha")).
         with(headers: { "Authorization" => "token token" }).
         to_return(status: 404)
+      stub_request(:get, File.join(url, "Directory.Packages.props?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(status: 404)
       stub_request(:get, File.join(url, "Directory.Build.targets?ref=sha")).
         with(headers: { "Authorization" => "token token" }).
         to_return(status: 404)
@@ -203,6 +206,9 @@ RSpec.describe Dependabot::Nuget::FileFetcher do
         )
 
       stub_request(:get, File.join(url, "Directory.Build.props?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(status: 404)
+      stub_request(:get, File.join(url, "Directory.Packages.props?ref=sha")).
         with(headers: { "Authorization" => "token token" }).
         to_return(status: 404)
       stub_request(:get, File.join(url, "Directory.Build.targets?ref=sha")).
@@ -470,6 +476,10 @@ RSpec.describe Dependabot::Nuget::FileFetcher do
           )
         stub_request(
           :get, File.join(url, "src/Validator/Directory.Build.props?ref=sha")
+        ).with(headers: { "Authorization" => "token token" }).
+          to_return(status: 404)
+        stub_request(
+          :get, File.join(url, "src/Validator/Directory.Packages.props?ref=sha")
         ).with(headers: { "Authorization" => "token token" }).
           to_return(status: 404)
         stub_request(

--- a/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
@@ -133,6 +133,22 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
         end
       end
 
+      context "with an updated package specified" do
+        let(:file_body) { fixture("csproj", "directory.packages.props") }
+
+        it "has the right details" do
+          expect(dependencies.map(&:name)).
+            to match_array(
+              %w(
+                System.AskJeeves
+                System.Google
+                System.Lycos
+                System.WebCrawler
+              )
+            )
+        end
+      end
+
       context "with a property version" do
         let(:file_body) do
           fixture("csproj", "property_version.csproj")

--- a/nuget/spec/dependabot/nuget/file_parser/property_value_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser/property_value_finder_spec.rb
@@ -157,5 +157,43 @@ RSpec.describe Dependabot::Nuget::FileParser::PropertyValueFinder do
         is_expected.to eq("SystemSearchEngineVersion")
       end
     end
+
+    context "from a directory.packages.props file" do
+      let(:files) { [file, build_file, imported_file] }
+
+      let(:file) do
+        Dependabot::DependencyFile.new(
+          name: "nested/my.csproj",
+          content: file_body
+        )
+      end
+      let(:file_body) { fixture("csproj", "property_version.csproj") }
+      let(:build_file) do
+        Dependabot::DependencyFile.new(
+          name: "Directory.Packages.props",
+          content: build_file_body
+        )
+      end
+      let(:build_file_body) do
+        fixture("property_files", "directory.packages.props")
+      end
+      let(:imported_file) do
+        Dependabot::DependencyFile.new(
+          name: "build/dependencies.props",
+          content: imported_file_body
+        )
+      end
+      let(:imported_file_body) do
+        fixture("property_files", "dependency.props")
+      end
+
+      let(:property_name) { "SystemSearchEngineVersion" }
+
+      its([:value]) { is_expected.to eq("3.0.0-alpha1-10221") }
+      its([:file]) { is_expected.to eq("Directory.Packages.props") }
+      its([:root_property_name]) do
+        is_expected.to eq("SystemSearchEngineVersion")
+      end
+    end
   end
 end

--- a/nuget/spec/dependabot/nuget/file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser_spec.rb
@@ -271,5 +271,35 @@ RSpec.describe Dependabot::Nuget::FileParser do
         end
       end
     end
+
+    context "with a directory.packages.props file" do
+      let(:files) { [csproj_file, packages_file] }
+      let(:packages_file) do
+        Dependabot::DependencyFile.new(
+          name: "directory.packages.props",
+          content: fixture("csproj", "directory.packages.props")
+        )
+      end
+
+      its(:length) { is_expected.to eq(9) }
+
+      describe "the last dependency" do
+        subject(:dependency) { dependencies.last }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("System.WebCrawler")
+          expect(dependency.version).to eq("1.1.1")
+          expect(dependency.requirements).to eq(
+            [{
+              requirement: "1.1.1",
+              file: "directory.packages.props",
+              groups: [],
+              source: nil
+            }]
+          )
+        end
+      end
+    end
   end
 end

--- a/nuget/spec/fixtures/csproj/directory.packages.props
+++ b/nuget/spec/fixtures/csproj/directory.packages.props
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageVersion Include="System.Lycos" Version="3.23.3" />
+    <PackageVersion Include="System.AskJeeves" Version="2.2.2" />
+    <PackageVersion Include="System.Google" Version="0.1.0-beta.3" />
+    <PackageVersion Include="System.WebCrawler" Version="1.1.1" />
+  </ItemGroup>
+</Project>

--- a/nuget/spec/fixtures/property_files/directory.packages.props
+++ b/nuget/spec/fixtures/property_files/directory.packages.props
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="build\dependencies.props" />
+  <PropertyGroup Label="Package Versions">
+    <SystemSearchEngineVersion>3.0.0-alpha1-10221</SystemSearchEngineVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="System.Lycos" Version="$(SystemSearchEngineVersion)" />
+    <PackageVersion Include="System.AskJeeves" Version="2.2.2" />
+    <PackageVersion Include="System.Google" Version="$(SystemSearchEngineVersion)" />
+    <PackageVersion Include="System.WebCrawler" Version="1.1.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This adds in support for the new `<PackageVersion />` element added for the nuget implementation of [Centrally managing NuGet package-versions](https://github.com/NuGet/Home/wiki/Centrally-managing-NuGet-package-versions)

The latest dotnet sdk (3.1.300) includes support for the new `Directory.Packages.props` file from the command line, it follows very similarly to the `<PackageReference Update="" />` syntax, just using `<PackageVersion Include="" />` instead.