### PR TITLE
Add fixes_advisory/affects_version to security adv

### DIFF
--- a/common/spec/dependabot/security_advisory_spec.rb
+++ b/common/spec/dependabot/security_advisory_spec.rb
@@ -120,4 +120,115 @@ RSpec.describe Dependabot::SecurityAdvisory do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe "#fixes_advisory?" do
+    subject { security_advisory.fixes_advisory?(dependency) }
+
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        package_manager: package_manager,
+        name: dependency_name,
+        version: dependency_version,
+        previous_version: dependency_previous_version,
+        requirements: [],
+        previous_requirements: []
+      )
+    end
+    let(:package_manager) { "dummy" }
+    let(:dependency_name) { "rails" }
+    let(:vulnerable_versions) { [] }
+    let(:safe_versions) { [Gem::Requirement.new("~> 1.11.0")] }
+    let(:dependency_version) { "1.11.1" }
+    let(:dependency_previous_version) { "0.7.1" }
+
+    it { is_expected.to eq(true) }
+
+    context "for a different package manager" do
+      let(:package_manager) { "npm_and_yarn" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "for a different dependency" do
+      let(:dependency_name) { "gemcutter" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "with a dependency that has already been patched" do
+      let(:dependency_previous_version) { "1.11.2" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "updating to a version that isn't fixed" do
+      let(:dependency_version) { "1.10.1" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "with no fixed versions" do
+      let(:safe_versions) { [] }
+      it { is_expected.to eq(false) }
+    end
+
+    context "with affected_versions specified" do
+      let(:safe_versions) { [] }
+      let(:vulnerable_versions) { ["~> 0.7.0"] }
+      it { is_expected.to eq(true) }
+
+      context "that don't match the old version" do
+        let(:vulnerable_versions) { ["~> 0.8.0"] }
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
+
+  describe "#affects_version?" do
+    subject { security_advisory.affects_version?(version_string) }
+
+    let(:version_string) { "0.7.1" }
+    let(:vulnerable_versions) { [] }
+    let(:safe_versions) { ["~> 1.11.0"] }
+
+    it { is_expected.to eq(true) }
+
+    context "with several requirements" do
+      let(:safe_versions) { ["~> 1.11.0", ">= 1.11.0.1"] }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a version that has already been patched" do
+      let(:version_string) { "1.11.2" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "with a git SHA" do
+      let(:version_string) { "d7a42dcd7cf631ba94b01231f535bda061f6af92" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "with no vulnerable or fixed versions" do
+      let(:safe_versions) { [] }
+      it { is_expected.to eq(false) }
+    end
+
+    context "with vulnerable_versions specified" do
+      let(:safe_versions) { [] }
+      let(:vulnerable_versions) { ["~> 0.7.0"] }
+
+      it { is_expected.to eq(true) }
+
+      context "and some other versions are patched" do
+        let(:safe_versions) { [">= 0.7.2"] }
+        it { is_expected.to eq(true) }
+      end
+
+      context "but this version is patched" do
+        let(:safe_versions) { [">= 0.7.1"] }
+        it { is_expected.to eq(false) }
+      end
+
+      context "that don't match this version" do
+        let(:vulnerable_versions) { ["~> 0.8.0"] }
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Going to use this to figure out if an update is a security fix:

```ruby
security_advisories.select do |advisory|
  advisory.fixes_advisory?(updated_dependency)
end.any?
```