### PR TITLE
v0.124.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v0.124.4, 30 October 2020
+
+- Ignore go files that start with underscore or dot
+- Go mod: handle missing package url meta tags
+- Ignore go files tagged with `+build`
+- Handle missing VCS when converting git_source path
+- Fix relative dir on mac where tmp is in /private
+- Handle missing directory in cloned repo
+- Improve relative path code in vendor updater
+- Correctly handle vendored updates in nested directory
+- Raise generic DependabotError when all else fails
+- Mark unknown revision errors as DependencyFileNotResolvable
+- Include backtrace from native bundler helpers
+- Mount native bundler helpers in dev shell
+- Bump friendsofphp/php-cs-fixer in /composer/helpers
+
 ## v0.124.3, 27 October 2020
 
 - Rename fixes_advisory? to fixed_by? and handle mixed case names

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.124.3"
+  VERSION = "0.124.4"
 end


### PR DESCRIPTION
## v0.124.4, 30 October 2020

- Ignore go files that start with underscore or dot
- Go mod: handle missing package url meta tags
- Ignore go files tagged with `+build`
- Handle missing VCS when converting git_source path
- Fix relative dir on mac where tmp is in /private
- Handle missing directory in cloned repo
- Improve relative path code in vendor updater
- Correctly handle vendored updates in nested directory
- Raise generic DependabotError when all else fails
- Mark unknown revision errors as DependencyFileNotResolvable
- Include backtrace from native bundler helpers
- Mount native bundler helpers in dev shell
- Bump friendsofphp/php-cs-fixer in /composer/helpers