### PR TITLE
Install all python versions on CI

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -61,5 +61,9 @@ RUN GREEN='\033[0;32m'; NC='\033[0m'; \
     cd $d && bundle install; \
   done
 
+COPY bin/install_python_versions bin/
+COPY python/lib/dependabot/python/python_versions.rb bin/
+RUN ./bin/install_python_versions
+
 RUN git config --global user.name dependabot-ci && git config --global user.email no-reply@github.com
 RUN cd omnibus && bundle install

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -8,6 +8,12 @@ ENV BUNDLE_PATH="/home/dependabot/.bundle" \
 
 COPY .rubocop.yml /home/dependabot/dependabot-core/
 
+# install all supported python versions
+# We do this before pulling in any code for efficient caching layers.
+COPY python/lib/dependabot/python/python_versions.rb bin/
+COPY python/helpers/ci_install_all_py_versions bin/
+RUN bin/ci_install_all_py_versions
+
 RUN mkdir -p \
   ${CODE_DIR}/bundler \
   ${CODE_DIR}/cargo \
@@ -61,9 +67,6 @@ RUN GREEN='\033[0;32m'; NC='\033[0m'; \
     cd $d && bundle install; \
   done
 
-COPY bin/install_python_versions bin/
-COPY python/lib/dependabot/python/python_versions.rb bin/
-RUN ./bin/install_python_versions
 
 RUN git config --global user.name dependabot-ci && git config --global user.email no-reply@github.com
 RUN cd omnibus && bundle install

--- a/bin/install_python_versions
+++ b/bin/install_python_versions
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "./python_versions"
+
+Dependabot::Python::PythonVersions::SUPPORTED_VERSIONS.each do |version|
+  `pyenv install #{version}`
+end

--- a/python/helpers/ci_install_all_py_versions
+++ b/python/helpers/ci_install_all_py_versions
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# This is executed on CI where we manually copy in this script and the python
+# versions from python/lib/dependabot/python/python_versions.
 require_relative "./python_versions"
 
 Dependabot::Python::PythonVersions::SUPPORTED_VERSIONS.each do |version|


### PR DESCRIPTION
Our python test suite takes a really long time, and the suspicion is
that most of that time is spent downloading python for versions that we
don't have installed locally.

Trying to keep the versions that we use in our tests up to date with the
pre-installed python versions is a losing battle, and bundling _all_ of
them in the container that we ship to users means it'll get huge.

But in our CI container it'd be really nice if we didn't have to try and
manually keep these aligned, so this hacky script will simply install
all supported python versions in our CI image.