### PR TITLE
Only replace version part of cargo line

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
@@ -101,7 +101,7 @@ module Dependabot
             simple_declaration_regex =
               /(?:^|["'])#{Regexp.escape(simple_declaration)}/
             content.gsub(simple_declaration_regex) do |line|
-              line.gsub(old_req, new_req)
+              line.gsub(/.+=.*\K(#{old_req})/, new_req)
             end
           elsif content.match?(feature_declaration_version_regex(dep))
             content.gsub(feature_declaration_version_regex(dep)) do |part|

--- a/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
@@ -99,6 +99,35 @@ RSpec.describe Dependabot::Cargo::FileUpdater::ManifestUpdater do
         end
       end
 
+      context "with a dependency name that includes the version range" do
+        let(:manifest_fixture_name) { "version_in_name" }
+        let(:dependency_name) { "curve25519-dalek" }
+        let(:dependency_version) { "3" }
+        let(:dependency_previous_version) { "2" }
+        let(:requirements) do
+          [{
+            file: "Cargo.toml",
+            requirement: "3",
+            groups: [],
+            source: nil
+          }]
+        end
+        let(:previous_requirements) do
+          [{
+            file: "Cargo.toml",
+            requirement: "2",
+            groups: [],
+            source: nil
+          }]
+        end
+
+        it "includes the new requirement" do
+          expect(updated_manifest_content).to include(
+            %(curve25519-dalek = "3")
+          )
+        end
+      end
+
       context "with a repeated dependency when only one req has changed" do
         let(:manifest_fixture_name) { "repeated_dependency" }
         let(:requirements) do

--- a/cargo/spec/fixtures/manifests/version_in_name
+++ b/cargo/spec/fixtures/manifests/version_in_name
@@ -1,0 +1,7 @@
+[package]
+name = "dependabot" # the name of the package
+version = "0.1.0"    # the current version, obeying semver
+authors = ["support@dependabot.com"]
+
+[dependencies]
+curve25519-dalek = "2"


### PR DESCRIPTION
We do a rather straight-forward regex replace on Cargo versions,
however, we did not take into account that the dependency name can
include the the version string. In order to avoid this, we only change
the part of the string after the `=` mark.