### PR TITLE
Fix missing truncation notice on GitHub PRs

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -316,7 +316,7 @@ module Dependabot
       def metadata_cascades_for_dep(dependency)
         MetadataPresenter.new(
           dependency: dependency,
-          provider: source.provider,
+          source: source,
           metadata_finder: metadata_finder(dependency),
           vulnerabilities_fixed: vulnerabilities_fixed[dependency.name],
           github_redirection_service: github_redirection_service).to_s

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -318,7 +318,7 @@ module Dependabot
           dependency: dependency,
           provider: source.provider,
           metadata_finder: metadata_finder(dependency),
-          vulnerabilities_fixed: vulnerabilities_fixed,
+          vulnerabilities_fixed: vulnerabilities_fixed[dependency.name],
           github_redirection_service: github_redirection_service).to_s
       end
 

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -313,17 +313,19 @@ module Dependabot
       end
 
       def metadata_cascades_for_dep(dep)
-        break_tag = source_provider_supports_html? ? "\n<br />" : "\n\n"
+        return ""
 
-        msg = ""
-        msg += vulnerabilities_cascade(dep)
-        msg += release_cascade(dep)
-        msg += changelog_cascade(dep)
-        msg += upgrade_guide_cascade(dep)
-        msg += commits_cascade(dep)
-        msg += maintainer_changes_cascade(dep)
-        msg += break_tag unless msg == ""
-        "\n" + sanitize_links_and_mentions(msg, unsafe: true)
+        # break_tag = source_provider_supports_html? ? "\n<br />" : "\n\n"
+
+        # msg = ""
+        # msg += vulnerabilities_cascade(dep)
+        # msg += release_cascade(dep)
+        # msg += changelog_cascade(dep)
+        # msg += upgrade_guide_cascade(dep)
+        # msg += commits_cascade(dep)
+        # msg += maintainer_changes_cascade(dep)
+        # msg += break_tag unless msg == ""
+        # "\n" + sanitize_links_and_mentions(msg, unsafe: true)
       end
 
       def vulnerabilities_cascade(dep)

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -313,65 +313,18 @@ module Dependabot
         end.join
       end
 
-      def metadata_cascades_for_dep(dep)
-        return ""
-
-        # break_tag = source_provider_supports_html? ? "\n<br />" : "\n\n"
-
-        # msg = ""
-        # msg += vulnerabilities_cascade(dep)
-        # msg += release_cascade(dep)
-        # msg += changelog_cascade(dep)
-        # msg += upgrade_guide_cascade(dep)
-        # msg += commits_cascade(dep)
-        # msg += maintainer_changes_cascade(dep)
-        # msg += break_tag unless msg == ""
-        # "\n" + sanitize_links_and_mentions(msg, unsafe: true)
+      def metadata_cascades_for_dep(dependency)
+        MetadataPresenter.new(
+          dependency: dependency,
+          provider: source.provider,
+          metadata_finder: metadata_finder(dependency),
+          vulnerabilities_fixed: vulnerabilities_fixed,
+          github_redirection_service: github_redirection_service).to_s
       end
-
-      # def releases_url(dependency)
-      #   metadata_finder(dependency).releases_url
-      # end
-
-      # def releases_text(dependency)
-      #   metadata_finder(dependency).releases_text
-      # end
-
-      # def changelog_url(dependency)
-      #   metadata_finder(dependency).changelog_url
-      # end
-
-      # def changelog_text(dependency)
-      #   metadata_finder(dependency).changelog_text
-      # end
-
-      # def upgrade_url(dependency)
-      #   metadata_finder(dependency).upgrade_guide_url
-      # end
-
-      # def upgrade_text(dependency)
-      #   metadata_finder(dependency).upgrade_guide_text
-      # end
-
-      # def commits_url(dependency)
-      #   metadata_finder(dependency).commits_url
-      # end
-
-      # def commits(dependency)
-      #   metadata_finder(dependency).commits
-      # end
-
-      # def maintainer_changes(dependency)
-      #   metadata_finder(dependency).maintainer_changes
-      # end
 
       def source_url(dependency)
         metadata_finder(dependency).source_url
       end
-
-      # def homepage_url(dependency)
-      #   metadata_finder(dependency).homepage_url
-      # end
 
       def metadata_finder(dependency)
         @metadata_finder ||= {}
@@ -479,28 +432,6 @@ module Dependabot
         end
 
         raise "No new requirement!"
-      end
-
-      def link_issues(text:, dependency:)
-        IssueLinker.
-          new(source_url: source_url(dependency)).
-          link_issues(text: text)
-      end
-
-      def fix_relative_links(text:, base_url:)
-        text.gsub(/\[.*?\]\([^)]+\)/) do |link|
-          next link if link.include?("://")
-
-          relative_path = link.match(/\((.*?)\)/).captures.last
-          base = base_url.split("://").last.gsub(%r{[^/]*$}, "")
-          path = File.join(base, relative_path)
-          absolute_path =
-            base_url.sub(
-              %r{(?<=://).*$},
-              Pathname.new(path).cleanpath.to_s
-            )
-          link.gsub(relative_path, absolute_path)
-        end
       end
 
       def ref_changed?(dependency)

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -319,7 +319,8 @@ module Dependabot
           source: source,
           metadata_finder: metadata_finder(dependency),
           vulnerabilities_fixed: vulnerabilities_fixed[dependency.name],
-          github_redirection_service: github_redirection_service).to_s
+          github_redirection_service: github_redirection_service
+        ).to_s
       end
 
       def source_url(dependency)

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -10,6 +10,7 @@ require "dependabot/pull_request_creator"
 module Dependabot
   class PullRequestCreator
     class MessageBuilder
+      require_relative "message_builder/metadata_presenter"
       require_relative "message_builder/issue_linker"
       require_relative "message_builder/link_and_mention_sanitizer"
       require_relative "pr_name_prefixer"
@@ -328,227 +329,49 @@ module Dependabot
         # "\n" + sanitize_links_and_mentions(msg, unsafe: true)
       end
 
-      def vulnerabilities_cascade(dep)
-        fixed_vulns = vulnerabilities_fixed[dep.name]
-        return "" unless fixed_vulns&.any?
+      # def releases_url(dependency)
+      #   metadata_finder(dependency).releases_url
+      # end
 
-        msg = ""
-        fixed_vulns.each { |v| msg += serialized_vulnerability_details(v) }
-        msg = sanitize_template_tags(msg)
-        msg = sanitize_links_and_mentions(msg)
+      # def releases_text(dependency)
+      #   metadata_finder(dependency).releases_text
+      # end
 
-        build_details_tag(summary: "Vulnerabilities fixed", body: msg)
-      end
+      # def changelog_url(dependency)
+      #   metadata_finder(dependency).changelog_url
+      # end
 
-      def release_cascade(dep)
-        return "" unless releases_text(dep) && releases_url(dep)
+      # def changelog_text(dependency)
+      #   metadata_finder(dependency).changelog_text
+      # end
 
-        msg = "*Sourced from [#{dep.display_name}'s releases]"\
-              "(#{releases_url(dep)}).*\n\n"
-        msg +=
-          begin
-            release_note_lines = releases_text(dep).split("\n").first(50)
-            release_note_lines = release_note_lines.map { |line| "> #{line}\n" }
-            if release_note_lines.count == 50
-              release_note_lines << truncated_line
-            end
-            release_note_lines.join
-          end
-        msg = link_issues(text: msg, dependency: dep)
-        msg = fix_relative_links(
-          text: msg,
-          base_url: source_url(dep) + "/blob/HEAD/"
-        )
-        msg = sanitize_template_tags(msg)
-        msg = sanitize_links_and_mentions(msg)
+      # def upgrade_url(dependency)
+      #   metadata_finder(dependency).upgrade_guide_url
+      # end
 
-        build_details_tag(summary: "Release notes", body: msg)
-      end
+      # def upgrade_text(dependency)
+      #   metadata_finder(dependency).upgrade_guide_text
+      # end
 
-      def changelog_cascade(dep)
-        return "" unless changelog_url(dep) && changelog_text(dep)
+      # def commits_url(dependency)
+      #   metadata_finder(dependency).commits_url
+      # end
 
-        msg = "*Sourced from "\
-              "[#{dep.display_name}'s changelog](#{changelog_url(dep)}).*\n\n"
-        msg +=
-          begin
-            changelog_lines = changelog_text(dep).split("\n").first(50)
-            changelog_lines = changelog_lines.map { |line| "> #{line}\n" }
-            changelog_lines << truncated_line if changelog_lines.count == 50
-            changelog_lines.join
-          end
-        msg = link_issues(text: msg, dependency: dep)
-        msg = fix_relative_links(text: msg, base_url: changelog_url(dep))
-        msg = sanitize_template_tags(msg)
-        msg = sanitize_links_and_mentions(msg)
+      # def commits(dependency)
+      #   metadata_finder(dependency).commits
+      # end
 
-        build_details_tag(summary: "Changelog", body: msg)
-      end
-
-      def upgrade_guide_cascade(dep)
-        return "" unless upgrade_url(dep) && upgrade_text(dep)
-
-        msg = "*Sourced from "\
-              "[#{dep.display_name}'s upgrade guide]"\
-              "(#{upgrade_url(dep)}).*\n\n"
-        msg +=
-          begin
-            upgrade_lines = upgrade_text(dep).split("\n").first(50)
-            upgrade_lines = upgrade_lines.map { |line| "> #{line}\n" }
-            upgrade_lines << truncated_line if upgrade_lines.count == 50
-            upgrade_lines.join
-          end
-        msg = link_issues(text: msg, dependency: dep)
-        msg = fix_relative_links(text: msg, base_url: upgrade_url(dep))
-        msg = sanitize_template_tags(msg)
-        msg = sanitize_links_and_mentions(msg)
-
-        build_details_tag(summary: "Upgrade guide", body: msg)
-      end
-
-      def commits_cascade(dep)
-        return "" unless commits_url(dep) && commits(dep)
-
-        msg = ""
-
-        commits(dep).reverse.first(10).each do |commit|
-          title = commit[:message].strip.split("\n").first
-          title = title.slice(0..76) + "..." if title && title.length > 80
-          title = title&.gsub(/(?<=[^\w.-])([_*`~])/, '\\1')
-          sha = commit[:sha][0, 7]
-          msg += "- [`#{sha}`](#{commit[:html_url]}) #{title}\n"
-        end
-
-        msg = msg.gsub(/\<.*?\>/) { |tag| "\\#{tag}" }
-
-        msg +=
-          if commits(dep).count > 10
-            "- Additional commits viewable in "\
-            "[compare view](#{commits_url(dep)})\n"
-          else
-            "- See full diff in [compare view](#{commits_url(dep)})\n"
-          end
-        msg = link_issues(text: msg, dependency: dep)
-        msg = sanitize_links_and_mentions(msg)
-
-        build_details_tag(summary: "Commits", body: msg)
-      end
-
-      def maintainer_changes_cascade(dep)
-        return "" unless maintainer_changes(dep)
-
-        build_details_tag(
-          summary: "Maintainer changes",
-          body: sanitize_links_and_mentions(maintainer_changes(dep)) + "\n"
-        )
-      end
-
-      def build_details_tag(summary:, body:)
-        # Azure DevOps does not support <details> tag (https://developercommunity.visualstudio.com/content/problem/608769/add-support-for-in-markdown.html)
-        # CodeCommit does not support the <details> tag (no url available)
-        if source_provider_supports_html?
-          msg = "<details>\n<summary>#{summary}</summary>\n\n"
-          msg += body
-          msg + "</details>\n"
-        else
-          "\n\##{summary}\n\n#{body}"
-        end
-      end
-
-      def source_provider_supports_html?
-        !%w(azure codecommit).include?(source.provider)
-      end
-
-      def serialized_vulnerability_details(details)
-        msg = vulnerability_source_line(details)
-
-        if details["title"]
-          msg += "> **#{details['title'].lines.map(&:strip).join(' ')}**\n"
-        end
-
-        if (description = details["description"])
-          description.strip.lines.first(20).each { |line| msg += "> #{line}" }
-          msg += truncated_line if description.strip.lines.count > 20
-        end
-
-        msg += "\n" unless msg.end_with?("\n")
-        msg += "> \n"
-        msg += vulnerability_version_range_lines(details)
-        msg + "\n"
-      end
-
-      def vulnerability_source_line(details)
-        if details["source_url"] && details["source_name"]
-          "*Sourced from [#{details['source_name']}]"\
-          "(#{details['source_url']}).*\n\n"
-        elsif details["source_name"]
-          "*Sourced from #{details['source_name']}.*\n\n"
-        else
-          ""
-        end
-      end
-
-      def vulnerability_version_range_lines(details)
-        msg = ""
-        %w(patched_versions unaffected_versions affected_versions).each do |tp|
-          type = tp.split("_").first.capitalize
-          next unless details[tp]
-
-          versions_string = details[tp].any? ? details[tp].join("; ") : "none"
-          versions_string = versions_string.gsub(/(?<!\\)~/, '\~')
-          msg += "> #{type} versions: #{versions_string}\n"
-        end
-        msg
-      end
-
-      def truncated_line
-        # Tables can spill out of truncated details, so we close them
-        "></tr></table> ... (truncated)\n"
-      end
-
-      def releases_url(dependency)
-        metadata_finder(dependency).releases_url
-      end
-
-      def releases_text(dependency)
-        metadata_finder(dependency).releases_text
-      end
-
-      def changelog_url(dependency)
-        metadata_finder(dependency).changelog_url
-      end
-
-      def changelog_text(dependency)
-        metadata_finder(dependency).changelog_text
-      end
-
-      def upgrade_url(dependency)
-        metadata_finder(dependency).upgrade_guide_url
-      end
-
-      def upgrade_text(dependency)
-        metadata_finder(dependency).upgrade_guide_text
-      end
-
-      def commits_url(dependency)
-        metadata_finder(dependency).commits_url
-      end
-
-      def commits(dependency)
-        metadata_finder(dependency).commits
-      end
-
-      def maintainer_changes(dependency)
-        metadata_finder(dependency).maintainer_changes
-      end
+      # def maintainer_changes(dependency)
+      #   metadata_finder(dependency).maintainer_changes
+      # end
 
       def source_url(dependency)
         metadata_finder(dependency).source_url
       end
 
-      def homepage_url(dependency)
-        metadata_finder(dependency).homepage_url
-      end
+      # def homepage_url(dependency)
+      #   metadata_finder(dependency).homepage_url
+      # end
 
       def metadata_finder(dependency)
         @metadata_finder ||= {}
@@ -677,26 +500,6 @@ module Dependabot
               Pathname.new(path).cleanpath.to_s
             )
           link.gsub(relative_path, absolute_path)
-        end
-      end
-
-      def sanitize_links_and_mentions(text, unsafe: false)
-        return text unless source.provider == "github"
-
-        LinkAndMentionSanitizer.
-          new(github_redirection_service: github_redirection_service).
-          sanitize_links_and_mentions(text: text, unsafe: unsafe)
-      end
-
-      def sanitize_template_tags(text)
-        text.gsub(/\<.*?\>/) do |tag|
-          tag_contents = tag.match(/\<(.*?)\>/).captures.first.strip
-
-          # Unclosed calls to template overflow out of the blockquote block,
-          # wrecking the rest of our PRs. Other tags don't share this problem.
-          next "\\#{tag}" if tag_contents.start_with?("template")
-
-          tag
         end
       end
 

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -241,7 +241,7 @@ module Dependabot
 
         def truncated_line
           # Tables can spill out of truncated details, so we close them
-          "></tr></table> ... (truncated)\n"
+          "></tr></table> \n ... (truncated)\n"
         end
 
         def break_tag

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -57,7 +57,7 @@ module Dependabot
         private
 
         def vulnerabilities_cascade(dep)
-          fixed_vulns = vulnerabilities_fixed[dep.name]
+          fixed_vulns = vulnerabilities_fixed
           return "" unless fixed_vulns&.any?
 
           msg = ""

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -37,7 +37,7 @@ module Dependabot
           msg += vulnerabilities_cascade
           msg += release_cascade
           msg += changelog_cascade
-          msg += upgrade_guide_cascade(dependency)
+          msg += upgrade_guide_cascade
           msg += commits_cascade(dependency)
           msg += maintainer_changes_cascade(dependency)
           msg += break_tag unless msg == ""
@@ -105,11 +105,11 @@ module Dependabot
           build_details_tag(summary: "Changelog", body: msg)
         end
 
-        def upgrade_guide_cascade(dep)
+        def upgrade_guide_cascade
           return "" unless upgrade_guide_url && upgrade_guide_text
 
           msg = "*Sourced from "\
-                "[#{dep.display_name}'s upgrade guide]"\
+                "[#{dependency.display_name}'s upgrade guide]"\
                 "(#{upgrade_guide_url}).*\n\n"
           msg +=
             begin
@@ -118,7 +118,7 @@ module Dependabot
               upgrade_lines << truncated_line if upgrade_lines.count == 50
               upgrade_lines.join
             end
-          msg = link_issues(text: msg, dependency: dep)
+          msg = link_issues(text: msg, dependency: dependency)
           msg = fix_relative_links(text: msg, base_url: upgrade_guide_url)
           msg = sanitize_template_tags(msg)
           msg = sanitize_links_and_mentions(msg)

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -36,7 +36,7 @@ module Dependabot
           msg = ""
           msg += vulnerabilities_cascade
           msg += release_cascade
-          msg += changelog_cascade(dependency)
+          msg += changelog_cascade
           msg += upgrade_guide_cascade(dependency)
           msg += commits_cascade(dependency)
           msg += maintainer_changes_cascade(dependency)
@@ -85,11 +85,11 @@ module Dependabot
           build_details_tag(summary: "Release notes", body: msg)
         end
 
-        def changelog_cascade(dep)
+        def changelog_cascade
           return "" unless changelog_url && changelog_text
 
           msg = "*Sourced from "\
-                "[#{dep.display_name}'s changelog](#{changelog_url}).*\n\n"
+                "[#{dependency.display_name}'s changelog](#{changelog_url}).*\n\n"
           msg +=
             begin
               changelog_lines = changelog_text.split("\n").first(50)
@@ -97,7 +97,7 @@ module Dependabot
               changelog_lines << truncated_line if changelog_lines.count == 50
               changelog_lines.join
             end
-          msg = link_issues(text: msg, dependency: dep)
+          msg = link_issues(text: msg, dependency: dependency)
           msg = fix_relative_links(text: msg, base_url: changelog_url)
           msg = sanitize_template_tags(msg)
           msg = sanitize_links_and_mentions(msg)

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -38,7 +38,7 @@ module Dependabot
           msg += release_cascade
           msg += changelog_cascade
           msg += upgrade_guide_cascade
-          msg += commits_cascade(dependency)
+          msg += commits_cascade
           msg += maintainer_changes_cascade(dependency)
           msg += break_tag unless msg == ""
           "\n" + sanitize_links_and_mentions(msg, unsafe: true)
@@ -126,7 +126,7 @@ module Dependabot
           build_details_tag(summary: "Upgrade guide", body: msg)
         end
 
-        def commits_cascade(dep)
+        def commits_cascade
           return "" unless commits_url && commits
 
           msg = ""
@@ -148,7 +148,7 @@ module Dependabot
             else
               "- See full diff in [compare view](#{commits_url})\n"
             end
-          msg = link_issues(text: msg, dependency: dep)
+          msg = link_issues(text: msg, dependency: dependency)
           msg = sanitize_links_and_mentions(msg)
 
           build_details_tag(summary: "Commits", body: msg)

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -75,7 +75,7 @@ module Dependabot
               end
               release_note_lines.join
             end
-          msg = link_issues(text: msg, dependency: dependency)
+          msg = link_issues(text: msg)
           msg = fix_relative_links(
             text: msg,
             base_url: source_url + "/blob/HEAD/"
@@ -99,7 +99,7 @@ module Dependabot
               changelog_lines << truncated_line if changelog_lines.count == 50
               changelog_lines.join
             end
-          msg = link_issues(text: msg, dependency: dependency)
+          msg = link_issues(text: msg)
           msg = fix_relative_links(text: msg, base_url: changelog_url)
           msg = sanitize_template_tags(msg)
           msg = sanitize_links_and_mentions(msg)
@@ -120,7 +120,7 @@ module Dependabot
               upgrade_lines << truncated_line if upgrade_lines.count == 50
               upgrade_lines.join
             end
-          msg = link_issues(text: msg, dependency: dependency)
+          msg = link_issues(text: msg)
           msg = fix_relative_links(text: msg, base_url: upgrade_guide_url)
           msg = sanitize_template_tags(msg)
           msg = sanitize_links_and_mentions(msg)
@@ -150,7 +150,7 @@ module Dependabot
             else
               "- See full diff in [compare view](#{commits_url})\n"
             end
-          msg = link_issues(text: msg, dependency: dependency)
+          msg = link_issues(text: msg)
           msg = sanitize_links_and_mentions(msg)
 
           build_details_tag(summary: "Commits", body: msg)
@@ -223,7 +223,7 @@ module Dependabot
           msg
         end
 
-        def link_issues(text:, dependency:)
+        def link_issues(text:)
           IssueLinker.
             new(source_url: source_url).
             link_issues(text: text)

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -19,15 +19,9 @@ module Dependabot
                        :maintainer_changes,
                        :releases_url,
                        :releases_text,
-                       :source_url
-
-        def upgrade_url
-          metadata_finder.upgrade_guide_url
-        end
-
-        def upgrade_text
-          metadata_finder.upgrade_guide_text
-        end
+                       :source_url,
+                       :upgrade_guide_url,
+                       :upgrade_guide_text
 
         def initialize(dependency:, provider:, metadata_finder:,
                        vulnerabilities_fixed:, github_redirection_service:)
@@ -114,20 +108,20 @@ module Dependabot
         end
 
         def upgrade_guide_cascade(dep)
-          return "" unless upgrade_url && upgrade_text
+          return "" unless upgrade_guide_url && upgrade_guide_text
 
           msg = "*Sourced from "\
                 "[#{dep.display_name}'s upgrade guide]"\
-                "(#{upgrade_url}).*\n\n"
+                "(#{upgrade_guide_url}).*\n\n"
           msg +=
             begin
-              upgrade_lines = upgrade_text.split("\n").first(50)
+              upgrade_lines = upgrade_guide_text.split("\n").first(50)
               upgrade_lines = upgrade_lines.map { |line| "> #{line}\n" }
               upgrade_lines << truncated_line if upgrade_lines.count == 50
               upgrade_lines.join
             end
           msg = link_issues(text: msg, dependency: dep)
-          msg = fix_relative_links(text: msg, base_url: upgrade_url)
+          msg = fix_relative_links(text: msg, base_url: upgrade_guide_url)
           msg = sanitize_template_tags(msg)
           msg = sanitize_links_and_mentions(msg)
 

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -34,7 +34,7 @@ module Dependabot
 
         def to_s
           msg = ""
-          msg += vulnerabilities_cascade(dependency)
+          msg += vulnerabilities_cascade
           msg += release_cascade(dependency)
           msg += changelog_cascade(dependency)
           msg += upgrade_guide_cascade(dependency)
@@ -46,12 +46,14 @@ module Dependabot
 
         private
 
-        def vulnerabilities_cascade(dep)
-          fixed_vulns = vulnerabilities_fixed
-          return "" unless fixed_vulns&.any?
+        def vulnerabilities_cascade
+          return "" unless vulnerabilities_fixed&.any?
 
           msg = ""
-          fixed_vulns.each { |v| msg += serialized_vulnerability_details(v) }
+          vulnerabilities_fixed.each do|v|
+            msg += serialized_vulnerability_details(v)
+          end
+
           msg = sanitize_template_tags(msg)
           msg = sanitize_links_and_mentions(msg)
 

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require "dependabot/pull_request_creator/message_builder"
+
+module Dependabot
+  class PullRequestCreator
+    class MessageBuilder
+      class MetadataPresenter
+        attr_reader :dependency, :provider, :metadata_finder
+
+        def initialize(dependency:, provider:, metadata_finder:)
+          @dependency = dependency
+          @provider = provider
+          @metadata_finder = metadata_finder
+        end
+
+        def to_s
+          msg = ""
+          msg += vulnerabilities_cascade(dep)
+          msg += release_cascade(dep)
+          msg += changelog_cascade(dep)
+          msg += upgrade_guide_cascade(dep)
+          msg += commits_cascade(dep)
+          msg += maintainer_changes_cascade(dep)
+          msg += break_tag unless msg == ""
+          "\n" + sanitize_links_and_mentions(msg, unsafe: true)
+        end
+
+        private
+
+        def vulnerabilities_cascade(dep)
+          fixed_vulns = vulnerabilities_fixed[dep.name]
+          return "" unless fixed_vulns&.any?
+
+          msg = ""
+          fixed_vulns.each { |v| msg += serialized_vulnerability_details(v) }
+          msg = sanitize_template_tags(msg)
+          msg = sanitize_links_and_mentions(msg)
+
+          build_details_tag(summary: "Vulnerabilities fixed", body: msg)
+        end
+
+        def release_cascade(dep)
+          return "" unless releases_text(dep) && releases_url(dep)
+
+          msg = "*Sourced from [#{dep.display_name}'s releases]"\
+                "(#{releases_url(dep)}).*\n\n"
+          msg +=
+            begin
+              release_note_lines = releases_text(dep).split("\n").first(50)
+              release_note_lines = release_note_lines.map { |line| "> #{line}\n" }
+              if release_note_lines.count == 50
+                release_note_lines << truncated_line
+              end
+              release_note_lines.join
+            end
+          msg = link_issues(text: msg, dependency: dep)
+          msg = fix_relative_links(
+            text: msg,
+            base_url: source_url(dep) + "/blob/HEAD/"
+          )
+          msg = sanitize_template_tags(msg)
+          msg = sanitize_links_and_mentions(msg)
+
+          build_details_tag(summary: "Release notes", body: msg)
+        end
+
+        def changelog_cascade(dep)
+          return "" unless changelog_url(dep) && changelog_text(dep)
+
+          msg = "*Sourced from "\
+                "[#{dep.display_name}'s changelog](#{changelog_url(dep)}).*\n\n"
+          msg +=
+            begin
+              changelog_lines = changelog_text(dep).split("\n").first(50)
+              changelog_lines = changelog_lines.map { |line| "> #{line}\n" }
+              changelog_lines << truncated_line if changelog_lines.count == 50
+              changelog_lines.join
+            end
+          msg = link_issues(text: msg, dependency: dep)
+          msg = fix_relative_links(text: msg, base_url: changelog_url(dep))
+          msg = sanitize_template_tags(msg)
+          msg = sanitize_links_and_mentions(msg)
+
+          build_details_tag(summary: "Changelog", body: msg)
+        end
+
+        def upgrade_guide_cascade(dep)
+          return "" unless upgrade_url(dep) && upgrade_text(dep)
+
+          msg = "*Sourced from "\
+                "[#{dep.display_name}'s upgrade guide]"\
+                "(#{upgrade_url(dep)}).*\n\n"
+          msg +=
+            begin
+              upgrade_lines = upgrade_text(dep).split("\n").first(50)
+              upgrade_lines = upgrade_lines.map { |line| "> #{line}\n" }
+              upgrade_lines << truncated_line if upgrade_lines.count == 50
+              upgrade_lines.join
+            end
+          msg = link_issues(text: msg, dependency: dep)
+          msg = fix_relative_links(text: msg, base_url: upgrade_url(dep))
+          msg = sanitize_template_tags(msg)
+          msg = sanitize_links_and_mentions(msg)
+
+          build_details_tag(summary: "Upgrade guide", body: msg)
+        end
+
+        def commits_cascade(dep)
+          return "" unless commits_url(dep) && commits(dep)
+
+          msg = ""
+
+          commits(dep).reverse.first(10).each do |commit|
+            title = commit[:message].strip.split("\n").first
+            title = title.slice(0..76) + "..." if title && title.length > 80
+            title = title&.gsub(/(?<=[^\w.-])([_*`~])/, '\\1')
+            sha = commit[:sha][0, 7]
+            msg += "- [`#{sha}`](#{commit[:html_url]}) #{title}\n"
+          end
+
+          msg = msg.gsub(/\<.*?\>/) { |tag| "\\#{tag}" }
+
+          msg +=
+            if commits(dep).count > 10
+              "- Additional commits viewable in "\
+              "[compare view](#{commits_url(dep)})\n"
+            else
+              "- See full diff in [compare view](#{commits_url(dep)})\n"
+            end
+          msg = link_issues(text: msg, dependency: dep)
+          msg = sanitize_links_and_mentions(msg)
+
+          build_details_tag(summary: "Commits", body: msg)
+        end
+
+        def maintainer_changes_cascade(dep)
+          return "" unless maintainer_changes(dep)
+
+          build_details_tag(
+            summary: "Maintainer changes",
+            body: sanitize_links_and_mentions(maintainer_changes(dep)) + "\n"
+          )
+        end
+
+        def build_details_tag(summary:, body:)
+          # Azure DevOps does not support <details> tag (https://developercommunity.visualstudio.com/content/problem/608769/add-support-for-in-markdown.html)
+          # CodeCommit does not support the <details> tag (no url available)
+          if source_provider_supports_html?
+            msg = "<details>\n<summary>#{summary}</summary>\n\n"
+            msg += body
+            msg + "</details>\n"
+          else
+            "\n\##{summary}\n\n#{body}"
+          end
+        end
+
+        def serialized_vulnerability_details(details)
+          msg = vulnerability_source_line(details)
+
+          if details["title"]
+            msg += "> **#{details['title'].lines.map(&:strip).join(' ')}**\n"
+          end
+
+          if (description = details["description"])
+            description.strip.lines.first(20).each { |line| msg += "> #{line}" }
+            msg += truncated_line if description.strip.lines.count > 20
+          end
+
+          msg += "\n" unless msg.end_with?("\n")
+          msg += "> \n"
+          msg += vulnerability_version_range_lines(details)
+          msg + "\n"
+        end
+
+        def vulnerability_source_line(details)
+          if details["source_url"] && details["source_name"]
+            "*Sourced from [#{details['source_name']}]"\
+            "(#{details['source_url']}).*\n\n"
+          elsif details["source_name"]
+            "*Sourced from #{details['source_name']}.*\n\n"
+          else
+            ""
+          end
+        end
+
+        def vulnerability_version_range_lines(details)
+          msg = ""
+          %w(patched_versions unaffected_versions affected_versions).each do |tp|
+            type = tp.split("_").first.capitalize
+            next unless details[tp]
+
+            versions_string = details[tp].any? ? details[tp].join("; ") : "none"
+            versions_string = versions_string.gsub(/(?<!\\)~/, '\~')
+            msg += "> #{type} versions: #{versions_string}\n"
+          end
+          msg
+        end
+
+        def truncated_line
+          # Tables can spill out of truncated details, so we close them
+          "></tr></table> ... (truncated)\n"
+        end
+
+        def break_tag
+          source_provider_supports_html? ? "\n<br />" : "\n\n"
+        end
+
+        def source_provider_supports_html?
+          !%w(azure codecommit).include?(provider)
+        end
+
+        def sanitize_links_and_mentions(text, unsafe: false)
+          return text unless source.provider == "github"
+
+          LinkAndMentionSanitizer.
+            new(github_redirection_service: github_redirection_service).
+            sanitize_links_and_mentions(text: text, unsafe: unsafe)
+        end
+
+        def sanitize_template_tags(text)
+          text.gsub(/\<.*?\>/) do |tag|
+            tag_contents = tag.match(/\<(.*?)\>/).captures.first.strip
+
+            # Unclosed calls to template overflow out of the blockquote block,
+            # wrecking the rest of our PRs. Other tags don't share this problem.
+            next "\\#{tag}" if tag_contents.start_with?("template")
+
+            tag
+          end
+        end
+      end
+    end
+  end
+end

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -50,7 +50,7 @@ module Dependabot
           return "" unless vulnerabilities_fixed&.any?
 
           msg = ""
-          vulnerabilities_fixed.each do|v|
+          vulnerabilities_fixed.each do |v|
             msg += serialized_vulnerability_details(v)
           end
 
@@ -68,7 +68,8 @@ module Dependabot
           msg +=
             begin
               release_note_lines = releases_text.split("\n").first(50)
-              release_note_lines = release_note_lines.map { |line| "> #{line}\n" }
+              release_note_lines =
+                release_note_lines.map { |line| "> #{line}\n" }
               if release_note_lines.count == 50
                 release_note_lines << truncated_line
               end
@@ -89,7 +90,8 @@ module Dependabot
           return "" unless changelog_url && changelog_text
 
           msg = "*Sourced from "\
-                "[#{dependency.display_name}'s changelog](#{changelog_url}).*\n\n"
+                "[#{dependency.display_name}'s changelog]"\
+                "(#{changelog_url}).*\n\n"
           msg +=
             begin
               changelog_lines = changelog_text.split("\n").first(50)
@@ -206,7 +208,11 @@ module Dependabot
 
         def vulnerability_version_range_lines(details)
           msg = ""
-          %w(patched_versions unaffected_versions affected_versions).each do |tp|
+          %w(
+            patched_versions
+            unaffected_versions
+            affected_versions
+          ).each do |tp|
             type = tp.split("_").first.capitalize
             next unless details[tp]
 

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -35,7 +35,7 @@ module Dependabot
         def to_s
           msg = ""
           msg += vulnerabilities_cascade
-          msg += release_cascade(dependency)
+          msg += release_cascade
           msg += changelog_cascade(dependency)
           msg += upgrade_guide_cascade(dependency)
           msg += commits_cascade(dependency)
@@ -60,10 +60,10 @@ module Dependabot
           build_details_tag(summary: "Vulnerabilities fixed", body: msg)
         end
 
-        def release_cascade(dep)
+        def release_cascade
           return "" unless releases_text && releases_url
 
-          msg = "*Sourced from [#{dep.display_name}'s releases]"\
+          msg = "*Sourced from [#{dependency.display_name}'s releases]"\
                 "(#{releases_url}).*\n\n"
           msg +=
             begin
@@ -74,7 +74,7 @@ module Dependabot
               end
               release_note_lines.join
             end
-          msg = link_issues(text: msg, dependency: dep)
+          msg = link_issues(text: msg, dependency: dependency)
           msg = fix_relative_links(
             text: msg,
             base_url: source_url + "/blob/HEAD/"

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -8,7 +8,7 @@ module Dependabot
       class MetadataPresenter
         extend Forwardable
 
-        attr_reader :dependency, :provider, :metadata_finder,
+        attr_reader :dependency, :source, :metadata_finder,
                     :vulnerabilities_fixed, :github_redirection_service
 
         def_delegators :metadata_finder,
@@ -23,10 +23,10 @@ module Dependabot
                        :upgrade_guide_url,
                        :upgrade_guide_text
 
-        def initialize(dependency:, provider:, metadata_finder:,
+        def initialize(dependency:, source:, metadata_finder:,
                        vulnerabilities_fixed:, github_redirection_service:)
           @dependency = dependency
-          @provider = provider
+          @source = source
           @metadata_finder = metadata_finder
           @vulnerabilities_fixed = vulnerabilities_fixed
           @github_redirection_service = github_redirection_service
@@ -249,11 +249,11 @@ module Dependabot
         end
 
         def source_provider_supports_html?
-          !%w(azure codecommit).include?(provider)
+          !%w(azure codecommit).include?(source.provider)
         end
 
         def sanitize_links_and_mentions(text, unsafe: false)
-          return text unless provider == "github"
+          return text unless source.provider == "github"
 
           LinkAndMentionSanitizer.
             new(github_redirection_service: github_redirection_service).

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -39,7 +39,7 @@ module Dependabot
           msg += changelog_cascade
           msg += upgrade_guide_cascade
           msg += commits_cascade
-          msg += maintainer_changes_cascade(dependency)
+          msg += maintainer_changes_cascade
           msg += break_tag unless msg == ""
           "\n" + sanitize_links_and_mentions(msg, unsafe: true)
         end
@@ -154,7 +154,7 @@ module Dependabot
           build_details_tag(summary: "Commits", body: msg)
         end
 
-        def maintainer_changes_cascade(dep)
+        def maintainer_changes_cascade
           return "" unless maintainer_changes
 
           build_details_tag(

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -32,18 +32,14 @@ module Dependabot
           @github_redirection_service = github_redirection_service
         end
 
-        def dep
-          dependency
-        end
-
         def to_s
           msg = ""
-          msg += vulnerabilities_cascade(dep)
-          msg += release_cascade(dep)
-          msg += changelog_cascade(dep)
-          msg += upgrade_guide_cascade(dep)
-          msg += commits_cascade(dep)
-          msg += maintainer_changes_cascade(dep)
+          msg += vulnerabilities_cascade(dependency)
+          msg += release_cascade(dependency)
+          msg += changelog_cascade(dependency)
+          msg += upgrade_guide_cascade(dependency)
+          msg += commits_cascade(dependency)
+          msg += maintainer_changes_cascade(dependency)
           msg += break_tag unless msg == ""
           "\n" + sanitize_links_and_mentions(msg, unsafe: true)
         end

--- a/common/spec/dependabot/pull_request_creator/message_builder/metadata_presenter_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/metadata_presenter_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe namespace::MetadataPresenter do
   subject(:presenter) do
     described_class.new(
       dependency: dependency,
-      provider: source.provider,
+      source: source,
       metadata_finder: metadata_finder,
       vulnerabilities_fixed: vulnerabilities_fixed,
       github_redirection_service: github_redirection_service

--- a/common/spec/dependabot/pull_request_creator/message_builder/metadata_presenter_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/metadata_presenter_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/pull_request_creator/message_builder/metadata_presenter"
+
+namespace = Dependabot::PullRequestCreator::MessageBuilder
+RSpec.describe namespace::MetadataPresenter do
+  let(:source) do
+    Dependabot::Source.new(provider: "github", repo: "gocardless/bump")
+  end
+
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "business",
+      version: "1.5.0",
+      previous_version: "1.4.0",
+      package_manager: "dummy",
+      requirements:
+        [{ file: "Gemfile", requirement: "~> 1.5.0", groups: [], source: nil }],
+      previous_requirements:
+        [{ file: "Gemfile", requirement: "~> 1.4.0", groups: [], source: nil }]
+    )
+  end
+
+  let(:credentials) do
+    [{
+      "type" => "git_source",
+      "host" => "github.com",
+      "username" => "x-access-token",
+      "password" => "token"
+    }]
+  end
+
+  class MockMetadataFinder < Dependabot::MetadataFinders::Base
+    def look_up_source
+      Dependabot::Source.new(provider: "github", repo: "gocardless/business")
+    end
+  end
+
+  let(:metadata_finder) do
+    instance_double(Dependabot::MetadataFinders::Base,
+                    changelog_url: "http://localhost/changelog.md",
+                    changelog_text: "",
+                    commits_url: "http://localhost/commits",
+                    commits: [],
+                    maintainer_changes: "",
+                    releases_url: "http://localhost/releases",
+                    releases_text: "",
+                    source_url: "http://localhost/",
+                    upgrade_guide_url: "http://localhost/upgrade.md",
+                    upgrade_guide_text: "")
+  end
+
+  let(:vulnerabilities_fixed) { [] }
+
+  let(:github_redirection_service) { "github-redirect.dependabot.com" }
+
+  subject(:presenter) do
+    described_class.new(
+      dependency: dependency,
+      provider: source.provider,
+      metadata_finder: metadata_finder,
+      vulnerabilities_fixed: vulnerabilities_fixed,
+      github_redirection_service: github_redirection_service
+    )
+  end
+
+  describe "#to_s" do
+    context "with a changelog that requires truncation" do
+      before do
+        allow(metadata_finder).
+          to receive(:changelog_text) { fixture("raw", "changelog.md") }
+      end
+
+      it "adds a truncation notice" do
+        expect(presenter.to_s).to include("(truncated)")
+      end
+
+      it "removes all content after the 50th line" do
+        expect(presenter.to_s).not_to include("## 1.0.0 - June 11, 2014")
+      end
+    end
+  end
+end

--- a/common/spec/dependabot/pull_request_creator/message_builder/metadata_presenter_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/metadata_presenter_spec.rb
@@ -22,15 +22,6 @@ RSpec.describe namespace::MetadataPresenter do
     )
   end
 
-  let(:credentials) do
-    [{
-      "type" => "git_source",
-      "host" => "github.com",
-      "username" => "x-access-token",
-      "password" => "token"
-    }]
-  end
-
   class MockMetadataFinder < Dependabot::MetadataFinders::Base
     def look_up_source
       Dependabot::Source.new(provider: "github", repo: "gocardless/business")

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -735,7 +735,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
     end
 
     context "for an application" do
-      it "has the right text" do
+      xit "has the right text" do
         expect(pr_message).
           to eq(
             "Bumps [business](https://github.com/gocardless/business) "\
@@ -760,7 +760,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       context "without a github link proxy" do
         let(:github_redirection_service) { nil }
 
-        it "has the right text" do
+        xit "has the right text" do
           commits = commits_details(base: "v1.4.0", head: "v1.5.0").
                     gsub("github-redirect.dependabot.com", "github.com")
           expect(pr_message).
@@ -796,7 +796,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
         end
 
-        it "has the right text" do
+        xit "has the right text" do
           expect(pr_message).
             to eq(
               "Bumps [business](https://github.com/gocardless/business) "\
@@ -875,7 +875,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           )
         end
 
-        it "has the right text" do
+        xit "has the right text" do
           commits_details = commits_details(
             base: "2468a02a6230e59ed1232d95d1ad3ef157195b03",
             head: "cff701b3bfb182afc99a85657d7c9f3d6c1ccce2"
@@ -892,7 +892,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           let(:new_ref) { "v1.1.0" }
           let(:old_ref) { "v1.0.0" }
 
-          it "has the right text" do
+          xit "has the right text" do
             commits_details = commits_details(
               base: "2468a02a6230e59ed1232d95d1ad3ef157195b03",
               head: "cff701b3bfb182afc99a85657d7c9f3d6c1ccce2"
@@ -930,7 +930,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 )
             end
 
-            it "has the right text" do
+            xit "has the right text" do
               commits_details = commits_details(
                 base: "v1.0.0",
                 head: "cff701b3bfb182afc99a85657d7c9f3d6c1ccce2"
@@ -1030,7 +1030,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
         end
 
-        it "has the right text" do
+        xit "has the right text" do
           commits_details = commits_details(
             base: "2468a02a6230e59ed1232d95d1ad3ef157195b03",
             head: "v1.5.0"
@@ -1117,7 +1117,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
         end
 
-        it "has the right text" do
+        xit "has the right text" do
           expect(pr_message).
             to eq(
               "Bumps [business](https://github.com/gocardless/business) from "\
@@ -1170,7 +1170,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               )
           end
 
-          it "has the right text" do
+          xit "has the right text" do
             expect(pr_message).
               to eq(
                 "Bumps [business](https://github.com/gocardless/business) "\
@@ -1210,7 +1210,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           }
         end
 
-        it "has the right text" do
+        xit "has the right text" do
           expect(pr_message).
             to start_with(
               "Bumps [business](https://github.com/gocardless/business) "\
@@ -1278,7 +1278,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
         end
 
-        it "has the right text" do
+        xit "has the right text" do
           expect(pr_message).
             to start_with(
               "Bumps [business](https://github.com/gocardless/business) from "\
@@ -1334,7 +1334,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             and_return("Maintainer change")
         end
 
-        it "has the right text" do
+        xit "has the right text" do
           expect(pr_message).to include(
             "<details>\n"\
             "<summary>Maintainer changes</summary>\n"\
@@ -1407,7 +1407,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
         end
 
-        it "includes details of both dependencies" do
+        xit "includes details of both dependencies" do
           expect(pr_message).
             to eq(
               "Bumps [business](https://github.com/gocardless/business) "\
@@ -1540,7 +1540,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         )
       end
 
-      it "has the right text" do
+      xit "has the right text" do
         expect(pr_message).
           to eq(
             "Updates the requirements on "\
@@ -1625,7 +1625,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
         end
 
-        it "includes details of both dependencies" do
+        xit "includes details of both dependencies" do
           expect(pr_message).
             to eq(
               "Updates the requirements on "\

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -735,7 +735,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
     end
 
     context "for an application" do
-      xit "has the right text" do
+      it "has the right text" do
         expect(pr_message).
           to eq(
             "Bumps [business](https://github.com/gocardless/business) "\
@@ -760,7 +760,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       context "without a github link proxy" do
         let(:github_redirection_service) { nil }
 
-        xit "has the right text" do
+        it "has the right text" do
           commits = commits_details(base: "v1.4.0", head: "v1.5.0").
                     gsub("github-redirect.dependabot.com", "github.com")
           expect(pr_message).
@@ -796,7 +796,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
         end
 
-        xit "has the right text" do
+        it "has the right text" do
           expect(pr_message).
             to eq(
               "Bumps [business](https://github.com/gocardless/business) "\
@@ -875,7 +875,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           )
         end
 
-        xit "has the right text" do
+        it "has the right text" do
           commits_details = commits_details(
             base: "2468a02a6230e59ed1232d95d1ad3ef157195b03",
             head: "cff701b3bfb182afc99a85657d7c9f3d6c1ccce2"
@@ -892,7 +892,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           let(:new_ref) { "v1.1.0" }
           let(:old_ref) { "v1.0.0" }
 
-          xit "has the right text" do
+          it "has the right text" do
             commits_details = commits_details(
               base: "2468a02a6230e59ed1232d95d1ad3ef157195b03",
               head: "cff701b3bfb182afc99a85657d7c9f3d6c1ccce2"
@@ -930,7 +930,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 )
             end
 
-            xit "has the right text" do
+            it "has the right text" do
               commits_details = commits_details(
                 base: "v1.0.0",
                 head: "cff701b3bfb182afc99a85657d7c9f3d6c1ccce2"
@@ -1030,7 +1030,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
         end
 
-        xit "has the right text" do
+        it "has the right text" do
           commits_details = commits_details(
             base: "2468a02a6230e59ed1232d95d1ad3ef157195b03",
             head: "v1.5.0"
@@ -1117,7 +1117,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
         end
 
-        xit "has the right text" do
+        it "has the right text" do
           expect(pr_message).
             to eq(
               "Bumps [business](https://github.com/gocardless/business) from "\
@@ -1170,7 +1170,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               )
           end
 
-          xit "has the right text" do
+          it "has the right text" do
             expect(pr_message).
               to eq(
                 "Bumps [business](https://github.com/gocardless/business) "\
@@ -1210,7 +1210,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           }
         end
 
-        xit "has the right text" do
+        it "has the right text" do
           expect(pr_message).
             to start_with(
               "Bumps [business](https://github.com/gocardless/business) "\
@@ -1278,7 +1278,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
         end
 
-        xit "has the right text" do
+        it "has the right text" do
           expect(pr_message).
             to start_with(
               "Bumps [business](https://github.com/gocardless/business) from "\
@@ -1334,7 +1334,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             and_return("Maintainer change")
         end
 
-        xit "has the right text" do
+        it "has the right text" do
           expect(pr_message).to include(
             "<details>\n"\
             "<summary>Maintainer changes</summary>\n"\
@@ -1407,7 +1407,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
         end
 
-        xit "includes details of both dependencies" do
+        it "includes details of both dependencies" do
           expect(pr_message).
             to eq(
               "Bumps [business](https://github.com/gocardless/business) "\
@@ -1540,7 +1540,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         )
       end
 
-      xit "has the right text" do
+      it "has the right text" do
         expect(pr_message).
           to eq(
             "Updates the requirements on "\
@@ -1625,7 +1625,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
         end
 
-        xit "includes details of both dependencies" do
+        it "includes details of both dependencies" do
           expect(pr_message).
             to eq(
               "Updates the requirements on "\


### PR DESCRIPTION
We've encountered PRs where the Change Log notes have been truncated without any indication there is more content, leading to some confusion.

On investigation, we discovered that in an attempt to fix any table structures we have broken by truncating by line number we add a closing table table as part of the truncation line.

We rely on a later sanitisation set to remove this tag it if is not required, i.e. malformed, but this sanitisation currently removes the entire line including the truncation notice.

The fix itself is trivial, [we just insert a new line after the closing table tag](https://github.com/dependabot/dependabot-core/commit/7d1b1a7beb8d833c4baa0ca4ad3872cb19ca1fb1) and the sanitisation process works as intended.

The challenge of this PR was extracting a testable surface as the PR Builder class currently relies on a lot of webmocking to do its job. I've performed an extract-to-class on the `metadata_cascades_for_dep` class to make this easier to work with.

To keep this change somewhat understandable I've:

1. Avoided changing any existing tests, only added a new case for this bug
2. With the exception of the last three commits, I've kept the tests passing on each commit
3. I've tried to commit clear steps to make it easier to review-by-commit

Thanks to @jurre for pairing on the debugging and scoping of this work. 