### PR TITLE
fix(docker): support platform option in from line

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -24,11 +24,13 @@ module Dependabot
       IMAGE = %r{(?<image>#{NAME_COMPONENT}(?:/#{NAME_COMPONENT})*)}.freeze
 
       FROM = /FROM/i.freeze
+      PLATFORM = /--platform\=(?<platform>\S+)/.freeze
       TAG = /:(?<tag>[\w][\w.-]{0,127})/.freeze
       DIGEST = /@(?<digest>[^\s]+)/.freeze
       NAME = /\s+AS\s+(?<name>[\w-]+)/.freeze
       FROM_LINE =
-        %r{^#{FROM}\s+(#{REGISTRY}/)?#{IMAGE}#{TAG}?#{DIGEST}?#{NAME}?}.freeze
+        %r{^#{FROM}\s+(#{PLATFORM}\s+)?(#{REGISTRY}/)?
+          #{IMAGE}#{TAG}?#{DIGEST}?#{NAME}?}x.freeze
 
       AWS_ECR_URL = /dkr\.ecr\.(?<region>[^.]+).amazonaws\.com/.freeze
 

--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -7,7 +7,7 @@ require "dependabot/errors"
 module Dependabot
   module Docker
     class FileUpdater < Dependabot::FileUpdaters::Base
-      FROM_REGEX = /FROM/i.freeze
+      FROM_REGEX = /FROM(\s+--platform\=\S+)?/i.freeze
 
       def self.updated_files_regex
         [/dockerfile/i]

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -628,5 +628,28 @@ RSpec.describe Dependabot::Docker::FileParser do
         end
       end
     end
+
+    context "with a platform" do
+      let(:dockerfile_body) { "FROM --platform=linux/amd64 ubuntu:artful" }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: { tag: "artful" }
+          }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("ubuntu")
+          expect(dependency.version).to eq("artful")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+    end
   end
 end

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -478,5 +478,44 @@ RSpec.describe Dependabot::Docker::FileUpdater do
         end
       end
     end
+
+    context "when dockerfile includes platform" do
+      let(:dockerfile_body) do
+        fixture("docker", "dockerfiles", "platform")
+      end
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "node",
+          version: "10.9-alpine",
+          previous_version: "10-alpine",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: { tag: "10.9-alpine" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: { tag: "10-alpine" }
+          }],
+          package_manager: "docker"
+        )
+      end
+
+      describe "the updated Dockerfile" do
+        subject(:updated_dockerfile) do
+          updated_files.find { |f| f.name == "Dockerfile" }
+        end
+
+        its(:content) do
+          is_expected.to include "FROM --platform=$BUILDPLATFORM " \
+                                 "node:10.9-alpine AS"
+        end
+        its(:content) { is_expected.to include "FROM node:10.9-alpine\n" }
+        its(:content) { is_expected.to include "RUN apk add" }
+      end
+    end
   end
 end

--- a/docker/spec/fixtures/docker/dockerfiles/platform
+++ b/docker/spec/fixtures/docker/dockerfiles/platform
@@ -1,0 +1,21 @@
+FROM --platform=$BUILDPLATFORM node:10-alpine AS BUILD
+
+RUN apk add --no-cache git
+
+WORKDIR /application
+
+COPY package.json yarn.lock ./
+
+RUN yarn
+
+COPY . .
+
+FROM node:10-alpine
+
+ENV NODE_PATH=/dependabot/node_modules
+
+COPY --from=BUILD /application/ /dependabot/
+
+WORKDIR /application
+
+ENTRYPOINT ["/dependabot/node_modules/.bin/dependabot"]


### PR DESCRIPTION
Dockerfiles can specify the platform in the from line. This change adds support for parsing and updating FROM lines with the platform flag specified.

```Dockerfile
FROM [--platform=<platform>] <image> [AS <name>]
```

https://docs.docker.com/engine/reference/builder/#from