### PR TITLE
Fix: Do not bother using array

### DIFF
--- a/composer/helpers/composer.json
+++ b/composer/helpers/composer.json
@@ -14,9 +14,7 @@
         }
     },
     "scripts": {
-        "lint": [
-            "php-cs-fixer fix --diff --verbose"
-        ],
+        "lint": "php-cs-fixer fix --diff --verbose",
         "stan": "phpstan analyse -l 5"
     },
     "config": {


### PR DESCRIPTION
This PR

* [x] uses a `string` instead of an `array` for a list of scripts that contains only a single entry