### PR TITLE
Handle `cannot find module` during go mod tidy

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -16,6 +16,7 @@ module Dependabot
         RESOLVABILITY_ERROR_REGEXES = [
           /go: .*: git fetch .*: exit status 128/.freeze,
           /verifying .*: checksum mismatch/.freeze,
+          /cannot find module providing package .*: exit status 128/m.freeze,
           /build .*: cannot find module providing package/.freeze,
           /module .* found \(.*\), but does not contain package/m.freeze
         ].freeze


### PR DESCRIPTION
Previously we would only catch this type of error during `go build`, by
explicitly matching for the `build` prefix. We also want to gracefully
handle this error when running `go mod tidy`.

I am not sure why this error sometimes arises during build time (likely
when running `go get`), and sometimes during other commands, and I also
cannot seem to replicate the error in a test scenario :/ it appears we're missing
test coverage for the existing error as well, so may be OK adding this as is?