### PR TITLE
Gracefully handle gomod package import that has changed

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -16,7 +16,8 @@ module Dependabot
         RESOLVABILITY_ERROR_REGEXES = [
           /go: .*: git fetch .*: exit status 128/.freeze,
           /verifying .*: checksum mismatch/.freeze,
-          /build .*: cannot find module providing package/.freeze
+          /build .*: cannot find module providing package/.freeze,
+          /module .* found \(.*\), but does not contain package/m.freeze
         ].freeze
 
         MODULE_PATH_MISMATCH_REGEXES = [

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -208,6 +208,21 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
               expect(go_files).to be_empty
             end
           end
+
+          context "renamed package name" do
+            let(:project_name) { "renamed_package" }
+            let(:dependency_name) { "github.com/googleapis/gnostic" }
+            # OpenAPIV2 has been renamed to openapiv2 in this version
+            let(:dependency_version) { "v0.5.1" }
+
+            it "raises a DependencyFileNotResolvable error" do
+              error_class = Dependabot::DependencyFileNotResolvable
+              expect { updater.updated_go_sum_content }.
+                to raise_error(error_class) do |error|
+                expect(error.message).to include("googleapis/gnostic/OpenAPIv2")
+              end
+            end
+          end
         end
 
         context "without a go.sum" do

--- a/go_modules/spec/fixtures/projects/renamed_package/go.mod
+++ b/go_modules/spec/fixtures/projects/renamed_package/go.mod
@@ -1,0 +1,5 @@
+module github.com/dependabot/vgotest
+
+go 1.15
+
+require github.com/googleapis/gnostic v0.3.1

--- a/go_modules/spec/fixtures/projects/renamed_package/go.sum
+++ b/go_modules/spec/fixtures/projects/renamed_package/go.sum
@@ -1,0 +1,9 @@
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
+github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go_modules/spec/fixtures/projects/renamed_package/main.go
+++ b/go_modules/spec/fixtures/projects/renamed_package/main.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	_ "github.com/googleapis/gnostic/OpenAPIv2"
+)
+
+func main() {
+}


### PR DESCRIPTION
When a module exists, but it (no longer) defines the package of a given
name, we get an error like such:

```
go: finding module for package github.com/googleapis/gnostic/OpenAPIv2
github.com/dependabot/vgotest imports
	github.com/googleapis/gnostic/OpenAPIv2: module github.com/googleapis/gnostic@latest found (v0.5.1), but does not contain package github.com/googleapis/gnostic/OpenAPIv2
```

In this case, we should not treat that as a failed update, but rather as
a DependencyFileNotResolvable.