### PR TITLE
Dockerfile.dev: set git author

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -23,6 +23,7 @@ RUN chown -R "${USERNAME}":"${USERNAME}" \
   /opt/go/gopath \
   /opt/rust/
 USER $USERNAME
+RUN git config --global user.name dependabot-ci && git config --global user.email no-reply@github.com
 
 ARG CODE_DIR=/home/$USERNAME/dependabot-core
 


### PR DESCRIPTION
Since #2476 , docker dev tests have required a git author be set.

This PR copies the `Dockerfile.ci` setup so developers don't have to configure this manually.