### PR TITLE
Support docker for GitHub Actions

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -1,61 +1,37 @@
 # frozen_string_literal: true
 
-require "docker_registry2"
-
 require "dependabot/dependency"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
 require "dependabot/errors"
-require "dependabot/docker/utils/credentials_finder"
+require 'dependabot/docker/utils/dockerfile_parser'
 
 module Dependabot
   module Docker
     class FileParser < Dependabot::FileParsers::Base
       require "dependabot/file_parsers/base/dependency_set"
 
-      # Details of Docker regular expressions is at
-      # https://github.com/docker/distribution/blob/master/reference/regexp.go
-      DOMAIN_COMPONENT =
-        /(?:[[:alnum:]]|[[:alnum:]][[[:alnum:]]-]*[[:alnum:]])/.freeze
-      DOMAIN = /(?:#{DOMAIN_COMPONENT}(?:\.#{DOMAIN_COMPONENT})+)/.freeze
-      REGISTRY = /(?<registry>#{DOMAIN}(?::\d+)?)/.freeze
-
-      NAME_COMPONENT = /(?:[a-z\d]+(?:(?:[._]|__|[-]*)[a-z\d]+)*)/.freeze
-      IMAGE = %r{(?<image>#{NAME_COMPONENT}(?:/#{NAME_COMPONENT})*)}.freeze
-
-      FROM = /FROM/i.freeze
-      TAG = /:(?<tag>[\w][\w.-]{0,127})/.freeze
-      DIGEST = /@(?<digest>[^\s]+)/.freeze
-      NAME = /\s+AS\s+(?<name>[\w-]+)/.freeze
-      FROM_LINE =
-        %r{^#{FROM}\s+(#{REGISTRY}/)?#{IMAGE}#{TAG}?#{DIGEST}?#{NAME}?}.freeze
-
-      AWS_ECR_URL = /dkr\.ecr\.(?<region>[^.]+).amazonaws\.com/.freeze
-
       def parse
         dependency_set = DependencySet.new
 
         dockerfiles.each do |dockerfile|
           dockerfile.content.each_line do |line|
-            next unless FROM_LINE.match?(line)
+            next unless Utils::DockerFileParser::FROM_LINE.match?(line)
 
-            parsed_from_line = FROM_LINE.match(line).named_captures
-            if parsed_from_line["registry"] == "docker.io"
-              parsed_from_line["registry"] = nil
-            end
+            docker_file_parser = Utils::DockerFileParser.new(line, credentials)
 
-            version = version_from(parsed_from_line)
+            version = docker_file_parser.version
             next unless version
 
             dependency_set << Dependency.new(
-              name: parsed_from_line.fetch("image"),
+              name: docker_file_parser.image,
               version: version,
               package_manager: "docker",
               requirements: [
                 requirement: nil,
                 groups: [],
                 file: dockerfile.name,
-                source: source_from(parsed_from_line)
+                source: docker_file_parser.source
               ]
             )
           end
@@ -70,88 +46,6 @@ module Dependabot
         # The Docker file fetcher only fetches Dockerfiles, so no need to
         # filter here
         dependency_files
-      end
-
-      def version_from(parsed_from_line)
-        return parsed_from_line.fetch("tag") if parsed_from_line.fetch("tag")
-
-        version_from_digest(
-          registry: parsed_from_line.fetch("registry"),
-          image: parsed_from_line.fetch("image"),
-          digest: parsed_from_line.fetch("digest")
-        )
-      end
-
-      def source_from(parsed_from_line)
-        source = {}
-
-        if parsed_from_line.fetch("registry")
-          source[:registry] = parsed_from_line.fetch("registry")
-        end
-
-        if parsed_from_line.fetch("tag")
-          source[:tag] = parsed_from_line.fetch("tag")
-        end
-
-        if parsed_from_line.fetch("digest")
-          source[:digest] = parsed_from_line.fetch("digest")
-        end
-
-        source
-      end
-
-      def version_from_digest(registry:, image:, digest:)
-        return unless digest
-
-        repo = docker_repo_name(image, registry)
-        client = docker_registry_client(registry)
-        client.tags(repo, auto_paginate: true).fetch("tags").find do |tag|
-          digest == client.digest(repo, tag)
-        rescue DockerRegistry2::NotFound
-          # Shouldn't happen, but it does. Example of existing tag with
-          # no manifest is "library/python", "2-windowsservercore".
-          false
-        end
-      rescue DockerRegistry2::RegistryAuthenticationException,
-             RestClient::Forbidden
-        raise if standard_registry?(registry)
-
-        raise PrivateSourceAuthenticationFailure, registry
-      end
-
-      def docker_repo_name(image, registry)
-        return image unless standard_registry?(registry)
-        return image unless image.split("/").count < 2
-
-        "library/#{image}"
-      end
-
-      def docker_registry_client(registry)
-        if registry
-          credentials = registry_credentials(registry)
-
-          DockerRegistry2::Registry.new(
-            "https://#{registry}",
-            user: credentials&.fetch("username", nil),
-            password: credentials&.fetch("password", nil)
-          )
-        else
-          DockerRegistry2::Registry.new("https://registry.hub.docker.com")
-        end
-      end
-
-      def registry_credentials(registry_url)
-        credentials_finder.credentials_for_registry(registry_url)
-      end
-
-      def credentials_finder
-        @credentials_finder ||= Utils::CredentialsFinder.new(credentials)
-      end
-
-      def standard_registry?(registry)
-        return true if registry.nil?
-
-        registry == "registry.hub.docker.com"
       end
 
       def check_required_files

--- a/docker/lib/dependabot/docker/utils/dockerfile_parser.rb
+++ b/docker/lib/dependabot/docker/utils/dockerfile_parser.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "docker_registry2"
+require "dependabot/docker/utils/credentials_finder"
+
+module Dependabot
+  module Docker
+    module Utils
+      class DockerFileParser
+        # Details of Docker regular expressions is at
+        # https://github.com/docker/distribution/blob/master/reference/regexp.go
+        DOMAIN_COMPONENT =
+          /(?:[[:alnum:]]|[[:alnum:]][[[:alnum:]]-]*[[:alnum:]])/.freeze
+        DOMAIN = /(?:#{DOMAIN_COMPONENT}(?:\.#{DOMAIN_COMPONENT})+)/.freeze
+        REGISTRY = /(?<registry>#{DOMAIN}(?::\d+)?)/.freeze
+
+        NAME_COMPONENT = /(?:[a-z\d]+(?:(?:[._]|__|[-]*)[a-z\d]+)*)/.freeze
+        IMAGE = %r{(?<image>#{NAME_COMPONENT}(?:/#{NAME_COMPONENT})*)}.freeze
+
+        FROM = /FROM/i.freeze
+        TAG = /:(?<tag>[\w][\w.-]{0,127})/.freeze
+        DIGEST = /@(?<digest>[^\s]+)/.freeze
+        NAME = /\s+AS\s+(?<name>[\w-]+)/.freeze
+        FROM_LINE =
+          %r{^#{FROM}\s+(#{REGISTRY}/)?#{IMAGE}#{TAG}?#{DIGEST}?#{NAME}?}.freeze
+
+        AWS_ECR_URL = /dkr\.ecr\.(?<region>[^.]+).amazonaws\.com/.freeze
+
+        def initialize(line, credentials)
+          parsed_from_line = FROM_LINE.match(line).named_captures
+          if parsed_from_line["registry"] == "docker.io"
+            parsed_from_line["registry"] = nil
+          end
+          @parsed_from_line = parsed_from_line
+          @credentials = credentials
+        end
+
+        def source
+          source_from(@parsed_from_line)
+        end
+
+        def image
+          @parsed_from_line.fetch("image")
+        end
+
+        def version
+          version_from(@parsed_from_line)
+        end
+
+        private
+
+        def version_from(parsed_from_line)
+          return parsed_from_line.fetch("tag") if parsed_from_line.fetch("tag")
+
+          version_from_digest(
+            registry: parsed_from_line.fetch("registry"),
+            image: parsed_from_line.fetch("image"),
+            digest: parsed_from_line.fetch("digest")
+          )
+        end
+
+        def source_from(parsed_from_line)
+          source = {}
+          source[:type] = "docker"
+
+          if parsed_from_line.fetch("image")
+            source[:image] = parsed_from_line.fetch("image")
+          end
+
+          if parsed_from_line.fetch("registry")
+            source[:registry] = parsed_from_line.fetch("registry")
+          end
+
+          if parsed_from_line.fetch("tag")
+            source[:tag] = parsed_from_line.fetch("tag")
+          end
+
+          if parsed_from_line.fetch("digest")
+            source[:digest] = parsed_from_line.fetch("digest")
+          end
+
+          source
+        end
+
+        def version_from_digest(registry:, image:, digest:)
+          return unless digest
+
+          repo = docker_repo_name(image, registry)
+          client = docker_registry_client(registry)
+          client.tags(repo, auto_paginate: true).fetch("tags").find do |tag|
+            digest == client.digest(repo, tag)
+          rescue DockerRegistry2::NotFound
+            # Shouldn't happen, but it does. Example of existing tag with
+            # no manifest is "library/python", "2-windowsservercore".
+            false
+          end
+        rescue DockerRegistry2::RegistryAuthenticationException,
+               RestClient::Forbidden
+          raise if standard_registry?(registry)
+
+          raise PrivateSourceAuthenticationFailure, registry
+        end
+
+        def docker_repo_name(image, registry)
+          return image unless standard_registry?(registry)
+          return image unless image.split("/").count < 2
+
+          "library/#{image}"
+        end
+
+        def docker_registry_client(registry)
+          if registry
+            credentials = registry_credentials(registry)
+
+            DockerRegistry2::Registry.new(
+              "https://#{registry}",
+              user: credentials&.fetch("username", nil),
+              password: credentials&.fetch("password", nil)
+            )
+          else
+            DockerRegistry2::Registry.new("https://registry.hub.docker.com")
+          end
+        end
+
+        def registry_credentials(registry_url)
+          credentials_finder.credentials_for_registry(registry_url)
+        end
+
+        def credentials_finder
+          @credentials_finder ||= CredentialsFinder.new(@credentials)
+        end
+
+        def standard_registry?(registry)
+          return true if registry.nil?
+
+          registry == "registry.hub.docker.com"
+        end
+      end
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -57,13 +57,16 @@ module Dependabot
 
         updated_requirement_pairs.each do |new_req, old_req|
           # TODO: Support updating Docker sources
-          next unless new_req.fetch(:source).fetch(:type) == "git"
+          if new_req.fetch(:source).fetch(:type) == "git"
 
           old_declaration = old_req.fetch(:metadata).fetch(:declaration_string)
           new_declaration =
             old_declaration.
             gsub(/@.*+/, "@#{new_req.fetch(:source).fetch(:ref)}")
-
+          elsif new_req.fetch(:source).fetch(:type) == "docker"
+            old_declaration = "docker://#{old_req.fetch(:source).fetch(:image)}:#{old_req.fetch(:source).fetch(:tag)}"
+            new_declaration = "docker://#{new_req.fetch(:source).fetch(:image)}:#{new_req.fetch(:source).fetch(:tag)}"
+          end
           # Replace the old declaration that's preceded by a non-word character
           # and followed by a whitespace character (comments) or EOL
           updated_content =

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -9,92 +9,15 @@ require "dependabot/github_actions/requirement"
 module Dependabot
   module GithubActions
     class UpdateChecker < Dependabot::UpdateCheckers::Base
-      def latest_version
-        @latest_version ||= fetch_latest_version
-      end
-
-      def latest_resolvable_version
+      attr_reader :docker_deps
+      attr_reader :dependency
+      def initialize(dependency:, dependency_files:, credentials:,
+                     ignored_versions: [], raise_on_ignored: false,
+                     security_advisories: [],
+                     requirements_update_strategy: nil)
         if dependency.package_manager == "docker"
-          return @docker_deps.latest_resolvable_version
-        end
-
-        # Resolvability isn't an issue for GitHub Actions.
-        latest_version
-      end
-
-      def latest_resolvable_version_with_no_unlock
-        if dependency.package_manager == "docker"
-          return @docker_deps.latest_resolvable_version_with_no_unlock
-        end
-
-        # No concept of "unlocking" for GitHub Actions (since no lockfile)
-        dependency.version
-      end
-
-      def updated_requirements
-        if dependency.package_manager == "docker"
-          return @docker_deps.updated_requirements
-        end
-
-        if updated_source == dependency_source_details
-          return dependency.requirements
-        end
-
-        dependency.requirements.map { |req| req.merge(source: updated_source) }
-      end
-
-      private
-
-      def version_up_to_date?
-        if dependency.package_manager == "docker"
-          return @docker_deps.send(:version_up_to_date?)
-        end
-
-        super
-      end
-
-      def version_can_update?(*)
-        if dependency.package_manager == "docker"
-          return !@docker_deps.send(:version_up_to_date?)
-        end
-
-        super
-      end
-
-      # copied from base class
-      def vulnerable?
-        return false if security_advisories.none?
-
-        # Can't (currently) detect whether dependencies without a version
-        # (i.e., for repos without a lockfile) are vulnerable
-        return false unless dependency.version
-
-        # Can't (currently) detect whether git dependencies are vulnerable
-        return false if existing_version_is_sha?
-
-        if dependency.package_manager == "docker"
-          # dirty hack
+          @dependency = dependency
           @security_advisories = []
-        end
-        version = version_class.new(dependency.version)
-        security_advisories.any? { |a| a.vulnerable?(version) }
-      end
-
-      def latest_version_resolvable_with_full_unlock?
-        # Full unlock checks aren't relevant for GitHub Actions
-        false
-      end
-
-      def updated_dependencies_after_full_unlock
-        raise NotImplementedError
-      end
-
-      def fetch_latest_version
-        # TODO: Support Docker sources
-        # return unless git_dependency?
-        if dependency.package_manager == "github_actions"
-          fetch_latest_version_for_git_dependency
-        elsif dependency.package_manager == "docker"
           @docker_deps = Docker::UpdateChecker.new(
             dependency: dependency,
             dependency_files: dependency_files,
@@ -108,8 +31,104 @@ module Dependabot
               safe_versions: []
             )
           )
-          @docker_deps.latest_version
+        else
+          super
         end
+      end
+
+      def latest_version
+        if dependency.package_manager == "docker"
+          return docker_deps.latest_version
+        end
+        @latest_version ||= fetch_latest_version
+      end
+
+      def latest_resolvable_version
+        if dependency.package_manager == "docker"
+          return docker_deps.latest_resolvable_version
+        end
+        # Resolvability isn't an issue for GitHub Actions.
+        latest_version
+      end
+
+      def latest_resolvable_version_with_no_unlock
+        if dependency.package_manager == "docker"
+          return docker_deps.latest_resolvable_version_with_no_unlock
+        end
+        # No concept of "unlocking" for GitHub Actions (since no lockfile)
+        dependency.version
+      end
+
+      def updated_requirements
+        if dependency.package_manager == "docker"
+          return docker_deps.updated_requirements
+        end
+        if updated_source == dependency_source_details
+          return dependency.requirements
+        end
+
+        dependency.requirements.map { |req| req.merge(source: updated_source) }
+      end
+
+      private
+
+      def version_up_to_date?
+        if dependency.package_manager == "docker"
+          return docker_deps.send(:version_up_to_date?)
+        end
+
+        super
+      end
+
+      def version_can_update?(*)
+        if dependency.package_manager == "docker"
+          return !docker_deps.send(:version_up_to_date?)
+        end
+
+        super
+      end
+
+      def ignore_reqs
+        if dependency.package_manager == "docker"
+          return docker_deps.send(:ignore_reqs)
+        end
+
+        super
+      end
+
+      # # copied from base class
+      # def vulnerable?
+      #   return false if security_advisories.none?
+
+      #   # Can't (currently) detect whether dependencies without a version
+      #   # (i.e., for repos without a lockfile) are vulnerable
+      #   return false unless dependency.version
+
+      #   # Can't (currently) detect whether git dependencies are vulnerable
+      #   return false if existing_version_is_sha?
+
+      #   if dependency.package_manager == "docker"
+      #     # dirty hack
+      #     @security_advisories = []
+      #   end
+      #   version = version_class.new(dependency.version)
+      #   security_advisories.any? { |a| a.vulnerable?(version) }
+      # end
+
+      def latest_version_resolvable_with_full_unlock?
+        # Full unlock checks aren't relevant for GitHub Actions
+        false
+      end
+
+      def updated_dependencies_after_full_unlock
+        raise NotImplementedError
+      end
+
+      def fetch_latest_version
+        # TODO: Support Docker sources
+        return unless git_dependency?
+
+        fetch_latest_version_for_git_dependency
       end
 
       def fetch_latest_version_for_git_dependency

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -96,25 +96,6 @@ module Dependabot
         super
       end
 
-      # # copied from base class
-      # def vulnerable?
-      #   return false if security_advisories.none?
-
-      #   # Can't (currently) detect whether dependencies without a version
-      #   # (i.e., for repos without a lockfile) are vulnerable
-      #   return false unless dependency.version
-
-      #   # Can't (currently) detect whether git dependencies are vulnerable
-      #   return false if existing_version_is_sha?
-
-      #   if dependency.package_manager == "docker"
-      #     # dirty hack
-      #     @security_advisories = []
-      #   end
-      #   version = version_class.new(dependency.version)
-      #   security_advisories.any? { |a| a.vulnerable?(version) }
-      # end
-
       def latest_version_resolvable_with_full_unlock?
         # Full unlock checks aren't relevant for GitHub Actions
         false

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -14,16 +14,28 @@ module Dependabot
       end
 
       def latest_resolvable_version
+        if dependency.package_manager == "docker"
+          return @docker_deps.latest_resolvable_version
+        end
+
         # Resolvability isn't an issue for GitHub Actions.
         latest_version
       end
 
       def latest_resolvable_version_with_no_unlock
+        if dependency.package_manager == "docker"
+          return @docker_deps.latest_resolvable_version_with_no_unlock
+        end
+
         # No concept of "unlocking" for GitHub Actions (since no lockfile)
         dependency.version
       end
 
       def updated_requirements
+        if dependency.package_manager == "docker"
+          return @docker_deps.updated_requirements
+        end
+
         if updated_source == dependency_source_details
           return dependency.requirements
         end
@@ -32,6 +44,41 @@ module Dependabot
       end
 
       private
+
+      def version_up_to_date?
+        if dependency.package_manager == "docker"
+          return @docker_deps.send(:version_up_to_date?)
+        end
+
+        super
+      end
+
+      def version_can_update?(*)
+        if dependency.package_manager == "docker"
+          return !@docker_deps.send(:version_up_to_date?)
+        end
+
+        super
+      end
+
+      # copied from base class
+      def vulnerable?
+        return false if security_advisories.none?
+
+        # Can't (currently) detect whether dependencies without a version
+        # (i.e., for repos without a lockfile) are vulnerable
+        return false unless dependency.version
+
+        # Can't (currently) detect whether git dependencies are vulnerable
+        return false if existing_version_is_sha?
+
+        if dependency.package_manager == "docker"
+          # dirty hack
+          @security_advisories = []
+        end
+        version = version_class.new(dependency.version)
+        security_advisories.any? { |a| a.vulnerable?(version) }
+      end
 
       def latest_version_resolvable_with_full_unlock?
         # Full unlock checks aren't relevant for GitHub Actions
@@ -44,9 +91,25 @@ module Dependabot
 
       def fetch_latest_version
         # TODO: Support Docker sources
-        return unless git_dependency?
-
-        fetch_latest_version_for_git_dependency
+        # return unless git_dependency?
+        if dependency.package_manager == "github_actions"
+          fetch_latest_version_for_git_dependency
+        elsif dependency.package_manager == "docker"
+          @docker_deps = Docker::UpdateChecker.new(
+            dependency: dependency,
+            dependency_files: dependency_files,
+            credentials: credentials,
+            requirements_update_strategy: requirements_update_strategy,
+            ignored_versions: ignored_versions,
+            security_advisories: Dependabot::SecurityAdvisory.new(
+              dependency_name: dependency.name,
+              package_manager: "docker",
+              vulnerable_versions: [],
+              safe_versions: []
+            )
+          )
+          @docker_deps.latest_version
+        end
       end
 
       def fetch_latest_version_for_git_dependency


### PR DESCRIPTION
This is mostly some hacks I did to get `docker` dependency update support for `github-actions`. Due to the way the current code is organized it seems harder to use the existing `docker` *package_manager*. Are we going to support some kind of sub-dependecy for `github-actions` type?

Fix https://github.com/dependabot/dependabot-core/issues/5541

*DO NOT MERGE*