### PR TITLE
Fix relative dir on mac where tmp is in /private

### DIFF
--- a/common/lib/dependabot/file_updaters/vendor_updater.rb
+++ b/common/lib/dependabot/file_updaters/vendor_updater.rb
@@ -18,7 +18,9 @@ module Dependabot
         return [] unless repo_contents_path && vendor_dir
 
         Dir.chdir(repo_contents_path) do
-          relative_dir = Pathname.new(vendor_dir).relative_path_from(Dir.pwd)
+          relative_dir = Pathname.new(vendor_dir).relative_path_from(
+            repo_contents_path
+          )
 
           status = SharedHelpers.run_shell_command(
             "git status --untracked-files=all --porcelain=v1 #{relative_dir}"


### PR DESCRIPTION
Get the relative vendor dir from the repo_contents_path which is what we
used to construct the vendor_dir.

When creating a tmp dir in mac it returns the directory as `/var/tmp`
but if you run `pwd` in the folder it's suddently in `/private/var/tmp`.