### PR TITLE
Ensure we don't mention usernames with parens around them

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -14,7 +14,7 @@ module Dependabot
           github\.com/(?<repo>#{GITHUB_USERNAME}/[^/\s]+)/
           (?:issue|pull)s?/(?<number>\d+)
         }x.freeze
-        MENTION_REGEX = %r{(?<![A-Za-z0-9`~])@#{GITHUB_USERNAME}/?}.freeze
+        MENTION_REGEX = %r{(?<![A-Za-z0-9`~()])@#{GITHUB_USERNAME}/?}.freeze
         # End of string
         EOS_REGEX = /\z/.freeze
         # We rely on GitHub to do the HTML sanitization

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -83,6 +83,15 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         it { is_expected.to eq("<p>Great work <code>@greysteil</code>!</p>\n") }
       end
 
+      context "that appears in parens" do
+        let(:text) { "by Esben Sparre Andreasen (@esbena)" }
+        it do
+          is_expected.to eq(
+            "<p>by Esben Sparre Andreasen (<code>@esbena</code>)</p>\n"
+          )
+        end
+      end
+
       context "with unmatched single code ticks previously" do
         let(:text) { fixture("changelogs", "sentry.md") }
         it do


### PR DESCRIPTION
It seems like people are getting notifications from README's such as:
https://github.com/gong-boy/SSDIProject/pull/11

Which is generated from a CHANGELOG like:
https://github.com/angular/angular.js/blob/master/CHANGELOG.md#180-nested-vaccination-2020-06-01

Previously we would generate something like (<a href="https://github.com/feelepxyz">@feelepxyz</a>),
for which I would not expect a notification, but to be absolutely sure
we may as well wrap these is a code block.