### PR TITLE
Fix: Consistently indent Dockerfiles with 2 spaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,50 +3,50 @@ FROM ubuntu:18.04
 ### SYSTEM DEPENDENCIES
 
 ENV DEBIAN_FRONTEND="noninteractive" \
-    LC_ALL="en_US.UTF-8" \
-    LANG="en_US.UTF-8"
+  LC_ALL="en_US.UTF-8" \
+  LANG="en_US.UTF-8"
 
 # Everything from `make` onwards in apt-get install is only installed to ensure
 # Python support works with all packages (which may require specific libraries
 # at install time).
 
 RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends \
-      build-essential \
-      dirmngr \
-      git \
-      bzr \
-      mercurial \
-      gnupg2 \
-      curl \
-      wget \
-      zlib1g-dev \
-      liblzma-dev \
-      tzdata \
-      zip \
-      unzip \
-      locales \
-      openssh-client \
-      make \
-      libpq-dev \
-      libssl-dev \
-      libbz2-dev \
-      libffi-dev \
-      libreadline-dev \
-      libsqlite3-dev \
-      libcurl4-openssl-dev \
-      llvm \
-      libncurses5-dev \
-      libncursesw5-dev \
-      libmysqlclient-dev \
-      xz-utils \
-      tk-dev \
-      libxml2-dev \
-      libxmlsec1-dev \
-      libgeos-dev \
-      python3-enchant \
-    && locale-gen en_US.UTF-8
+  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    dirmngr \
+    git \
+    bzr \
+    mercurial \
+    gnupg2 \
+    curl \
+    wget \
+    zlib1g-dev \
+    liblzma-dev \
+    tzdata \
+    zip \
+    unzip \
+    locales \
+    openssh-client \
+    make \
+    libpq-dev \
+    libssl-dev \
+    libbz2-dev \
+    libffi-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libcurl4-openssl-dev \
+    llvm \
+    libncurses5-dev \
+    libncursesw5-dev \
+    libmysqlclient-dev \
+    xz-utils \
+    tk-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    libgeos-dev \
+    python3-enchant \
+  && locale-gen en_US.UTF-8
 
 
 ### RUBY
@@ -54,33 +54,33 @@ RUN apt-get update \
 # Install Ruby 2.6.6, update RubyGems, and install Bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
 RUN apt-get install -y software-properties-common \
-    && apt-add-repository ppa:brightbox/ruby-ng \
-    && apt-get update \
-    && apt-get install -y ruby2.6 ruby2.6-dev \
-    && gem update --system 3.0.3 \
-    && gem install bundler -v 1.17.3 --no-document
+  && apt-add-repository ppa:brightbox/ruby-ng \
+  && apt-get update \
+  && apt-get install -y ruby2.6 ruby2.6-dev \
+  && gem update --system 3.0.3 \
+  && gem install bundler -v 1.17.3 --no-document
 
 
 ### PYTHON
 
 # Install Python 2.7 and 3.8 with pyenv. Using pyenv lets us support multiple Pythons
 ENV PYENV_ROOT=/usr/local/.pyenv \
-    PATH="/usr/local/.pyenv/bin:$PATH"
+  PATH="/usr/local/.pyenv/bin:$PATH"
 RUN git clone https://github.com/pyenv/pyenv.git /usr/local/.pyenv \
-    && cd /usr/local/.pyenv && git checkout v1.2.20 && cd - \
-    && pyenv install 3.8.5 \
-    && pyenv install 2.7.18 \
-    && pyenv global 3.8.5
+  && cd /usr/local/.pyenv && git checkout v1.2.20 && cd - \
+  && pyenv install 3.8.5 \
+  && pyenv install 2.7.18 \
+  && pyenv global 3.8.5
 
 
 ### JAVASCRIPT
 
 # Install Node 10.0 and Yarn
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
-    && apt-get install -y nodejs \
-    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-    && apt-get update && apt-get install -y yarn
+  && apt-get install -y nodejs \
+  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+  && apt-get update && apt-get install -y yarn
 
 
 ### ELM
@@ -88,10 +88,10 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
 # Install Elm 0.18 and Elm 0.19
 ENV PATH="$PATH:/node_modules/.bin"
 RUN npm install elm@0.18.0 \
-    && wget "https://github.com/elm/compiler/releases/download/0.19.0/binaries-for-linux.tar.gz" \
-    && tar xzf binaries-for-linux.tar.gz \
-    && mv elm /usr/local/bin/elm19 \
-    && rm -f binaries-for-linux.tar.gz
+  && wget "https://github.com/elm/compiler/releases/download/0.19.0/binaries-for-linux.tar.gz" \
+  && tar xzf binaries-for-linux.tar.gz \
+  && mv elm /usr/local/bin/elm19 \
+  && rm -f binaries-for-linux.tar.gz
 
 
 ### PHP
@@ -100,43 +100,43 @@ RUN npm install elm@0.18.0 \
 ENV COMPOSER_ALLOW_SUPERUSER=1
 COPY --from=composer:1.10.9 /usr/bin/composer /usr/local/bin/composer
 RUN add-apt-repository ppa:ondrej/php \
-    && apt-get update \
-    && apt-get install -y \
-      php7.4 \
-      php7.4-apcu \
-      php7.4-bcmath \
-      php7.4-cli \
-      php7.4-common \
-      php7.4-curl \
-      php7.4-gd \
-      php7.4-geoip \
-      php7.4-gettext \
-      php7.4-gmp \
-      php7.4-imagick \
-      php7.4-imap \
-      php7.4-intl \
-      php7.4-json \
-      php7.4-ldap \
-      php7.4-mbstring \
-      php7.4-memcached \
-      php7.4-mongodb \
-      php7.4-mysql \
-      php7.4-redis \
-      php7.4-soap \
-      php7.4-sqlite3 \
-      php7.4-tidy \
-      php7.4-xml \
-      php7.4-zip \
-      php7.4-zmq
+  && apt-get update \
+  && apt-get install -y \
+    php7.4 \
+    php7.4-apcu \
+    php7.4-bcmath \
+    php7.4-cli \
+    php7.4-common \
+    php7.4-curl \
+    php7.4-gd \
+    php7.4-geoip \
+    php7.4-gettext \
+    php7.4-gmp \
+    php7.4-imagick \
+    php7.4-imap \
+    php7.4-intl \
+    php7.4-json \
+    php7.4-ldap \
+    php7.4-mbstring \
+    php7.4-memcached \
+    php7.4-mongodb \
+    php7.4-mysql \
+    php7.4-redis \
+    php7.4-soap \
+    php7.4-sqlite3 \
+    php7.4-tidy \
+    php7.4-xml \
+    php7.4-zip \
+    php7.4-zmq
 
 
 ### GO
 
 # Install Go and dep
 RUN curl https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz | tar -xz -C /opt \
-    && wget -O /opt/go/bin/dep https://github.com/golang/dep/releases/download/v0.5.4/dep-linux-amd64 \
-    && chmod +x /opt/go/bin/dep \
-    && mkdir /opt/go/gopath
+  && wget -O /opt/go/bin/dep https://github.com/golang/dep/releases/download/v0.5.4/dep-linux-amd64 \
+  && chmod +x /opt/go/bin/dep \
+  && mkdir /opt/go/gopath
 ENV PATH=/opt/go/bin:$PATH GOPATH=/opt/go/gopath
 
 
@@ -145,20 +145,20 @@ ENV PATH=/opt/go/bin:$PATH GOPATH=/opt/go/gopath
 # Install Erlang, Elixir and Hex
 ENV PATH="$PATH:/usr/local/elixir/bin"
 RUN wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
-    && dpkg -i erlang-solutions_1.0_all.deb \
-    && apt-get update \
-    && apt-get install -y esl-erlang \
-    && wget https://github.com/elixir-lang/elixir/releases/download/v1.9.1/Precompiled.zip \
-    && unzip -d /usr/local/elixir -x Precompiled.zip \
-    && rm -f Precompiled.zip \
-    && mix local.hex --force
+  && dpkg -i erlang-solutions_1.0_all.deb \
+  && apt-get update \
+  && apt-get install -y esl-erlang \
+  && wget https://github.com/elixir-lang/elixir/releases/download/v1.9.1/Precompiled.zip \
+  && unzip -d /usr/local/elixir -x Precompiled.zip \
+  && rm -f Precompiled.zip \
+  && mix local.hex --force
 
 
 ### RUST
 
 # Install Rust 1.37.0
 ENV RUSTUP_HOME=/opt/rust \
-    PATH="${PATH}:/opt/rust/bin"
+  PATH="${PATH}:/opt/rust/bin"
 RUN export CARGO_HOME=/opt/rust ; curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 
@@ -173,13 +173,13 @@ COPY python/helpers /opt/python/helpers
 COPY terraform/helpers /opt/terraform/helpers
 
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt" \
-    PATH="$PATH:/opt/terraform/bin:/opt/python/bin:/opt/go_modules/bin:/opt/dep/bin" \
-    MIX_HOME="/opt/hex/mix"
+  PATH="$PATH:/opt/terraform/bin:/opt/python/bin:/opt/go_modules/bin:/opt/dep/bin" \
+  MIX_HOME="/opt/hex/mix"
 
 RUN bash /opt/terraform/helpers/build /opt/terraform && \
-    bash /opt/python/helpers/build /opt/python && \
-    bash /opt/dep/helpers/build /opt/dep && \
-    bash /opt/go_modules/helpers/build /opt/go_modules && \
-    bash /opt/npm_and_yarn/helpers/build /opt/npm_and_yarn && \
-    bash /opt/hex/helpers/build /opt/hex && \
-    bash /opt/composer/helpers/build /opt/composer
+  bash /opt/python/helpers/build /opt/python && \
+  bash /opt/dep/helpers/build /opt/dep && \
+  bash /opt/go_modules/helpers/build /opt/go_modules && \
+  bash /opt/npm_and_yarn/helpers/build /opt/npm_and_yarn && \
+  bash /opt/hex/helpers/build /opt/hex && \
+  bash /opt/composer/helpers/build /opt/composer

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,29 +3,30 @@ ARG CODE_DIR=/home/dependabot/dependabot-core
 WORKDIR ${CODE_DIR}
 
 ENV BUNDLE_PATH="/home/dependabot/.bundle" \
-    BUNDLE_BIN=".bundle/binstubs" \
-    PATH=".bundle/binstubs:$PATH:/home/dependabot/.bundle/bin"
+  BUNDLE_BIN=".bundle/binstubs" \
+  PATH=".bundle/binstubs:$PATH:/home/dependabot/.bundle/bin"
 
 COPY .rubocop.yml /home/dependabot/dependabot-core/
 
-RUN mkdir -p ${CODE_DIR}/composer \
-             ${CODE_DIR}/bundler \
-             ${CODE_DIR}/cargo \
-             ${CODE_DIR}/common \
-             ${CODE_DIR}/dep \
-             ${CODE_DIR}/docker \
-             ${CODE_DIR}/elm \
-             ${CODE_DIR}/git_submodules \
-             ${CODE_DIR}/github_actions \
-             ${CODE_DIR}/go_modules \
-             ${CODE_DIR}/gradle \
-             ${CODE_DIR}/hex \
-             ${CODE_DIR}/maven \
-             ${CODE_DIR}/npm_and_yarn \
-             ${CODE_DIR}/nuget \
-             ${CODE_DIR}/omnibus \
-             ${CODE_DIR}/python \
-             ${CODE_DIR}/terraform
+RUN mkdir -p \
+  ${CODE_DIR}/composer \
+  ${CODE_DIR}/bundler \
+  ${CODE_DIR}/cargo \
+  ${CODE_DIR}/common \
+  ${CODE_DIR}/dep \
+  ${CODE_DIR}/docker \
+  ${CODE_DIR}/elm \
+  ${CODE_DIR}/git_submodules \
+  ${CODE_DIR}/github_actions \
+  ${CODE_DIR}/go_modules \
+  ${CODE_DIR}/gradle \
+  ${CODE_DIR}/hex \
+  ${CODE_DIR}/maven \
+  ${CODE_DIR}/npm_and_yarn \
+  ${CODE_DIR}/nuget \
+  ${CODE_DIR}/omnibus \
+  ${CODE_DIR}/python \
+  ${CODE_DIR}/terraform
 
 COPY common/ ${CODE_DIR}/common/
 COPY bundler/ ${CODE_DIR}/bundler/
@@ -49,15 +50,15 @@ COPY terraform/ ${CODE_DIR}/terraform/
 RUN cd common && bundle install
 
 RUN GREEN='\033[0;32m'; NC='\033[0m'; \
-    for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
-                   -not -path "${CODE_DIR}/omnibus/Gemfile" \
-                   -not -path "${CODE_DIR}/common/Gemfile" \
-                   -name 'Gemfile' | xargs dirname`; do \
-      echo && \
-      echo "---------------------------------------------------------------------------" && \
-      echo "Installing gems for ${GREEN}$(realpath --relative-to=${CODE_DIR} $d)${NC}..." && \
-      echo "---------------------------------------------------------------------------" && \
-      cd $d && bundle install; \
-    done
+  for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
+    -not -path "${CODE_DIR}/omnibus/Gemfile" \
+    -not -path "${CODE_DIR}/common/Gemfile" \
+    -name 'Gemfile' | xargs dirname`; do \
+    echo && \
+    echo "---------------------------------------------------------------------------" && \
+    echo "Installing gems for ${GREEN}$(realpath --relative-to=${CODE_DIR} $d)${NC}..." && \
+    echo "---------------------------------------------------------------------------" && \
+    cd $d && bundle install; \
+  done
 
 RUN cd omnibus && bundle install

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -9,10 +9,10 @@ ENV BUNDLE_PATH="/home/dependabot/.bundle" \
 COPY .rubocop.yml /home/dependabot/dependabot-core/
 
 RUN mkdir -p \
-  ${CODE_DIR}/composer \
   ${CODE_DIR}/bundler \
   ${CODE_DIR}/cargo \
   ${CODE_DIR}/common \
+  ${CODE_DIR}/composer \
   ${CODE_DIR}/dep \
   ${CODE_DIR}/docker \
   ${CODE_DIR}/elm \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -17,7 +17,7 @@ ARG USER_GID=$USER_UID
 ARG USERNAME=dependabot
 
 RUN groupadd -o --gid "${USER_GID}" "${USERNAME}" && \
-    useradd --uid "${USER_UID}" --gid "${USER_GID}" -m "${USERNAME}"
+  useradd --uid "${USER_UID}" --gid "${USER_GID}" -m "${USERNAME}"
 RUN chown -R "${USERNAME}":"${USERNAME}" \
   /usr/local/.pyenv \
   /opt/go/gopath \
@@ -27,36 +27,37 @@ USER $USERNAME
 ARG CODE_DIR=/home/$USERNAME/dependabot-core
 
 RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/master/vimrc-vanilla.vim && \
-    echo 'export PS1="[dependabot-core-dev] \w \[$(tput setaf 4)\]$ \[$(tput sgr 0)\]"' >> ~/.bashrc
+  echo 'export PS1="[dependabot-core-dev] \w \[$(tput setaf 4)\]$ \[$(tput sgr 0)\]"' >> ~/.bashrc
 
 RUN mkdir -p ${CODE_DIR}/common/lib/dependabot
 WORKDIR ${CODE_DIR}
 
 ENV BUNDLE_PATH="/home/$USERNAME/.bundle" \
-    BUNDLE_BIN=".bundle/binstubs"
+  BUNDLE_BIN=".bundle/binstubs"
 ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
 
 COPY common/Gemfile common/dependabot-common.gemspec ${CODE_DIR}/common/
 COPY common/lib/dependabot/version.rb ${CODE_DIR}/common/lib/dependabot/
 RUN cd common && bundle install
 
-RUN mkdir -p ${CODE_DIR}/bundler \
-             ${CODE_DIR}/cargo \
-             ${CODE_DIR}/composer \
-             ${CODE_DIR}/dep \
-             ${CODE_DIR}/docker \
-             ${CODE_DIR}/elm \
-             ${CODE_DIR}/git_submodules \
-             ${CODE_DIR}/github_actions \
-             ${CODE_DIR}/go_modules \
-             ${CODE_DIR}/gradle \
-             ${CODE_DIR}/hex \
-             ${CODE_DIR}/maven \
-             ${CODE_DIR}/npm_and_yarn \
-             ${CODE_DIR}/nuget \
-             ${CODE_DIR}/omnibus \
-             ${CODE_DIR}/python \
-             ${CODE_DIR}/terraform
+RUN mkdir -p \
+  ${CODE_DIR}/bundler \
+  ${CODE_DIR}/cargo \
+  ${CODE_DIR}/composer \
+  ${CODE_DIR}/dep \
+  ${CODE_DIR}/docker \
+  ${CODE_DIR}/elm \
+  ${CODE_DIR}/git_submodules \
+  ${CODE_DIR}/github_actions \
+  ${CODE_DIR}/go_modules \
+  ${CODE_DIR}/gradle \
+  ${CODE_DIR}/hex \
+  ${CODE_DIR}/maven \
+  ${CODE_DIR}/npm_and_yarn \
+  ${CODE_DIR}/nuget \
+  ${CODE_DIR}/omnibus \
+  ${CODE_DIR}/python \
+  ${CODE_DIR}/terraform
 
 COPY bundler/Gemfile bundler/dependabot-bundler.gemspec ${CODE_DIR}/bundler/
 COPY cargo/Gemfile cargo/dependabot-cargo.gemspec ${CODE_DIR}/cargo/
@@ -77,16 +78,16 @@ COPY python/Gemfile python/dependabot-python.gemspec ${CODE_DIR}/python/
 COPY terraform/Gemfile terraform/dependabot-terraform.gemspec ${CODE_DIR}/terraform/
 
 RUN GREEN='\033[0;32m'; NC='\033[0m'; \
-    for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
-                   -not -path "${CODE_DIR}/omnibus/Gemfile" \
-                   -not -path "${CODE_DIR}/common/Gemfile" \
-                   -name 'Gemfile' | xargs dirname`; do \
-      echo && \
-      echo "---------------------------------------------------------------------------" && \
-      echo "Installing gems for ${GREEN}$(realpath --relative-to=${CODE_DIR} $d)${NC}..." && \
-      echo "---------------------------------------------------------------------------" && \
-      cd $d && bundle install; \
-    done
+  for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
+    -not -path "${CODE_DIR}/omnibus/Gemfile" \
+    -not -path "${CODE_DIR}/common/Gemfile" \
+    -name 'Gemfile' | xargs dirname`; do \
+    echo && \
+    echo "---------------------------------------------------------------------------" && \
+    echo "Installing gems for ${GREEN}$(realpath --relative-to=${CODE_DIR} $d)${NC}..." && \
+    echo "---------------------------------------------------------------------------" && \
+    cd $d && bundle install; \
+  done
 
 RUN cd omnibus && bundle install
 # Make omnibus gems available to bundler in root directory
@@ -97,4 +98,4 @@ RUN mkdir -p ~/.vscode-server ~/.vscode-server-insiders
 
 # Declare pass-thru environment variables used for debugging
 ENV LOCAL_GITHUB_ACCESS_TOKEN="" \
-    LOCAL_CONFIG_VARIABLES=""
+  LOCAL_CONFIG_VARIABLES=""


### PR DESCRIPTION
This PR

* [x] consistently indents `Dockerfile`s with `2` spaces
* [x] sorts list of directories

💁‍♂️ There currently is no specific rule for `Dockerfile`s to be indented with anything other than 2 spaces, see [`editorconfig`](https://github.com/dependabot/dependabot-core/blob/6b5a42e35ef400f63544ed8d26030af6bd1b3fba/.editorconfig).