### PR TITLE
Handle deleting binary files

### DIFF
--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -170,13 +170,13 @@ module Dependabot
               sha: file.content
             }
           else
-            content = if file.binary?
+            content = if file.deleted?
+                        { sha: nil }
+                      elsif file.binary?
                         sha = github_client_for_source.create_blob(
                           source.repo, file.content, "base64"
                         )
                         { sha: sha }
-                      elsif file.deleted?
-                        { sha: nil }
                       else
                         { content: file.content }
                       end

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -132,13 +132,13 @@ module Dependabot
               sha: file.content
             }
           else
-            content = if file.binary?
+            content = if file.deleted?
+                        { sha: nil }
+                      elsif file.binary?
                         sha = github_client_for_source.create_blob(
                           source.repo, file.content, "base64"
                         )
                         { sha: sha }
-                      elsif file.deleted?
-                        { sha: nil }
                       else
                         { content: file.content }
                       end

--- a/common/spec/dependabot/pull_request_creator/github_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/github_spec.rb
@@ -286,7 +286,9 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
             name: "addressable-2.7.0.gem",
             directory: "vendor/cache",
             content: nil,
-            deleted: true
+            deleted: true,
+            content_encoding:
+              Dependabot::DependencyFile::ContentEncoding::BASE64
           )
         ]
       end

--- a/common/spec/dependabot/pull_request_updater/github_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/github_spec.rb
@@ -244,7 +244,9 @@ RSpec.describe Dependabot::PullRequestUpdater::Github do
             name: "addressable-2.7.0.gem",
             directory: "vendor/cache",
             content: nil,
-            deleted: true
+            deleted: true,
+            content_encoding:
+              Dependabot::DependencyFile::ContentEncoding::BASE64
           )
         ]
       end


### PR DESCRIPTION
Always check if the file was deleted before checking if it was binary,
so we delete files either way.