### PR TITLE
Handle cargo native dependencies

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -170,6 +170,8 @@ module Dependabot
 
             next if virtual_manifest?(file)
 
+            File.write(File.join(dir, "build.rs"), dummy_app_content)
+
             FileUtils.mkdir_p(File.join(dir, "src"))
             File.write(File.join(dir, "src/lib.rs"), dummy_app_content)
             File.write(File.join(dir, "src/main.rs"), dummy_app_content)

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -337,6 +337,8 @@ module Dependabot
 
             next if virtual_manifest?(file)
 
+            File.write(File.join(dir, "build.rs"), dummy_app_content)
+
             FileUtils.mkdir_p(File.join(dir, "src"))
             File.write(File.join(dir, "src/lib.rs"), dummy_app_content)
             File.write(File.join(dir, "src/main.rs"), dummy_app_content)

--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -337,6 +337,16 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
         end
       end
 
+      context "when there is a linked dependency" do
+        let(:dependency_files) { [manifest, lockfile] }
+        let(:manifest_fixture_name) { "linked_dependency" }
+
+        it "updates the dependency version in the lockfile" do
+          expect(updated_lockfile_content).
+            to include(%(name = "time"\nversion = "0.1.40"))
+        end
+      end
+
       context "when there is a workspace" do
         let(:dependency_files) { [manifest, lockfile, workspace_child] }
         let(:manifest_fixture_name) { "workspace_root" }

--- a/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
@@ -112,6 +112,12 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
       it { is_expected.to be >= Gem::Version.new("0.1.41") }
     end
 
+    context "with a linked dependency" do
+      let(:manifest_fixture_name) { "linked_dependency" }
+
+      it { is_expected.to be >= Gem::Version.new("0.2.10") }
+    end
+
     context "with a yanked version (for another dependency)" do
       let(:manifest_fixture_name) { "yanked_version" }
       let(:lockfile_fixture_name) { "yanked_version" }

--- a/cargo/spec/fixtures/manifests/linked_dependency
+++ b/cargo/spec/fixtures/manifests/linked_dependency
@@ -1,0 +1,9 @@
+[package]
+name = "dependabot" # the name of the package
+version = "0.1.0"    # the current version, obeying semver
+authors = ["support@dependabot.com"]
+links = "glfw3"
+
+[dependencies]
+time = "0.1.12"
+regex = "0.1.41"


### PR DESCRIPTION
Previously, when specifying a native dependency using `links =
"dependency"`, we would fail as we do not copy over the build.rs file,
which is needed to actually link to the binary. However, to run `cargo
update` we don't actually need to link the dependency, we just need
cargo not to fail. So adding a dummy build.rs file, like we do for
src/main.rs fixes the issue.

Fixes: https://github.com/dependabot/feedback/issues/943