### PR TITLE
Upgrade elixir/mix to 1.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ RUN wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
   && dpkg -i erlang-solutions_1.0_all.deb \
   && apt-get update \
   && apt-get install -y esl-erlang \
-  && wget https://github.com/elixir-lang/elixir/releases/download/v1.9.1/Precompiled.zip \
+  && wget https://github.com/elixir-lang/elixir/releases/download/v1.10.0/Precompiled.zip \
   && unzip -d /usr/local/elixir -x Precompiled.zip \
   && rm -f Precompiled.zip \
   && mix local.hex --force


### PR DESCRIPTION
https://elixir-lang.org/blog/2020/01/27/elixir-v1-10-0-released/