### PR TITLE
Fix failing non-existing author email

### DIFF
--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -314,7 +314,7 @@ module Dependabot
           azure_client_for_source.commits
 
         @recent_azure_commit_messages.
-          reject { |c| c.fetch("author").fetch("email", "") == dependabot_email }.
+          reject { |c| azure_commit_author_email(c) == dependabot_email }.
           reject { |c| c.fetch("comment")&.start_with?("Merge") }.
           map { |c| c.fetch("comment") }.
           compact.
@@ -374,7 +374,7 @@ module Dependabot
           azure_client_for_source.commits
 
         @recent_azure_commit_messages.
-          find { |c| c.fetch("author").fetch("email", "") == dependabot_email }&.
+          find { |c| azure_commit_author_email(c) == dependabot_email }&.
           message&.
           strip
       end
@@ -387,6 +387,10 @@ module Dependabot
           find { |c| c.author.email == dependabot_email }&.
           message&.
           strip
+      end
+
+      def azure_commit_author_email(commit)
+        commit.fetch("author").fetch("email", "")
       end
 
       def github_client_for_source

--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -314,7 +314,7 @@ module Dependabot
           azure_client_for_source.commits
 
         @recent_azure_commit_messages.
-          reject { |c| c.fetch("author").fetch("email") == dependabot_email }.
+          reject { |c| c.fetch("author").fetch("email", "") == dependabot_email }.
           reject { |c| c.fetch("comment")&.start_with?("Merge") }.
           map { |c| c.fetch("comment") }.
           compact.
@@ -374,7 +374,7 @@ module Dependabot
           azure_client_for_source.commits
 
         @recent_azure_commit_messages.
-          find { |c| c.fetch("author").fetch("email") == dependabot_email }&.
+          find { |c| c.fetch("author").fetch("email", "") == dependabot_email }&.
           message&.
           strip
       end

--- a/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
@@ -119,6 +119,30 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
         it { is_expected.to eq("") }
       end
 
+      context "from Azure with no author email" do
+        let(:source) do
+          Dependabot::Source.new(provider: "azure",
+                                 repo: "org/gocardless/_git/bump")
+        end
+        let(:watched_repo_url) do
+          "https://dev.azure.com/org/gocardless/_apis/git/repositories/bump"
+        end
+
+        let(:commits_response) do
+          fixture("azure", "commits_no_author_email.json")
+        end
+        before do
+          stub_request(:get, watched_repo_url + "/commits").
+            to_return(
+              status: 200,
+              body: commits_response,
+              headers: json_header
+            )
+        end
+
+        it { is_expected.to eq("") }
+      end
+
       context "with a security vulnerability fixed" do
         let(:security_fix) { true }
         it { is_expected.to eq("[Security] ") }

--- a/common/spec/fixtures/azure/commits_no_author_email.json
+++ b/common/spec/fixtures/azure/commits_no_author_email.json
@@ -1,0 +1,25 @@
+{
+    "count": 1,
+    "value": [
+        {
+            "commitId": "9c8376e9b2e943c2c72fac4b239876f377f0305a",
+            "author": {
+                "name": "No Email",
+                "date": "2019-06-11T20:21:23Z"
+            },
+            "committer": {
+                "name": "Bob Jones",
+                "email": "Bob.Jones@org.com",
+                "date": "2019-06-11T20:21:23Z"
+            },
+            "comment": "Added example file",
+            "changeCounts": {
+                "Add": 1,
+                "Edit": 0,
+                "Delete": 0
+            },
+            "url": "https://dev.azure.com/org/8929b42a-8f67-4075-bdb1-908ea8ebfb3a/_apis/git/repositories/3c492e10-aa73-4855-b11e-5d6d9bd7d03a/commits/9c8376e9b2e943c2c72fac4b239876f377f0305a",
+            "remoteUrl": "https://dev.azure.com/org/gocardless/_git/bump/commit/9c8376e9b2e943c2c72fac4b239876f377f0305a"
+        }
+    ]
+}


### PR DESCRIPTION
Azure deploy user and Collection Build Service can commit to repository without having an email address. `last_azure_dependabot_commit_message` and `recent_azure_commit_messages` methods are failing with key not found error if repository has one of those commits. This commit fixes the issue