### PR TITLE
re-entrant docker-dev-shell

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -3,6 +3,7 @@
 set -e
 
 IMAGE_NAME="${IMAGE_NAME:=dependabot/dependabot-core-development}"
+CONTAINER_NAME="${CONTAINER_NAME:=dependabot-core-development}"
 DOCKERFILE="Dockerfile.development"
 HELP=false
 REBUILD=false
@@ -31,6 +32,7 @@ if [ "$HELP" = "true" ]; then
 fi
 
 build_image() {
+  export BUILT_IMAGE=true
   echo "$(tput setaf 2)=> building image from Dockerfile$(tput sgr0)"
   docker build -t dependabot/dependabot-core --build-arg BUILDKIT_INLINE_CACHE=1 .
   echo "$(tput setaf 2)=> building image from $DOCKERFILE$(tput sgr0)"
@@ -46,6 +48,20 @@ elif [ "$REBUILD" = "true" ]; then
   build_image
 else
   echo "$(tput setaf 4) > image $IMAGE_NAME already exists$(tput sgr0)"
+fi
+
+set +e
+RUNNING=$(docker ps --format '{{.Names}}' | grep "$CONTAINER_NAME")
+set -e
+echo $RUNNING
+if [ -n "$RUNNING" ]; then
+  if [ -z "$BUILT_IMAGE" ]; then
+    # image was not rebuilt - can we reuse existing?
+    exec docker exec -ti "$CONTAINER_NAME" bash
+  else
+    # image was rebuilt - exit running container
+    docker stop "$CONTAINER_NAME"
+  fi
 fi
 
 DOCKER_OPTS=()
@@ -150,6 +166,7 @@ docker run --rm -ti \
   -v "$(pwd)/omnibus/lib:$CODE_DIR/omnibus/lib" \
   -v "$(pwd)/omnibus/spec:$CODE_DIR/omnibus/spec" \
   -v "$(pwd)/dry-run:$CODE_DIR/dry-run" \
+  --name "$CONTAINER_NAME" \
   "${DOCKER_OPTS[@]}" \
   --cap-add=SYS_PTRACE \
   "$IMAGE_NAME" "${CONTAINER_ARGS[@]}"


### PR DESCRIPTION
Modifies `bin/docker-dev-shell` helper to use a fixed container name, and reuse the container when it's already running.

This is a papercut: I'm usually `docker exec`-ing in to check out a tempdir while sitting in a breakpoint.