### PR TITLE
Fix error handling for packages that 404

### DIFF
--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -11,8 +11,8 @@ module Dependabot
   module GoModules
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       RESOLVABILITY_ERROR_REGEXES = [
-        # Package url/proxy doesn't include any redirect meta tags
-        /no go-import meta tags/
+        # Package url 404s
+        /unrecognized import path/
       ].freeze
 
       def latest_resolvable_version

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
 
     it "doesn't update Git SHAs not on master to newer commits to master"
 
-    context "when the package url doesn't include any valid meta tags" do
+    context "when the package url returns 404" do
       let(:dependency_files) { [go_mod] }
       let(:project_name) { "missing_meta_tag" }
       let(:repo_contents_path) { build_tmp_repo(project_name) }


### PR DESCRIPTION
Bumping gomodules-extracted (https://github.com/dependabot/dependabot-core/pull/2619) caused the raised error to change for import paths that 404/don't include valid meta tags.