### PR TITLE
Support cargo 1.46.0 ref not found message

### DIFF
--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -15,8 +15,10 @@ module Dependabot
           /Unable to update (?<url>.*?)$/.freeze
         BRANCH_NOT_FOUND_REGEX =
           /#{UNABLE_TO_UPDATE}.*to find branch `(?<branch>[^`]+)`/m.freeze
+        REVSPEC_PATTERN = /revspec '.*' not found/.freeze
+        OBJECT_PATTERN = /object not found - no match for id \(.*\)/.freeze
         REF_NOT_FOUND_REGEX =
-          /#{UNABLE_TO_UPDATE}.*revspec '.*' not found/m.freeze
+          /#{UNABLE_TO_UPDATE}.*(#{REVSPEC_PATTERN}|#{OBJECT_PATTERN})/m.freeze
 
         def initialize(dependency:, credentials:,
                        original_dependency_files:, prepared_dependency_files:)


### PR DESCRIPTION
In cargo 1.45.0 the message we were matching against was:

```
    Updating crates.io index
    Updating git repository `https://github.com/BurntSushi/utf8-ranges`
error: failed to get `utf8-ranges` as a dependency of package `dependabot v0.1.0 (/home/dependabot/dependabot-core/cargo/tmp/dependabot_20200902-3407-1pi6vdm)`

Caused by:
  failed to load source for dependency `utf8-ranges`

Caused by:
  Unable to update https://github.com/BurntSushi/utf8-ranges#11111b37

Caused by:
  revspec '11111b376b93484341c68fbca3ca110ae5cd2708' not found; class=Reference (4); code=NotFound (-3)
```

In cargo 1.46.0 this has been changed to:

```
    Updating crates.io index
    Updating git repository `https://github.com/BurntSushi/utf8-ranges`
error: failed to get `utf8-ranges` as a dependency of package `dependabot v0.1.0 (/home/dependabot/dependabot-core/cargo/tmp/dependabot_20200902-15-ij9hoa)`

Caused by:
  failed to load source for dependency `utf8-ranges`

Caused by:
  Unable to update https://github.com/BurntSushi/utf8-ranges#11111b37

Caused by:
  object not found - no match for id (11111b376b93484341c68fbca3ca110ae5cd2708); class=Odb (9); code=NotFound (-3)
```

This change matches against both messages, and ensures we raise a
`GitDependencyReferenceNotFound` as expected.