### PR TITLE
[Bundler] Extract a DependencySource class from LatestVersionFinder

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -108,10 +108,9 @@ module Dependabot
         end
 
         def dependency_source
-          @dependency_source = DependencySource.new(
+          @dependency_source ||= DependencySource.new(
             dependency: dependency,
             dependency_files: dependency_files,
-            repo_contents_path: repo_contents_path,
             credentials: credentials
           )
         end

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -10,14 +10,13 @@ require "dependabot/bundler/update_checker"
 require "dependabot/bundler/requirement"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
+require "dependabot/bundler/update_checker/latest_version_finder/" \
+        "dependency_source"
 
 module Dependabot
   module Bundler
     class UpdateChecker
       class LatestVersionFinder
-        require_relative "shared_bundler_helpers"
-        include SharedBundlerHelpers
-
         def initialize(dependency:, dependency_files:, repo_contents_path: nil,
                        credentials:, ignored_versions:, raise_on_ignored: false,
                        security_advisories:)
@@ -44,11 +43,11 @@ module Dependabot
                     :credentials, :ignored_versions, :security_advisories
 
         def fetch_latest_version_details
-          if dependency_source_type == "git"
-            return latest_git_version_details
+          if dependency_source.git?
+            return dependency_source.latest_git_version_details
           end
 
-          relevant_versions = registry_versions
+          relevant_versions = dependency_source.versions
           relevant_versions = filter_prerelease_versions(relevant_versions)
           relevant_versions = filter_ignored_versions(relevant_versions)
 
@@ -56,9 +55,9 @@ module Dependabot
         end
 
         def fetch_lowest_security_fix_version
-          return if dependency_source_type == "git"
+          return if dependency_source.git?
 
-          relevant_versions = registry_versions
+          relevant_versions = dependency_source.versions
           relevant_versions = filter_prerelease_versions(relevant_versions)
           relevant_versions = filter_vulnerable_versions(relevant_versions)
           relevant_versions = filter_ignored_versions(relevant_versions)
@@ -93,71 +92,6 @@ module Dependabot
             select { |version| version > Gem::Version.new(dependency.version) }
         end
 
-        def registry_versions
-          return rubygems_versions if dependency.name == "bundler"
-          return rubygems_versions unless gemfile
-          return [] if dependency_source_type == "unknown"
-
-          if dependency_source_type == "private"
-            private_registry_versions
-          else
-            rubygems_versions
-          end
-        end
-
-        def rubygems_versions
-          @rubygems_versions ||=
-            begin
-              response = Excon.get(
-                "https://rubygems.org/api/v1/versions/#{dependency.name}.json",
-                idempotent: true,
-                **SharedHelpers.excon_defaults
-              )
-
-              JSON.parse(response.body).
-                map { |d| Gem::Version.new(d["number"]) }
-            end
-        rescue JSON::ParserError, Excon::Error::Timeout
-          @rubygems_versions = []
-        end
-
-        def private_registry_versions
-          @private_registry_versions ||=
-            in_a_temporary_bundler_context do
-              dependency_source.
-                fetchers.flat_map do |fetcher|
-                  fetcher.
-                    specs_with_retry([dependency.name], dependency_source).
-                    search_all(dependency.name)
-                end.
-                map(&:version)
-            end
-        end
-
-        def latest_git_version_details
-          dependency_source_details =
-            dependency.requirements.map { |r| r.fetch(:source) }.
-            uniq.compact.first
-
-          in_a_temporary_bundler_context do
-            SharedHelpers.with_git_configured(credentials: credentials) do
-              # Note: we don't set `ref`, as we want to unpin the dependency
-              source = ::Bundler::Source::Git.new(
-                "uri" => dependency_source_details[:url],
-                "branch" => dependency_source_details[:branch],
-                "name" => dependency.name,
-                "submodules" => true
-              )
-
-              # Tell Bundler we're fine with fetching the source remotely
-              source.instance_variable_set(:@allow_remote, true)
-
-              spec = source.specs.first
-              { version: spec.version, commit_sha: spec.source.revision }
-            end
-          end
-        end
-
         def wants_prerelease?
           @wants_prerelease ||=
             begin
@@ -174,34 +108,12 @@ module Dependabot
         end
 
         def dependency_source
-          return nil unless gemfile
-
-          @dependency_source ||=
-            in_a_temporary_bundler_context do
-              definition = ::Bundler::Definition.build(gemfile.name, nil, {})
-
-              specified_source =
-                definition.dependencies.
-                find { |dep| dep.name == dependency.name }&.source
-
-              specified_source || definition.send(:sources).default_source
-            end
-        end
-
-        def dependency_source_type
-          case dependency_source
-          when ::Bundler::Source::Rubygems
-            remote = dependency_source.remotes.first
-            if remote.nil? || remote.to_s == "https://rubygems.org/"
-              "rubygems"
-            else
-              "private"
-            end
-          when ::Bundler::Source::Git
-            "git"
-          else
-            "unknown"
-          end
+          @dependency_source = DependencySource.new(
+            dependency: dependency,
+            dependency_files: dependency_files,
+            repo_contents_path: repo_contents_path,
+            credentials: credentials
+          )
         end
 
         def ignore_reqs

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
@@ -74,10 +74,6 @@ module Dependabot
 
           private
 
-          def other?
-            source_type == OTHER
-          end
-
           def rubygems_versions
             @rubygems_versions ||=
               begin

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+module Dependabot
+  module Bundler
+    class UpdateChecker
+      class LatestVersionFinder
+        class DependencySource
+          require_relative "../shared_bundler_helpers"
+          include SharedBundlerHelpers
+
+          RUBYGEMS = "rubygems"
+          PRIVATE_REGISTRY = "private"
+          GIT = "git"
+          OTHER = "other"
+
+          attr_reader :dependency, :dependency_files, :repo_contents_path,
+                      :credentials
+
+          def initialize(dependency:,
+                         dependency_files:,
+                         repo_contents_path: nil,
+                         credentials:)
+            @dependency          = dependency
+            @dependency_files    = dependency_files
+            @repo_contents_path  = repo_contents_path
+            @credentials         = credentials
+          end
+
+          def versions
+            return rubygems_versions if dependency.name == "bundler"
+            return rubygems_versions unless gemfile
+
+            case source_type
+            when OTHER
+              []
+            when GIT
+              latest_git_version_details
+            when PRIVATE_REGISTRY
+              private_registry_versions
+            else
+              rubygems_versions
+            end
+          end
+
+          def latest_git_version_details
+            return unless git?
+
+            dependency_source_details =
+              dependency.requirements.map { |r| r.fetch(:source) }.
+              uniq.compact.first
+
+            in_a_temporary_bundler_context do
+              SharedHelpers.with_git_configured(credentials: credentials) do
+                # Note: we don't set `ref`, as we want to unpin the dependency
+                source = ::Bundler::Source::Git.new(
+                  "uri" => dependency_source_details[:url],
+                  "branch" => dependency_source_details[:branch],
+                  "name" => dependency.name,
+                  "submodules" => true
+                )
+
+                # Tell Bundler we're fine with fetching the source remotely
+                source.instance_variable_set(:@allow_remote, true)
+
+                spec = source.specs.first
+                { version: spec.version, commit_sha: spec.source.revision }
+              end
+            end
+          end
+
+          def git?
+            source_type == GIT
+          end
+
+          private
+
+          def other?
+            source_type == OTHER
+          end
+
+          def rubygems_versions
+            @rubygems_versions ||=
+              begin
+                response = Excon.get(
+                  dependency_rubygems_uri,
+                  idempotent: true,
+                  **SharedHelpers.excon_defaults
+                )
+
+                JSON.parse(response.body).
+                  map { |d| Gem::Version.new(d["number"]) }
+              end
+          rescue JSON::ParserError, Excon::Error::Timeout
+            @rubygems_versions = []
+          end
+
+          def dependency_rubygems_uri
+            "https://rubygems.org/api/v1/versions/#{dependency.name}.json"
+          end
+
+          def private_registry_versions
+            @private_registry_versions ||=
+              in_a_temporary_bundler_context do
+                bundler_source.
+                  fetchers.flat_map do |fetcher|
+                    fetcher.
+                      specs_with_retry([dependency.name], bundler_source).
+                      search_all(dependency.name)
+                  end.
+                  map(&:version)
+              end
+          end
+
+          def bundler_source
+            return nil unless gemfile
+
+            @bundler_source ||=
+              in_a_temporary_bundler_context do
+                definition = ::Bundler::Definition.build(gemfile.name, nil, {})
+
+                specified_source =
+                  definition.dependencies.
+                  find { |dep| dep.name == dependency.name }&.source
+
+                specified_source || definition.send(:sources).default_source
+              end
+          end
+
+          def source_type
+            @source_type ||= case bundler_source
+                             when ::Bundler::Source::Rubygems
+                               remote = bundler_source.remotes.first
+                               if remote.nil? || remote.to_s == "https://rubygems.org/"
+                                 RUBYGEMS
+                               else
+                                 PRIVATE_REGISTRY
+                               end
+                             when ::Bundler::Source::Git
+                               GIT
+                             else
+                               OTHER
+                             end
+          end
+
+          def gemfile
+            dependency_files.find { |f| f.name == "Gemfile" } ||
+              dependency_files.find { |f| f.name == "gems.rb" }
+          end
+        end
+      end
+    end
+  end
+end

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
@@ -18,23 +18,22 @@ module Dependabot
 
           def initialize(dependency:,
                          dependency_files:,
-                         repo_contents_path: nil,
                          credentials:)
             @dependency          = dependency
             @dependency_files    = dependency_files
-            @repo_contents_path  = repo_contents_path
             @credentials         = credentials
           end
 
+          # The latest version details for the dependency from a registry
+          #
+          # @return [Array<Gem::Version>]
           def versions
             return rubygems_versions if dependency.name == "bundler"
             return rubygems_versions unless gemfile
 
             case source_type
-            when OTHER
+            when OTHER, GIT
               []
-            when GIT
-              latest_git_version_details
             when PRIVATE_REGISTRY
               private_registry_versions
             else
@@ -42,6 +41,9 @@ module Dependabot
             end
           end
 
+          # The latest version details for the dependency from a git repo
+          #
+          # @return [Hash{Symbol => String}, nil]
           def latest_git_version_details
             return unless git?
 

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -536,5 +536,22 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
 
       it { is_expected.to eq(Gem::Version.new("1.5.0")) }
     end
+
+    context "with a git source" do
+      let(:gemfile_fixture_name) { "git_source" }
+      let(:lockfile_fixture_name) { "git_source.lock" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "with a path source" do
+      let(:gemfile_fixture_name) { "path_source" }
+      let(:lockfile_fixture_name) { "path_source.lock" }
+
+      let(:dependency_name) { "example" }
+      let(:source) { { type: "path" } }
+
+      it { is_expected.to be_nil }
+    end
   end
 end

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -390,12 +390,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       let(:gemfile_fixture_name) { "git_source" }
       let(:lockfile_fixture_name) { "git_source.lock" }
 
-      before do
-        rubygems_response = fixture("ruby", "rubygems_response_versions.json")
-        stub_request(:get, rubygems_url + "versions/business.json").
-          to_return(status: 200, body: rubygems_response)
-      end
-
       context "that is the gem we're checking for" do
         let(:dependency_name) { "business" }
         let(:current_version) { "a1b78a929dac93a52f08db4f2847d76d6cfe39bd" }


### PR DESCRIPTION
This branch extracts a preamble refactor for https://github.com/dependabot/dependabot-core/pull/2552 that drops all the points where we call out to Bundler in `LatestVersionFinder` into a subclass.

This leaves `LatestVersionFinder` responsible for filtering versions returned from the `DependencySource` according to `ignored_versions` and `security_advisories` and creates a seam that will allow us to swap out the DependencySource implementation with one that shells out and ultimately returns the same output.

I've left tests as-is apart from adding some to document existing behaviour, I may extract some more specs on the `DependencySource` as a follow-up PR.