### PR TITLE
docker-dev-shell --rebuild no args

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -7,7 +7,7 @@ DOCKERFILE="Dockerfile.development"
 HELP=false
 REBUILD=false
 
-OPTS=`getopt -o hr: --long help,rebuild: -n 'parse-options' -- "$@"`
+OPTS=`getopt -o hr --long help,rebuild -n 'parse-options' -- "$@"`
 if [ $? != 0 ]; then
   echo "failed parsing options" >&2
   exit 1


### PR DESCRIPTION
This PR updates the `docker-dev-shell` script to fix a misconfiguration that specifies the `--rebuild` accepts an argument.

The `getopt` baked into OSX doesn't mind this, but `util-linux-2.33.1.0.1` fails.

Per https://linux.die.net/man/1/getopt

```
Each long option name in longopts may be followed by one colon to indicate it has a required argument, and by two colons to indicate it has an optional argument.

Each short option character in shortopts may be followed by one colon to indicate it has a required argument, and by two colons to indicate it has an optional argument.
```