### PR TITLE
go_modules: stub repo_contents_path

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -3,6 +3,7 @@
 set -e
 
 IMAGE_NAME="${IMAGE_NAME:=dependabot/dependabot-core-development}"
+CONTAINER_NAME="${CONTAINER_NAME:=dependabot-core-development}"
 DOCKERFILE="Dockerfile.development"
 HELP=false
 REBUILD=false
@@ -31,6 +32,7 @@ if [ "$HELP" = "true" ]; then
 fi
 
 build_image() {
+  export BUILT_IMAGE=true
   echo "$(tput setaf 2)=> building image from Dockerfile$(tput sgr0)"
   docker build -t dependabot/dependabot-core --build-arg BUILDKIT_INLINE_CACHE=1 .
   echo "$(tput setaf 2)=> building image from $DOCKERFILE$(tput sgr0)"
@@ -46,6 +48,20 @@ elif [ "$REBUILD" = "true" ]; then
   build_image
 else
   echo "$(tput setaf 4) > image $IMAGE_NAME already exists$(tput sgr0)"
+fi
+
+set +e
+RUNNING=$(docker ps --format '{{.Names}}' | grep "$CONTAINER_NAME")
+set -e
+echo $RUNNING
+if [ -n "$RUNNING" ]; then
+  if [ -z "$BUILT_IMAGE" ]; then
+    # image was not rebuilt - can we reuse existing?
+    exec docker exec -ti "$CONTAINER_NAME" bash
+  else
+    # image was rebuilt - exit running container
+    docker stop "$CONTAINER_NAME"
+  fi
 fi
 
 DOCKER_OPTS=()
@@ -150,6 +166,7 @@ docker run --rm -ti \
   -v "$(pwd)/omnibus/lib:$CODE_DIR/omnibus/lib" \
   -v "$(pwd)/omnibus/spec:$CODE_DIR/omnibus/spec" \
   -v "$(pwd)/dry-run:$CODE_DIR/dry-run" \
+  --name "$CONTAINER_NAME" \
   "${DOCKER_OPTS[@]}" \
   --cap-add=SYS_PTRACE \
   "$IMAGE_NAME" "${CONTAINER_ARGS[@]}"

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -171,10 +171,6 @@ end
 
 $package_manager, $repo_name = ARGV
 
-if Dependabot::Utils.always_clone_for_package_manager?($package_manager)
-  $options[:clone] = true
-end
-
 def show_diff(original_file, updated_file)
   return unless original_file
 

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+module Dependabot
+  module Bundler
+    class UpdateChecker
+      class LatestVersionFinder
+        class DependencySource
+          require_relative "../shared_bundler_helpers"
+          include SharedBundlerHelpers
+
+          RUBYGEMS = "rubygems"
+          PRIVATE_REGISTRY = "private"
+          GIT = "git"
+          OTHER = "other"
+
+          attr_reader :dependency, :dependency_files, :repo_contents_path,
+                      :credentials
+
+          def initialize(dependency:,
+                         dependency_files:,
+                         credentials:)
+            @dependency          = dependency
+            @dependency_files    = dependency_files
+            @credentials         = credentials
+          end
+
+          # The latest version details for the dependency from a registry
+          #
+          # @return [Array<Gem::Version>]
+          def versions
+            return rubygems_versions if dependency.name == "bundler"
+            return rubygems_versions unless gemfile
+
+            case source_type
+            when OTHER, GIT
+              []
+            when PRIVATE_REGISTRY
+              private_registry_versions
+            else
+              rubygems_versions
+            end
+          end
+
+          # The latest version details for the dependency from a git repo
+          #
+          # @return [Hash{Symbol => String}, nil]
+          def latest_git_version_details
+            return unless git?
+
+            dependency_source_details =
+              dependency.requirements.map { |r| r.fetch(:source) }.
+              uniq.compact.first
+
+            in_a_temporary_bundler_context do
+              SharedHelpers.with_git_configured(credentials: credentials) do
+                # Note: we don't set `ref`, as we want to unpin the dependency
+                source = ::Bundler::Source::Git.new(
+                  "uri" => dependency_source_details[:url],
+                  "branch" => dependency_source_details[:branch],
+                  "name" => dependency.name,
+                  "submodules" => true
+                )
+
+                # Tell Bundler we're fine with fetching the source remotely
+                source.instance_variable_set(:@allow_remote, true)
+
+                spec = source.specs.first
+                { version: spec.version, commit_sha: spec.source.revision }
+              end
+            end
+          end
+
+          def git?
+            source_type == GIT
+          end
+
+          private
+
+          def rubygems_versions
+            @rubygems_versions ||=
+              begin
+                response = Excon.get(
+                  dependency_rubygems_uri,
+                  idempotent: true,
+                  **SharedHelpers.excon_defaults
+                )
+
+                JSON.parse(response.body).
+                  map { |d| Gem::Version.new(d["number"]) }
+              end
+          rescue JSON::ParserError, Excon::Error::Timeout
+            @rubygems_versions = []
+          end
+
+          def dependency_rubygems_uri
+            "https://rubygems.org/api/v1/versions/#{dependency.name}.json"
+          end
+
+          def private_registry_versions
+            @private_registry_versions ||=
+              in_a_temporary_bundler_context do
+                bundler_source.
+                  fetchers.flat_map do |fetcher|
+                    fetcher.
+                      specs_with_retry([dependency.name], bundler_source).
+                      search_all(dependency.name)
+                  end.
+                  map(&:version)
+              end
+          end
+
+          def bundler_source
+            return nil unless gemfile
+
+            @bundler_source ||=
+              in_a_temporary_bundler_context do
+                definition = ::Bundler::Definition.build(gemfile.name, nil, {})
+
+                specified_source =
+                  definition.dependencies.
+                  find { |dep| dep.name == dependency.name }&.source
+
+                specified_source || definition.send(:sources).default_source
+              end
+          end
+
+          def source_type
+            @source_type ||= case bundler_source
+                             when ::Bundler::Source::Rubygems
+                               remote = bundler_source.remotes.first
+                               if remote.nil? || remote.to_s == "https://rubygems.org/"
+                                 RUBYGEMS
+                               else
+                                 PRIVATE_REGISTRY
+                               end
+                             when ::Bundler::Source::Git
+                               GIT
+                             else
+                               OTHER
+                             end
+          end
+
+          def gemfile
+            dependency_files.find { |f| f.name == "Gemfile" } ||
+              dependency_files.find { |f| f.name == "gems.rb" }
+          end
+        end
+      end
+    end
+  end
+end

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -390,12 +390,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       let(:gemfile_fixture_name) { "git_source" }
       let(:lockfile_fixture_name) { "git_source.lock" }
 
-      before do
-        rubygems_response = fixture("ruby", "rubygems_response_versions.json")
-        stub_request(:get, rubygems_url + "versions/business.json").
-          to_return(status: 200, body: rubygems_response)
-      end
-
       context "that is the gem we're checking for" do
         let(:dependency_name) { "business" }
         let(:current_version) { "a1b78a929dac93a52f08db4f2847d76d6cfe39bd" }
@@ -541,6 +535,23 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       end
 
       it { is_expected.to eq(Gem::Version.new("1.5.0")) }
+    end
+
+    context "with a git source" do
+      let(:gemfile_fixture_name) { "git_source" }
+      let(:lockfile_fixture_name) { "git_source.lock" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "with a path source" do
+      let(:gemfile_fixture_name) { "path_source" }
+      let(:lockfile_fixture_name) { "path_source.lock" }
+
+      let(:dependency_name) { "example" }
+      let(:source) { { type: "path" } }
+
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -88,7 +88,11 @@ module Dependabot
 
       def fetch_file_if_present(filename, fetch_submodules: false)
         unless repo_contents_path.nil?
-          return load_cloned_file_if_present(filename)
+          begin
+            return load_cloned_file_if_present(filename)
+          rescue Dependabot::DependencyFileNotFound
+            return
+          end
         end
 
         dir = File.dirname(filename)

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -2,6 +2,7 @@
 
 require "aws-sdk-codecommit"
 require "octokit"
+require "fileutils"
 require "spec_helper"
 require "dependabot/source"
 require "dependabot/file_fetchers/base"
@@ -37,6 +38,7 @@ RSpec.describe Dependabot::FileFetchers::Base do
       Dependabot::Clients::CodeCommit
     ).to receive(:cc_client).and_return(stubbed_cc_client)
   end
+  let(:repo_contents_path) { nil }
 
   let(:child_class) do
     Class.new(described_class) do
@@ -56,7 +58,11 @@ RSpec.describe Dependabot::FileFetchers::Base do
     end
   end
   let(:file_fetcher_instance) do
-    child_class.new(source: source, credentials: credentials)
+    child_class.new(
+      source: source,
+      credentials: credentials,
+      repo_contents_path: repo_contents_path
+    )
   end
 
   describe "#commit" do
@@ -1309,6 +1315,172 @@ RSpec.describe Dependabot::FileFetchers::Base do
         it "hits the right GitHub URL" do
           files
           expect(WebMock).to have_requested(:get, file_url)
+        end
+      end
+    end
+  end
+
+  context "with repo_contents_path" do
+    let(:repo_contents_path) { Dir.mktmpdir }
+    after { FileUtils.rm_rf(repo_contents_path) }
+
+    # `git clone` against a file:// URL that is filled by the test
+    let(:repo_path) { Dir.mktmpdir }
+    after { FileUtils.rm_rf(repo_path) }
+    let(:fill_repo) {}
+    before do
+      Dir.chdir(repo_path) do
+        `git init .`
+        fill_repo
+        `git add .`
+        `git commit --allow-empty -m'fake clone source'`
+      end
+
+      allow(source).
+        to receive(:url).and_return("file://#{repo_path}")
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+    end
+
+    describe "#files" do
+      subject(:files) { file_fetcher_instance.files }
+
+      let(:contents) { "foo=1.0.0" }
+
+      context "with a git source" do
+        let(:fill_repo) do
+          File.write("requirements.txt", contents)
+        end
+
+        its(:length) { is_expected.to eq(1) }
+
+        describe "the file" do
+          subject { files.find { |file| file.name == "requirements.txt" } }
+
+          it { is_expected.to be_a(Dependabot::DependencyFile) }
+          its(:content) { is_expected.to eq(contents) }
+          its(:directory) { is_expected.to eq("/") }
+        end
+      end
+
+      context "with an invalid source" do
+        before do
+          allow(source).
+            to receive(:url).and_return("file://does/not/exist")
+        end
+
+        it "raises RepoNotFound" do
+          expect { subject }.
+            to raise_error(Dependabot::RepoNotFound)
+        end
+      end
+
+      context "file not found" do
+        it "raises DependencyFileNotFound" do
+          expect { subject }.
+            to raise_error(Dependabot::DependencyFileNotFound) do |error|
+            expect(error.file_path).to eq("/requirements.txt")
+          end
+        end
+      end
+
+      context "symlink" do
+        let(:fill_repo) do
+          Dir.mkdir("symlinked")
+          file_path = File.join("symlinked", "requirements.txt")
+          File.write(file_path, contents)
+          File.symlink(file_path, "requirements.txt")
+        end
+
+        describe "the file" do
+          subject { files.find { |file| file.name == "requirements.txt" } }
+
+          it { is_expected.to be_a(Dependabot::DependencyFile) }
+          its(:type) { is_expected.to include("symlink") }
+          its(:symlink_target) do
+            is_expected.to include("symlinked/requirements.txt")
+          end
+        end
+      end
+
+      context "when the file is in a directory" do
+        let(:child_class) do
+          Class.new(described_class) do
+            def self.required_files_in?(filenames)
+              filenames.include?("nested/requirements.txt")
+            end
+
+            def self.required_files_message
+              "Repo must contain a nested/requirements.txt."
+            end
+
+            private
+
+            def fetch_files
+              [fetch_file_from_host("nested/requirements.txt")]
+            end
+          end
+        end
+
+        context "file not found" do
+          it "raises DependencyFileNotFound" do
+            expect { subject }.
+              to raise_error(Dependabot::DependencyFileNotFound) do |error|
+              expect(error.file_path).to eq("/nested/requirements.txt")
+            end
+          end
+        end
+
+        context "with a git source" do
+          let(:fill_repo) do
+            Dir.mkdir("nested")
+            path = File.join("nested", "requirements.txt")
+            File.write(path, contents)
+          end
+
+          its(:length) { is_expected.to eq(1) }
+
+          describe "the file" do
+            subject do
+              files.find { |file| file.name == "nested/requirements.txt" }
+            end
+
+            it { is_expected.to be_a(Dependabot::DependencyFile) }
+            its(:content) { is_expected.to eq(contents) }
+            its(:directory) { is_expected.to eq("/") }
+          end
+        end
+      end
+
+      context "with a directory specified" do
+        let(:directory) { "/nested" }
+
+        context "file not found" do
+          it "raises DependencyFileNotFound" do
+            expect { subject }.
+              to raise_error(Dependabot::DependencyFileNotFound) do |error|
+              expect(error.file_path).to eq("/nested/requirements.txt")
+            end
+          end
+        end
+
+        context "with a git source" do
+          let(:fill_repo) do
+            Dir.mkdir("nested")
+            path = File.join("nested", "requirements.txt")
+            File.write(path, contents)
+          end
+
+          its(:length) { is_expected.to eq(1) }
+
+          describe "the file" do
+            subject do
+              files.find { |file| file.name == "requirements.txt" }
+            end
+
+            it { is_expected.to be_a(Dependabot::DependencyFile) }
+            its(:content) { is_expected.to eq(contents) }
+            its(:directory) { is_expected.to eq(directory) }
+          end
         end
       end
     end

--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -51,22 +51,6 @@ module Dependabot
         @go_sum ||= fetch_file_if_present("go.sum")
       end
 
-      def fetch_file_if_present(filename)
-        return unless File.exist?(filename)
-
-        content = File.read(filename)
-        cleaned_path = filename.gsub(%r{^/}, "")
-        type = @linked_paths.key?(cleaned_path) ? "symlink" : type
-
-        DependencyFile.new(
-          name: Pathname.new(filename).cleanpath.to_path,
-          directory: directory,
-          type: type,
-          content: content,
-          symlink_target: @linked_paths.dig(cleaned_path, :path)
-        )
-      end
-
       def main
         return @main if defined?(@main)
 

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -26,11 +26,12 @@ module Dependabot
         ].freeze
 
         def initialize(dependencies:, credentials:, repo_contents_path:,
-                       directory:)
+                       directory:, tidy:)
           @dependencies = dependencies
           @credentials = credentials
           @repo_contents_path = repo_contents_path
           @directory = directory
+          @tidy = tidy
         end
 
         def updated_go_mod_content
@@ -103,6 +104,8 @@ module Dependabot
         end
 
         def run_go_mod_tidy
+          return unless tidy?
+
           command = "go mod tidy"
           _, stderr, status = Open3.capture3(ENVIRONMENT, command)
           handle_subprocess_error(stderr) unless status.success?
@@ -261,6 +264,10 @@ module Dependabot
 
         def write_go_mod(body)
           File.write("go.mod", body)
+        end
+
+        def tidy?
+          !!@tidy
         end
       end
     end

--- a/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
@@ -17,13 +17,16 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
       branch: branch
     )
   end
+  let(:repo_contents_path) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(repo_contents_path) }
   let(:file_fetcher_instance) do
-    described_class.new(source: source, credentials: github_credentials)
+    described_class.new(source: source, credentials: github_credentials,
+                        repo_contents_path: repo_contents_path)
   end
   let(:directory) { "/" }
 
   after do
-    FileUtils.rm_rf(file_fetcher_instance.clone_repo_contents)
+    FileUtils.rm_rf(repo_contents_path)
   end
 
   it "fetches the go.mod and go.sum" do

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
         "password" => "token"
       }],
       repo_contents_path: repo_contents_path,
-      directory: "/"
+      directory: "/",
+      tidy: true
     )
   end
 

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -94,5 +94,28 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
         expect(updated_files.find { |f| f.name == "go.sum" }).to be_nil
       end
     end
+
+    context "without repo_contents_path" do
+      let(:updater) do
+        described_class.new(
+          dependency_files: files,
+          dependencies: [dependency],
+          credentials: [{
+            "type" => "git_source",
+            "host" => "github.com",
+            "username" => "x-access-token",
+            "password" => "token"
+          }]
+        )
+      end
+
+      it "includes an updated go.mod" do
+        expect(updated_files.find { |f| f.name == "go.mod" }).to_not be_nil
+      end
+
+      it "includes an updated go.sum" do
+        expect(updated_files.find { |f| f.name == "go.sum" }).to_not be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
This is an idea to {have,eat} 🍰  in #2551 . Per discussion there, we think that cloning full repositories is our long term direction for `go_modules` updates.

This PR provides a migration path by bootstrapping a temporary git repository from `DependencyFiles[]` if the instantiator of `GoModules::FileUpdater` hasn't provided `repo_contents_path`.

This keeps our internal implementation forward-facing, but provides a migration path during transition.