### PR TITLE
Include backtrace in bundler native errors

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -161,6 +161,8 @@ docker run --rm -ti \
   -v "$(pwd)/bundler/dependabot-bundler.gemspec:$CODE_DIR/bundler/dependabot-bundler.gemspec" \
   -v "$(pwd)/bundler/lib:$CODE_DIR/bundler/lib" \
   -v "$(pwd)/bundler/spec:$CODE_DIR/bundler/spec" \
+  -v "$(pwd)/bundler/helpers:/opt/bundler" \
+  -v "$(pwd)/bundler/helpers:/opt/bundler/helpers" \
   -v "$(pwd)/omnibus/Gemfile:$CODE_DIR/omnibus/Gemfile" \
   -v "$(pwd)/omnibus/dependabot-omnibus.gemspec:$CODE_DIR/omnibus/dependabot-omnibus.gemspec" \
   -v "$(pwd)/omnibus/lib:$CODE_DIR/omnibus/lib" \

--- a/bundler/helpers/run.rb
+++ b/bundler/helpers/run.rb
@@ -23,6 +23,8 @@ begin
 
   output({ result: Functions.send(function, **args) })
 rescue => error
-  output({ error: error.message, error_class: error.class })
+  output(
+    { error: error.message, error_class: error.class, trace: error.backtrace }
+  )
   exit(1)
 end

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -58,13 +58,14 @@ module Dependabot
     end
 
     class HelperSubprocessFailed < StandardError
-      attr_reader :error_class, :error_context
+      attr_reader :error_class, :error_context, :trace
 
-      def initialize(message:, error_context:, error_class: nil)
+      def initialize(message:, error_context:, error_class: nil, trace: nil)
         super(message)
         @error_class = error_class || ""
         @error_context = error_context
         @command = error_context[:command]
+        @trace = trace
       end
 
       def raven_context
@@ -113,7 +114,8 @@ module Dependabot
       raise HelperSubprocessFailed.new(
         message: response["error"],
         error_class: response["error_class"],
-        error_context: error_context
+        error_context: error_context,
+        trace: response["trace"]
       )
     rescue JSON::ParserError
       raise HelperSubprocessFailed.new(


### PR DESCRIPTION
This forwards the backtrace from any native bundler helper, which makes it easier to figure out what happened in the native helper when ran from core.

I named this `trace` as to not clash with `StandardError#backtrace`, but open to alternatives.