### PR TITLE
Allow Azure client to set linked work item

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,7 +86,7 @@ Metrics/CyclomaticComplexity:
 
 Metrics/PerceivedComplexity:
   Max: 10 # default: 8
-  
+
 Metrics/AbcSize:
   Max: 35
 
@@ -101,7 +101,6 @@ Metrics/BlockLength:
     - '*/dependabot-*.gemspec'
 
 Metrics/ParameterLists:
-  Max: 6
   CountKeywordArgs: false
 
 Naming/FileName:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,6 +101,7 @@ Metrics/BlockLength:
     - '*/dependabot-*.gemspec'
 
 Metrics/ParameterLists:
+  Max: 6
   CountKeywordArgs: false
 
 Naming/FileName:

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -155,7 +155,7 @@ module Dependabot
 
       # rubocop:disable Metrics/ParameterLists
       def create_pull_request(pr_name, source_branch, target_branch,
-                              pr_description, labels, work_item)
+                              pr_description, labels, work_item = nil)
         # Azure DevOps only support descriptions up to 4000 characters
         # https://developercommunity.visualstudio.com/content/problem/608770/remove-4000-character-limit-on-pull-request-descri.html
         azure_max_length = 3999

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -154,7 +154,7 @@ module Dependabot
       end
 
       def create_pull_request(pr_name, source_branch, target_branch,
-                              pr_description, labels)
+                              pr_description, labels, work_item)
         # Azure DevOps only support descriptions up to 4000 characters
         # https://developercommunity.visualstudio.com/content/problem/608770/remove-4000-character-limit-on-pull-request-descri.html
         azure_max_length = 3999
@@ -169,7 +169,8 @@ module Dependabot
           targetRefName: "refs/heads/" + target_branch,
           title: pr_name,
           description: pr_description,
-          labels: labels.map { |label| { name: label } }
+          labels: labels.map { |label| { name: label } },
+          workItemRefs: [{id: work_item}]
         }
 
         post(source.api_endpoint +

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -153,6 +153,7 @@ module Dependabot
           "/pushes?api-version=5.0", content.to_json)
       end
 
+      # rubocop:disable Metrics/ParameterLists
       def create_pull_request(pr_name, source_branch, target_branch,
                               pr_description, labels, work_item)
         # Azure DevOps only support descriptions up to 4000 characters
@@ -163,6 +164,7 @@ module Dependabot
           truncate_length = azure_max_length - truncated_msg.length
           pr_description = pr_description[0..truncate_length] + truncated_msg
         end
+        # rubocop:enable Metrics/ParameterLists
 
         content = {
           sourceRefName: "refs/heads/" + source_branch,

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -170,7 +170,7 @@ module Dependabot
           title: pr_name,
           description: pr_description,
           labels: labels.map { |label| { name: label } },
-          workItemRefs: [{id: work_item}]
+          workItemRefs: [{ id: work_item }]
         }
 
         post(source.api_endpoint +

--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -23,7 +23,7 @@ module Dependabot
                 :commit_message_options, :vulnerabilities_fixed,
                 :reviewers, :assignees, :milestone, :branch_name_separator,
                 :branch_name_prefix, :github_redirection_service,
-                :custom_headers, :work_item
+                :custom_headers, :provider_metadata
 
     def initialize(source:, base_commit:, dependencies:, files:, credentials:,
                    pr_message_header: nil, pr_message_footer: nil,
@@ -34,7 +34,7 @@ module Dependabot
                    label_language: false, automerge_candidate: false,
                    github_redirection_service: "github-redirect.dependabot.com",
                    custom_headers: nil, require_up_to_date_base: false,
-                   work_item: nil)
+                   provider_metadata: {})
       @dependencies               = dependencies
       @source                     = source
       @base_commit                = base_commit
@@ -57,7 +57,7 @@ module Dependabot
       @github_redirection_service = github_redirection_service
       @custom_headers             = custom_headers
       @require_up_to_date_base    = require_up_to_date_base
-      @work_item                  = work_item
+      @provider_metadata          = provider_metadata
 
       check_dependencies_have_previous_version
     end
@@ -145,7 +145,7 @@ module Dependabot
         pr_name: message_builder.pr_name,
         author_details: author_details,
         labeler: labeler,
-        work_item: work_item
+        work_item: provider_metadata&.fetch(:work_item)
       )
     end
 

--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -23,7 +23,7 @@ module Dependabot
                 :commit_message_options, :vulnerabilities_fixed,
                 :reviewers, :assignees, :milestone, :branch_name_separator,
                 :branch_name_prefix, :github_redirection_service,
-                :custom_headers
+                :custom_headers, :work_item
 
     def initialize(source:, base_commit:, dependencies:, files:, credentials:,
                    pr_message_header: nil, pr_message_footer: nil,
@@ -33,7 +33,8 @@ module Dependabot
                    branch_name_separator: "/", branch_name_prefix: "dependabot",
                    label_language: false, automerge_candidate: false,
                    github_redirection_service: "github-redirect.dependabot.com",
-                   custom_headers: nil, require_up_to_date_base: false)
+                   custom_headers: nil, require_up_to_date_base: false,
+                   work_item: nil)
       @dependencies               = dependencies
       @source                     = source
       @base_commit                = base_commit
@@ -56,6 +57,7 @@ module Dependabot
       @github_redirection_service = github_redirection_service
       @custom_headers             = custom_headers
       @require_up_to_date_base    = require_up_to_date_base
+      @work_item                  = work_item
 
       check_dependencies_have_previous_version
     end
@@ -142,7 +144,8 @@ module Dependabot
         pr_description: message_builder.pr_message,
         pr_name: message_builder.pr_name,
         author_details: author_details,
-        labeler: labeler
+        labeler: labeler,
+        work_item: work_item
       )
     end
 

--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -145,7 +145,7 @@ module Dependabot
         pr_name: message_builder.pr_name,
         author_details: author_details,
         labeler: labeler,
-        work_item: provider_metadata&.fetch(:work_item)
+        work_item: provider_metadata&.fetch(:work_item, nil)
       )
     end
 

--- a/common/lib/dependabot/pull_request_creator/azure.rb
+++ b/common/lib/dependabot/pull_request_creator/azure.rb
@@ -8,11 +8,11 @@ module Dependabot
     class Azure
       attr_reader :source, :branch_name, :base_commit, :credentials,
                   :files, :commit_message, :pr_description, :pr_name,
-                  :author_details, :labeler
+                  :author_details, :labeler, :work_item
 
       def initialize(source:, branch_name:, base_commit:, credentials:,
                      files:, commit_message:, pr_description:, pr_name:,
-                     author_details:, labeler:)
+                     author_details:, labeler:, work_item:)
         @source         = source
         @branch_name    = branch_name
         @base_commit    = base_commit
@@ -23,6 +23,7 @@ module Dependabot
         @pr_name        = pr_name
         @author_details = author_details
         @labeler        = labeler
+        @work_item      = work_item
       end
 
       def create
@@ -79,7 +80,8 @@ module Dependabot
           branch_name,
           source.branch || default_branch,
           pr_description,
-          labeler.labels_for_pr
+          labeler.labels_for_pr,
+          work_item
         )
       end
 

--- a/common/lib/dependabot/pull_request_creator/azure.rb
+++ b/common/lib/dependabot/pull_request_creator/azure.rb
@@ -12,7 +12,7 @@ module Dependabot
 
       def initialize(source:, branch_name:, base_commit:, credentials:,
                      files:, commit_message:, pr_description:, pr_name:,
-                     author_details:, labeler:, work_item:)
+                     author_details:, labeler:, work_item: nil)
         @source         = source
         @branch_name    = branch_name
         @base_commit    = base_commit

--- a/common/lib/dependabot/pull_request_creator/azure.rb
+++ b/common/lib/dependabot/pull_request_creator/azure.rb
@@ -47,9 +47,7 @@ module Dependabot
       end
 
       def branch_exists?
-        @branch_ref ||= azure_client_for_source.branch(branch_name)
-
-        @branch_ref
+        azure_client_for_source.branch(branch_name)
       rescue ::Azure::Error::NotFound
         false
       end

--- a/common/spec/dependabot/pull_request_creator/azure_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/azure_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Dependabot::PullRequestCreator::Azure do
       pr_description: pr_description,
       pr_name: pr_name,
       author_details: author_details,
-      labeler: labeler
+      labeler: labeler,
+      work_item: work_item
     )
   end
 
@@ -53,6 +54,7 @@ RSpec.describe Dependabot::PullRequestCreator::Azure do
       automerge_candidate: false
     )
   end
+  let(:work_item) { 123 }
   let(:custom_labels) { nil }
   let(:dependency) do
     Dependabot::Dependency.new(

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -249,7 +249,8 @@ RSpec.describe Dependabot::PullRequestCreator do
             pr_description: "PR msg",
             pr_name: "PR name",
             author_details: author_details,
-            labeler: instance_of(described_class::Labeler)
+            labeler: instance_of(described_class::Labeler),
+            work_item: 123
           ).and_return(dummy_creator)
         expect(dummy_creator).to receive(:create)
         creator.create

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Dependabot::PullRequestCreator do
       assignees: assignees,
       milestone: milestone,
       author_details: author_details,
-      signature_key: signature_key
+      signature_key: signature_key,
+      work_item: work_item
     )
   end
 
@@ -45,6 +46,7 @@ RSpec.describe Dependabot::PullRequestCreator do
   let(:source) { Dependabot::Source.new(provider: "github", repo: "gc/bump") }
   let(:files) { [gemfile] }
   let(:base_commit) { "basecommitsha" }
+  let(:work_item) { 123 }
   let(:credentials) do
     [{
       "type" => "git_source",

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Dependabot::PullRequestCreator do
   let(:source) { Dependabot::Source.new(provider: "github", repo: "gc/bump") }
   let(:files) { [gemfile] }
   let(:base_commit) { "basecommitsha" }
-  let(:provider_metadata) { { work_item: 123 } }
+  let(:provider_metadata) { nil }
   let(:credentials) do
     [{
       "type" => "git_source",
@@ -237,6 +237,7 @@ RSpec.describe Dependabot::PullRequestCreator do
     context "with an Azure source" do
       let(:source) { Dependabot::Source.new(provider: "azure", repo: "gc/bp") }
       let(:dummy_creator) { instance_double(described_class::Azure) }
+      let(:provider_metadata) { { work_item: 123 } }
 
       it "delegates to PullRequestCreator::Azure with correct params" do
         expect(described_class::Azure).

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Dependabot::PullRequestCreator do
       milestone: milestone,
       author_details: author_details,
       signature_key: signature_key,
-      work_item: work_item
+      provider_metadata: provider_metadata
     )
   end
 
@@ -46,7 +46,7 @@ RSpec.describe Dependabot::PullRequestCreator do
   let(:source) { Dependabot::Source.new(provider: "github", repo: "gc/bump") }
   let(:files) { [gemfile] }
   let(:base_commit) { "basecommitsha" }
-  let(:work_item) { 123 }
+  let(:provider_metadata) { { work_item: 123 } }
   let(:credentials) do
     [{
       "type" => "git_source",


### PR DESCRIPTION
This PR adds the ability to link work items when create a pull request in Azure DevOps.

The API is pretty forgiving, and allows the JSON `"workItemRefs": [{"id": null}]`

API docs: https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull%20requests/create?view=azure-devops-rest-5.0