### PR TITLE
on: create: tags filtering does not work

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,7 @@ name: Push docker images
 on:
   push:
     branches:
-    - main
-  create:
+      - main
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 

--- a/.github/workflows/gems.yml
+++ b/.github/workflows/gems.yml
@@ -1,6 +1,6 @@
 name: Release gems
 on:
-  create:
+  push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 


### PR DESCRIPTION
AFAICT `create` events aren't filtered like `push|pull_requests` events are.

We can see this as the `Release gems` triggering more frequently than expected: https://github.com/dependabot/dependabot-core/actions?query=workflow%3A%22Release+gems%22 

# Related
- special snowflake: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags
- same assumption: https://github.community/t/how-to-run-github-actions-workflow-only-for-new-tags/16075/22
