### PR TITLE
Updating PR: Handle new protected branch error

### DIFF
--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -162,7 +162,7 @@ module Dependabot
         return nil if e.message.match?(/Reference does not exist/i)
         return nil if e.message.match?(/Reference cannot be updated/i)
 
-        if e.message.match?(/force\-push to a protected/i) ||
+        if e.message.match?(/protected branch/i) ||
            e.message.match?(/not authorized to push/i) ||
            e.message.match?(/must not contain merge commits/)
           raise BranchProtected

--- a/common/spec/dependabot/pull_request_updater/github_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/github_spec.rb
@@ -520,6 +520,24 @@ RSpec.describe Dependabot::PullRequestUpdater::Github do
       end
     end
 
+    context "when unauthorized to push to (this) protected branch" do
+      before do
+        stub_request(
+          :patch,
+          "#{watched_repo_url}/git/refs/heads/#{branch_name}"
+        ).to_return(
+          status: 422,
+          body: fixture("github", "force_push_this_protected_branch.json"),
+          headers: json_header
+        )
+      end
+
+      it "raises a helpful error" do
+        expect { updater.update }.
+          to raise_error(Dependabot::PullRequestUpdater::BranchProtected)
+      end
+    end
+
     context "when pushing to a protected branch enforcing linear history" do
       before do
         stub_request(

--- a/common/spec/fixtures/github/force_push_this_protected_branch.json
+++ b/common/spec/fixtures/github/force_push_this_protected_branch.json
@@ -1,0 +1,4 @@
+{
+  "message": "Cannot force-push to this protected branch",
+  "documentation_url": "https://help.github.com/articles/about-protected-branches"
+}


### PR DESCRIPTION
Relaxing the error message check to raise a `BranchProtected` error when
the API error includes the words `protected branch`.

When force pushing to a protected branch the error can have two forms:

- Cannot force-push to this protected branch
- Cannot force-push to a protected branch