### PR TITLE
Go mod: handle missing package url meta tags

### DIFF
--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -10,6 +10,11 @@ require "dependabot/go_modules/version"
 module Dependabot
   module GoModules
     class UpdateChecker < Dependabot::UpdateCheckers::Base
+      RESOLVABILITY_ERROR_REGEXES = [
+        # Package url/proxy doesn't include any redirect meta tags
+        /no go-import meta tags/
+      ].freeze
+
       def latest_resolvable_version
         # We don't yet support updating indirect dependencies for go_modules
         #
@@ -73,6 +78,15 @@ module Dependabot
         retry_count ||= 0
         retry_count += 1
         retry if transitory_failure?(e) && retry_count < 2
+
+        handle_subprocess_error(e)
+      end
+
+      def handle_subprocess_error(error)
+        if RESOLVABILITY_ERROR_REGEXES.any? { |rgx| error.message =~ rgx }
+          raise Dependabot::DependencyFileNotResolvable, error.message
+        end
+
         raise
       end
 

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -134,5 +134,27 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
     end
 
     it "doesn't update Git SHAs not on master to newer commits to master"
+
+    context "when the package url doesn't include any valid meta tags" do
+      let(:dependency_files) { [go_mod] }
+      let(:project_name) { "missing_meta_tag" }
+      let(:repo_contents_path) { build_tmp_repo(project_name) }
+
+      let(:dependency_name) { "example.com/test/package" }
+      let(:dependency_version) { "1.7.0" }
+
+      let(:go_mod) do
+        Dependabot::DependencyFile.new(name: "go.mod", content: go_mod_body)
+      end
+      let(:go_mod_body) { fixture("projects", project_name, "go.mod") }
+
+      it "raises a DependencyFileNotResolvable error" do
+        error_class = Dependabot::DependencyFileNotResolvable
+        expect { latest_resolvable_version }.
+          to raise_error(error_class) do |error|
+          expect(error.message).to include("example.com/test/package")
+        end
+      end
+    end
   end
 end

--- a/go_modules/spec/fixtures/projects/missing_meta_tag/go.mod
+++ b/go_modules/spec/fixtures/projects/missing_meta_tag/go.mod
@@ -1,0 +1,7 @@
+module github.com/dependabot/vgotest
+
+go 1.12
+
+require (
+	example.com/test/package v1.7.0
+)


### PR DESCRIPTION
Raise DependencyFileNotResolvable error when checking for latest version
for a package that doesn't have any valid meta tags.