### PR TITLE
[github_actions] Fix: Update references to actions when they are single- or double-quoted strings

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -69,7 +69,7 @@ module Dependabot
           updated_content =
             updated_content.
             gsub(
-              /(?<=\W)#{Regexp.escape(old_declaration)}(?=\s|$)/,
+              /(?<=\W|"|')#{Regexp.escape(old_declaration)}(?=\s|"|'|$)/,
               new_declaration
             )
         end

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -80,8 +80,21 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
         updated_files.find { |f| f.name == ".github/workflows/workflow.yml" }
       end
 
-      its(:content) { is_expected.to include "actions/setup-node@v1.1.0\n" }
-      its(:content) { is_expected.to_not include "actions/setup-node@master" }
+      its(:content) do
+        is_expected.to include "\"actions/setup-node@v1.1.0\"\n"
+        is_expected.to_not include "\"actions/setup-node@master\""
+      end
+
+      its(:content) do
+        is_expected.to include "'actions/setup-node@v1.1.0'\n"
+        is_expected.to_not include "'actions/setup-node@master'"
+      end
+
+      its(:content) do
+        is_expected.to include "actions/setup-node@v1.1.0\n"
+        is_expected.to_not include "actions/setup-node@master"
+      end
+
       its(:content) { is_expected.to include "actions/checkout@master\n" }
 
       context "with a path" do

--- a/github_actions/spec/fixtures/workflow_files/workflow.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow.yml
@@ -85,3 +85,30 @@ jobs:
     - name: Run the unit tests
       run: |
         node ./scripts/run-yarn.js test:unit
+
+  set-up-node-with-double-quotes:
+    name: "Set up node with double quotes"
+
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Set up node with double quotes"
+        uses: "actions/setup-node@master"
+
+  set-up-node-with-single-quotes:
+    name: 'Set up node with single quotes'
+
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - name: 'Set up node with single quotes'
+        uses: 'actions/setup-node@master'
+
+  set-up-node-without-quotes:
+    name: Set up node without quotes
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up node without quotes
+        uses: actions/setup-node@master


### PR DESCRIPTION
This PR

* [x] asserts that references to actions are updated when they are single- or double-quoted strings
* [x] adjusts a regular expression to handle updates of action when they are single- or double-quoted strings

Fixes #2346.