### PR TITLE
Handle missing repo when fetching recent commits

### DIFF
--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -355,7 +355,7 @@ module Dependabot
       def recent_github_commits
         @recent_github_commits ||=
           github_client_for_source.commits(source.repo, per_page: 100)
-      rescue Octokit::Conflict
+      rescue Octokit::Conflict, Octokit::NotFound
         @recent_github_commits ||= []
       end
 

--- a/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
@@ -98,6 +98,15 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
         it { is_expected.to eq("") }
       end
 
+      context "that 404s when asked for commits" do
+        before do
+          stub_request(:get, watched_repo_url + "/commits?per_page=100").
+            to_return(status: 404, headers: json_header)
+        end
+
+        it { is_expected.to eq("") }
+      end
+
       context "from GitLab" do
         let(:source) do
           Dependabot::Source.new(provider: "gitlab", repo: "gocardless/bump")


### PR DESCRIPTION
Fixes https://github.com/github/dsp-dependabot/issues/280

Looks like the repo can be removed by the time we try to create the PR.
This is currently raising preventing the PR creation from gracefully
handling the missing repo.