### PR TITLE
Build main dockerfile in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,13 @@ jobs:
         run: |
           docker pull ubuntu:18.04
           docker pull "dependabot/dependabot-core:latest"
+      - name: Build dependabot-core image
+        run: |
+          docker build \
+            -t "dependabot/dependabot-core:latest" \
+            --cache-from ubuntu:18.04 \
+            --cache-from "dependabot/dependabot-core:latest" \
+            .
       - name: Build dependabot-core-ci image
         run: |
           rm .dockerignore


### PR DESCRIPTION
When running in ci also build `Dockerfile` to re-build native helpers.