### PR TITLE
Ignore changed  .gemspec from vendor/cache folder

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -73,7 +73,7 @@ module Dependabot
     end
 
     def check_dependencies_have_previous_version
-      return if library? && dependencies.all? { |d| requirements_changed?(d) }
+      return if dependencies.all? { |d| requirements_changed?(d) }
       return if dependencies.all?(&:previous_version)
 
       raise "Dependencies must have a previous version or changed " \
@@ -212,12 +212,6 @@ module Dependabot
           label_language: label_language?,
           automerge_candidate: automerge_candidate?
         )
-    end
-
-    def library?
-      return true if files.any? { |file| file.name.end_with?(".gemspec") }
-
-      dependencies.any? { |d| !d.appears_in_lockfile? }
     end
 
     def includes_security_fixes?

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -165,12 +165,12 @@ module Dependabot
         updated_reqs.first[:requirement]
       end
 
-      # TODO: Look into bringing this in line with existing library checks that
-      # we do in the update checkers, which are also overriden by passing an
-      # explicit `requirements_update_strategy`.
+      # TODO: Bring this in line with existing library checks that we do in the
+      # update checkers, which are also overriden by passing an explicit
+      # `requirements_update_strategy`.
+      #
+      # TODO re-use in MessageBuilder
       def library?
-        return true if files.map(&:name).any? { |nm| nm.end_with?(".gemspec") }
-
         dependencies.any? { |d| !d.appears_in_lockfile? }
       end
 

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -459,8 +459,16 @@ module Dependabot
         previous_ref(dependency) != new_ref(dependency)
       end
 
+      # TODO: Bring this in line with existing library checks that we do in the
+      # update checkers, which are also overriden by passing an explicit
+      # `requirements_update_strategy`.
+      #
+      # TODO re-use in BranchNamer
       def library?
-        return true if files.map(&:name).any? { |nm| nm.end_with?(".gemspec") }
+        # Reject any nested child gemspecs/vendored git dependencies
+        root_files = files.map(&:name).
+                     select { |p| Pathname.new(p).dirname.to_s == "." }
+        return true if root_files.select { |nm| nm.end_with?(".gemspec") }.any?
 
         dependencies.any? { |d| previous_version(d).nil? }
       end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -404,6 +404,18 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             end
           end
         end
+
+        context "with a vendored .gemspec" do
+          let(:files) { [gemfile, gemfile_lock, gemspec] }
+          let(:gemspec) do
+            Dependabot::DependencyFile.new(
+              name: "vendor/cache/dep/git.gemspec",
+              content: fixture("ruby", "gemspecs", "example")
+            )
+          end
+
+          it { is_expected.to eq("Bump business from 1.4.0 to 1.5.0") }
+        end
       end
 
       context "that uses angular commits" do


### PR DESCRIPTION
When we vendor a bundler project we often end up with an updated `.gemspec` files in the vendor folder but we don't care about these when creating the PR branch or message as this incorrectly identifies the dependency as a library and attempts to generate a updated requirement.

The requirement sometimes doesn't change when only bumping the version in the lockfile.

This is a quick fix to keep the existing logic but we should refactor this to get it in line with the existing logic to determine if a project is a library as this varies between package manager.