### PR TITLE
Fix ci on forks by caching the ci image in packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           rm .dockerignore
           docker build \
-            -t "dependabot/dependabot-core-ci:${{ github.sha }}" \
+            -t "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}" \
             -f Dockerfile.ci \
             --cache-from ubuntu:18.04 \
             --cache-from "dependabot/dependabot-core:latest" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
-on: [push]
+on:
+  - push
+  - pull_request
 
 jobs:
   ci-image:
@@ -8,9 +10,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Log in to the Docker registry
-        run: |
-          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
       - name: Prepare environment variables
         run: |
           echo ::set-env name=VERSION::$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)
@@ -19,20 +18,11 @@ jobs:
           docker pull ubuntu:18.04
           docker pull "dependabot/dependabot-core:latest"
           docker pull "dependabot/dependabot-core-ci:latest" || true
-      - name: Build dependabot-core image
-        run: |
-          docker build \
-            -t "dependabot/dependabot-core:latest" \
-            -t "dependabot/dependabot-core:${{ env.VERSION }}" \
-            --cache-from ubuntu:18.04 \
-            --cache-from "dependabot/dependabot-core:latest" \
-            .
       - name: Build dependabot-core-ci image
         run: |
           rm .dockerignore
           docker build \
-            -t "dependabot/dependabot-core-ci:${{ github.sha }}" \
-            -t "dependabot/dependabot-core-ci:latest" \
+            -t "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}" \
             -f Dockerfile.ci \
             --cache-from ubuntu:18.04 \
             --cache-from "dependabot/dependabot-core:latest" \
@@ -40,13 +30,13 @@ jobs:
             .
       - name: Push dependabot-core-ci image to CI cache repo
         run: |
-          docker push "dependabot/dependabot-core-ci:latest"
-          docker push "dependabot/dependabot-core-ci:${{ github.sha }}"
+          docker login docker.pkg.github.com -u x -p ${{ secrets.GITHUB_TOKEN }}
+          docker push "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}"
 
   rubocop:
     name: Rubocop
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run Rubocop linting
@@ -56,7 +46,7 @@ jobs:
   bundler:
     name: Bundler
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run bundler tests
@@ -66,7 +56,7 @@ jobs:
   cargo:
     name: Cargo
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run cargo tests
@@ -76,7 +66,7 @@ jobs:
   common:
     name: Common
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run common tests
@@ -86,7 +76,7 @@ jobs:
   composer:
     name: Composer
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run composer tests
@@ -96,7 +86,7 @@ jobs:
   dep:
     name: Dep
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run dep tests
@@ -106,7 +96,7 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run docker tests
@@ -116,7 +106,7 @@ jobs:
   elm:
     name: Elm
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run elm tests
@@ -126,7 +116,7 @@ jobs:
   git-submodules:
     name: Git submodules
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run git submodules tests
@@ -136,7 +126,7 @@ jobs:
   go-modules:
     name: Go modules
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run go modules tests
@@ -146,7 +136,7 @@ jobs:
   gradle:
     name: Gradle
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run gradle tests
@@ -156,7 +146,7 @@ jobs:
   hex:
     name: Hex
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run hex tests
@@ -166,7 +156,7 @@ jobs:
   maven:
     name: Maven
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run maven tests
@@ -176,7 +166,7 @@ jobs:
   npm-and-yarn:
     name: npm and yarn
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run npn and yarn tests
@@ -186,7 +176,7 @@ jobs:
   npm-and-yarn-js:
     name: npm and yarn js
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run js linting
@@ -199,7 +189,7 @@ jobs:
   nuget:
     name: Nuget
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run nuget tests
@@ -209,7 +199,7 @@ jobs:
   omnibus:
     name: Omnibus
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run omnibus tests
@@ -219,7 +209,7 @@ jobs:
   python:
     name: Python
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run python tests
@@ -229,7 +219,7 @@ jobs:
   terraform:
     name: Terraform
     runs-on: ubuntu-latest
-    container: dependabot/dependabot-core-ci:${{ github.sha }}
+    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
       - name: Run terraform tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,41 +28,39 @@ jobs:
             --cache-from "dependabot/dependabot-core:latest" \
             --cache-from "dependabot/dependabot-core-ci:latest" \
             .
-          docker image save -o dependabot-core-ci-image.tar "dependabot/dependabot-core-ci:${{ github.sha }}"
-      - name: Save image as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: dependabot-core-ci-image.tar
-          path: dependabot-core-ci-image.tar
+      - name: Push ci image
+        run: |
+          docker login docker.pkg.github.com -u x -p ${{ secrets.GITHUB_TOKEN }}
+          docker push "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}"
 
   rubocop:
     name: Rubocop
     runs-on: ubuntu-latest
     needs: ci-image
     steps:
-      - name: Load docker image from artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: dependabot-core-ci-image.tar
-      - name: Restore image
+      - name: Pull ci image
         run: |
-          docker image import dependabot-core-ci-image.tar "dependabot/dependabot-core-ci:${{ github.sha }}"
+          docker login docker.pkg.github.com -u x -p ${{ secrets.GITHUB_TOKEN }}
+          docker pull "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}"
       - name: Run Rubocop linting
         run: |
-          docker run --rm dependabot/dependabot-core-ci:${{ github.sha }} bash -c "cd /home/dependabot/dependabot-core && rake ci:rubocop"
+          docker run --rm docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }} bash -c "cd /home/dependabot/dependabot-core && rake ci:rubocop"
 
   js-tests:
     name: npm and yarn js
     runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
+      - name: Pull ci image
+        run: |
+          docker login docker.pkg.github.com -u x -p ${{ secrets.GITHUB_TOKEN }}
+          docker pull "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}"
       - name: Run js linting
-        run: yarn lint
-        working-directory: /opt/npm_and_yarn
+        run: |
+          docker run --rm docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }} bash -c  "cd /opt/npm_and_yarn && yarn lint"
       - name: Run js tests
-        run: yarn test
-        working-directory: /opt/npm_and_yarn
+        run: |
+          docker run --rm docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }} bash -c  "cd /opt/npm_and_yarn && yarn test"
 
   rspec:
     name: Rspec
@@ -89,13 +87,10 @@ jobs:
           - python
           - terraform
     steps:
-      - name: Load docker image from artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: dependabot-core-ci-image.tar
-      - name: Restore image
+      - name: Pull ci image
         run: |
-          docker image import dependabot-core-ci-image.tar "dependabot/dependabot-core-ci:${{ github.sha }}"
+          docker login docker.pkg.github.com -u x -p ${{ secrets.GITHUB_TOKEN }}
+          docker pull "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}"
       - name: Run ${{ matrix.suite }} tests with rspec
         run: |
-          docker run --rm dependabot/dependabot-core-ci:${{ github.sha }} bash -c "cd /home/dependabot/dependabot-core/${{ matrix.suite }} && bundle exec rspec spec"
+          docker run --rm docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }} bash -c "cd /home/dependabot/dependabot-core/${{ matrix.suite }} && bundle exec rspec spec"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,158 +22,36 @@ jobs:
         run: |
           rm .dockerignore
           docker build \
-            -t "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}" \
+            -t "dependabot/dependabot-core-ci:${{ github.sha }}" \
             -f Dockerfile.ci \
             --cache-from ubuntu:18.04 \
             --cache-from "dependabot/dependabot-core:latest" \
             --cache-from "dependabot/dependabot-core-ci:latest" \
             .
-      - name: Push dependabot-core-ci image to CI cache repo
-        run: |
-          docker login docker.pkg.github.com -u x -p ${{ secrets.GITHUB_TOKEN }}
-          docker push "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}"
+          docker image save -o dependabot-core-ci-image.tar "dependabot/dependabot-core-ci:${{ github.sha }}"
+      - name: Save image as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dependabot-core-ci-image.tar
+          path: dependabot-core-ci-image.tar
 
   rubocop:
     name: Rubocop
     runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
     steps:
+      - name: Load docker image from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dependabot-core-ci-image.tar
+      - name: Restore image
+        run: |
+          docker image import dependabot-core-ci-image.tar "dependabot/dependabot-core-ci:${{ github.sha }}"
       - name: Run Rubocop linting
         run: |
-          cd /home/dependabot/dependabot-core && rake ci:rubocop
+          docker run --rm dependabot/dependabot-core-ci:${{ github.sha }} bash -c "cd /home/dependabot/dependabot-core && rake ci:rubocop"
 
-  bundler:
-    name: Bundler
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run bundler tests
-        run: |
-          bash -c "cd /home/dependabot/dependabot-core/bundler && bundle exec rspec spec"
-
-  cargo:
-    name: Cargo
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run cargo tests
-        run: |
-          cd /home/dependabot/dependabot-core/cargo && bundle exec rspec spec
-
-  common:
-    name: Common
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run common tests
-        run: |
-          cd /home/dependabot/dependabot-core/common && bundle exec rspec spec
-
-  composer:
-    name: Composer
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run composer tests
-        run: |
-          cd /home/dependabot/dependabot-core/composer && bundle exec rspec spec
-
-  dep:
-    name: Dep
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run dep tests
-        run: |
-          cd /home/dependabot/dependabot-core/dep && bundle exec rspec spec
-
-  docker:
-    name: Docker
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run docker tests
-        run: |
-          cd /home/dependabot/dependabot-core/docker && bundle exec rspec spec
-
-  elm:
-    name: Elm
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run elm tests
-        run: |
-          cd /home/dependabot/dependabot-core/elm && bundle exec rspec spec
-
-  git-submodules:
-    name: Git submodules
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run git submodules tests
-        run: |
-          cd /home/dependabot/dependabot-core/git_submodules && bundle exec rspec spec
-
-  go-modules:
-    name: Go modules
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run go modules tests
-        run: |
-          cd /home/dependabot/dependabot-core/go_modules && bundle exec rspec spec
-
-  gradle:
-    name: Gradle
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run gradle tests
-        run: |
-          cd /home/dependabot/dependabot-core/gradle && bundle exec rspec spec
-
-  hex:
-    name: Hex
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run hex tests
-        run: |
-          cd /home/dependabot/dependabot-core/hex && bundle exec rspec spec
-
-  maven:
-    name: Maven
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run maven tests
-        run: |
-          cd /home/dependabot/dependabot-core/maven && bundle exec rspec spec
-
-  npm-and-yarn:
-    name: npm and yarn
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run npn and yarn tests
-        run: |
-          cd /home/dependabot/dependabot-core/npm_and_yarn && bundle exec rspec spec
-
-  npm-and-yarn-js:
+  js-tests:
     name: npm and yarn js
     runs-on: ubuntu-latest
     container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
@@ -186,42 +64,38 @@ jobs:
         run: yarn test
         working-directory: /opt/npm_and_yarn
 
-  nuget:
-    name: Nuget
+  rspec:
+    name: Rspec
     runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
     needs: ci-image
+    strategy:
+      matrix:
+        suite:
+          - bundler
+          - cargo
+          - common
+          - composer
+          - dep
+          - docker
+          - elm
+          - git_submodules
+          - go_modules
+          - gradle
+          - hex
+          - maven
+          - npm_and_yarn
+          - nuget
+          - omnibus
+          - python
+          - terraform
     steps:
-      - name: Run nuget tests
+      - name: Load docker image from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dependabot-core-ci-image.tar
+      - name: Restore image
         run: |
-          cd /home/dependabot/dependabot-core/nuget && bundle exec rspec spec
-
-  omnibus:
-    name: Omnibus
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run omnibus tests
+          docker image import dependabot-core-ci-image.tar "dependabot/dependabot-core-ci:${{ github.sha }}"
+      - name: Run ${{ matrix.suite }} tests with rspec
         run: |
-          cd /home/dependabot/dependabot-core/omnibus && bundle exec rspec spec
-
-  python:
-    name: Python
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run python tests
-        run: |
-          cd /home/dependabot/dependabot-core/python && bundle exec rspec spec
-
-  terraform:
-    name: Terraform
-    runs-on: ubuntu-latest
-    container: docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}
-    needs: ci-image
-    steps:
-      - name: Run terraform tests
-        run: |
-          cd /home/dependabot/dependabot-core/terraform && bundle exec rspec spec
+          docker run --rm dependabot/dependabot-core-ci:${{ github.sha }} bash -c "cd /home/dependabot/dependabot-core/${{ matrix.suite }} && bundle exec rspec spec"


### PR DESCRIPTION
This should fix ci on forks by removing the requirement to authenticate with Docker Hub.

Leverage the packages to store the ci image which is repo agnostic.