### PR TITLE
Fix for PR description limit issue for AzureDevOps(ADO)

### DIFF
--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -164,9 +164,7 @@ module Dependabot
           end_index = get_description_end_index(pr_description, truncate_length)
           pr_description = end_index == -1 ? "" : pr_description[0..end_index]  + truncated_msg
         end
-
-        puts "Create pull request from source: #{source_branch} to target: #{target_branch}"
-        puts "PR name:#{pr_name}"
+       
         content = {
           sourceRefName: "refs/heads/" + source_branch,
           targetRefName: "refs/heads/" + target_branch,


### PR DESCRIPTION
**Issue**
While running dependabot-core on a `AzureDevOps repo`, it failed to create PR for dependency update with error **`PR description limit exceeded (Description limit cannot be more than 4000 characters)`**. However, to avoid this error, `create_pull_request` function in `azure_client` checks whether the `pr_description length` is greater than the `permissible limit ( i.e currently 4000 characters)` and accordingly trims the description.
https://github.com/dependabot/dependabot-core/blob/f4cf8cfdcc44fa4f309af2df264a3dabe7ee5b7b/common/lib/dependabot/clients/azure.rb#L160

**Cause**
The error was caused due to a `special unicode character` i.e 🎉 which occured multiple times in the PR description. In `UTF-8 encoding`( used in dependabot-core) this character has length `1` whereas in `UTF-16 encoding` (used in ADO), the size of the character is `2`. This diff in size resulted in the pr_description not getting trimmed properly and hence resulting in `pr description length > 4000` on ADO.

**Fix**
Modified `pr_description trimming` part to calculate the `PR description length using UTF-16 encoding` and find the `end index` upto which the description needs to be trimmed.