### PR TITLE
fix: go mod tidy instead of go get

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -121,7 +121,7 @@ module Dependabot
           File.write("go.sum", go_sum.content) if go_sum
           File.write("main.go", dummy_main_go)
 
-          _, stderr, status = Open3.capture3(ENVIRONMENT, "go get -d")
+          _, stderr, status = Open3.capture3(ENVIRONMENT, "go mod tidy")
           handle_subprocess_error(stderr) unless status.success?
 
           updated_go_sum = go_sum ? File.read("go.sum") : nil


### PR DESCRIPTION
go get adds new dependencies but leaves the old, now unused, dependency versions in the go sum file.

this fixes: https://github.com/dependabot/dependabot-core/issues/2229

FYI im not a ruby dev or anything, just a dependabot user with broken pipelines :)
if this is unhelpful / wrong or anything like that feel free to close my PR, no harm done