### PR TITLE
Undefined names: import PipSession and parse_requirements

### DIFF
--- a/python/spec/fixtures/setup_files/with_parse_reqs.py
+++ b/python/spec/fixtures/setup_files/with_parse_reqs.py
@@ -1,3 +1,5 @@
+from pip._internal.network.session import PipSession
+from pip._internal.req.req_file import parse_requirements
 from setuptools import setup, find_packages
 
 reqs = [str(r.req) for r in parse_requirements('requirements.txt', session=PipSession()) if r.req is not None]


### PR DESCRIPTION
`PipSession()` and `parse_requirements()` are both used on line 5 but they are not defined or imported which may raise a `NameError` at runtime.
* https://github.com/pypa/pip/blob/master/src/pip/_internal/network/session.py#L228
* https://github.com/pypa/pip/blob/master/src/pip/_internal/req/req_file.py#L127