### PR TITLE
Use Maven version ranges for ignored_versions in Maven and Gradle

### DIFF
--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -15,6 +15,8 @@ module Dependabot
         GRADLE_PLUGINS_REPO = "https://plugins.gradle.org/m2"
         TYPE_SUFFICES = %w(jre android java).freeze
 
+        GRADLE_RANGE_REGEX = /[\(\[].*,.*[\)\]]/.freeze
+
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, raise_on_ignored: false,
                        security_advisories:)
@@ -97,7 +99,7 @@ module Dependabot
           filtered = possible_versions
 
           ignored_versions.each do |req|
-            ignore_req = Gradle::Requirement.new(req)
+            ignore_req = Gradle::Requirement.new(parse_requirement_string(req))
             filtered =
               filtered.
               reject { |v| ignore_req.satisfied_by?(v.fetch(:version)) }
@@ -126,6 +128,12 @@ module Dependabot
           possible_versions.select do |v|
             v.fetch(:version) > version_class.new(dependency.version)
           end
+        end
+
+        def parse_requirement_string(string)
+          return string if string.match?(GRADLE_RANGE_REGEX)
+
+          string.split(",").map(&:strip)
         end
 
         def wants_prerelease?

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -97,7 +97,7 @@ module Dependabot
           filtered = possible_versions
 
           ignored_versions.each do |req|
-            ignore_req = Gradle::Requirement.new(req.split(","))
+            ignore_req = Gradle::Requirement.new(req)
             filtered =
               filtered.
               reject { |v| ignore_req.satisfied_by?(v.fetch(:version)) }

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
     end
 
     context "when the user has asked to ignore a major version" do
-      let(:ignored_versions) { [">= 23.0, < 24"] }
+      let(:ignored_versions) { ["[23.0,24]"] }
       let(:dependency_version) { "17.0" }
       its([:version]) { is_expected.to eq(version_class.new("22.0")) }
     end

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
     end
 
     context "when the user has asked to ignore a major version" do
-      let(:ignored_versions) { ["[23.0,24]"] }
+      let(:ignored_versions) { ["[23.0,24)"] }
       let(:dependency_version) { "17.0" }
       its([:version]) { is_expected.to eq(version_class.new("22.0")) }
     end

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -121,6 +121,12 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
       its([:version]) { is_expected.to eq(version_class.new("22.0")) }
     end
 
+    context "when the user has asked to ignore a version range using Ruby syntax" do
+      let(:ignored_versions) { [">= 23.0, < 24"] }
+      let(:dependency_version) { "17.0" }
+      its([:version]) { is_expected.to eq(version_class.new("22.0")) }
+    end
+
     context "when the user has asked to ignore all versions" do
       let(:ignored_versions) { [">= 0"] }
       let(:dependency_version) { "17.0" }

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
       its([:version]) { is_expected.to eq(version_class.new("22.0")) }
     end
 
-    context "when the user has asked to ignore a version range using Ruby syntax" do
+    context "when a version range is specified using Ruby syntax" do
       let(:ignored_versions) { [">= 23.0, < 24"] }
       let(:dependency_version) { "17.0" }
       its([:version]) { is_expected.to eq(version_class.new("22.0")) }

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -94,7 +94,7 @@ module Dependabot
           filtered = possible_versions
 
           ignored_versions.each do |req|
-            ignore_req = Maven::Requirement.new(req.split(","))
+            ignore_req = Maven::Requirement.new(req)
             filtered =
               filtered.
               reject { |v| ignore_req.satisfied_by?(v.fetch(:version)) }

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       its([:version]) { is_expected.to eq(version_class.new("22.0")) }
     end
 
-    context "when the user has asked to ignore a major version using Ruby syntax" do
+    context "when a version range is specified using Ruby syntax" do
       let(:ignored_versions) { [">= 23.0, < 24"] }
       let(:dependency_version) { "17.0" }
       let(:maven_central_version_files_url) do

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -188,6 +188,19 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       its([:version]) { is_expected.to eq(version_class.new("22.0")) }
     end
 
+    context "when the user has asked to ignore a major version using Ruby syntax" do
+      let(:ignored_versions) { [">= 23.0, < 24"] }
+      let(:dependency_version) { "17.0" }
+      let(:maven_central_version_files_url) do
+        "https://repo.maven.apache.org/maven2/"\
+        "com/google/guava/guava/22.0/guava-22.0.jar"
+      end
+      let(:maven_central_version_files) do
+        fixture("maven_central_version_files", "guava-22.0.html")
+      end
+      its([:version]) { is_expected.to eq(version_class.new("22.0")) }
+    end
+
     context "when the current version isn't normal" do
       let(:dependency_version) { "RELEASE802" }
       let(:maven_central_version_files_url) do

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
     end
 
     context "when the user has asked to ignore a major version" do
-      let(:ignored_versions) { [">= 23.0, < 24"] }
+      let(:ignored_versions) { ["[23.0,24)"] }
       let(:dependency_version) { "17.0" }
       let(:maven_central_version_files_url) do
         "https://repo.maven.apache.org/maven2/"\
@@ -373,7 +373,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
     end
 
     context "when the user has ignored all versions" do
-      let(:ignored_versions) { [">= 17.0, < 24"] }
+      let(:ignored_versions) { ["[17.0,)"] }
 
       it "returns nil" do
         expect(subject).to be_nil

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -14,6 +14,8 @@ module Dependabot
       class VersionFinder
         require_relative "repository_finder"
 
+        NUGET_RANGE_REGEX = /[\(\[].*,.*[\)\]]/.freeze
+
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, raise_on_ignored: false,
                        security_advisories:)
@@ -67,7 +69,7 @@ module Dependabot
           filtered = possible_versions
 
           ignored_versions.each do |req|
-            ignore_req = requirement_class.new(req.split(","))
+            ignore_req = requirement_class.new(parse_requirement_string(req))
             filtered =
               filtered.
               reject { |v| ignore_req.satisfied_by?(v.fetch(:version)) }
@@ -96,6 +98,12 @@ module Dependabot
           possible_versions.select do |v|
             v.fetch(:version) > version_class.new(dependency.version)
           end
+        end
+
+        def parse_requirement_string(string)
+           return string if string.match?(NUGET_RANGE_REGEX)
+
+           string.split(",").map(&:strip)
         end
 
         def available_v3_versions
@@ -169,7 +177,7 @@ module Dependabot
           end
 
           dependency.requirements.any? do |req|
-            reqs = (req.fetch(:requirement) || "").split(",").map(&:strip)
+            reqs = parse_requirement_string(req.fetch(:requirement) || "")
             next unless reqs.any? { |r| r.include?("-") }
 
             requirement_class.

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -101,9 +101,9 @@ module Dependabot
         end
 
         def parse_requirement_string(string)
-           return string if string.match?(NUGET_RANGE_REGEX)
+          return string if string.match?(NUGET_RANGE_REGEX)
 
-           string.split(",").map(&:strip)
+          string.split(",").map(&:strip)
         end
 
         def available_v3_versions

--- a/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
@@ -102,11 +102,30 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
     end
 
     context "when the user is ignoring the latest version" do
+      let(:ignored_versions) { ["[2.a,3.0.0)"] }
+      its([:version]) { is_expected.to eq(version_class.new("1.1.2")) }
+    end
+
+    context "when a version range is specified using Ruby syntax" do
       let(:ignored_versions) { [">= 2.a, < 3.0.0"] }
       its([:version]) { is_expected.to eq(version_class.new("1.1.2")) }
     end
 
     context "when the user has ignored all versions" do
+      let(:ignored_versions) { ["[0,)"] }
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "raises an error" do
+          expect { subject }.to raise_error(Dependabot::AllVersionsIgnored)
+        end
+      end
+    end
+
+    context "when an open version range is specified using Ruby syntax" do
       let(:ignored_versions) { ["> 0"] }
       it "returns nil" do
         expect(subject).to be_nil


### PR DESCRIPTION
Despite the [docs](https://dependabot.com/docs/config-file/#ignored_updates), which say that ignored updates should match the package manager, it looks like Maven & Gradle ranges have always been implemented using Gem’s pattern.

I’m not 100% confident that this will fix the actual issue with `config.yml`, since the implementation that parses that file into a Dependabot run doesn’t seem to be open source.

fixes #1845