### PR TITLE
Fix python path dependencies with file

### DIFF
--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -19,6 +19,10 @@ VCR.configure do |config|
   config.hook_into :webmock
   config.configure_rspec_metadata!
 
+  unless ENV["DEPENDABOT_TEST_DEBUG_LOGGER"].nil?
+    config.debug_logger = File.open(ENV["DEPENDABOT_TEST_DEBUG_LOGGER"], "w")
+  end
+
   # Prevent access tokens being written to VCR cassettes
   unless ENV["DEPENDABOT_TEST_ACCESS_TOKEN"].nil?
     config.filter_sensitive_data("<TOKEN>") do

--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -350,14 +350,14 @@ module Dependabot
       def parse_path_setup_paths(req_file)
         uneditable_reqs =
           req_file.content.
-          scan(/^['"]?(?<path>\..*?)(?=\[|#|'|"|$)/).
+          scan(/^['"]?(?:file:)?(?<path>\..*?)(?=\[|#|'|"|$)/).
           flatten.
           map(&:strip).
           reject { |p| p.include?("://") }
 
         editable_reqs =
           req_file.content.
-          scan(/^(?:-e)\s+['"]?(?<path>.*?)(?=\[|#|'|"|$)/).
+          scan(/^(?:-e)\s+['"]?(?:file:)?(?<path>.*?)(?=\[|#|'|"|$)/).
           flatten.
           map(&:strip).
           reject { |p| p.include?("://") || p.include?("git@") }

--- a/python/spec/dependabot/python/file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/file_fetcher_spec.rb
@@ -814,6 +814,9 @@ RSpec.describe Dependabot::Python::FileFetcher do
                 body: fixture("github", "setup_content.json"),
                 headers: { "content-type" => "application/json" }
               )
+            stub_request(:get, url + "file:./setup.py?ref=sha").
+              with(headers: { "Authorization" => "token token" }).
+              to_return(status: 404)
           end
 
           it "fetches the path dependencies" do

--- a/python/spec/fixtures/github/requirements_with_path_dependencies.json
+++ b/python/spec/fixtures/github/requirements_with_path_dependencies.json
@@ -8,7 +8,7 @@
   "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/8d9a77a86256c11409622fd16d799d9718f1ff62",
   "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/requirements.txt?token=ABMwe8vXxd4DBCEsxz3jMusk5sr_fFsoks5WJWE-wA%3D%3D",
   "type": "file",
-  "content": "LWUgLgotZSAiLi9teSIKLWUgJy4vbXktc2luZ2xlJwoKLi9teS1vdGhlcgou\nL3NvbWUvemlwLWZpbGUudGFyLmd6Cg==\n",
+  "content": "LWUgLgotZSAiLi9teSIKLWUgJy4vbXktc2luZ2xlJwoKLi9teS1vdGhlcgouL3NvbWUvemlwLWZpbGUudGFyLmd6CgpmaWxlOi4KLWUgZmlsZTouCg==\n",
   "encoding": "base64",
   "_links": {
     "self": "https://api.github.com/repos/gocardless/bump/contents/requirements.txt?ref=master",


### PR DESCRIPTION
This should fix https://github.com/dependabot/dependabot-core/issues/1977

This PR updates the regex in Dependabot::Python::FileFetcher.parse_path_setup_paths to ignore if there is a `file:` at the beginning of the requirement path.