### PR TITLE
CI: fix docker cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         run: |
           docker login docker.pkg.github.com -u x -p ${{ secrets.GITHUB_TOKEN }}
           docker pull "dependabot/dependabot-core:latest"
+          docker pull "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:latest"
+          docker logout
       - name: Build dependabot-core image
         env:
           DOCKER_BUILDKIT: 1
@@ -32,20 +34,24 @@ jobs:
             --cache-from "dependabot/dependabot-core:latest" \
             .
       - name: Build dependabot-core-ci image
+        env:
+          DOCKER_BUILDKIT: 1
         run: |
           rm .dockerignore
           docker build \
             -t "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:latest" \
             -t "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}" \
             -f Dockerfile.ci \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --cache-from "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:latest" \
             .
       - name: Push image to packages
         run: |
           docker push "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:latest"
           docker push "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}"
 
-  helper:
-    name: Helper
+  ci:
+    name: CI
     runs-on: ubuntu-latest
     needs: ci-image
     strategy:
@@ -74,6 +80,7 @@ jobs:
         run: |
           docker login docker.pkg.github.com -u x -p ${{ secrets.GITHUB_TOKEN }}
           docker pull "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}"
+          docker logout
       - name: Run Rubocop linting
         run: |
           docker run --rm docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }} bash -c "cd /home/dependabot/dependabot-core/${{ matrix.suite }} && bundle exec rubocop . -c ../.rubocop.yml"
@@ -90,6 +97,7 @@ jobs:
         run: |
           docker login docker.pkg.github.com -u x -p ${{ secrets.GITHUB_TOKEN }}
           docker pull "docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }}"
+          docker logout
       - name: Run js linting
         run: |
           docker run --rm docker.pkg.github.com/${{ github.repository }}/dependabot-core-ci:${{ github.sha }} bash -c "cd /opt/npm_and_yarn && yarn lint"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,3 +27,4 @@ jobs:
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
           docker push "dependabot/dependabot-core:latest"
+          docker logout

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,84 +1,63 @@
 FROM dependabot/dependabot-core
-WORKDIR /home/dependabot/dependabot-core
+ARG CODE_DIR=/home/dependabot/dependabot-core
+WORKDIR ${CODE_DIR}
 
 ENV BUNDLE_PATH="/home/dependabot/.bundle" \
     BUNDLE_BIN=".bundle/binstubs" \
     PATH=".bundle/binstubs:$PATH:/home/dependabot/.bundle/bin"
 
-RUN gem install rake
+COPY .rubocop.yml /home/dependabot/dependabot-core/
 
-COPY Rakefile \
-     .rubocop.yml \
-     /home/dependabot/dependabot-core/
+RUN mkdir -p ${CODE_DIR}/composer \
+             ${CODE_DIR}/bundler \
+             ${CODE_DIR}/cargo \
+             ${CODE_DIR}/common \
+             ${CODE_DIR}/dep \
+             ${CODE_DIR}/docker \
+             ${CODE_DIR}/elm \
+             ${CODE_DIR}/git_submodules \
+             ${CODE_DIR}/github_actions \
+             ${CODE_DIR}/go_modules \
+             ${CODE_DIR}/gradle \
+             ${CODE_DIR}/hex \
+             ${CODE_DIR}/maven \
+             ${CODE_DIR}/npm_and_yarn \
+             ${CODE_DIR}/nuget \
+             ${CODE_DIR}/omnibus \
+             ${CODE_DIR}/python \
+             ${CODE_DIR}/terraform
 
-RUN mkdir -p /home/dependabot/dependabot-core/common
-COPY common/ /home/dependabot/dependabot-core/common/
+COPY common/ ${CODE_DIR}/common/
+COPY bundler/ ${CODE_DIR}/bundler/
+COPY cargo/ ${CODE_DIR}/cargo/
+COPY composer/ ${CODE_DIR}/composer/
+COPY dep/ ${CODE_DIR}/dep/
+COPY docker/ ${CODE_DIR}/docker/
+COPY elm/ ${CODE_DIR}/elm/
+COPY git_submodules/ ${CODE_DIR}/git_submodules/
+COPY github_actions/ ${CODE_DIR}/github_actions/
+COPY go_modules/ ${CODE_DIR}/go_modules/
+COPY gradle/ ${CODE_DIR}/gradle/
+COPY hex/ ${CODE_DIR}/hex/
+COPY maven/ ${CODE_DIR}/maven/
+COPY npm_and_yarn/ ${CODE_DIR}/npm_and_yarn/
+COPY nuget/ ${CODE_DIR}/nuget/
+COPY omnibus/ ${CODE_DIR}/omnibus/
+COPY python/ ${CODE_DIR}/python/
+COPY terraform/ ${CODE_DIR}/terraform/
+
 RUN cd common && bundle install
 
-RUN mkdir -p /home/dependabot/dependabot-core/terraform
-COPY terraform/ /home/dependabot/dependabot-core/terraform/
-RUN cd terraform && bundle install
+RUN GREEN='\033[0;32m'; NC='\033[0m'; \
+    for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
+                   -not -path "${CODE_DIR}/omnibus/Gemfile" \
+                   -not -path "${CODE_DIR}/common/Gemfile" \
+                   -name 'Gemfile' | xargs dirname`; do \
+      echo && \
+      echo "---------------------------------------------------------------------------" && \
+      echo "Installing gems for ${GREEN}$(realpath --relative-to=${CODE_DIR} $d)${NC}..." && \
+      echo "---------------------------------------------------------------------------" && \
+      cd $d && bundle install; \
+    done
 
-RUN mkdir -p /home/dependabot/dependabot-core/elm
-COPY elm/ /home/dependabot/dependabot-core/elm/
-RUN cd elm && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/python
-COPY python/ /home/dependabot/dependabot-core/python/
-RUN cd python && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/docker
-COPY docker/ /home/dependabot/dependabot-core/docker/
-RUN cd docker && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/git_submodules
-COPY git_submodules/ /home/dependabot/dependabot-core/git_submodules/
-RUN cd git_submodules && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/github_actions
-COPY github_actions/ /home/dependabot/dependabot-core/github_actions/
-RUN cd github_actions && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/maven
-COPY maven/ /home/dependabot/dependabot-core/maven/
-RUN cd maven && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/gradle
-COPY gradle/ /home/dependabot/dependabot-core/gradle/
-RUN cd gradle && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/hex
-COPY hex/ /home/dependabot/dependabot-core/hex/
-RUN cd hex && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/nuget
-COPY nuget/ /home/dependabot/dependabot-core/nuget/
-RUN cd nuget && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/composer
-COPY composer/ /home/dependabot/dependabot-core/composer/
-RUN cd composer && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/cargo
-COPY cargo/ /home/dependabot/dependabot-core/cargo/
-RUN cd cargo && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/dep
-COPY dep/ /home/dependabot/dependabot-core/dep/
-RUN cd dep && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/go_modules
-COPY go_modules/ /home/dependabot/dependabot-core/go_modules/
-RUN cd go_modules && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/npm_and_yarn
-COPY npm_and_yarn/ /home/dependabot/dependabot-core/npm_and_yarn/
-RUN cd npm_and_yarn && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/bundler
-COPY bundler/ /home/dependabot/dependabot-core/bundler/
-RUN cd bundler && bundle install
-
-RUN mkdir -p /home/dependabot/dependabot-core/omnibus
-COPY omnibus/ /home/dependabot/dependabot-core/omnibus/
 RUN cd omnibus && bundle install

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -7,6 +7,9 @@ DOCKERFILE="Dockerfile.development"
 HELP=false
 REBUILD=false
 
+# Enable docker buildkit with inline cache builds
+export DOCKER_BUILDKIT=1
+
 OPTS=`getopt -o hr --long help,rebuild -n 'parse-options' -- "$@"`
 if [ $? != 0 ]; then
   echo "failed parsing options" >&2
@@ -29,9 +32,9 @@ fi
 
 build_image() {
   echo "$(tput setaf 2)=> building image from Dockerfile$(tput sgr0)"
-  docker build -t dependabot/dependabot-core .
+  docker build -t dependabot/dependabot-core --cache-from dependabot/dependabot-core --build-arg BUILDKIT_INLINE_CACHE=1 .
   echo "$(tput setaf 2)=> building image from $DOCKERFILE$(tput sgr0)"
-  docker build --build-arg "USER_UID=$UID" --build-arg "USER_GID=$(id -g)" -t "$IMAGE_NAME" -f "$DOCKERFILE" .
+  docker build --build-arg "USER_UID=$UID" --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg "USER_GID=$(id -g)" -t "$IMAGE_NAME" -f "$DOCKERFILE" .
 }
 
 IMAGE_ID=$(docker inspect --type=image -f '{{.Id}}' "$IMAGE_NAME" 2> /dev/null || true)


### PR DESCRIPTION
Fix caching for the ci image build using buildkit. This was previously failing because docker build seemed to just hang when building the ci image with `DOCKER_BUILDKIT=1`. Not sure why yet, thought it might have something to do with this bug: https://github.com/moby/buildkit/issues/1123 but doesn't seem like it, my current theory is that the previous Dockerfile.ci had too many layers and exporting the cache timed out.

Previously we where just using `--cache-from image` without the inline buildkit cache which seemed to result in super fast builds that didn't rebuild when stuff changed. Builds would only take 1s even though some helper manifests had changed.

Verified the build cache seems to be working by upgrading pip here (which includes a breaking change) https://github.com/dependabot/dependabot-core/runs/957672260 and downgrading here (passing) https://github.com/dependabot/dependabot-core/runs/957668539