### PR TITLE
dry-run --updater-options=

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -389,11 +389,18 @@ def peer_dependencies_can_update?(checker, reqs_to_unlock)
 end
 
 def file_updater_for(dependencies)
+  unless ENV["UPDATER_OPTIONS"].to_s.strip.empty?
+    options = ENV["UPDATER_OPTIONS"].split(",").
+                  map {|o| [o.downcase.to_sym, true] }
+    options = Hash[options]
+  end
+
   Dependabot::FileUpdaters.for_package_manager($package_manager).new(
     dependencies: dependencies,
     dependency_files: $files,
     repo_contents_path: $repo_contents_path,
-    credentials: $options[:credentials]
+    credentials: $options[:credentials],
+    options: options,
   )
 end
 


### PR DESCRIPTION
This accepts a comma separated list representing the keys in the `options` hash passed to `FileUpdater`s.
It's good enough while that's a bitmap, but won't play nicely if options accept values.

We can use this to toggle all the cool features masked behind `options` in the updater, without needing to turn each into a command line flag.
Maybe we should still accept the list via option instead of yanking it from environment?

# Related
- Continues https://github.com/dependabot/dependabot-core/pull/2597
- Formalized hack from testing https://github.com/dependabot/dependabot-core/pull/2596 + https://github.com/dependabot/dependabot-core/pull/2551