### PR TITLE
Add error message to DependencyFileNotParseable

### DIFF
--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -177,8 +177,10 @@ module Dependabot
             PathGemspecFinder.new(gemfile: file).path_gemspec_paths
           end.uniq
         end
-      rescue ::Bundler::LockfileError
-        raise Dependabot::DependencyFileNotParseable, lockfile.path
+      rescue ::Bundler::LockfileError => e
+        msg = e.message.strip
+        raise Dependabot::DependencyFileNotParseable.new(lockfile.path,
+                                                         msg)
       rescue ::Bundler::Plugin::UnknownSourceError
         # Quietly ignore plugin errors - we'll raise a better error during
         # parsing

--- a/bundler/lib/dependabot/bundler/file_fetcher/child_gemfile_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher/child_gemfile_finder.rb
@@ -18,8 +18,9 @@ module Dependabot
         def child_gemfile_paths
           ast = Parser::CurrentRuby.parse(gemfile.content)
           find_child_gemfile_paths(ast)
-        rescue Parser::SyntaxError
-          raise Dependabot::DependencyFileNotParseable, gemfile.path
+        rescue Parser::SyntaxError => e
+          msg = e.message.strip
+          raise Dependabot::DependencyFileNotParseable.new(gemfile.path, msg)
         end
 
         private

--- a/bundler/lib/dependabot/bundler/file_fetcher/gemspec_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher/gemspec_finder.rb
@@ -18,8 +18,9 @@ module Dependabot
         def gemspec_directories
           ast = Parser::CurrentRuby.parse(gemfile.content)
           find_gemspec_paths(ast)
-        rescue Parser::SyntaxError
-          raise Dependabot::DependencyFileNotParseable, gemfile.path
+        rescue Parser::SyntaxError => e
+          msg = e.message.strip
+          raise Dependabot::DependencyFileNotParseable.new(gemfile.path, msg)
         end
 
         private

--- a/bundler/lib/dependabot/bundler/file_fetcher/path_gemspec_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher/path_gemspec_finder.rb
@@ -18,8 +18,9 @@ module Dependabot
         def path_gemspec_paths
           ast = Parser::CurrentRuby.parse(gemfile.content)
           find_path_gemspec_paths(ast)
-        rescue Parser::SyntaxError
-          raise Dependabot::DependencyFileNotParseable, gemfile.path
+        rescue Parser::SyntaxError => e
+          msg = e.message.strip
+          raise Dependabot::DependencyFileNotParseable.new(gemfile.path, msg)
         end
 
         private

--- a/bundler/lib/dependabot/bundler/file_fetcher/require_relative_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher/require_relative_finder.rb
@@ -18,8 +18,9 @@ module Dependabot
         def require_relative_paths
           ast = Parser::CurrentRuby.parse(file.content)
           find_require_relative_paths(ast)
-        rescue Parser::SyntaxError
-          raise Dependabot::DependencyFileNotParseable, file.path
+        rescue Parser::SyntaxError => e
+          msg = e.message.strip
+          raise Dependabot::DependencyFileNotParseable.new(file.path, msg)
         end
 
         private

--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -271,8 +271,9 @@ module Dependabot
 
       def parsed_file(file)
         TomlRB.parse(file.content)
-      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-        raise Dependabot::DependencyFileNotParseable, file.path
+      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+        msg = e.message.strip
+        raise Dependabot::DependencyFileNotParseable.new(file.path, msg)
       end
 
       def cargo_toml

--- a/cargo/lib/dependabot/cargo/file_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser.rb
@@ -215,8 +215,9 @@ module Dependabot
       def parsed_file(file)
         @parsed_file ||= {}
         @parsed_file[file.name] ||= TomlRB.parse(file.content)
-      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-        raise Dependabot::DependencyFileNotParseable, file.path
+      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+        msg = e.message.strip
+        raise Dependabot::DependencyFileNotParseable.new(file.path, msg)
       end
 
       def manifest_files

--- a/composer/lib/dependabot/composer/file_fetcher.rb
+++ b/composer/lib/dependabot/composer/file_fetcher.rb
@@ -124,8 +124,10 @@ module Dependabot
 
       def parsed_composer_json
         @parsed_composer_json ||= JSON.parse(composer_json.content)
-      rescue JSON::ParserError
-        raise Dependabot::DependencyFileNotParseable, composer_json.path
+      rescue JSON::ParserError => e
+        msg = e.message.strip
+        raise Dependabot::DependencyFileNotParseable.new(composer_json.path,
+                                                         msg)
       end
 
       def parsed_lockfile

--- a/composer/lib/dependabot/composer/file_parser.rb
+++ b/composer/lib/dependabot/composer/file_parser.rb
@@ -190,14 +190,17 @@ module Dependabot
         return unless lockfile
 
         @parsed_lockfile ||= JSON.parse(lockfile.content)
-      rescue JSON::ParserError
-        raise Dependabot::DependencyFileNotParseable, lockfile.path
+      rescue JSON::ParserError => e
+        msg = e.message.strip
+        raise Dependabot::DependencyFileNotParseable.new(lockfile.path, msg)
       end
 
       def parsed_composer_json
         @parsed_composer_json ||= JSON.parse(composer_json.content)
-      rescue JSON::ParserError
-        raise Dependabot::DependencyFileNotParseable, composer_json.path
+      rescue JSON::ParserError => e
+        msg = e.message.strip
+        raise Dependabot::DependencyFileNotParseable.new(composer_json.path,
+                                                         msg)
       end
 
       def composer_json

--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -48,8 +48,9 @@ module Dependabot
         end
 
         dependency_set
-      rescue Psych::SyntaxError, Psych::DisallowedClass, Psych::BadAlias
-        raise Dependabot::DependencyFileNotParseable, file.path
+      rescue Psych::SyntaxError, Psych::DisallowedClass, Psych::BadAlias => e
+        msg = e.message.strip
+        raise Dependabot::DependencyFileNotParseable.new(file.path, msg)
       end
 
       def build_github_dependency(file, string)

--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -146,16 +146,18 @@ module Dependabot
         raise "No Pipfile" unless pipfile
 
         @parsed_pipfile ||= TomlRB.parse(pipfile.content)
-      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-        raise Dependabot::DependencyFileNotParseable, pipfile.path
+      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+        msg = e.message.strip
+        raise Dependabot::DependencyFileNotParseable.new(pipfile.path, msg)
       end
 
       def parsed_pyproject
         raise "No pyproject.toml" unless pyproject
 
         @parsed_pyproject ||= TomlRB.parse(pyproject.content)
-      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-        raise Dependabot::DependencyFileNotParseable, pyproject.path
+      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+        msg = e.message.strip
+        raise Dependabot::DependencyFileNotParseable.new(pyproject.path, msg)
       end
 
       def req_txt_and_in_files

--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -219,8 +219,9 @@ module Dependabot
         return true if poetry_lock || pyproject_lock
 
         !TomlRB.parse(pyproject.content).dig("tool", "poetry").nil?
-      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-        raise Dependabot::DependencyFileNotParseable, pyproject.path
+      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+        msg = e.message.strip
+        raise Dependabot::DependencyFileNotParseable.new(pyproject.path, msg)
       end
 
       def output_file_regex(filename)

--- a/python/lib/dependabot/python/file_parser/pipfile_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pipfile_files_parser.rb
@@ -141,14 +141,17 @@ module Dependabot
 
         def parsed_pipfile
           @parsed_pipfile ||= TomlRB.parse(pipfile.content)
-        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-          raise Dependabot::DependencyFileNotParseable, pipfile.path
+        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+          msg = e.message.strip
+          raise Dependabot::DependencyFileNotParseable.new(pipfile.path, msg)
         end
 
         def parsed_pipfile_lock
           @parsed_pipfile_lock ||= JSON.parse(pipfile_lock.content)
-        rescue JSON::ParserError
-          raise Dependabot::DependencyFileNotParseable, pipfile_lock.path
+        rescue JSON::ParserError => e
+          msg = e.message.strip
+          raise Dependabot::DependencyFileNotParseable.new(pipfile_lock.path,
+                                                           msg)
         end
 
         def pipfile

--- a/python/lib/dependabot/python/file_parser/poetry_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/poetry_files_parser.rb
@@ -108,19 +108,24 @@ module Dependabot
         def parsed_pyproject
           @parsed_pyproject ||= TomlRB.parse(pyproject.content)
         rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-          raise Dependabot::DependencyFileNotParseable, pyproject.path
+          msg = e.message.strip
+          raise Dependabot::DependencyFileNotParseable.new(pyproject.path, msg)
         end
 
         def parsed_pyproject_lock
           @parsed_pyproject_lock ||= TomlRB.parse(pyproject_lock.content)
-        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-          raise Dependabot::DependencyFileNotParseable, pyproject_lock.path
+        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+          msg = e.message.strip
+          raise Dependabot::DependencyFileNotParseable.new(pyproject_lock.path,
+                                                           msg)
         end
 
         def parsed_poetry_lock
           @parsed_poetry_lock ||= TomlRB.parse(poetry_lock.content)
-        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-          raise Dependabot::DependencyFileNotParseable, poetry_lock.path
+        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+          msg = e.message.strip
+          raise Dependabot::DependencyFileNotParseable.new(poetry_lock.path,
+                                                           msg)
         end
 
         def pyproject


### PR DESCRIPTION
This should make these errors a lot easier to debug as we currently only show the file path that wasn't parseable.

We've done this in a few places already, e.g. go modules.

The error is presented in the backend. If the error has a `message` it's presented in the issue as `The error Dependabot encountered was: error message as code block`

## TODO 

- [ ] Add some tests 🤠
- [ ] Figure out if we will start leaking anything on public repos, e.g. errors containing config variables 