### PR TITLE
Release notes for v0.123.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.123.0, 13 October 2020
+
+- Bundler: Refactored Dependabot's use of Bundler commands to shell out instead
+  of running in a forked process.
+  - This aligns Bundler with other package managers and will enable us to
+    support other Bundler versions in future.
+
 ## v0.122.1, 13 October 2020
 
 - Bump phpstan/phpstan from 0.12.48 to 0.12.49 in /composer/helpers

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.122.1"
+  VERSION = "0.123.0"
 end


### PR DESCRIPTION
- Bundler: Refactored Dependabot's use of Bundler commands to shell out instead
  of running in a subprocess.
  - This aligns Bundler with other package managers and will enable us to
    support other Bundler versions in future.