### PR TITLE
Fix: Add github_actions to job matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           - docker
           - elm
           - git_submodules
+          - github_actions
           - go_modules
           - gradle
           - hex


### PR DESCRIPTION
This PR

* [x] adds `github_actions` to the job matrix

🙈 I missed this in e32df23ef, sorry!