### PR TITLE
PullRequestCreator::AnnotationError

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -17,6 +17,16 @@ module Dependabot
     class RepoDisabled < StandardError; end
     class NoHistoryInCommon < StandardError; end
 
+    # AnnotationError is raised if a PR was created, but failed annotation
+    class AnnotationError < StandardError
+      attr_reader :cause, :pull_request
+      def initialize(cause, pull_request)
+        super(cause.message)
+        @cause = cause
+        @pull_request = pull_request
+      end
+    end
+
     attr_reader :source, :dependencies, :files, :base_commit,
                 :credentials, :pr_message_header, :pr_message_footer,
                 :custom_labels, :author_details, :signature_key,

--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -7,6 +7,7 @@ require "dependabot/pull_request_creator"
 require "dependabot/pull_request_creator/commit_signer"
 module Dependabot
   class PullRequestCreator
+    # rubocop:disable Metrics/ClassLength
     class Github
       attr_reader :source, :branch_name, :base_commit, :credentials,
                   :files, :pr_description, :pr_name, :commit_message,
@@ -41,7 +42,7 @@ module Dependabot
         return if require_up_to_date_base? && !base_commit_is_up_to_date?
 
         create_annotated_pull_request
-      rescue Octokit::Error => e
+      rescue AnnotationError, Octokit::Error => e
         handle_error(e)
       end
 
@@ -111,7 +112,11 @@ module Dependabot
         pull_request = create_pull_request
         return unless pull_request
 
-        annotate_pull_request(pull_request)
+        begin
+          annotate_pull_request(pull_request)
+        rescue StandardError => e
+          raise AnnotationError.new(e, pull_request)
+        end
 
         pull_request
       end
@@ -417,7 +422,14 @@ module Dependabot
       end
 
       def handle_error(err)
-        case err
+        cause = case err
+                when AnnotationError
+                  err.cause
+                else
+                  err
+                end
+
+        case cause
         when Octokit::Forbidden
           raise RepoDisabled, err.message if err.message.include?("disabled")
           raise RepoArchived, err.message if err.message.include?("archived")
@@ -436,5 +448,6 @@ module Dependabot
         end
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end


### PR DESCRIPTION
PullRequestCreators like `GitHub` separate the creation of PRs from
labelling, assigning reviewers, etc.

Since creating a pull request is a very noticeable side-effect for
customers, we'd prefer to throw an exception that attaches the 
half-completed PR, giving callers a hook for recovery.

An alternative would be _deleting_ the "failed" PR if annotation fails. Assuming PR creation is retried, I avoided that to squelch the `opened->closed->opened` noise.