### PR TITLE
Encode '@' in python HTTP basic auth passwords

### DIFF
--- a/python/lib/dependabot/python/authed_url_builder.rb
+++ b/python/lib/dependabot/python/authed_url_builder.rb
@@ -16,6 +16,8 @@ module Dependabot
           else token
           end
 
+        basic_auth_details = basic_auth_details.gsub("@", "%40")
+
         url.sub("://", "://#{basic_auth_details}@")
       end
     end

--- a/python/spec/dependabot/python/authed_url_builder_spec.rb
+++ b/python/spec/dependabot/python/authed_url_builder_spec.rb
@@ -58,6 +58,26 @@ RSpec.describe Dependabot::Python::AuthedUrlBuilder do
             to eq("https://token:pass@pypi.weasyldev.com/weasyl/source/+simple")
         end
       end
+
+      context "that includes an @" do
+        let(:token) { "token:pass@23" }
+
+        it "builds the URL correctly" do
+          expect(authed_url). to eq(
+            "https://token:pass%4023@pypi.weasyldev.com/weasyl/source/+simple"
+          )
+        end
+      end
+
+      context "that includes an @ and is base64 encoded" do
+        let(:token) { "dG9rZW46cGFzc0AyMw==" }
+
+        it "builds the URL correctly" do
+          expect(authed_url). to eq(
+            "https://token:pass%4023@pypi.weasyldev.com/weasyl/source/+simple"
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If a password contains an `@` sign, when we construct a URL with it, it
will result in an invalid URL, since we now have multiple `@` signs,
resulting in the URL parser not being able to determine where the
password stops and the address begins.