### PR TITLE
Handle missing directory in cloned repo

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -329,12 +329,18 @@ source = Dependabot::Source.new(
   commit: $options[:commit]
 )
 
-$repo_contents_path = Dir.mktmpdir if $options[:clone]
+always_clone = Dependabot::Utils.
+               always_clone_for_package_manager?($package_manager)
+if $options[:clone] || always_clone
+  $repo_contents_path = Dir.mktmpdir
+  puts "=> cloning into #{$repo_contents_path}"
+end
 
 fetcher = Dependabot::FileFetchers.for_package_manager($package_manager).
           new(source: source, credentials: $options[:credentials],
               repo_contents_path: $repo_contents_path)
-$files = if $options[:clone]
+$files = if $options[:clone] || always_clone
+           fetcher.clone_repo_contents
            fetcher.files
          else
            cached_dependency_files_read do

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -42,6 +42,9 @@ module Dependabot
         path = Pathname.new(File.join(repo_contents_path, directory)).
                expand_path
         reset_git_repo(repo_contents_path)
+        # Handle missing directories by creating an empty one and relying on the
+        # file fetcher to raise a DependencyFileNotFound error
+        FileUtils.mkdir_p(path) unless Dir.exist?(path)
         Dir.chdir(path) { yield(path) }
       else
         in_a_temporary_directory(directory, &block)

--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -65,15 +65,23 @@ module Dependabot
       def use_repo_contents_stub
         @repo_contents_stub = true
         @repo_contents_path = Dir.mktmpdir
+
         Dir.chdir(@repo_contents_path) do
           dependency_files.each do |file|
-            File.write(file.name, file.content)
+            path = File.join(@repo_contents_path, directory, file.name)
+            path = Pathname.new(path).expand_path
+            FileUtils.mkdir_p(path.dirname) unless Dir.exist?(path.dirname)
+            File.write(path, file.content)
           end
-          `git config --global user.email "no-reply@github.com"`
-          `git config --global user.name "Dependabot"`
-          `git init .`
-          `git add .`
-          `git commit -m'fake repo_contents_path'`
+
+          # Only used to create a backup git config that's reset
+          SharedHelpers.with_git_configured(credentials: []) do
+            `git config --global user.email "no-reply@github.com"`
+            `git config --global user.name "Dependabot"`
+            `git init .`
+            `git add .`
+            `git commit -m'fake repo_contents_path'`
+          end
         end
       end
 

--- a/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
     end
   end
 
+  context "when directory is missing" do
+    let(:directory) { "/missing" }
+
+    it "raises a helpful error" do
+      expect { file_fetcher_instance.files }.
+        to raise_error(Dependabot::DependencyFileNotFound)
+    end
+  end
+
   context "for an application" do
     let(:repo) { "dependabot-fixtures/go-modules-app" }
 

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require "dependabot/dependency"
 require "dependabot/dependency_file"
 require "dependabot/go_modules/file_updater"
+require "dependabot/shared_helpers"
 require_common_spec "file_updaters/shared_examples_for_file_updaters"
 
 RSpec.describe Dependabot::GoModules::FileUpdater do
@@ -103,15 +104,21 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
       before do
         # We don't have git configured in prod, so simulate the same setup here
         Dir.chdir(repo_contents_path) do
-          `git config --global --unset user.email`
-          `git config --global --unset user.name`
+          # Only used to create a backup git config that's reset
+          Dependabot::SharedHelpers.with_git_configured(credentials: []) do
+            `git config --global --unset user.email`
+            `git config --global --unset user.name`
+          end
         end
       end
 
       after do
         Dir.chdir(repo_contents_path) do
-          `git config --global user.email "no-reply@github.com"`
-          `git config --global user.name "dependabot-ci"`
+          # Only used to create a backup git config that's reset
+          Dependabot::SharedHelpers.with_git_configured(credentials: []) do
+            `git config --global user.email "no-reply@github.com"`
+            `git config --global user.name "dependabot-ci"`
+          end
         end
       end
 
@@ -155,6 +162,25 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
           ).and_return(double)
 
         updater.updated_dependency_files
+      end
+
+      context "when dependency files are nested in a directory" do
+        let(:go_mod) do
+          Dependabot::DependencyFile.new(name: "go.mod", content: go_mod_body,
+                                         directory: "/nested")
+        end
+        let(:go_sum) do
+          Dependabot::DependencyFile.new(name: "go.sum", content: go_sum_body,
+                                         directory: "/nested")
+        end
+
+        it "includes an updated go.mod" do
+          expect(updated_files.find { |f| f.name == "go.mod" }).to_not be_nil
+        end
+
+        it "includes an updated go.sum" do
+          expect(updated_files.find { |f| f.name == "go.sum" }).to_not be_nil
+        end
       end
     end
 


### PR DESCRIPTION
Handle missing directory in cloned repo by creating an empty one and
relying on file fetcher to raise because it can't find a manifest file.

Fixed up some issues around dry-run cloning and the go mod clone stub
(which might not be needed anymore?).