### PR TITLE
Add trailing slash to pypi index request

### DIFF
--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -277,7 +277,7 @@ module Dependabot
         return false unless details
 
         index_response = Excon.get(
-          "https://pypi.org/pypi/#{normalised_name(details['name'])}/json",
+          "https://pypi.org/pypi/#{normalised_name(details['name'])}/json/",
           idempotent: true,
           **SharedHelpers.excon_defaults
         )

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -505,7 +505,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
 
       context "for a library" do
         before do
-          stub_request(:get, "https://pypi.org/pypi/pendulum/json").
+          stub_request(:get, "https://pypi.org/pypi/pendulum/json/").
             to_return(
               status: 200,
               body: fixture("pypi", "pypi_response_pendulum.json")
@@ -517,7 +517,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
 
       context "for a non-library" do
         before do
-          stub_request(:get, "https://pypi.org/pypi/pendulum/json").
+          stub_request(:get, "https://pypi.org/pypi/pendulum/json/").
             to_return(status: 404)
         end
 


### PR DESCRIPTION
This PR continues https://github.com/dependabot/dependabot-core/pull/2557 , resolving another extra redirect and removing some pressure from Dependabot operating against `pypi.org.`
