### PR TITLE
Release notes for v0.123.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.123.1, 19 October 2020
+
+- Go mod: Handle `cannot find module` during go mod tidy
+- Python: Add 3.9.0 and upgrade pyenv to v1.2.21 (@ulgens)
+- Bundler: Ignore changed .gemspec from vendor/cache folder
+
 ## v0.123.0, 13 October 2020
 
 - Bundler: Refactored Dependabot's use of Bundler commands to shell out instead

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.123.0"
+  VERSION = "0.123.1"
 end


### PR DESCRIPTION
- Go mod: Handle `cannot find module` during go mod tidy
- Python: Add 3.9.0 and upgrade pyenv to v1.2.21 (@ulgens)
- Bundler: Ignore changed .gemspec from vendor/cache folder