### PR TITLE
common: increase default http client read timeout

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -129,7 +129,7 @@ module Dependabot
       {
         connect_timeout: 5,
         write_timeout: 5,
-        read_timeout: 5,
+        read_timeout: 20,
         omit_default_port: true,
         middlewares: excon_middleware
       }


### PR DESCRIPTION
This PR increases the read timeout used for HTTP connections.

This is a specific problem for `npm_and_yarn` ecosystem + GitHub Package Registry. It could be scoped tighter.

It doesn't seems a crazy default? The connect timeout seems more important (to avoid waiting for private/LAN registries that we can't reach).