### PR TITLE
base: enforce version type

### DIFF
--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -213,7 +213,12 @@ module Dependabot
         # this case we treat the version as up-to-date so that it's ignored.
         return true if latest_version.to_s.match?(/^[0-9a-f]{40}$/)
 
-        latest_version <= version_class.new(dependency.version)
+        latest = if latest_version.is_a?(String)
+                   version_class.new(latest_version)
+                 else
+                   latest_version
+                 end
+        latest <= version_class.new(dependency.version)
       end
 
       def numeric_version_can_update?(requirements_to_unlock:)

--- a/common/spec/dependabot/update_checkers/base_spec.rb
+++ b/common/spec/dependabot/update_checkers/base_spec.rb
@@ -98,6 +98,11 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
       it { is_expected.to be_falsey }
     end
 
+    context "when the latest version is vendored commit string" do
+      let(:latest_version) { "1.5.0.0.gcafecafe" }
+      it { is_expected.to be_truthy }
+    end
+
     context "when the dependency has a SHA-1 hash version" do
       let(:dependency) do
         Dependabot::Dependency.new(


### PR DESCRIPTION
This PR patches `numeric_version_up_to_date?` to cast any returned `String` into the appropriate dependency version class for comparison.

This is a bandaid on an exception I encountered using a `Gemfile` pinned to a commit., e.g. https://github.com/rtomayko/posix-spawn/commit/a37695d07f0b9d0c9b66f74b4dc3c8f0408d3907
```
gem "posix-spawn", "~> 0.3.13", github: "rtomayko/posix-spawn", ref: "a37695d07f0b9d0c9b66f74b4dc3c8f0408d3907"
```

In this configuration, the bundler `UpdateChecker.latest_version` returns a `String`, https://github.com/dependabot/dependabot-core/blob/main/bundler/lib/dependabot/bundler/update_checker.rb#L18

That results in a runtime exception:
```
Traceback (most recent call last):
	6: from bin/dry-run.rb:402:in `<main>'
	5: from bin/dry-run.rb:402:in `each'
	4: from bin/dry-run.rb:410:in `block in <main>'
	3: from /home/dependabot/dependabot-core/common/lib/dependabot/update_checkers/base.rb:29:in `up_to_date?'
	2: from /home/dependabot/dependabot-core/common/lib/dependabot/update_checkers/base.rb:167:in `version_up_to_date?'
	1: from /home/dependabot/dependabot-core/common/lib/dependabot/update_checkers/base.rb:217:in `numeric_version_up_to_date?'
/home/dependabot/dependabot-core/common/lib/dependabot/update_checkers/base.rb:217:in `<=': comparison of String with Dependabot::Bundler::Version failed (ArgumentError)
```

