### PR TITLE
actions docker.yaml: publish tag ontag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,9 @@ on:
   push:
     branches:
     - main
+  create:
     tags:
-    - '*'
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   push-core-image:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
     - main
+    tags:
+    - '*'
 
 jobs:
   push-core-image:
@@ -23,7 +25,15 @@ jobs:
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --cache-from "dependabot/dependabot-core:latest" \
             .
-      - name: Push image to packages
+      - name: Push image to packages (latest)
+        if: '!contains(github.ref, "refs/tags")'
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
           docker push "dependabot/dependabot-core:latest"
+      - name: Push image to packages (tagged)
+        if: contains(github.ref, "refs/tags")
+        run: |
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)"
+          docker tag "dependabot/dependabot-core:latest" "dependabot/dependabot-core:$VERSION"
+          docker push "dependabot/dependabot-core:$VERSION"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,3 +38,4 @@ jobs:
           VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)"
           docker tag "dependabot/dependabot-core:latest" "dependabot/dependabot-core:$VERSION"
           docker push "dependabot/dependabot-core:$VERSION"
+          docker logout


### PR DESCRIPTION
This appends the `docker.yaml` workflow to:
- be triggered when a tag is pushed
- if triggered from a tag, push `dependabot/dependabot-core:$VERSION` after `dependabot/dependabot-core:latest`

For reference, the release process pushes a commit to the default branch and a tag in rapid succession: https://github.com/dependabot/dependabot-core/blob/main/bin/bump-version.rb#L50-L54

We _could_ have just pushed `:$VERSION` on every build, but this approach keeps tagged images ~immutable.