### PR TITLE
Explain update not possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /node_modules
 /.env
+/.envrc
 /tmp
 /pkg
 /dependabot-*.gem

--- a/bundler/lib/dependabot/bundler/update_checker.rb
+++ b/bundler/lib/dependabot/bundler/update_checker.rb
@@ -26,6 +26,11 @@ module Dependabot
         latest_resolvable_version_details&.fetch(:version)
       end
 
+      def lowest_security_fix_version
+        latest_version_finder(remove_git_source: false).
+          lowest_security_fix_version
+      end
+
       def lowest_resolvable_security_fix_version
         raise "Dependency not vulnerable!" unless vulnerable?
         return latest_resolvable_version if git_dependency?

--- a/cargo/lib/dependabot/cargo/update_checker.rb
+++ b/cargo/lib/dependabot/cargo/update_checker.rb
@@ -42,6 +42,10 @@ module Dependabot
           end
       end
 
+      def lowest_security_fix_version
+        latest_version_finder.lowest_security_fix_version
+      end
+
       def lowest_resolvable_security_fix_version
         raise "Dependency not vulnerable!" unless vulnerable?
 
@@ -214,7 +218,7 @@ module Dependabot
       end
 
       def fetch_lowest_resolvable_security_fix_version
-        fix_version = latest_version_finder.lowest_security_fix_version
+        fix_version = lowest_security_fix_version
         return latest_resolvable_version if fix_version.nil?
 
         if path_dependency? || git_dependency? || git_subdependency?

--- a/cargo/spec/dependabot/cargo/update_checker_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker_spec.rb
@@ -187,6 +187,30 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
     end
   end
 
+  describe "#lowest_security_fix_version" do
+    subject { checker.lowest_security_fix_version }
+
+    it "finds the lowest available non-vulnerable version" do
+      is_expected.to eq(Gem::Version.new("0.1.39"))
+    end
+
+    context "with a security vulnerability" do
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: dependency_name,
+            package_manager: "cargo",
+            vulnerable_versions: ["<= 0.1.39"]
+          )
+        ]
+      end
+
+      it "finds the lowest available non-vulnerable version" do
+        is_expected.to eq(Gem::Version.new("0.1.40"))
+      end
+    end
+  end
+
   describe "#latest_resolvable_version" do
     subject { checker.latest_resolvable_version }
 

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -79,6 +79,12 @@ module Dependabot
         raise NotImplementedError
       end
 
+      # Lowest available security fix version not checking resolvability
+      # @return [Dependabot::<package manager>::Version, #to_s] version class
+      def lowest_security_fix_version
+        raise NotImplementedError
+      end
+
       def lowest_resolvable_security_fix_version
         raise NotImplementedError
       end

--- a/composer/lib/dependabot/composer/update_checker.rb
+++ b/composer/lib/dependabot/composer/update_checker.rb
@@ -34,6 +34,10 @@ module Dependabot
           ).latest_resolvable_version
       end
 
+      def lowest_security_fix_version
+        latest_version_finder.lowest_security_fix_version
+      end
+
       def lowest_resolvable_security_fix_version
         raise "Dependency not vulnerable!" unless vulnerable?
 
@@ -105,7 +109,7 @@ module Dependabot
       def fetch_lowest_resolvable_security_fix_version
         return nil if path_dependency? || git_dependency?
 
-        fix_version = latest_version_finder.lowest_security_fix_version
+        fix_version = lowest_security_fix_version
         return latest_resolvable_version if fix_version.nil?
 
         resolved_fix_version = VersionResolver.new(

--- a/gradle/lib/dependabot/gradle/update_checker.rb
+++ b/gradle/lib/dependabot/gradle/update_checker.rb
@@ -30,12 +30,16 @@ module Dependabot
         latest_version
       end
 
+      def lowest_security_fix_version
+        lowest_security_fix_version_details&.fetch(:version)
+      end
+
       def lowest_resolvable_security_fix_version
         return if git_dependency?
         return nil if version_comes_from_multi_dependency_property?
         return nil if version_comes_from_dependency_set?
 
-        lowest_security_fix_version_details&.fetch(:version)
+        lowest_security_fix_version
       end
 
       def latest_resolvable_version_with_no_unlock

--- a/gradle/spec/dependabot/gradle/update_checker_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker_spec.rb
@@ -163,6 +163,30 @@ RSpec.describe Dependabot::Gradle::UpdateChecker do
     end
   end
 
+  describe "#lowest_security_fix_version" do
+    subject { checker.lowest_security_fix_version }
+
+    it "finds the lowest available non-vulnerable version" do
+      is_expected.to eq(version_class.new("23.4-jre"))
+    end
+
+    context "with a security vulnerability" do
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: dependency_name,
+            package_manager: "gradle",
+            vulnerable_versions: ["< 23.5.0"]
+          )
+        ]
+      end
+
+      it "finds the lowest available non-vulnerable version" do
+        is_expected.to eq(version_class.new("23.5-jre"))
+      end
+    end
+  end
+
   describe "#latest_resolvable_version" do
     subject { checker.latest_resolvable_version }
     it { is_expected.to eq(version_class.new("23.6-jre")) }

--- a/maven/lib/dependabot/maven/update_checker.rb
+++ b/maven/lib/dependabot/maven/update_checker.rb
@@ -26,10 +26,14 @@ module Dependabot
         latest_version
       end
 
+      def lowest_security_fix_version
+        lowest_security_fix_version_details&.fetch(:version)
+      end
+
       def lowest_resolvable_security_fix_version
         return nil if version_comes_from_multi_dependency_property?
 
-        lowest_security_fix_version_details&.fetch(:version)
+        lowest_security_fix_version
       end
 
       def latest_resolvable_version_with_no_unlock

--- a/maven/spec/dependabot/maven/update_checker_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker_spec.rb
@@ -190,6 +190,44 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
     end
   end
 
+  describe "#lowest_security_fix_version" do
+    subject { checker.lowest_security_fix_version }
+
+    before do
+      version_files_url = "https://repo.maven.apache.org/maven2/com/google/"\
+                          "guava/guava/23.4-jre/guava-23.4-jre.jar"
+      stub_request(:head, version_files_url).
+        to_return(status: 200)
+    end
+
+    it "finds the lowest available non-vulnerable version" do
+      is_expected.to eq(version_class.new("23.4-jre"))
+    end
+
+    context "with a security vulnerability" do
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: dependency_name,
+            package_manager: "maven",
+            vulnerable_versions: ["< 23.5.0"]
+          )
+        ]
+      end
+
+      before do
+        version_files_url = "https://repo.maven.apache.org/maven2/com/google/"\
+                            "guava/guava/23.5-jre/guava-23.5-jre.jar"
+        stub_request(:head, version_files_url).
+          to_return(status: 200)
+      end
+
+      it "finds the lowest available non-vulnerable version" do
+        is_expected.to eq(version_class.new("23.5-jre"))
+      end
+    end
+  end
+
   describe "#latest_resolvable_version" do
     subject { checker.latest_resolvable_version }
     it { is_expected.to eq(version_class.new("23.6-jre")) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -36,12 +36,19 @@ module Dependabot
           end
       end
 
+      def lowest_security_fix_version
+        latest_version_finder.lowest_security_fix_version
+      end
+
       def lowest_resolvable_security_fix_version
         raise "Dependency not vulnerable!" unless vulnerable?
+        # Note: we currently don't resolve transitive/sub-dependencies as
+        # npm/yarn don't provide any control over updating to a specific
+        # sub-dependency
         return latest_resolvable_version unless dependency.top_level?
 
         # TODO: Might want to check resolvability here?
-        latest_version_finder.lowest_security_fix_version
+        lowest_security_fix_version
       end
 
       def latest_resolvable_version_with_no_unlock

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -52,9 +52,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
     }]
   end
 
+  let(:dependency_name) { "etag" }
   let(:dependency) do
     Dependabot::Dependency.new(
-      name: "etag",
+      name: dependency_name,
       version: dependency_version,
       requirements: [
         { file: "package.json", requirement: "^1.0.0", groups: [], source: nil }
@@ -369,6 +370,41 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           let(:upload_pack_fixture) { "no_tags" }
           it { is_expected.to be_nil }
         end
+      end
+    end
+  end
+
+  describe "#lowest_security_fix_version" do
+    subject { checker.lowest_security_fix_version }
+
+    before do
+      stub_request(:get, registry_listing_url + "/1.0.1").
+        to_return(status: 200)
+    end
+
+    it "finds the lowest available non-vulnerable version" do
+      expect(checker.lowest_security_fix_version).
+        to eq(Gem::Version.new("1.0.1"))
+    end
+
+    context "with a security vulnerability" do
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: dependency_name,
+            package_manager: "npm_and_yarn",
+            vulnerable_versions: ["<= 1.2.0"]
+          )
+        ]
+      end
+
+      before do
+        stub_request(:get, registry_listing_url + "/1.2.1").
+          to_return(status: 200)
+      end
+
+      it "finds the lowest available non-vulnerable version" do
+        is_expected.to eq(Gem::Version.new("1.2.1"))
       end
     end
   end

--- a/nuget/lib/dependabot/nuget/update_checker.rb
+++ b/nuget/lib/dependabot/nuget/update_checker.rb
@@ -22,10 +22,14 @@ module Dependabot
         latest_version
       end
 
+      def lowest_security_fix_version
+        lowest_security_fix_version_details&.fetch(:version)
+      end
+
       def lowest_resolvable_security_fix_version
         return nil if version_comes_from_multi_dependency_property?
 
-        lowest_security_fix_version_details&.fetch(:version)
+        lowest_security_fix_version
       end
 
       def latest_resolvable_version_with_no_unlock

--- a/nuget/spec/dependabot/nuget/update_checker_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker_spec.rb
@@ -113,6 +113,30 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
     end
   end
 
+  describe "#lowest_security_fix_version" do
+    subject { checker.lowest_security_fix_version }
+
+    it "finds the lowest available non-vulnerable version" do
+      is_expected.to eq(version_class.new("1.1.2"))
+    end
+
+    context "with a security vulnerability" do
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: dependency_name,
+            package_manager: "nuget",
+            vulnerable_versions: ["< 1.2.0"]
+          )
+        ]
+      end
+
+      it "finds the lowest available non-vulnerable version" do
+        is_expected.to eq(version_class.new("2.0.0"))
+      end
+    end
+  end
+
   describe "#latest_resolvable_version" do
     subject(:latest_resolvable_version) { checker.latest_resolvable_version }
 

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -74,6 +74,10 @@ module Dependabot
           end
       end
 
+      def lowest_security_fix_version
+        latest_version_finder.lowest_security_fix_version
+      end
+
       def lowest_resolvable_security_fix_version
         raise "Dependency not vulnerable!" unless vulnerable?
 
@@ -119,7 +123,7 @@ module Dependabot
       end
 
       def fetch_lowest_resolvable_security_fix_version
-        fix_version = latest_version_finder.lowest_security_fix_version
+        fix_version = lowest_security_fix_version
         return latest_resolvable_version if fix_version.nil?
 
         if resolver_type == :requirements

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -115,6 +115,29 @@ RSpec.describe Dependabot::Python::UpdateChecker do
     end
   end
 
+  describe "#lowest_security_fix_version" do
+    subject { checker.lowest_security_fix_version }
+
+    it "finds the lowest available non-vulnerable version" do
+      is_expected.to eq(Gem::Version.new("2.0.1"))
+    end
+
+    context "with a security vulnerability" do
+      let(:dependency_version) { "2.0.0" }
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: dependency_name,
+            package_manager: "pip",
+            vulnerable_versions: ["<= 2.1.0"]
+          )
+        ]
+      end
+
+      it { is_expected.to eq(Gem::Version.new("2.1.1")) }
+    end
+  end
+
   describe "#latest_resolvable_version" do
     subject { checker.latest_resolvable_version }
 


### PR DESCRIPTION
In order to better explain why a security update is not possible, we're exposing the  `lowest_security_fix_version` which returns the lowest available non-vulnerable version from the package registry not taking resolvability into account. We'll use this alongside the existing method `lowest_resolvable_security_fix_version` to explain which version is the latest possible version that can be installed and which version is the earliest non-vulnerable/fixed version.

Planned "update not possible" error message:

`Dependabot cannot update #{dependency_name} to a non-vulnerable version`

```
The latest possible version that can be installed is #{lowest_resolvable_security_fix_version},
another dependency is locking  #{dependency_name} to a vulnerable version range.
The earliest fixed version is #{lowest_security_fix_version}.
```

