### PR TITLE
Add test coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,4 +101,4 @@ jobs:
           docker run --rm "$CORE_CI_IMAGE" bash -c "cd /opt/npm_and_yarn && yarn test"
       - name: Run ${{ matrix.suite }} tests with rspec
         run: |
-          docker run --rm "$CORE_CI_IMAGE" bash -c "cd /home/dependabot/dependabot-core/${{ matrix.suite }} && bundle exec rspec spec"
+          docker run --env "CI=true" --rm "$CORE_CI_IMAGE" bash -c "cd /home/dependabot/dependabot-core/${{ matrix.suite }} && bundle exec rspec spec"

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ vendor
 /dry-run
 **/bin/helper
 /.core-bash_history
+coverage/

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-its", "~> 1.2"
   spec.add_development_dependency "rubocop", "~> 0.92.0"
   spec.add_development_dependency "simplecov", "~> 0.19.0"
+  spec.add_development_dependency "simplecov-console", "~> 0.7.2"
   spec.add_development_dependency "vcr", "6.0.0"
   spec.add_development_dependency "webmock", "~> 3.4"
 

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_development_dependency "rspec-its", "~> 1.2"
   spec.add_development_dependency "rubocop", "~> 0.92.0"
+  spec.add_development_dependency "simplecov", "~> 0.19.0"
   spec.add_development_dependency "vcr", "6.0.0"
   spec.add_development_dependency "webmock", "~> 3.4"
 

--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require "rspec/its"
 require "webmock/rspec"
 require "vcr"
 require "byebug"
+require "simplecov"
 
 require_relative "dummy_package_manager/dummy"
 

--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -22,7 +22,8 @@ SimpleCov.start do
 
   enable_coverage :branch
   minimum_coverage line: 80, branch: 70
-  minimum_coverage_by_file 80
+  # TODO: Enable minimum coverage per file once outliers have been increased
+  # minimum_coverage_by_file 80
   refuse_coverage_drop
 end
 

--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -5,8 +5,26 @@ require "webmock/rspec"
 require "vcr"
 require "byebug"
 require "simplecov"
+require "simplecov-console"
 
 require_relative "dummy_package_manager/dummy"
+
+SimpleCov::Formatter::Console.output_style = "block"
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::Console
+  ]
+)
+
+SimpleCov.start do
+  add_filter "/spec/"
+
+  enable_coverage :branch
+  minimum_coverage line: 80, branch: 70
+  minimum_coverage_by_file 80
+  refuse_coverage_drop
+end
 
 RSpec.configure do |config|
   config.color = true

--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -10,12 +10,11 @@ require "simplecov-console"
 require_relative "dummy_package_manager/dummy"
 
 SimpleCov::Formatter::Console.output_style = "block"
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
-  [
-    SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::Console
-  ]
-)
+SimpleCov.formatter = if ENV["CI"]
+                        SimpleCov::Formatter::Console
+                      else
+                        SimpleCov::Formatter::HTMLFormatter
+                      end
 
 SimpleCov.start do
   add_filter "/spec/"

--- a/go_modules/spec/spec_helper.rb
+++ b/go_modules/spec/spec_helper.rb
@@ -9,3 +9,6 @@ def require_common_spec(path)
 end
 
 require "#{common_dir}/spec/spec_helper.rb"
+
+# TODO: Bring branch coverage up
+SimpleCov.minimum_coverage line: 80, branch: 65

--- a/nuget/spec/spec_helper.rb
+++ b/nuget/spec/spec_helper.rb
@@ -9,3 +9,6 @@ def require_common_spec(path)
 end
 
 require "#{common_dir}/spec/spec_helper.rb"
+
+# TODO: Bring branch coverage up
+SimpleCov.minimum_coverage line: 80, branch: 65

--- a/terraform/spec/spec_helper.rb
+++ b/terraform/spec/spec_helper.rb
@@ -9,3 +9,6 @@ def require_common_spec(path)
 end
 
 require "#{common_dir}/spec/spec_helper.rb"
+
+# TODO: Bring branch coverage up
+SimpleCov.minimum_coverage line: 80, branch: 55


### PR DESCRIPTION
We are working on some refactors of Dependabot Core and after I introduced  a bug into the 0.19.5 release in https://github.com/dependabot/dependabot-core/pull/2539, I realised the root cause was a test stub bypassing the affected code https://github.com/dependabot/dependabot-core/pull/2543#discussion_r492243627

This PR introduces [simplecov](https://github.com/simplecov-ruby/simplecov) to generate HTML coverage reports locally
<img width="1647" alt="Screenshot 2020-09-30 at 12 13 10" src="https://user-images.githubusercontent.com/896971/94678469-73afd880-0316-11eb-8c03-e9c90fed4bd5.png">

 Along with a summary in CI:
![Screenshot 2020-09-30 at 12 13 56](https://user-images.githubusercontent.com/896971/94678482-7ad6e680-0316-11eb-9bd9-81517e3da4b9.png)

It adds a few safety rails for work in progress:
- CI will fail if any builds drop below 80% line coverage / 70% branch coverage
- When working locally, CI will fail if any changes made between test runs drop the coverage

At time of writing, this does not implement a per-file coverage minimum and some specific test suites have their branch coverage lowered to provide a base-line.

The goal as we work is to bring up these values and improve the cover of any low-scoring files so we can turn on per-file coverage checks and bring up branch coverage to ~80%. It remains to be seen if this is a practical goal or will result in a lot of `:nocov:` blocks, so we can revise the targets as we go.