### PR TITLE
Configure git when creating a temp repo for gomod updates

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -20,6 +20,8 @@ module Dependabot
           dependency_files.each do |file|
             File.write(file.name, file.content)
           end
+          `git config --global user.email "no-reply@github.com"`
+          `git config --global user.name "Dependabot"`
           `git init .`
           `git add .`
           `git commit -m'fake repo_contents_path'`

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -127,6 +127,21 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
     end
 
     context "without repo_contents_path" do
+      before do
+        # We don't have git configured in prod, so simulate that in tests
+        Dir.chdir(repo_contents_path) do
+          `git config --global --unset user.email`
+          `git config --global --unset user.name`
+        end
+      end
+
+      after do
+        Dir.chdir(repo_contents_path) do
+          `git config --global user.email "no-reply@github.com"`
+          `git config --global user.name "dependabot-ci"`
+        end
+      end
+
       let(:updater) do
         described_class.new(
           dependency_files: files,


### PR DESCRIPTION
In production we do not have git configured, so when creating a temp
repo we need to do that. It was passing on CI and locally because we set
it in the docker container there, so the tests now explicitly unset
this.