### PR TITLE
Force encode nuspec files to utf-8 for regex matching

### DIFF
--- a/nuget/lib/dependabot/nuget/metadata_finder.rb
+++ b/nuget/lib/dependabot/nuget/metadata_finder.rb
@@ -32,7 +32,8 @@ module Dependabot
 
       def source_from_anywhere_in_nuspec(nuspec)
         github_urls = []
-        nuspec.to_s.scan(Source::SOURCE_REGEX) do
+        nuspec.to_s.force_encoding(Encoding::UTF_8).
+          scan(Source::SOURCE_REGEX) do
           github_urls << Regexp.last_match.to_s
         end
 


### PR DESCRIPTION
Windows has a history of using UTF-16, recent versions of windows
default to UTF-8, but we sometimes encounter files that are encoded as
UTF-16. When trying to regex match on such a string, we get an error:

```
incompatible encoding regexp match (US-ASCII regexp with UTF-16 string)
```

By enforcing the encoding we should be able to prevent this.