### PR TITLE
Inline buildkit cache when building images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - "wip/**"
       - "main"
   pull_request_target:
-    branches-ignore:
-      - "actions/**"
+    branches:
+      - "**"
 jobs:
   ci-image:
     name: Build CI image
@@ -24,18 +24,24 @@ jobs:
           docker pull "dependabot/dependabot-core:latest"
           docker pull "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:latest"
       - name: Build dependabot-core image
+        env:
+          DOCKER_BUILDKIT: 1
         run: |
           docker build \
             -t "dependabot/dependabot-core:latest" \
+            --build-arg BUILDKIT_INLINE_CACHE=1
             --cache-from "dependabot/dependabot-core:latest" \
             .
       - name: Build dependabot-core-ci image
+        env:
+          DOCKER_BUILDKIT: 1
         run: |
           rm .dockerignore
           docker build \
             -t "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:latest" \
             -t "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}" \
             -f Dockerfile.ci \
+            --build-arg BUILDKIT_INLINE_CACHE=1
             --cache-from "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:latest" \
             .
       - name: Push image to packages

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,10 +11,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Build and push Docker images
-        uses: whoan/docker-build-with-cache-action@v5
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          image_name: "dependabot/dependabot-core"
-          image_tag: "latest"
+      - name: Pull Docker base image & warm Docker cache
+        run: |
+          docker pull "dependabot/dependabot-core:latest"
+      - name: Build dependabot-core image
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker build \
+            -t "dependabot/dependabot-core:latest" \
+            --build-arg BUILDKIT_INLINE_CACHE=1
+            --cache-from "dependabot/dependabot-core:latest" \
+            .
+      - name: Push image to packages
+        run: |
+          docker push "dependabot/dependabot-core:latest"


### PR DESCRIPTION
Hopefully improving caching, it seems docker is currently too agressive
in it's cache usage so we're not re-building native helpers.