### PR TITLE
Fix excon_defaults extra headers

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -151,13 +151,14 @@ module Dependabot
 
     def self.excon_defaults(options = nil)
       options ||= {}
+      headers = options.delete(:headers)
       {
         connect_timeout: 5,
         write_timeout: 5,
         read_timeout: 20,
         omit_default_port: true,
         middlewares: excon_middleware,
-        headers: excon_headers(options[:headers])
+        headers: excon_headers(headers)
       }.merge(options)
     end
 

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -136,10 +136,77 @@ RSpec.describe Dependabot::SharedHelpers do
     end
   end
 
+  describe ".excon_headers" do
+    it "includes dependabot user-agent header" do
+      expect(described_class.excon_headers).to include(
+        "User-Agent" => %r{
+          dependabot-core/#{Dependabot::VERSION}\s|
+          excon/[\.0-9]+\s|
+          ruby/[\.0-9]+\s\(.+\)\s|
+          (|
+          \+https://github.com/dependabot/|dependabot-core|
+          )|
+        }x
+      )
+    end
+
+    it "allows extra headers" do
+      expect(
+        described_class.excon_headers(
+          "Accept" => "text/html"
+        )
+      ).to include(
+        "User-Agent" => /dependabot/,
+        "Accept" => "text/html"
+      )
+    end
+
+    it "allows overriding user-agent headers" do
+      expect(
+        described_class.excon_headers(
+          "User-Agent" => "custom"
+        )
+      ).to include(
+        "User-Agent" => "custom"
+      )
+    end
+  end
+
   describe ".excon_defaults" do
-    it "sets useful User-Agent header" do
-      ua = Dependabot::SharedHelpers.excon_defaults[:headers]["User-Agent"]
-      expect(ua).to include("dependabot-core/#{Dependabot::VERSION}")
+    subject(:excon_defaults) do
+      described_class.excon_defaults
+    end
+
+    it "includes the defaults" do
+      expect(subject).to eq(
+        connect_timeout: 5,
+        write_timeout: 5,
+        read_timeout: 20,
+        omit_default_port: true,
+        middlewares: described_class.excon_middleware,
+        headers: described_class.excon_headers
+      )
+    end
+
+    it "allows overriding options and merges headers" do
+      expect(
+        described_class.excon_defaults(
+          read_timeout: 30,
+          headers: {
+            "Accept" => "text/html"
+          }
+        )
+      ).to include(
+        connect_timeout: 5,
+        write_timeout: 5,
+        read_timeout: 30,
+        omit_default_port: true,
+        middlewares: described_class.excon_middleware,
+        headers: {
+          "User-Agent" => /dependabot/,
+          "Accept" => "text/html"
+        }
+      )
     end
   end
 end


### PR DESCRIPTION
Fix `SharedHelpers.excon_defaults` when merging extra headers.

Extra `headers` passed in as an argument would always override the
default `excon_headers` that sets the `User-agent`, e.g.:

```
SharedHelpers.excon_defaults(
  headers: { "Accept": "text/html" }
)

{
  ...,
  headers: { "Accept": "text/html" }
}
```

It will now return:

```
{
  ...,
  headers: { "Accept": "text/html", "User-Agent": "dependabot/..." }
}
```