### PR TITLE
Add vendoring support for go_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Gemfile.lock
 vendor
 !bundler/spec/fixtures/vendored_gems/vendor
 !common/spec/fixtures/projects/**/*/vendor
+!go_modules/spec/fixtures/projects/**/*
 .DS_Store
 *.pyc
 *git.store

--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -3,6 +3,7 @@
 require "dependabot/shared_helpers"
 require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
+require "dependabot/file_updaters/vendor_updater"
 
 module Dependabot
   module GoModules
@@ -52,6 +53,12 @@ module Dependabot
                 content: file_updater.updated_go_sum_content
               )
           end
+
+          vendor_updater.
+            updated_vendor_cache_files(base_directory: directory).
+            each do |file|
+            updated_files << file
+          end
         end
 
         raise "No files changed!" if updated_files.none?
@@ -79,6 +86,17 @@ module Dependabot
         dependency_files.first.directory
       end
 
+      def vendor_dir
+        File.join(repo_contents_path, directory, "vendor")
+      end
+
+      def vendor_updater
+        Dependabot::FileUpdaters::VendorUpdater.new(
+          repo_contents_path: repo_contents_path,
+          vendor_dir: vendor_dir
+        )
+      end
+
       def file_updater
         @file_updater ||=
           GoModUpdater.new(
@@ -86,8 +104,12 @@ module Dependabot
             credentials: credentials,
             repo_contents_path: repo_contents_path,
             directory: directory,
-            tidy: !@repo_contents_stub && options.fetch(:go_mod_tidy, false)
+            options: { tidy: tidy?, vendor: options.fetch(:vendor, false) }
           )
+      end
+
+      def tidy?
+        !@repo_contents_stub && options.fetch(:go_mod_tidy, false)
       end
     end
   end

--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -114,7 +114,7 @@ module Dependabot
 
       def vendor?
         File.exist?(File.join(vendor_dir, "modules.txt")) &&
-          options.fetch(:vendor, false)
+          options.fetch(:go_mod_vendor, false)
       end
     end
   end

--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -104,12 +104,17 @@ module Dependabot
             credentials: credentials,
             repo_contents_path: repo_contents_path,
             directory: directory,
-            options: { tidy: tidy?, vendor: options.fetch(:vendor, false) }
+            options: { tidy: tidy?, vendor: vendor? }
           )
       end
 
       def tidy?
         !@repo_contents_stub && options.fetch(:go_mod_tidy, false)
+      end
+
+      def vendor?
+        File.exist?(File.join(vendor_dir, "modules.txt")) &&
+          options.fetch(:vendor, false)
       end
     end
   end

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
       }],
       repo_contents_path: repo_contents_path,
       directory: "/",
-      tidy: tidy
+      options: { tidy: tidy, vendor: false }
     )
   end
 

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
   let(:files) { [go_mod, go_sum] }
   let(:project_name) { "go_sum" }
   let(:repo_contents_path) { build_tmp_repo(project_name) }
+  let(:vendor) { false }
 
   let(:credentials) do
     [{
@@ -31,7 +32,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
       "password" => "token"
     }]
   end
-  let(:options) { {} }
+  let(:options) { { vendor: vendor } }
 
   let(:go_mod) do
     Dependabot::DependencyFile.new(name: "go.mod", content: go_mod_body)
@@ -110,7 +111,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
             credentials: credentials,
             repo_contents_path: repo_contents_path,
             directory: "/",
-            tidy: true
+            options: { tidy: true, vendor: false }
           ).and_return(dummy_updater)
 
         updater.updated_dependency_files
@@ -146,6 +147,92 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
 
       it "includes an updated go.sum" do
         expect(updated_files.find { |f| f.name == "go.sum" }).to_not be_nil
+      end
+    end
+
+    context "vendoring" do
+      let(:project_name) { "vendor" }
+      let(:vendor) { true }
+
+      let(:dependency_name) { "github.com/pkg/errors" }
+      let(:dependency_version) { "v0.9.1" }
+      let(:dependency_previous_version) { "v0.8.0" }
+      let(:requirements) do
+        [{
+          file: "go.mod",
+          requirement: dependency_version,
+          groups: [],
+          source: {
+            type: "default",
+            source: "github.com/pkg"
+          }
+        }]
+      end
+      let(:previous_requirements) do
+        [{
+          file: "go.mod",
+          requirement: dependency_previous_version,
+          groups: [],
+          source: {
+            type: "default",
+            source: "github.com/pkg"
+          }
+        }]
+      end
+
+      it "updates the version" do
+        expect(go_mod_body).to include("github.com/pkg/errors v0.8.0")
+
+        updater.updated_dependency_files
+
+        go_mod_file = updater.updated_dependency_files.find do |file|
+          file.name == "go.mod"
+        end
+
+        expect(go_mod_file.content).to include "github.com/pkg/errors v0.9.1"
+      end
+
+      it "includes the vendored files" do
+        expect(updater.updated_dependency_files.map(&:name)).to match_array(
+          %w(
+            go.mod
+            go.sum
+            vendor/github.com/pkg/errors/.travis.yml
+            vendor/github.com/pkg/errors/Makefile
+            vendor/github.com/pkg/errors/README.md
+            vendor/github.com/pkg/errors/errors.go
+            vendor/github.com/pkg/errors/go113.go
+            vendor/github.com/pkg/errors/stack.go
+            vendor/modules.txt
+          )
+        )
+      end
+
+      it "updates the vendor/modules.txt file to the right version" do
+        modules_file = updater.updated_dependency_files.find do |file|
+          file.name == "vendor/modules.txt"
+        end
+
+        expect(modules_file.content).to include "github.com/pkg/errors v0.9.1"
+      end
+
+      it "includes the new source code" do
+        # Sample to verify the source code matches:
+        # https://github.com/pkg/errors/compare/v0.8.0...v0.9.1
+        stack_file = updater.updated_dependency_files.find do |file|
+          file.name == "vendor/github.com/pkg/errors/stack.go"
+        end
+
+        expect(stack_file.content).to include(
+          <<~LINE
+            Format formats the stack of Frames according to the fmt.Formatter interface.
+          LINE
+        )
+        expect(stack_file.content).to_not include(
+          <<~LINE
+            segments from the beginning of the file path until the number of path
+          LINE
+        )
       end
     end
   end

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
       "password" => "token"
     }]
   end
-  let(:options) { { vendor: vendor } }
+  let(:options) { { go_mod_vendor: vendor } }
 
   let(:go_mod) do
     Dependabot::DependencyFile.new(name: "go.mod", content: go_mod_body)
@@ -94,7 +94,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
     end
 
     context "options" do
-      let(:options) { { go_mod_tidy: true, vendor: vendor } }
+      let(:options) { { go_mod_tidy: true, go_mod_vendor: vendor } }
       let(:dummy_updater) do
         instance_double(
           Dependabot::GoModules::FileUpdater::GoModUpdater,
@@ -226,7 +226,8 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
           file.name == "vendor/modules.txt"
         end
 
-        expect(modules_file.content).to_not include "github.com/pkg/errors v0.8.0"
+        expect(modules_file.content).
+          to_not include "github.com/pkg/errors v0.8.0"
         expect(modules_file.content).to include "github.com/pkg/errors v0.9.1"
       end
 

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
         }]
       end
 
-      it "updates the version" do
+      it "updates the go.mod" do
         expect(go_mod_body).to include("github.com/pkg/errors v0.8.0")
 
         updater.updated_dependency_files
@@ -226,6 +226,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
           file.name == "vendor/modules.txt"
         end
 
+        expect(modules_file.content).to_not include "github.com/pkg/errors v0.8.0"
         expect(modules_file.content).to include "github.com/pkg/errors v0.9.1"
       end
 

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
     end
 
     context "options" do
-      let(:options) { { go_mod_tidy: true } }
+      let(:options) { { go_mod_tidy: true, vendor: vendor } }
       let(:dummy_updater) do
         instance_double(
           Dependabot::GoModules::FileUpdater::GoModUpdater,
@@ -115,6 +115,19 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
           ).and_return(dummy_updater)
 
         updater.updated_dependency_files
+      end
+
+      context "vendor option is passed but vendor directory not checked in" do
+        let(:vendor) { true }
+
+        it "does not includes the vendored files" do
+          expect(updater.updated_dependency_files.map(&:name)).to match_array(
+            %w(
+              go.mod
+              go.sum
+            )
+          )
+        end
       end
     end
 

--- a/go_modules/spec/fixtures/projects/vendor/go.mod
+++ b/go_modules/spec/fixtures/projects/vendor/go.mod
@@ -1,0 +1,5 @@
+module github.com/dependabot/vgotest
+
+go 1.12
+
+require github.com/pkg/errors v0.8.0

--- a/go_modules/spec/fixtures/projects/vendor/go.sum
+++ b/go_modules/spec/fixtures/projects/vendor/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go_modules/spec/fixtures/projects/vendor/main.go
+++ b/go_modules/spec/fixtures/projects/vendor/main.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	_ "github.com/pkg/errors"
+)
+
+func main() {
+}

--- a/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/.gitignore
+++ b/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/.travis.yml
+++ b/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.3
+  - 1.5.4
+  - 1.6.2
+  - 1.7.1
+  - tip
+
+script:
+  - go test -v ./...

--- a/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/LICENSE
+++ b/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/README.md
+++ b/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## Licence
+
+BSD-2-Clause

--- a/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/appveyor.yml
+++ b/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/errors.go
+++ b/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,269 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// and the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required the errors.WithStack and errors.WithMessage
+// functions destructure errors.Wrap into its component operations of annotating
+// an error with a stack trace and an a message, respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// causer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// stackTracer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is call, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/stack.go
+++ b/go_modules/spec/fixtures/projects/vendor/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,178 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}

--- a/go_modules/spec/fixtures/projects/vendor/vendor/modules.txt
+++ b/go_modules/spec/fixtures/projects/vendor/vendor/modules.txt
@@ -1,0 +1,2 @@
+# github.com/pkg/errors v0.8.0
+github.com/pkg/errors


### PR DESCRIPTION
This builds on the work we've done for go mod tidy, and adds support
for running `go mod vendor` and committing the results.

We now also expose a `vendor` flag in the `FileUpdater`, in the bundler
implementation this is not yet used, as we implicitly rely on the
`repo_contents_path` being available there. We should start using that
flag there as well, but leaving it as is for now to make upgrading
easier.

This relies on changes in:
- https://github.com/dependabot/dependabot-core/pull/2551
- https://github.com/dependabot/dependabot-core/pull/2598

And needs to be rebased once those changes land.