### PR TITLE
Handle missing VCS when converting git_source path

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -174,6 +174,15 @@ module Dependabot
           ref: git_revision(dep),
           branch: nil
         }
+      rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
+        if e.message == "Cannot detect VCS"
+          msg = e.message + " for #{dep['Path']}. Attempted to detect VCS "\
+                            "because the version looks like a git revision: "\
+                            "#{dep['Version']}"
+          raise Dependabot::DependencyFileNotResolvable, msg
+        end
+
+        raise
       end
 
       def git_revision(dep)

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -236,5 +236,20 @@ RSpec.describe Dependabot::GoModules::FileParser do
         expect(dependency.name).to eq("rsc.io/qr")
       end
     end
+
+    context "that is not resolvable" do
+      let(:go_mod_content) do
+        fixture("projects", "unknown_vcs", "go.mod")
+      end
+
+      it "raises the correct error" do
+        expect { parser.parse }.
+          to raise_error do |err|
+            expect(err).to be_a(Dependabot::DependencyFileNotResolvable)
+            expect(err.message).
+              to start_with("Cannot detect VCS for unknown/vcs")
+          end
+      end
+    end
   end
 end

--- a/go_modules/spec/fixtures/projects/unknown_vcs/go.mod
+++ b/go_modules/spec/fixtures/projects/unknown_vcs/go.mod
@@ -1,0 +1,11 @@
+module unknown/vcs/go
+
+go 1.12
+
+require (
+	unknown/vcs v0.0.0-00010101000000-000000000000
+)
+
+replace (
+	unknown/vcs => ../../
+)

--- a/go_modules/spec/fixtures/projects/unknown_vcs/main.go
+++ b/go_modules/spec/fixtures/projects/unknown_vcs/main.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	_ "unknown/vcs/go"
+)
+
+func main() {
+}


### PR DESCRIPTION
Copied from go dep implementation:
https://github.com/dependabot/dependabot-core/blob/main/dep/lib/dependabot/dep/file_parser.rb#L142