### PR TITLE
Add binary and deleted properties to dependency_file

### DIFF
--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -5,17 +5,22 @@ require "pathname"
 module Dependabot
   class DependencyFile
     attr_accessor :name, :content, :directory, :type, :support_file,
-                  :symlink_target, :binary, :deleted
+                  :symlink_target, :content_encoding, :deleted
+
+    class ContentEncoding
+      UTF_8 = "utf-8"
+      BASE64 = "base64"
+    end
 
     def initialize(name:, content:, directory: "/", type: "file",
-                   support_file: false, symlink_target: nil, binary: false,
-                   deleted: false)
+                   support_file: false, symlink_target: nil,
+                   content_encoding: ContentEncoding::UTF_8, deleted: false)
       @name = name
       @content = content
       @directory = clean_directory(directory)
       @symlink_target = symlink_target
       @support_file = support_file
-      @binary = binary
+      @content_encoding = content_encoding
       @deleted = deleted
 
       # Type is used *very* sparingly. It lets the git_modules updater know that
@@ -38,7 +43,7 @@ module Dependabot
         "directory" => directory,
         "type" => type,
         "support_file" => support_file,
-        "binary" => binary,
+        "content_encoding" => content_encoding,
         "deleted" => deleted
       }
 
@@ -68,10 +73,6 @@ module Dependabot
 
     def support_file?
       @support_file
-    end
-
-    def binary?
-      @binary
     end
 
     def deleted?

--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -5,15 +5,18 @@ require "pathname"
 module Dependabot
   class DependencyFile
     attr_accessor :name, :content, :directory, :type, :support_file,
-                  :symlink_target
+                  :symlink_target, :binary, :deleted
 
     def initialize(name:, content:, directory: "/", type: "file",
-                   support_file: false, symlink_target: nil)
+                   support_file: false, symlink_target: nil, binary: false,
+                   deleted: false)
       @name = name
       @content = content
       @directory = clean_directory(directory)
       @symlink_target = symlink_target
       @support_file = support_file
+      @binary = binary
+      @deleted = deleted
 
       # Type is used *very* sparingly. It lets the git_modules updater know that
       # a "file" is actually a submodule, and lets our Go updaters know which
@@ -34,7 +37,9 @@ module Dependabot
         "content" => content,
         "directory" => directory,
         "type" => type,
-        "support_file" => support_file
+        "support_file" => support_file,
+        "binary" => binary,
+        "deleted" => deleted
       }
 
       details["symlink_target"] = symlink_target if symlink_target
@@ -63,6 +68,14 @@ module Dependabot
 
     def support_file?
       @support_file
+    end
+
+    def binary?
+      @binary
+    end
+
+    def deleted?
+      @deleted
     end
 
     private

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -76,7 +76,9 @@ RSpec.describe Dependabot::DependencyFile do
           "content" => "a",
           "directory" => "/",
           "type" => "file",
-          "support_file" => false
+          "support_file" => false,
+          "binary" => false,
+          "deleted" => false
         )
       end
     end
@@ -98,7 +100,9 @@ RSpec.describe Dependabot::DependencyFile do
           "directory" => "/",
           "type" => "symlink",
           "support_file" => false,
-          "symlink_target" => "nested/Gemfile"
+          "symlink_target" => "nested/Gemfile",
+          "binary" => false,
+          "deleted" => false
         )
       end
     end

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Dependabot::DependencyFile do
           "directory" => "/",
           "type" => "file",
           "support_file" => false,
-          "binary" => false,
+          "content_encoding" => "utf-8",
           "deleted" => false
         )
       end
@@ -101,7 +101,7 @@ RSpec.describe Dependabot::DependencyFile do
           "type" => "symlink",
           "support_file" => false,
           "symlink_target" => "nested/Gemfile",
-          "binary" => false,
+          "content_encoding" => "utf-8",
           "deleted" => false
         )
       end


### PR DESCRIPTION
A very minimal change to `DependencyFile` to allow us to specify wether files are binary and/or deleted.