### PR TITLE
Properly escape both username and password in auth url

### DIFF
--- a/python/lib/dependabot/python/authed_url_builder.rb
+++ b/python/lib/dependabot/python/authed_url_builder.rb
@@ -16,7 +16,10 @@ module Dependabot
           else token
           end
 
-        basic_auth_details = basic_auth_details.gsub("@", "%40")
+        if basic_auth_details.include?(":")
+          username, _, password = basic_auth_details.partition(":")
+          basic_auth_details = "#{CGI.escape(username)}:#{CGI.escape(password)}"
+        end
 
         url.sub("://", "://#{basic_auth_details}@")
       end

--- a/python/spec/dependabot/python/authed_url_builder_spec.rb
+++ b/python/spec/dependabot/python/authed_url_builder_spec.rb
@@ -69,6 +69,26 @@ RSpec.describe Dependabot::Python::AuthedUrlBuilder do
         end
       end
 
+      context "that includes an #" do
+        let(:token) { "token:pass#23" }
+
+        it "builds the URL correctly" do
+          expect(authed_url). to eq(
+            "https://token:pass%2323@pypi.weasyldev.com/weasyl/source/+simple"
+          )
+        end
+      end
+
+      context "that has multiple colons" do
+        let(:token) { "token:pass:23" }
+
+        it "builds the URL correctly" do
+          expect(authed_url). to eq(
+            "https://token:pass%3A23@pypi.weasyldev.com/weasyl/source/+simple"
+          )
+        end
+      end
+
       context "that includes an @ and is base64 encoded" do
         let(:token) { "dG9rZW46cGFzc0AyMw==" }
 


### PR DESCRIPTION
Both the username and password may contain characters that are not valid
in HTTP basic auth, we want to escape both, and will assume that the
first colon is what should be split on.