### PR TITLE
Don't downgrade a pinned commit to a tag.

### DIFF
--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -90,11 +90,12 @@ module Dependabot
           return dependency_source_details.merge(ref: new_tag.fetch(:tag))
         end
 
-        # Update the git tag if updating a pinned commit
+        # Update the git commit if updating a pinned commit
         if git_commit_checker.pinned_ref_looks_like_commit_sha? &&
            (latest_tag = git_commit_checker.local_tag_for_latest_version) &&
-           git_commit_checker.branch_or_ref_in_release?(latest_tag[:version])
-          return dependency_source_details.merge(ref: latest_tag.fetch(:tag))
+           git_commit_checker.branch_or_ref_in_release?(latest_tag[:version]) &&
+           (latest_commit = latest_tag.fetch(:commit_sha)) != current_commit
+          return dependency_source_details.merge(ref: latest_commit)
         end
 
         # Otherwise return the original source

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
             source: {
               type: "git",
               url: "https://github.com/actions/setup-node",
-              ref: "v1.1.0",
+              ref: "5273d0df9c603edc4284ac8402cf650b4f1f6686",
               branch: nil
             },
             metadata: { declaration_string: "actions/setup-node@master" }
@@ -296,7 +296,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
               source: {
                 type: "git",
                 url: "https://github.com/actions/setup-node",
-                ref: "v1.0.4",
+                ref: "fc9ff49b90869a686df00e922af871c12215986a",
                 branch: nil
               },
               metadata: { declaration_string: "actions/setup-node@master" }


### PR DESCRIPTION
If an action is pinned to a commit, this is most likely as a security precaution, so always update pinned commits to the commit hash corresponding to the latest tag.

Fixes https://github.com/dependabot/dependabot-core/issues/2470.