### PR TITLE
Allow requirements.txt files of up to 200kb

### DIFF
--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -166,7 +166,7 @@ module Dependabot
         repo_contents.
           select { |f| f.type == "file" }.
           select { |f| f.name.end_with?(".txt", ".in") }.
-          reject { |f| f.size > 100_000 }.
+          reject { |f| f.size > 200_000 }.
           map { |f| fetch_file_from_host(f.name) }.
           select { |f| requirements_file?(f) }.
           each { |f| @req_txt_and_in_files << f }
@@ -186,7 +186,7 @@ module Dependabot
         repo_contents(dir: relative_reqs_dir).
           select { |f| f.type == "file" }.
           select { |f| f.name.end_with?(".txt", ".in") }.
-          reject { |f| f.size > 100_000 }.
+          reject { |f| f.size > 200_000 }.
           map { |f| fetch_file_from_host("#{relative_reqs_dir}/#{f.name}") }.
           select { |f| requirements_file?(f) }
       end

--- a/python/spec/dependabot/python/file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/file_fetcher_spec.rb
@@ -1068,5 +1068,18 @@ RSpec.describe Dependabot::Python::FileFetcher do
         end
       end
     end
+
+    context "with a very large requirements.txt file" do
+      let(:repo_contents) do
+        fixture("github", "contents_python_large_requirements_txt.json")
+      end
+
+      it "raises a Dependabot::DependencyFileNotFound error" do
+        expect { file_fetcher_instance.files }.
+          to raise_error(Dependabot::DependencyFileNotFound) do |error|
+            expect(error.file_name).to eq("requirements.txt")
+          end
+      end
+    end
   end
 end

--- a/python/spec/fixtures/github/contents_python_large_requirements_txt.json
+++ b/python/spec/fixtures/github/contents_python_large_requirements_txt.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "requirements.txt",
+    "path": "requirements.txt",
+    "sha": "88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+    "size": 5000000,
+    "url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/requirements.txt?ref=develop",
+    "html_url": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/requirements.txt",
+    "git_url": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+    "download_url": "https://raw.githubusercontent.com/CityOfNewYork/NYCOpenRecords/develop/requirements.txt",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/contents/requirements.txt?ref=develop",
+      "git": "https://api.github.com/repos/CityOfNewYork/NYCOpenRecords/git/trees/88b4e0a1c8093fae2b4fa52534035f9f85ed0956",
+      "html": "https://github.com/CityOfNewYork/NYCOpenRecords/tree/develop/requirements.txt"
+    }
+  }
+]


### PR DESCRIPTION
We have a limit on the size of .txt files that we fetch for Python
repositories, most likely because we try to fetch _all_ files with that
extension, and the GitHub contents API only allows fetching files up to
1mb.

Some users are now running into the 100kb size limit that we've set, and
are getting back a pretty opaque `DependencyFileNotFound` error.

In order to resolve the issue for the cases that have been reported,
increasing to 200kb seems like a reasonable first step.

@greysteil you added the original 100kb size limit: https://github.com/dependabot/dependabot-core/commit/86c769c096b57ca41b5c93f939f43ca0ca3b0db8. Do you happen to remember if what I've typed up here is indeed the reason, or is there another reason we cap at 100kb?