### PR TITLE
Fix NoMethodError when updating NuGet packages from Directory.Packages.props

### DIFF
--- a/nuget/lib/dependabot/nuget/file_updater/project_file_declaration_finder.rb
+++ b/nuget/lib/dependabot/nuget/file_updater/project_file_declaration_finder.rb
@@ -46,6 +46,7 @@ module Dependabot
         def get_element_from_node(node)
           node.at_xpath("/PackageReference") ||
             node.at_xpath("/GlobalPackageReference") ||
+            node.at_xpath("/PackageVersion") ||
             node.at_xpath("/Dependency") ||
             node.at_xpath("/DevelopmentDependency")
         end


### PR DESCRIPTION
Fix `NoMethodError` when a NuGet package defined in a `Directory.Packages.props` file needs updating.

It looks like the support added in #1880 missed updating the `get_element_from_node` function to expect the `PackageVersion` node.

I noticed this in my dependabot logs after updating some of my repositories to use central NuGet package management (https://github.com/martincostello/alexa-london-travel/pull/256 is one example).

I did try trying to write an integration test for this by updating the `property_value_updater_spec` to include a `.csproj` that defined a `<PackageReference Include="Foo" />` element (note that there's no `Version` attribute because it's centrally defined) to replicate the error before applying what I think is the fix, but I'm not very familiar with Ruby and couldn't get the tests to fail.

An excerpt from the dependabot logs for a failing update are below.

```
updater | INFO <job_34433667> Checking if Moq 4.14.4 needs updating
  proxy | 2020/07/10 04:03:21 GET https://api-v2v3search-0.nuget.org:443/query?q=moq&prerelease=true
  proxy | 2020/07/10 04:03:21 200 https://api-v2v3search-0.nuget.org:443/query?q=moq&prerelease=true
updater | INFO <job_34433667> Latest version is 4.14.5
updater | INFO <job_34433667> Requirements to unlock own
updater | INFO <job_34433667> Requirements update strategy 
updater | INFO <job_34433667> Updating Moq from 4.14.4 to 4.14.5
updater | I, [2020-07-10T04:03:21.759273 #73]  INFO -- sentry: ** [Raven] Sending event a00b2f68ba5b4e62b8a74372ddb4bfee to Sentry
  proxy | 2020/07/10 04:03:22 POST https://sentry.io:443/api/1451818/store/
  proxy | 2020/07/10 04:03:22 200 https://sentry.io:443/api/1451818/store/
updater | ERROR <job_34433667> Error processing Moq (NoMethodError)
updater | ERROR <job_34433667> undefined method `attribute' for nil:NilClass
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-nuget-0.118.7/lib/dependabot/nuget/file_updater/project_file_declaration_finder.rb:59:in `block in fetch_declaration_strings'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-nuget-0.118.7/lib/dependabot/nuget/file_updater/project_file_declaration_finder.rb:54:in `select'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-nuget-0.118.7/lib/dependabot/nuget/file_updater/project_file_declaration_finder.rb:54:in `fetch_declaration_strings'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-nuget-0.118.7/lib/dependabot/nuget/file_updater/project_file_declaration_finder.rb:35:in `declaration_strings'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-nuget-0.118.7/lib/dependabot/nuget/file_updater.rb:132:in `original_declarations'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-nuget-0.118.7/lib/dependabot/nuget/file_updater.rb:109:in `update_declaration'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-nuget-0.118.7/lib/dependabot/nuget/file_updater.rb:84:in `block in update_files_for_dependency'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-nuget-0.118.7/lib/dependabot/nuget/file_updater.rb:74:in `each'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-nuget-0.118.7/lib/dependabot/nuget/file_updater.rb:74:in `update_files_for_dependency'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-nuget-0.118.7/lib/dependabot/nuget/file_updater.rb:32:in `block in updated_dependency_files'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-nuget-0.118.7/lib/dependabot/nuget/file_updater.rb:31:in `each'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-nuget-0.118.7/lib/dependabot/nuget/file_updater.rb:31:in `updated_dependency_files'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:433:in `generate_dependency_files_for'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:230:in `check_and_create_pull_request'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:65:in `check_and_create_pr_with_error_handling'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:51:in `block in run'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:51:in `each'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:51:in `run'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/lib/dependabot/update_files_job.rb:16:in `perform_job'
updater | ERROR <job_34433667> /home/dependabot/dependabot-updater/lib/dependabot/base_job.rb:29:in `run'
updater | ERROR <job_34433667> bin/update_files.rb:21:in `<main>'
```