### PR TITLE
Fix: Configure phpstan level via phpstan.neon

### DIFF
--- a/composer/helpers/composer.json
+++ b/composer/helpers/composer.json
@@ -17,7 +17,7 @@
         "lint": [
             "php-cs-fixer fix --diff --verbose"
         ],
-        "stan": "phpstan analyse -l 5"
+        "stan": "phpstan analyse"
     },
     "config": {
         "sort-packages": true

--- a/composer/helpers/phpstan.neon
+++ b/composer/helpers/phpstan.neon
@@ -1,4 +1,5 @@
 parameters:
 	inferPrivatePropertyTypeFromConstructor: true
+	level: 5
 	paths:
 		- src


### PR DESCRIPTION
This PR

* [x] configures the `phpstan` level via `phpstan.neon`

Slightly related to #2338.