### PR TITLE
docker.yaml syntax fix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Push docker images
 on:
   push:
     branches:
-    - main
+    - '*'
   create:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
@@ -21,21 +21,13 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run: |
-          docker build \
-            -t "dependabot/dependabot-core:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            .
+          echo "lol1"
       - name: Push image to packages (latest)
         if: '!contains(github.ref, "refs/tags")'
         run: |
-          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          docker push "dependabot/dependabot-core:latest"
-          docker logout
+          echo "lol2"
       - name: Push image to packages (tagged)
         if: contains(github.ref, "refs/tags")
         run: |
-          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)"
-          docker tag "dependabot/dependabot-core:latest" "dependabot/dependabot-core:$VERSION"
-          docker push "dependabot/dependabot-core:$VERSION"
-          docker logout
+          echo "lol3"
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,11 +23,11 @@ jobs:
         run: |
           echo "lol1"
       - name: Push image to packages (latest)
-        if: '!contains(github.ref, "refs/tags")'
+        if: "!contains(github.ref, 'refs/tags')"
         run: |
           echo "lol2"
       - name: Push image to packages (tagged)
-        if: contains(github.ref, "refs/tags")
+        if: "contains(github.ref, 'refs/tags')"
         run: |
           echo "lol3"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Push docker images
 on:
   push:
     branches:
-    - '*'
+    - main
   create:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
@@ -21,13 +21,21 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run: |
-          echo "lol1"
+          docker build \
+            -t "dependabot/dependabot-core:latest" \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            .
       - name: Push image to packages (latest)
         if: "!contains(github.ref, 'refs/tags')"
         run: |
-          echo "lol2"
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          docker push "dependabot/dependabot-core:latest"
+          docker logout
       - name: Push image to packages (tagged)
         if: "contains(github.ref, 'refs/tags')"
         run: |
-          echo "lol3"
-
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)"
+          docker tag "dependabot/dependabot-core:latest" "dependabot/dependabot-core:$VERSION"
+          docker push "dependabot/dependabot-core:$VERSION"
+          docker logout


### PR DESCRIPTION
This fixes a regression introduced by #2431 that blocks _all_ docker publishing.

The YAML editor didn't mind, and Actions apparently doesn't validate syntax until the workflow is _triggered_  (e.g. when the previous PR was merged to main, it [didn't work](https://github.com/dependabot/dependabot-core/actions/runs/199385282) ).

To verify this syntax, I forced this YAML to be evaluated and verified the runner interprets the workflow as expected: https://github.com/dependabot/dependabot-core/actions/runs/199413936


# Related
- Continues #2431 