### PR TITLE
NPM and Yarn: Fix for getting metadata for direct dependency update

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -214,9 +214,18 @@ module Dependabot
       end
 
       def registry_auth_headers
-        return {} unless auth_token
+        token = auth_token
+        return {} unless token
 
-        { "Authorization" => "Bearer #{auth_token}" }
+        if token.include?(":")
+          encoded_token = Base64.encode64(token).delete("\n")
+          { "Authorization" => "Basic #{encoded_token}" }
+        elsif Base64.decode64(token).ascii_only? &&
+              Base64.decode64(token).include?(":")
+            { "Authorization" => "Basic #{token.delete("\n")}" }
+        else
+          { "Authorization" => "Bearer #{token}" }
+        end
       end
 
       def dependency_registry


### PR DESCRIPTION
**Issue**
For `direct dependency update`, dependabot-core is unable to fetch metadata such as `release notes`, `changelog,`etc. when using a `base64 encoded token` for connecting to a `private` registry as mentioned in the issue: [Issue #2293](https://github.com/dependabot/dependabot-core/issues/2293). This results in a PR without `detailed description` relevant to the updated package.
In case of `subdependency`, it fetches the details from the `public` registry hence does not face this authentication issue.
Attaching some images for clear context:

****Image without detailed description****

<img src="https://user-images.githubusercontent.com/20723344/88051242-eb72c180-cb75-11ea-9573-708c57cd452c.PNG" width = "275">


****Image with detailed description****

<img src="https://user-images.githubusercontent.com/20723344/88050175-faf10b00-cb73-11ea-9e39-02f737cc7ae9.PNG" width = "300">




**Cause**
Only `bearer` authorization is enabled for connecting to the `private` registry for fetching metadata whereas in other scenarios( like `getting latest version` of package from registry), it decides the authorization based on the auth token provided. Here is a code reference: https://github.com/dependabot/dependabot-core/blob/9f7b26453519e1b2a2db21d19078d4a65755bf6d/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb#L73

**Fix**
Added support for different types of auth tokens by deciding auth headers based on the auth token provided. 