### PR TITLE
Add OAuth support in azure client

### DIFF
--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -164,9 +164,7 @@ module Dependabot
           end_index = get_description_end_index(pr_description, truncate_length)
           pr_description = end_index == -1 ? "" : pr_description[0..end_index]  + truncated_msg
         end
-
-        puts "Create pull request from source: #{source_branch} to target: #{target_branch}"
-        puts "PR name:#{pr_name}"
+       
         content = {
           sourceRefName: "refs/heads/" + source_branch,
           targetRefName: "refs/heads/" + target_branch,

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -195,9 +195,11 @@ module Dependabot
       def post(url, json)
         response = Excon.post(
           url,
-          headers: auth_header.merge({
-            "Content-Type" => "application/json"
-          }),
+          headers: auth_header.merge(
+            {
+              "Content-Type" => "application/json"
+            }
+          ),
           body: json,
           user: credentials&.fetch("username", nil),
           password: credentials&.fetch("password", nil),
@@ -219,7 +221,7 @@ module Dependabot
           { "Authorization" => "Basic #{encoded_token}" }
         elsif Base64.decode64(token).ascii_only? &&
               Base64.decode64(token).include?(":")
-            { "Authorization" => "Basic #{token.delete("\n")}" }
+          { "Authorization" => "Basic #{token.delete("\n")}" }
         else
           { "Authorization" => "Bearer #{token}" }
         end

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -3,8 +3,7 @@
 require "spec_helper"
 require "dependabot/clients/azure"
 
-RSpec.shared_examples "#get using auth headers" do
-|credential|
+RSpec.shared_examples "#get using auth headers" do |credential|
   before do
     stub_request(:get, base_url).
       with(headers: credential["headers"]).

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -3,6 +3,22 @@
 require "spec_helper"
 require "dependabot/clients/azure"
 
+RSpec.shared_examples "Successfully completes get request with auth headers" do |credential|
+  before do
+    stub_request(:get, base_url).
+      with(headers: credential["headers"]).
+      to_return(status: 200, body: '{"result": "Success"}')
+  end
+
+
+  it "Using #{credential["token_type"]} token in credentials" do
+
+    client = described_class.for_source(source: source, credentials: credential["credentials"])
+    response = JSON.parse(client.get(base_url).body)
+    expect(response["result"]).to eq("Success")
+  end
+end
+
 RSpec.describe Dependabot::Clients::Azure do
   let(:username) { "username" }
   let(:password) { "password" }
@@ -108,5 +124,18 @@ RSpec.describe Dependabot::Clients::Azure do
           )
       end
     end
+  end
+
+  describe "#get" do
+    context "Using auth headers" do
+        token = ":test_token"
+        encoded_token = Base64.encode64(":test_token").delete("\n")
+        bearer_token = "test_token"
+
+        include_examples 'Successfully completes get request with auth headers', {"token_type" => "basic non encoded", "credentials" => [{"type" => "git_source", "host" => "dev.azure.com", "token" => token}], "headers" => { "Authorization" => "Basic #{encoded_token}"}}
+        include_examples 'Successfully completes get request with auth headers', {"token_type" => "basic encoded", "credentials" => [{"type" => "git_source", "host" => "dev.azure.com", "token" => "#{encoded_token}"}], "headers" => { "Authorization" => "Basic #{encoded_token}" }}
+        include_examples 'Successfully completes get request with auth headers', {"token_type" => "bearer", "credentials" => [{"type" => "git_source", "host" => "dev.azure.com", "token" => "#{bearer_token}"}], "headers" => { "Authorization" => "Bearer #{bearer_token}" }}
+    end
+
   end
 end

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -3,17 +3,17 @@
 require "spec_helper"
 require "dependabot/clients/azure"
 
-RSpec.shared_examples "Successfully completes get request with auth headers" do |credential|
+RSpec.shared_examples "Successfully completes get request with auth headers"do 
+|credential|
   before do
     stub_request(:get, base_url).
       with(headers: credential["headers"]).
       to_return(status: 200, body: '{"result": "Success"}')
   end
 
-
-  it "Using #{credential["token_type"]} token in credentials" do
-
-    client = described_class.for_source(source: source, credentials: credential["credentials"])
+  it "Using #{credential['token_type']} token in credentials" do
+    client = described_class.for_source(source: source,
+             credentials: credential["credentials"])
     response = JSON.parse(client.get(base_url).body)
     expect(response["result"]).to eq("Success")
   end
@@ -128,13 +128,30 @@ RSpec.describe Dependabot::Clients::Azure do
 
   describe "#get" do
     context "Using auth headers" do
-        token = ":test_token"
-        encoded_token = Base64.encode64(":test_token").delete("\n")
-        bearer_token = "test_token"
+      token = ":test_token"
+      encoded_token = Base64.encode64(":test_token").delete("\n")
+      bearer_token = "test_token"
+      basic_non_encoded_token_test_hash = 
+      { "token_type" => "basic non encoded",
+        "credentials" => [{"type" => "git_source", "host" => "dev.azure.com", "token" => token}],
+        "headers" => { "Authorization" => "Basic #{encoded_token}"}
+      }
+      basic_encoded_token_test_hash = 
+      {
+        "token_type" => "basic encoded",
+        "credentials" => [{"type" => "git_source", "host" => "dev.azure.com", "token" => "#{encoded_token}"}],
+        "headers" => { "Authorization" => "Basic #{encoded_token}" }
+      }
+      bearer_token_test_hash = 
+      {
+        "token_type" => "bearer",
+        "credentials" => [{"type" => "git_source", "host" => "dev.azure.com", "token" => "#{bearer_token}"}],
+        "headers" => { "Authorization" => "Bearer #{bearer_token}" }
+      }
 
-        include_examples 'Successfully completes get request with auth headers', {"token_type" => "basic non encoded", "credentials" => [{"type" => "git_source", "host" => "dev.azure.com", "token" => token}], "headers" => { "Authorization" => "Basic #{encoded_token}"}}
-        include_examples 'Successfully completes get request with auth headers', {"token_type" => "basic encoded", "credentials" => [{"type" => "git_source", "host" => "dev.azure.com", "token" => "#{encoded_token}"}], "headers" => { "Authorization" => "Basic #{encoded_token}" }}
-        include_examples 'Successfully completes get request with auth headers', {"token_type" => "bearer", "credentials" => [{"type" => "git_source", "host" => "dev.azure.com", "token" => "#{bearer_token}"}], "headers" => { "Authorization" => "Bearer #{bearer_token}" }}
+        include_examples "Successfully completes get request with auth headers", basic_non_encoded_token_test_hash
+        include_examples "Successfully completes get request with auth headers", basic_encoded_token_test_hash
+        include_examples "Successfully completes get request with auth headers", bearer_token_test_hash
     end
 
   end

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "dependabot/clients/azure"
 
-RSpec.shared_examples "Successfully completes get request with auth headers" do
+RSpec.shared_examples "#get using auth headers" do
 |credential|
   before do
     stub_request(:get, base_url).
@@ -13,9 +13,9 @@ RSpec.shared_examples "Successfully completes get request with auth headers" do
 
   it "Using #{credential['token_type']} token in credentials" do
     client = described_class.for_source(
-             source: source,
-             credentials: credential["credentials"]
-            )
+      source: source,
+      credentials: credential["credentials"]
+    )
     response = JSON.parse(client.get(base_url).body)
     expect(response["result"]).to eq("Success")
   end
@@ -133,48 +133,46 @@ RSpec.describe Dependabot::Clients::Azure do
       token = ":test_token"
       encoded_token = Base64.encode64(":test_token").delete("\n")
       bearer_token = "test_token"
-      basic_non_encoded_token_test_hash =
-      { "token_type" => "basic non encoded",
-        "credentials" => [
-          {
-            "type" => "git_source",
-            "host" => "dev.azure.com",
-            "token" => token
-          }
-        ],
-        "headers" => { "Authorization" => "Basic #{encoded_token}" }
-      }
-      basic_encoded_token_test_hash =
-      {
-        "token_type" => "basic encoded",
-        "credentials" => [
-          {
-            "type" => "git_source",
-            "host" => "dev.azure.com",
-            "token" => "#{encoded_token}"
-          }
-        ],
-        "headers" => { "Authorization" => "Basic #{encoded_token}" }
-      }
-      bearer_token_test_hash =
-      {
-        "token_type" => "bearer",
-        "credentials" => [
-          {
-            "type" => "git_source",
-            "host" => "dev.azure.com",
-            "token" => "#{bearer_token}"
-          }
-        ],
-        "headers" => { "Authorization" => "Bearer #{bearer_token}" }
-      }
+      basic_non_encoded_token_data =
+        {
+          "token_type" => "basic non encoded",
+          "credentials" => [
+            {
+              "type" => "git_source",
+              "host" => "dev.azure.com",
+              "token" => token
+            }
+          ],
+          "headers" => { "Authorization" => "Basic #{encoded_token}" }
+        }
+      basic_encoded_token_data =
+        {
+          "token_type" => "basic encoded",
+          "credentials" => [
+            {
+              "type" => "git_source",
+              "host" => "dev.azure.com",
+              "token" => encoded_token.to_s
+            }
+          ],
+          "headers" => { "Authorization" => "Basic #{encoded_token}" }
+        }
+      bearer_token_data =
+        {
+          "token_type" => "bearer",
+          "credentials" => [
+            {
+              "type" => "git_source",
+              "host" => "dev.azure.com",
+              "token" => bearer_token
+            }
+          ],
+          "headers" => { "Authorization" => "Bearer #{bearer_token}" }
+        }
 
-      include_examples "Successfully completes get request with auth headers",
-                        basic_non_encoded_token_test_hash
-      include_examples "Successfully completes get request with auth headers",
-                        basic_encoded_token_test_hash
-      include_examples "Successfully completes get request with auth headers",
-                        bearer_token_test_hash
+      include_examples "#get using auth headers", basic_non_encoded_token_data
+      include_examples "#get using auth headers", basic_encoded_token_data
+      include_examples "#get using auth headers", bearer_token_data
     end
   end
 end

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "dependabot/clients/azure"
 
-RSpec.shared_examples "Successfully completes get request with auth headers"do 
+RSpec.shared_examples "Successfully completes get request with auth headers" do
 |credential|
   before do
     stub_request(:get, base_url).
@@ -12,8 +12,10 @@ RSpec.shared_examples "Successfully completes get request with auth headers"do
   end
 
   it "Using #{credential['token_type']} token in credentials" do
-    client = described_class.for_source(source: source,
-             credentials: credential["credentials"])
+    client = described_class.for_source(
+             source: source,
+             credentials: credential["credentials"]
+            )
     response = JSON.parse(client.get(base_url).body)
     expect(response["result"]).to eq("Success")
   end
@@ -131,28 +133,48 @@ RSpec.describe Dependabot::Clients::Azure do
       token = ":test_token"
       encoded_token = Base64.encode64(":test_token").delete("\n")
       bearer_token = "test_token"
-      basic_non_encoded_token_test_hash = 
+      basic_non_encoded_token_test_hash =
       { "token_type" => "basic non encoded",
-        "credentials" => [{"type" => "git_source", "host" => "dev.azure.com", "token" => token}],
-        "headers" => { "Authorization" => "Basic #{encoded_token}"}
-      }
-      basic_encoded_token_test_hash = 
-      {
-        "token_type" => "basic encoded",
-        "credentials" => [{"type" => "git_source", "host" => "dev.azure.com", "token" => "#{encoded_token}"}],
+        "credentials" => [
+          {
+            "type" => "git_source",
+            "host" => "dev.azure.com",
+            "token" => token
+          }
+        ],
         "headers" => { "Authorization" => "Basic #{encoded_token}" }
       }
-      bearer_token_test_hash = 
+      basic_encoded_token_test_hash =
+      {
+        "token_type" => "basic encoded",
+        "credentials" => [
+          {
+            "type" => "git_source",
+            "host" => "dev.azure.com",
+            "token" => "#{encoded_token}"
+          }
+        ],
+        "headers" => { "Authorization" => "Basic #{encoded_token}" }
+      }
+      bearer_token_test_hash =
       {
         "token_type" => "bearer",
-        "credentials" => [{"type" => "git_source", "host" => "dev.azure.com", "token" => "#{bearer_token}"}],
+        "credentials" => [
+          {
+            "type" => "git_source",
+            "host" => "dev.azure.com",
+            "token" => "#{bearer_token}"
+          }
+        ],
         "headers" => { "Authorization" => "Bearer #{bearer_token}" }
       }
 
-        include_examples "Successfully completes get request with auth headers", basic_non_encoded_token_test_hash
-        include_examples "Successfully completes get request with auth headers", basic_encoded_token_test_hash
-        include_examples "Successfully completes get request with auth headers", bearer_token_test_hash
+      include_examples "Successfully completes get request with auth headers",
+                        basic_non_encoded_token_test_hash
+      include_examples "Successfully completes get request with auth headers",
+                        basic_encoded_token_test_hash
+      include_examples "Successfully completes get request with auth headers",
+                        bearer_token_test_hash
     end
-
   end
 end


### PR DESCRIPTION
**Issue**
Currently, `azure_client` supports only `basic authentication` using `username` and `password`. For our service, which we have built on top of dependabot-core, we require support for `OAuth` tokens in `azure_client`. We found this as something which we could contribute back to dependabot-core hence creating this PR.

**Solution**
 For enabling authentication using tokens, it will be expecting a separate field named `'token'` in the `credentials` hash instead of `username` and `password`. Using the token, it will decide on the `authorization headers` for the `Excon` request in the same manner as it is done for connecting to registries in dependabot-core. For e.g 
https://github.com/dependabot/dependabot-core/blob/main/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb#L73-L85

If the user provides `username` and `password`, it will follow the current implementation as is. For the case of `'token' field`, it will set the `username` and `password` in the request to `nil` and will send the token in the `headers` with the appropriate `authorization`.

**Tests**
Added tests to verify the usage of authorization headers for get function in azure_client.

@jurre Let me know your thoughts on this PR 

