### PR TITLE
v0.122.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.122.0, 7 October 2020
+
+- Add experimental support for `go mod vendor`
+- Enable code coverage reporting of dependabot-core
+
 ## v0.121.1, 7 October 2020
 
 - Configure git when creating a temp repo for gomod updates

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.121.1"
+  VERSION = "0.122.0"
 end


### PR DESCRIPTION
This is a release of https://github.com/dependabot/dependabot-core/compare/v0.121.1...v0.122.0-release-notes

   * https://github.com/dependabot/dependabot-core/pull/2576
   * https://github.com/dependabot/dependabot-core/pull/2596