### PR TITLE
Update tests to account for business 2.0 update

### DIFF
--- a/bundler/spec/dependabot/bundler/file_updater/gemfile_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/gemfile_updater_spec.rb
@@ -218,11 +218,12 @@ RSpec.describe Dependabot::Bundler::FileUpdater::GemfileUpdater do
     context "with a gem that has a git source" do
       let(:gemfile_fixture_name) { "git_source_with_version" }
       let(:lockfile_fixture_name) { "git_source_with_version.lock" }
+      let(:dependency_name) { "dependabot-test-ruby-package" }
       let(:dependency) do
         Dependabot::Dependency.new(
-          name: "business",
-          version: "c170ea081c121c00ed6fe8764e3557e731454b9d",
-          previous_version: "c5bf1bd47935504072ac0eba1006cf4d67af6a7a",
+          name: "dependabot-test-ruby-package",
+          version: "1c6331732c41e4557a16dacb82534f1d1c831848",
+          previous_version: "81073f9462f228c6894e3e384d0718def310d99f",
           requirements: requirements,
           previous_requirements: previous_requirements,
           package_manager: "bundler"
@@ -231,11 +232,12 @@ RSpec.describe Dependabot::Bundler::FileUpdater::GemfileUpdater do
       let(:requirements) do
         [{
           file: "Gemfile",
-          requirement: "~> 1.14.0",
+          requirement: "~> 1.1.0",
           groups: [],
           source: {
             type: "git",
-            url: "http://github.com/gocardless/business"
+            url: "http://github.com/dependabot-fixtures/"\
+            "dependabot-test-ruby-package"
           }
         }]
       end
@@ -246,34 +248,42 @@ RSpec.describe Dependabot::Bundler::FileUpdater::GemfileUpdater do
           groups: [],
           source: {
             type: "git",
-            url: "http://github.com/gocardless/business"
+            url: "http://github.com/dependabot-fixtures/"\
+            "dependabot-test-ruby-package"
           }
         }]
       end
 
-      it { is_expected.to include "\"business\", \"~> 1.14.0\", git" }
+      it do
+        is_expected.to include(
+          "\"dependabot-test-ruby-package\", \"~> 1.1.0\", git"
+        )
+      end
 
       context "that should have its tag updated" do
         let(:gemfile_body) do
-          %(gem "business", "~> 1.0.0", ) +
-            %(git: "https://github.com/gocardless/business", tag: "v1.0.0")
+          %(gem "dependabot-test-ruby-package", "~> 1.0.0", ) +
+            %(git: "https://github.com/dependabot-fixtures/\
+          dependabot-test-ruby-package", tag: "v1.0.0")
         end
         let(:requirements) do
           [{
             file: "Gemfile",
-            requirement: "~> 1.8.0",
+            requirement: "~> 1.1.0",
             groups: [],
             source: {
               type: "git",
-              url: "http://github.com/gocardless/business",
-              ref: "v1.8.0"
+              url: "http://github.com/dependabot-fixtures/"\
+              "dependabot-test-ruby-package",
+              ref: "v1.1.0"
             }
           }]
         end
 
         let(:expected_string) do
-          %(gem "business", "~> 1.8.0", ) +
-            %(git: "https://github.com/gocardless/business", tag: "v1.8.0")
+          %(gem "dependabot-test-ruby-package", "~> 1.1.0", ) +
+            %(git: "https://github.com/dependabot-fixtures/\
+          dependabot-test-ruby-package", tag: "v1.1.0")
         end
 
         it { is_expected.to eq(expected_string) }
@@ -282,9 +292,9 @@ RSpec.describe Dependabot::Bundler::FileUpdater::GemfileUpdater do
       context "that should be removed" do
         let(:dependency) do
           Dependabot::Dependency.new(
-            name: "business",
-            version: "1.8.0",
-            previous_version: "c5bf1bd47935504072ac0eba1006cf4d67af6a7a",
+            name: "dependabot-test-ruby-package",
+            version: "1.1.0",
+            previous_version: "81073f9462f228c6894e3e384d0718def310d99f",
             requirements: requirements,
             previous_requirements: previous_requirements,
             package_manager: "bundler"
@@ -293,65 +303,90 @@ RSpec.describe Dependabot::Bundler::FileUpdater::GemfileUpdater do
         let(:requirements) do
           [{
             file: "Gemfile",
-            requirement: "~> 1.8.0",
+            requirement: "~> 1.1.0",
             groups: [],
             source: nil
           }]
         end
 
-        it { is_expected.to include "\"business\", \"~> 1.8.0\"\n" }
+        it do
+          is_expected.to include(
+            "\"dependabot-test-ruby-package\", \"~> 1.1.0\""
+          )
+        end
 
         context "with a tag (i.e., multiple git-related arguments)" do
           let(:gemfile_body) do
-            %(gem "business", git: "git_url", tag: "old_tag")
+            %(gem "dependabot-test-ruby-package",) +
+              %(git: "git_url", tag: "old_tag")
           end
-          it { is_expected.to eq(%(gem "business")) }
+          it { is_expected.to eq(%(gem "dependabot-test-ruby-package")) }
         end
 
         context "with non-git args at the start" do
           let(:gemfile_body) do
-            %(gem "business", "1.0.0", require: false, git: "git_url")
+            %(gem "dependabot-test-ruby-package", "1.0.0", ) +
+              %(require: false, git: "git_url")
           end
           it do
-            is_expected.to eq(%(gem "business", "~> 1.8.0", require: false))
+            is_expected.to eq(
+              %(gem "dependabot-test-ruby-package", "~> 1.1.0", require: false)
+            )
           end
         end
 
         context "with non-git args at the end" do
           let(:gemfile_body) do
-            %(gem "business", "1.0.0", git: "git_url", require: false)
+            %(gem "dependabot-test-ruby-package", "1.0.0", ) +
+              %(git: "git_url", require: false)
           end
           it do
-            is_expected.to eq(%(gem "business", "~> 1.8.0", require: false))
+            is_expected.to eq(
+              %(gem "dependabot-test-ruby-package", "~> 1.1.0", require: false)
+            )
           end
         end
 
         context "with non-git args on a subsequent line" do
           let(:gemfile_body) do
-            %(gem("business", "1.0.0", git: "git_url",\nrequire: false))
+            %{gem("dependabot-test-ruby-package", "1.0.0", } +
+              %{git: "git_url",\nrequire: false)}
           end
           it do
-            is_expected.to eq(%(gem("business", "~> 1.8.0", require: false)))
+            is_expected.to eq(
+              %(gem("dependabot-test-ruby-package", "~> 1.1.0", require: false))
+            )
           end
         end
 
         context "with git args on a subsequent line" do
           let(:gemfile_body) do
-            %(gem "business", '1.0.0', require: false,\ngit: "git_url")
+            %(gem "dependabot-test-ruby-package", '1.0.0', ) +
+              %(require: false,\ngit: "git_url")
           end
           it do
-            is_expected.to eq(%(gem "business", '~> 1.8.0', require: false))
+            is_expected.to eq(
+              %(gem "dependabot-test-ruby-package", '~> 1.1.0', require: false)
+            )
           end
         end
 
         context "with a custom arg" do
-          let(:gemfile_body) { %(gem "business", "1.0.0", github: "git_url") }
-          it { is_expected.to eq(%(gem "business", "~> 1.8.0")) }
+          let(:gemfile_body) do
+            %(gem "dependabot-test-ruby-package", "1.0.0", github: "git_url")
+          end
+          it do
+            is_expected.to eq(%(gem "dependabot-test-ruby-package", "~> 1.1.0"))
+          end
         end
 
         context "with a comment" do
-          let(:gemfile_body) { %(gem "business", git: "git_url" # My gem) }
-          it { is_expected.to eq(%(gem "business" # My gem)) }
+          let(:gemfile_body) do
+            %(gem "dependabot-test-ruby-package", git: "git_url" # My gem)
+          end
+          it do
+            is_expected.to eq(%(gem "dependabot-test-ruby-package" # My gem))
+          end
         end
       end
     end

--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -882,9 +882,9 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
             let(:lockfile_fixture_name) { "git_source_with_version.lock" }
             let(:dependency) do
               Dependabot::Dependency.new(
-                name: "business",
-                version: "71083639645603d3bc25f7f5b11c96f0d07bf252",
-                previous_version: "c5bf1bd47935504072ac0eba1006cf4d67af6a7a",
+                name: "dependabot-test-ruby-package",
+                version: "1c6331732c41e4557a16dacb82534f1d1c831848",
+                previous_version: "81073f9462f228c6894e3e384d0718def310d99f",
                 requirements: requirements,
                 previous_requirements: previous_requirements,
                 package_manager: "bundler"
@@ -893,11 +893,12 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
             let(:requirements) do
               [{
                 file: "Gemfile",
-                requirement: "~> 1.18.0",
+                requirement: "~> 1.0.1",
                 groups: [],
                 source: {
                   type: "git",
-                  url: "http://github.com/gocardless/business"
+                  url: "https://github.com/dependabot-fixtures/"\
+                  "dependabot-test-ruby-package"
                 }
               }]
             end
@@ -908,11 +909,14 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
                 groups: [],
                 source: {
                   type: "git",
-                  url: "http://github.com/gocardless/business"
+                  url: "https://github.com/dependabot-fixtures/"\
+                  "dependabot-test-ruby-package"
                 }
               }]
             end
-            its(:content) { is_expected.to include "business (~> 1.18.0)!" }
+            its(:content) do
+              is_expected.to include "dependabot-test-ruby-package (~> 1.0.1)!"
+            end
           end
         end
       end

--- a/bundler/spec/dependabot/bundler/update_checker/file_preparer_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/file_preparer_spec.rb
@@ -152,9 +152,13 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::FilePreparer do
           let(:gemfile_body) do
             fixture("ruby", "gemfiles", "git_source_with_version")
           end
-          let(:dependency_name) { "business" }
+          let(:dependency_name) { "dependabot-test-ruby-package" }
 
-          its(:content) { is_expected.to include(%("business", ">= 0", git:)) }
+          its(:content) do
+            is_expected.to include(
+              %("dependabot-test-ruby-package", ">= 0", git:)
+            )
+          end
         end
 
         context "that should be removed" do

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -995,27 +995,34 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
               groups: [],
               source: {
                 type: "git",
-                url: "https://github.com/gocardless/business",
+                url: "https://github.com/dependabot-fixtures/"\
+                "dependabot-test-ruby-package",
                 branch: "master",
                 ref: "master"
               }
             }]
           end
-          let(:dependency_name) { "business" }
-          let(:current_version) { "c5bf1bd47935504072ac0eba1006cf4d67af6a7a" }
+          let(:dependency_name) { "dependabot-test-ruby-package" }
+          let(:current_version) { "81073f9462f228c6894e3e384d0718def310d99f" }
 
           before do
             allow_any_instance_of(Dependabot::GitCommitChecker).
               to receive(:branch_or_ref_in_release?).
               and_return(false)
-            git_url = "https://github.com/gocardless/business.git"
+            stub_request(
+              :get, rubygems_url + "versions/dependabot-test-ruby-package.json"
+            ).to_return(status: 404)
+            git_url = "https://github.com/dependabot-fixtures/"\
+              "dependabot-test-ruby-package.git"
             git_header = {
               "content-type" => "application/x-git-upload-pack-advertisement"
             }
             stub_request(:get, git_url + "/info/refs?service=git-upload-pack").
               to_return(
                 status: 200,
-                body: fixture("git", "upload_packs", "business"),
+                body: fixture("git",
+                              "upload_packs",
+                              "dependabot-test-ruby-package"),
                 headers: git_header
               )
           end
@@ -1565,8 +1572,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         let(:gemfile_fixture_name) { "git_source_with_version" }
         let(:lockfile_fixture_name) { "git_source_with_version.lock" }
 
-        let(:dependency_name) { "business" }
-        let(:current_version) { "c5bf1bd47935504072ac0eba1006cf4d67af6a7a" }
+        let(:dependency_name) { "dependabot-test-ruby-package" }
+        let(:current_version) { "81073f9462f228c6894e3e384d0718def310d99f" }
         let(:requirements) do
           [{
             file: "Gemfile",
@@ -1574,7 +1581,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
             groups: [:default],
             source: {
               type: "git",
-              url: "https://github.com/gocardless/business",
+              url: "https://github.com/dependabot-fixtures/"\
+              "dependabot-test-ruby-package",
               branch: "master",
               ref: "master"
             }
@@ -1585,14 +1593,20 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           allow_any_instance_of(Dependabot::GitCommitChecker).
             to receive(:branch_or_ref_in_release?).
             and_return(false)
-          git_url = "https://github.com/gocardless/business.git"
+          stub_request(
+            :get, rubygems_url + "versions/dependabot-test-ruby-package.json"
+          ).to_return(status: 404)
+          git_url = "https://github.com/dependabot-fixtures/"\
+            "dependabot-test-ruby-package.git"
           git_header = {
             "content-type" => "application/x-git-upload-pack-advertisement"
           }
           stub_request(:get, git_url + "/info/refs?service=git-upload-pack").
             to_return(
               status: 200,
-              body: fixture("git", "upload_packs", "business"),
+              body: fixture("git",
+                            "upload_packs",
+                            "dependabot-test-ruby-package"),
               headers: git_header
             )
         end
@@ -1602,8 +1616,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
             to receive(:new).with(
               requirements: requirements,
               update_strategy: :bump_versions,
-              latest_version: /^2./,
-              latest_resolvable_version: /^1./,
+              latest_version: "1.0.1",
+              latest_resolvable_version: "1.0.1",
               updated_source: requirements.first[:source]
             ).and_call_original
 
@@ -1655,6 +1669,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           end
 
           context "and the release looks like a version" do
+            let(:current_version) { "c5bf1bd47935504072ac0eba1006cf4d67af6a7a" }
             let(:requirements) do
               [{
                 file: "Gemfile",
@@ -1667,6 +1682,20 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
                   ref: "v1.0.0"
                 }
               }]
+            end
+
+            before do
+              git_url = "https://github.com/gocardless/business.git"
+              git_header = {
+                "content-type" => "application/x-git-upload-pack-advertisement"
+              }
+              stub_request(
+                :get, git_url + "/info/refs?service=git-upload-pack"
+              ).to_return(
+                status: 200,
+                body: fixture("git", "upload_packs", "business"),
+                headers: git_header
+              )
             end
 
             it "delegates to Bundler::RequirementsUpdater" do

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -1602,7 +1602,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
             to receive(:new).with(
               requirements: requirements,
               update_strategy: :bump_versions,
-              latest_version: /^1./,
+              latest_version: /^2./,
               latest_resolvable_version: /^1./,
               updated_source: requirements.first[:source]
             ).and_call_original
@@ -1643,7 +1643,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
                 to receive(:new).with(
                   requirements: requirements,
                   update_strategy: :bump_versions,
-                  latest_version: /^1./,
+                  latest_version: /^2./,
                   latest_resolvable_version: /^1./,
                   updated_source: requirements.first[:source]
                 ).and_call_original
@@ -1705,7 +1705,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
                 to receive(:new).with(
                   requirements: requirements,
                   update_strategy: :bump_versions,
-                  latest_version: /^1./,
+                  latest_version: /^2./,
                   latest_resolvable_version: /^1./,
                   updated_source: nil
                 ).and_call_original

--- a/bundler/spec/fixtures/git/upload_packs/dependabot-test-ruby-package
+++ b/bundler/spec/fixtures/git/upload_packs/dependabot-test-ruby-package
@@ -1,0 +1,6 @@
+001e# service=git-upload-pack
+000001431c6331732c41e4557a16dacb82534f1d1c831848 HEADmulti_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not deepen-relative no-progress include-tag multi_ack_detailed allow-tip-sha1-in-want allow-reachable-sha1-in-want no-done symref=HEAD:refs/heads/master filter agent=git/github-g8c0f36024410
+003f1c6331732c41e4557a16dacb82534f1d1c831848 refs/heads/master
+003e81073f9462f228c6894e3e384d0718def310d99f refs/tags/v1.0.0
+003e1c6331732c41e4557a16dacb82534f1d1c831848 refs/tags/v1.0.1
+0000

--- a/bundler/spec/fixtures/ruby/gemfiles/git_source_with_version
+++ b/bundler/spec/fixtures/ruby/gemfiles/git_source_with_version
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem "business", "~> 1.0.0", git: "https://github.com/gocardless/business", ref: "b12c186"
+gem "dependabot-test-ruby-package", "~> 1.0.0", git: "https://github.com/dependabot-fixtures/dependabot-test-ruby-package"

--- a/bundler/spec/fixtures/ruby/lockfiles/git_source_with_version.lock
+++ b/bundler/spec/fixtures/ruby/lockfiles/git_source_with_version.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: https://github.com/gocardless/business
-  revision: c5bf1bd47935504072ac0eba1006cf4d67af6a7a
+  remote: https://github.com/dependabot-fixtures/dependabot-test-ruby-package
+  revision: 81073f9462f228c6894e3e384d0718def310d99f
   specs:
     business (1.0.0)
 
@@ -12,7 +12,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  business (~> 1.0.0)!
+  dependabot-test-ruby-package (~> 1.0.0)!
 
 BUNDLED WITH
    1.16.0.pre.2


### PR DESCRIPTION
We rely on the `business` gem for these tests, which recently got a [2.0
upgrade], which breaks these tests.

This is the simplest thing we can do to fix those tests, but I would
recommend that we swap out these public gems for dummy / cloned versions
that we can pin to a specific version.

[2.0 upgrade]: https://github.com/gocardless/business/blob/master/CHANGELOG.md#200---may-4-2020