### PR TITLE
bundler vendoring: git sources

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - '*/tmp/**/*'
     - 'tmp/**/*'
     - '*/helpers/**/*'
+    - '*/spec/fixtures/**/*'
 
 Layout/DotPosition:
   EnforcedStyle: trailing

--- a/bundler/.gitignore
+++ b/bundler/.gitignore
@@ -3,5 +3,6 @@
 /tmp
 /dependabot-*.gem
 Gemfile.lock
+spec/fixtures/projects/*/.bundle/
 !spec/fixtures/projects/**/Gemfile.lock
 !spec/fixtures/projects/**/vendor

--- a/bundler/lib/dependabot/bundler/file_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater.rb
@@ -84,7 +84,7 @@ module Dependabot
         Dir.chdir(repo_contents_path) do
           relative_dir = vendor_cache_dir.sub("#{repo_contents_path}/", "")
           status = SharedHelpers.run_shell_command(
-            "git status --porcelain=v1 #{relative_dir}"
+            "git status --untracked-files=all --porcelain=v1 #{relative_dir}"
           )
           changed_paths = status.split("\n").map { |l| l.split(" ") }
           changed_paths.map do |type, path|

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -170,6 +170,7 @@ module Dependabot
           unlocked_gems = definition.instance_variable_get(:@unlock).
                           fetch(:gems)
           bundler_opts = {
+            cache_all: true,
             cache_all_platforms: true,
             no_prune: true
           }

--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -1589,7 +1589,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
       end
 
       context "with dependencies that are not unlocked by the update" do
-        let(:repo_contents_path) { build_tmp_repo("conditional") }
+        let(:project_name) { "conditional" }
 
         before do
           stub_request(:get, "https://rubygems.org/gems/statesman-1.2.1.gem").
@@ -1612,9 +1612,8 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
       end
 
       context "with a git dependency" do
-        let(:repo_contents_path) { build_tmp_repo("vendored_git") }
-        let(:gemfile_fixture_name) { "git_source_with_version" }
-        let(:lockfile_fixture_name) { "git_source_with_version.lock" }
+        let(:project_name) { "vendored_git" }
+
         let(:dependency) do
           Dependabot::Dependency.new(
             name: "dependabot-test-ruby-package",

--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -1650,18 +1650,19 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
           }]
         end
 
+        removed = "vendor/cache/dependabot-test-ruby-package-81073f9462f2"
+
         it "vendors the new dependency" do
+          added = "vendor/cache/dependabot-test-ruby-package-1c6331732c41"
           expect(updater.updated_dependency_files.map(&:name)).to match_array(
             [
-              # removed:
-              "vendor/cache/dependabot-test-ruby-package-81073f9462f2/.bundlecache",
-              "vendor/cache/dependabot-test-ruby-package-81073f9462f2/README.md",
-              "vendor/cache/dependabot-test-ruby-package-81073f9462f2/test-ruby-package.gemspec",
-              # added:
-              "vendor/cache/dependabot-test-ruby-package-1c6331732c41/.bundlecache",
-              "vendor/cache/dependabot-test-ruby-package-1c6331732c41/.gitignore",
-              "vendor/cache/dependabot-test-ruby-package-1c6331732c41/README.md",
-              "vendor/cache/dependabot-test-ruby-package-1c6331732c41/dependabot-test-ruby-package.gemspec",
+              "#{removed}/.bundlecache",
+              "#{removed}/README.md",
+              "#{removed}/test-ruby-package.gemspec",
+              "#{added}/.bundlecache",
+              "#{added}/.gitignore",
+              "#{added}/README.md",
+              "#{added}/dependabot-test-ruby-package.gemspec",
               # modified:
               "Gemfile",
               "Gemfile.lock"
@@ -1671,7 +1672,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
 
         it "deletes the old vendored repo" do
           file = updater.updated_dependency_files.find do |f|
-            f.name == "vendor/cache/dependabot-test-ruby-package-81073f9462f2/.bundlecache"
+            f.name == "#{removed}/.bundlecache"
           end
 
           expect(file&.deleted?).to eq true

--- a/bundler/spec/fixtures/projects/vendored_git/Gemfile
+++ b/bundler/spec/fixtures/projects/vendored_git/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "dependabot-test-ruby-package", "~> 1.0.0", git: "https://github.com/dependabot-fixtures/dependabot-test-ruby-package"

--- a/bundler/spec/fixtures/projects/vendored_git/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/vendored_git/Gemfile.lock
@@ -1,0 +1,18 @@
+GIT
+  remote: https://github.com/dependabot-fixtures/dependabot-test-ruby-package
+  revision: 81073f9462f228c6894e3e384d0718def310d99f
+  specs:
+    business (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  dependabot-test-ruby-package (~> 1.0.0)!
+
+BUNDLED WITH
+   1.16.0.pre.2

--- a/bundler/spec/fixtures/projects/vendored_git/vendor/cache/dependabot-test-ruby-package-81073f9462f2/README.md
+++ b/bundler/spec/fixtures/projects/vendored_git/vendor/cache/dependabot-test-ruby-package-81073f9462f2/README.md
@@ -1,0 +1,3 @@
+## dependabot-test-ruby-package v1.0.0
+
+A dummy Ruby package for testing Dependabot.

--- a/bundler/spec/fixtures/projects/vendored_git/vendor/cache/dependabot-test-ruby-package-81073f9462f2/test-ruby-package.gemspec
+++ b/bundler/spec/fixtures/projects/vendored_git/vendor/cache/dependabot-test-ruby-package-81073f9462f2/test-ruby-package.gemspec
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+# stub: dependabot-test-ruby-package 1.0.0 ruby lib
+
+Gem::Specification.new do |s|
+  s.name = "dependabot-test-ruby-package".freeze
+  s.version = "1.0.0"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["Dependabot".freeze]
+  s.date = "2020-08-25"
+  s.email = "noreply@github.com".freeze
+  s.homepage = "http://github.com/dependabot-fixtures/dependabot-test-ruby-package".freeze
+  s.licenses = ["MIT".freeze]
+  s.rubygems_version = "3.1.2".freeze
+  s.summary = "A dummy package for testing Dependabot".freeze
+
+  s.installed_by_version = "3.1.2" if s.respond_to? :installed_by_version
+end


### PR DESCRIPTION
This extends https://github.com/dependabot/dependabot-core/pull/2476 with a test case demonstrating updating a vendored git dependency.