### PR TITLE
bundler vendoring: detect non-binary extensions

### DIFF
--- a/bundler/dependabot-bundler.gemspec
+++ b/bundler/dependabot-bundler.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = common_gemspec.required_ruby_version
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
-  spec.add_dependency "mimemagic", "~> 0.3.5"
 
   common_gemspec.development_dependencies.each do |dep|
     spec.add_development_dependency dep.name, dep.requirement.to_s

--- a/bundler/dependabot-bundler.gemspec
+++ b/bundler/dependabot-bundler.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = common_gemspec.required_ruby_version
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
+  spec.add_dependency "mimemagic", "~> 0.3.5"
 
   common_gemspec.development_dependencies.each do |dep|
     spec.add_development_dependency dep.name, dep.requirement.to_s

--- a/bundler/lib/dependabot/bundler/file_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "mimemagic"
-
 require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
 
@@ -108,11 +106,37 @@ module Dependabot
         end
       end
 
-      def binary_file?(path)
-        magic = MimeMagic.by_path(path)
-        return true unless magic
+      # notable filenames without a reliable extension:
+      TEXT_FILE_NAMES = [
+        "Gemfile",
+        "Gemfile.lock",
+        ".bundlecache",
+        ".gitignore"
+      ].freeze
 
-        !magic.text?
+      TEXT_FILE_EXTS = [
+        # code
+        ".rb",
+        ".erb",
+        ".gemspec",
+        ".js",
+        ".html",
+        # config
+        ".json",
+        ".xml",
+        ".toml",
+        ".yaml",
+        ".yml",
+        # docs
+        ".md",
+        ".txt"
+      ].freeze
+
+      def binary_file?(path)
+        return false if TEXT_FILE_NAMES.include?(File.basename(path))
+        return false if TEXT_FILE_EXTS.include?(File.extname(path))
+
+        true
       end
 
       def check_required_files

--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -1650,9 +1650,9 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
         end
 
         removed = "vendor/cache/dependabot-test-ruby-package-81073f9462f2"
+        added = "vendor/cache/dependabot-test-ruby-package-1c6331732c41"
 
         it "vendors the new dependency" do
-          added = "vendor/cache/dependabot-test-ruby-package-1c6331732c41"
           expect(updater.updated_dependency_files.map(&:name)).to match_array(
             [
               "#{removed}/.bundlecache",
@@ -1675,6 +1675,14 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
           end
 
           expect(file&.deleted?).to eq true
+        end
+
+        it "does not base64 encode vendored code" do
+          file = updater.updated_dependency_files.find do |f|
+            f.name == "#{added}/README.md"
+          end
+
+          expect(file.content_encoding).to eq("")
         end
       end
     end

--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -1678,11 +1678,9 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
         end
 
         it "does not base64 encode vendored code" do
-          file = updater.updated_dependency_files.find do |f|
-            f.name == "#{added}/README.md"
-          end
-
-          expect(file.content_encoding).to eq("")
+          updater.updated_dependency_files.
+            select { |f| f.name.start_with?(added) }.
+            each { |f| expect(f.content_encoding).to eq("") }
         end
       end
     end


### PR DESCRIPTION
This extends #2476 to avoid base64 encoding files that are probably not binary.

This is important because of how the `PullRequestCreator::GitHub` [creates PRs](https://github.com/dependabot/dependabot-core/blob/f9ee541691b91f76308a972bb535d40443bce33f/common/lib/dependabot/pull_request_creator/github.rb#L173-L182). Since binary files are created as blobs, a PR that updates many files (e.g. a vendored git dependency #2479 ) would have a slow sequential upload process.

We'd prefer to batch content as much as possible within the `POST /repos/:owner/:repo/git/trees` call.
The trade-off of this approach is the growing size of that API call, I couldn't find any documented limits just some [reports](https://github.community/t/creating-new-tree-with-git-data-api-returns-502/1320/5) of potential problems with >thousands of files.

I didn't see anything with this capability in scope, so ~added https://github.com/minad/mimemagic to avoid reinventing~ invented something.