### PR TITLE
Update to poetry to 1.0.10

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -3,7 +3,7 @@ pip-tools==5.3.1
 hashin==0.15.0
 pipenv==2018.11.26
 pipfile==0.0.2
-poetry==1.0.9
+poetry==1.0.10
 
 # Some dependencies will only install if Cython is present
 Cython==0.29.21

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -22,12 +22,18 @@ module Dependabot
     class UpdateChecker
       # This class does version resolution for pyproject.toml files.
       class PoetryVersionResolver
-        GIT_REFERENCE_NOT_FOUND_REGEX =
-          /'git'.*pypoetry-git-(?<name>.+?).{8}','checkout','(?<tag>.+?)'/.
-          freeze
-        GIT_DEPENDENCY_UNREACHABLE_REGEX =
-          /'\['git',\s+'clone',\s+'(?<url>.+?)'.*\s+exit\s+status\s+128/m.
-          freeze
+        GIT_REFERENCE_NOT_FOUND_REGEX = /
+          'git'.*pypoetry-git-(?<name>.+?).{8}',
+          'checkout',
+          '(?<tag>.+?)'
+        /x.freeze
+        GIT_DEPENDENCY_UNREACHABLE_REGEX = /
+            '\['git',
+            \s+'clone',
+            \s+'--recurse-submodules',
+            \s+'(?<url>.+?)'.*
+            \s+exit\s+status\s+128
+          /mx.freeze
 
         attr_reader :dependency, :dependency_files, :credentials
 


### PR DESCRIPTION
A change in poetry 1.0.10 has changed how the `git clone` operation is performed. It now includes the `--recurse-submodules` option which wasn't there previously. This PR should superseed #2407.