### PR TITLE
Allow passing tidy as option to go_modules updater

### DIFF
--- a/common/lib/dependabot/file_updaters/base.rb
+++ b/common/lib/dependabot/file_updaters/base.rb
@@ -4,18 +4,19 @@ module Dependabot
   module FileUpdaters
     class Base
       attr_reader :dependencies, :dependency_files, :repo_contents_path,
-                  :credentials
+                  :credentials, :options
 
       def self.updated_files_regex
         raise NotImplementedError
       end
 
       def initialize(dependencies:, dependency_files:, repo_contents_path: nil,
-                     credentials:)
+                     credentials:, options: {})
         @dependencies = dependencies
         @dependency_files = dependency_files
         @repo_contents_path = repo_contents_path
         @credentials = credentials
+        @options = options
 
         check_required_files
       end

--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -86,7 +86,7 @@ module Dependabot
             credentials: credentials,
             repo_contents_path: repo_contents_path,
             directory: directory,
-            tidy: options.fetch(:tidy, false)
+            tidy: !@repo_contents_stub && options.fetch(:tidy, false)
           )
       end
     end

--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -86,7 +86,7 @@ module Dependabot
             credentials: credentials,
             repo_contents_path: repo_contents_path,
             directory: directory,
-            tidy: !@repo_contents_stub && options.fetch(:tidy, false)
+            tidy: !@repo_contents_stub && options.fetch(:go_mod_tidy, false)
           )
       end
     end

--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -10,7 +10,7 @@ module Dependabot
       require_relative "file_updater/go_mod_updater"
 
       def initialize(dependencies:, dependency_files:, repo_contents_path: nil,
-                     credentials:)
+                     credentials:, options: {})
         super
         return unless repo_contents_path.nil?
 
@@ -86,7 +86,7 @@ module Dependabot
             credentials: credentials,
             repo_contents_path: repo_contents_path,
             directory: directory,
-            tidy: !@repo_contents_stub
+            tidy: options.fetch(:tidy, false)
           )
       end
     end

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
     end
 
     context "options" do
-      let(:options) { { tidy: true } }
+      let(:options) { { go_mod_tidy: true } }
       let(:dummy_updater) do
         instance_double(
           Dependabot::GoModules::FileUpdater::GoModUpdater,

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -13,19 +13,25 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
     described_class.new(
       dependency_files: files,
       dependencies: [dependency],
-      credentials: [{
-        "type" => "git_source",
-        "host" => "github.com",
-        "username" => "x-access-token",
-        "password" => "token"
-      }],
-      repo_contents_path: repo_contents_path
+      credentials: credentials,
+      repo_contents_path: repo_contents_path,
+      options: options
     )
   end
 
   let(:files) { [go_mod, go_sum] }
   let(:project_name) { "go_sum" }
   let(:repo_contents_path) { build_tmp_repo(project_name) }
+
+  let(:credentials) do
+    [{
+      "type" => "git_source",
+      "host" => "github.com",
+      "username" => "x-access-token",
+      "password" => "token"
+    }]
+  end
+  let(:options) { {} }
 
   let(:go_mod) do
     Dependabot::DependencyFile.new(name: "go.mod", content: go_mod_body)
@@ -84,6 +90,31 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
 
     it "includes an updated go.sum" do
       expect(updated_files.find { |f| f.name == "go.sum" }).to_not be_nil
+    end
+
+    context "options" do
+      let(:options) { { tidy: true } }
+      let(:dummy_updater) do
+        instance_double(
+          Dependabot::GoModules::FileUpdater::GoModUpdater,
+          updated_go_mod_content: "",
+          updated_go_sum_content: ""
+        )
+      end
+
+      it "uses the tidy option" do
+        expect(Dependabot::GoModules::FileUpdater::GoModUpdater).
+          to receive(:new).
+          with(
+            dependencies: [dependency],
+            credentials: credentials,
+            repo_contents_path: repo_contents_path,
+            directory: "/",
+            tidy: true
+          ).and_return(dummy_updater)
+
+        updater.updated_dependency_files
+      end
     end
 
     context "without a go.sum" do


### PR DESCRIPTION
This PR targets #2551 

This allows us to pass configuration options to Updater classes,
starting with `tidy` for gomod. Current plans are for go mod tidy
support to be default and not configurable, but in order to roll these
changes out gradually we temporarily allow passing it as an option.

These options can be used to conditionally enable features in the
future, like for instance vendoring.