### PR TITLE
Fix: Collapse jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
           docker push "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:latest"
           docker push "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}"
 
-  rubocop:
-    name: Rubocop
+  helper:
+    name: Helper
     runs-on: ubuntu-latest
     needs: ci-image
     strategy:
@@ -77,38 +77,6 @@ jobs:
       - name: Run Rubocop linting
         run: |
           docker run --rm docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }} bash -c "cd /home/dependabot/dependabot-core/${{ matrix.suite }} && bundle exec rubocop . -c ../.rubocop.yml"
-
-  rspec:
-    name: Rspec
-    runs-on: ubuntu-latest
-    needs: ci-image
-    strategy:
-      matrix:
-        suite:
-          - bundler
-          - cargo
-          - common
-          - composer
-          - dep
-          - docker
-          - elm
-          - git_submodules
-          - github_actions
-          - go_modules
-          - gradle
-          - hex
-          - maven
-          - npm_and_yarn
-          - nuget
-          - omnibus
-          - python
-          - terraform
-
-    steps:
-      - name: Pull image from packages
-        run: |
-          docker login docker.pkg.github.com -u x -p ${{ secrets.GITHUB_TOKEN }}
-          docker pull "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}"
       - name: Run ${{ matrix.suite }} tests with rspec
         run: |
           docker run --rm docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }} bash -c "cd /home/dependabot/dependabot-core/${{ matrix.suite }} && bundle exec rspec spec"


### PR DESCRIPTION
This PR

* [x] collapses the `rubocop` and `rspec` into a `helper` job

💁‍♂️ Currently the [CI workflow](https://github.com/dependabot/dependabot-core/blob/6b5a42e35ef400f63544ed8d26030af6bd1b3fba/.github/workflows/ci.yml) consists of 38 jobs. [According to a recent workflow run](https://github.com/dependabot/dependabot-core/actions/runs/198691974), this takes  32 minutes and 45 seconds.
Most of that time is taken up by

- building the CI images (~10 minutes, once)
- pulling the CI images (~1.45 minutes, 37 times)

If we collapse the jobs, we could reduce the time it takes to

- building the CI images (~10 minutes, once)
- pulling the CI images (~1.45 minutes, 19 times)

### Before

![Screen Shot 2020-08-07 at 08 30 35](https://user-images.githubusercontent.com/605483/89616232-50256000-d888-11ea-9adf-87f85ea46b11.png)

### After

Looks like we can't observe the result as we use the newly introduced `pull_request_target` event.