### PR TITLE
Always return a Version object for indirect gomodule dependencies

### DIFF
--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -17,6 +17,8 @@ module Dependabot
         # dependency to the go.mod file forcing the resolver to pick this
         # version (possibly as # indirect)
         unless dependency.top_level?
+          return unless dependency.version
+
           return version_class.new(dependency.version)
         end
 

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -16,7 +16,9 @@ module Dependabot
         # To update indirect dependencies we'll need to promote the indirect
         # dependency to the go.mod file forcing the resolver to pick this
         # version (possibly as # indirect)
-        return dependency.version unless dependency.top_level?
+        unless dependency.top_level?
+          return version_class.new(dependency.version)
+        end
 
         @latest_resolvable_version ||=
           version_class.new(find_latest_resolvable_version.gsub(/^v/, ""))

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -94,12 +94,18 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
     end
 
     it "doesn't update regular releases to newer pre-releases" do
-      expect(latest_resolvable_version).to_not eq("1.2.0-pre2")
+      expect(latest_resolvable_version).to_not eq(
+        Dependabot::GoModules::Version.new("1.2.0-pre2")
+      )
     end
 
     context "doesn't update indirect dependencies (not supported)" do
       let(:requirements) { [] }
-      it { is_expected.to eq(dependency.version) }
+      it do
+        is_expected.to eq(
+          Dependabot::GoModules::Version.new(dependency.version)
+        )
+      end
     end
 
     it "updates v2+ modules"


### PR DESCRIPTION
When dealing with an indirect gomodules dependency, we were retuning a
string value that came from the Dependency object. We use this version
to compare with a Dependency object in
common/lib/dependabot/update_checkers/base.rb:216, which resulted in an
ArgumentError. We already return a Version object when the dependency is
top_level.