### PR TITLE
Handle empty pipfile requirement string

### DIFF
--- a/python/lib/dependabot/python/file_parser/pipfile_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pipfile_files_parser.rb
@@ -52,6 +52,10 @@ module Dependabot
               next if git_or_path_requirement?(req)
               next if pipfile_lock && !dependency_version(dep_name, req, group)
 
+              # Empty requirements are not allowed in Dependabot::Dependency and
+              # equivalent to "*" (latest available version)
+              req = "*" if req == ""
+
               dependencies <<
                 Dependency.new(
                   name: normalised_name(dep_name),

--- a/python/spec/dependabot/python/file_parser/pipfile_files_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pipfile_files_parser_spec.rb
@@ -422,5 +422,28 @@ RSpec.describe Dependabot::Python::FileParser::PipfileFilesParser do
         end
       end
     end
+
+    context "with an empty requirement string" do
+      let(:pipfile_fixture_name) { "empty_requirement" }
+      let(:files) { [pipfile] }
+      let(:dependencies) do
+        parser.dependency_set.dependencies.select(&:top_level?)
+      end
+
+      subject { dependencies.find { |d| d.name == "tensorflow-gpu" } }
+
+      let(:expected_requirements) do
+        [{
+          requirement: "*",
+          file: "Pipfile",
+          source: nil,
+          groups: ["develop"]
+        }]
+      end
+
+      it { is_expected.to be_a(Dependabot::Dependency) }
+      its(:name) { is_expected.to eq("tensorflow-gpu") }
+      its(:requirements) { is_expected.to eq(expected_requirements) }
+    end
   end
 end

--- a/python/spec/fixtures/pipfiles/empty_requirement
+++ b/python/spec/fixtures/pipfiles/empty_requirement
@@ -1,0 +1,8 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+tenacity = "*"
+tensorflow-gpu = ""


### PR DESCRIPTION
Dependabot doesn't allow the `Dependabot::Dependency`
requirements.requirement string to be a blank string.

Pip treats `""` equal to `"*"` so we can set this when building the
`Dependabot::Dependency` object.