### PR TITLE
[composer] Fix: Explicitly require latest stable version of composer/composer

### DIFF
--- a/composer/helpers/composer.json
+++ b/composer/helpers/composer.json
@@ -2,7 +2,7 @@
     "require": {
         "php": "^7.4",
         "ext-json": "*",
-        "composer/composer": "^1.8"
+        "composer/composer": "^1.10.9"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.9",

--- a/composer/helpers/composer.lock
+++ b/composer/helpers/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1c4b6abaa9790d5c89b60507b2e7bdd",
+    "content-hash": "5a7b480edaeff5f76761647b6e98981c",
     "packages": [
         {
             "name": "composer/ca-bundle",


### PR DESCRIPTION
This PR

* [x] explicitly requires the latest stable version of `composer/composer`