### PR TITLE
docker-dev-shell: mount .bash_history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ vendor
 /npm_and_yarn/helpers/install-dir
 /dry-run
 **/bin/helper
+/.core-bash_history

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -66,7 +66,9 @@ fi
 
 echo "$(tput setaf 2)=> running docker development shell$(tput sgr0)"
 CODE_DIR="/home/dependabot/dependabot-core"
+touch .core-bash_history
 docker run --rm -ti \
+  -v "$(pwd)/.core-bash_history:/home/dependabot/.bash_history" \
   -v "$(pwd)/.rubocop.yml:$CODE_DIR/.rubocop.yml" \
   -v "$(pwd)/bin:$CODE_DIR/bin" \
   -v "$(pwd)/common/Gemfile:$CODE_DIR/common/Gemfile" \


### PR DESCRIPTION
This adjusts the `bin/docker-dev-shell` helper script to provide a persistent `~/.bash_history`, allowing the history to persist across invocations.

I opted for a `.gitignore`-ed file in the working directory; a docker volume might have been cleaner - but more work for whats just a papercut.