### PR TITLE
Safely output markdown from link_and_mention_sanitizer

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -323,7 +323,7 @@ module Dependabot
         msg += commits_cascade(dep)
         msg += maintainer_changes_cascade(dep)
         msg += break_tag unless msg == ""
-        "\n" + sanitize_links_and_mentions(msg)
+        "\n" + sanitize_links_and_mentions(msg, unsafe: true)
       end
 
       def vulnerabilities_cascade(dep)
@@ -680,12 +680,12 @@ module Dependabot
         end
       end
 
-      def sanitize_links_and_mentions(text)
+      def sanitize_links_and_mentions(text, unsafe: false)
         return text unless source.provider == "github"
 
         LinkAndMentionSanitizer.
           new(github_redirection_service: github_redirection_service).
-          sanitize_links_and_mentions(text: text)
+          sanitize_links_and_mentions(text: text, unsafe: unsafe)
       end
 
       def sanitize_template_tags(text)

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -437,7 +437,7 @@ module Dependabot
 
         build_details_tag(
           summary: "Maintainer changes",
-          body: maintainer_changes(dep) + "\n"
+          body: sanitize_links_and_mentions(maintainer_changes(dep)) + "\n"
         )
       end
 

--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -17,9 +17,8 @@ module Dependabot
         MENTION_REGEX = %r{(?<![A-Za-z0-9`~])@#{GITHUB_USERNAME}/?}.freeze
         # End of string
         EOS_REGEX = /\z/.freeze
-        # We rely on GitHub to do the HTML sanitization
         COMMONMARKER_OPTIONS = %i(
-          DEFAULT GITHUB_PRE_LANG FULL_INFO_STRING
+          GITHUB_PRE_LANG FULL_INFO_STRING
         ).freeze
         COMMONMARKER_EXTENSIONS = %i(
           table tasklist strikethrough autolink tagfilter
@@ -31,14 +30,15 @@ module Dependabot
           @github_redirection_service = github_redirection_service
         end
 
-        def sanitize_links_and_mentions(text:)
+        def sanitize_links_and_mentions(text:, unsafe: false)
           doc = CommonMarker.render_doc(
             text, :LIBERAL_HTML_TAG, COMMONMARKER_EXTENSIONS
           )
 
           sanitize_mentions(doc)
           sanitize_links(doc)
-          doc.to_html(COMMONMARKER_OPTIONS, COMMONMARKER_EXTENSIONS)
+          mode = unsafe ? :UNSAFE : :DEFAULT
+          doc.to_html(([mode] + COMMONMARKER_OPTIONS), COMMONMARKER_EXTENSIONS)
         end
 
         private

--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -19,7 +19,7 @@ module Dependabot
         EOS_REGEX = /\z/.freeze
         # We rely on GitHub to do the HTML sanitization
         COMMONMARKER_OPTIONS = %i(
-          UNSAFE GITHUB_PRE_LANG FULL_INFO_STRING
+          DEFAULT GITHUB_PRE_LANG FULL_INFO_STRING
         ).freeze
         COMMONMARKER_EXTENSIONS = %i(
           table tasklist strikethrough autolink tagfilter

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -307,5 +307,15 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         is_expected.to eq(html)
       end
     end
+
+    context "with HTML tags" do
+      let(:text) { "This contains \"<option>\" and \"<select>\" tags" }
+      it do
+        is_expected.to eq(
+          "<p>This contains &quot;<!-- raw HTML omitted -->&quot; "\
+          "and &quot;<!-- raw HTML omitted -->&quot; tags</p>\n"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
When configured as UNSAFE, CommonMarker will leave in any HTML tags
present in the text, which can cause our markdown to break when rendered
by GitHub.

This change ensures that no unsafe attributes are included in the
output, but things like `<code>` blocks for usernames etc still continue
to work.