### PR TITLE
Go mod: Add/fix specs for missing meta tag and 404

### DIFF
--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -11,8 +11,10 @@ module Dependabot
   module GoModules
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       RESOLVABILITY_ERROR_REGEXES = [
+        # Package url/proxy doesn't include any redirect meta tags
+        /no go-import meta tags/,
         # Package url 404s
-        /unrecognized import path/
+        /404 Not Found/
       ].freeze
 
       def latest_resolvable_version

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
 
     context "when the package url returns 404" do
       let(:dependency_files) { [go_mod] }
-      let(:project_name) { "missing_meta_tag" }
+      let(:project_name) { "missing_package" }
       let(:repo_contents_path) { build_tmp_repo(project_name) }
 
       let(:dependency_name) { "example.com/test/package" }
@@ -153,6 +153,28 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
         expect { latest_resolvable_version }.
           to raise_error(error_class) do |error|
           expect(error.message).to include("example.com/test/package")
+        end
+      end
+    end
+
+    context "when the package url doesn't include any valid meta tags" do
+      let(:dependency_files) { [go_mod] }
+      let(:project_name) { "missing_meta_tag" }
+      let(:repo_contents_path) { build_tmp_repo(project_name) }
+
+      let(:dependency_name) { "web.archive.org/web/dependabot.com" }
+      let(:dependency_version) { "1.7.0" }
+
+      let(:go_mod) do
+        Dependabot::DependencyFile.new(name: "go.mod", content: go_mod_body)
+      end
+      let(:go_mod_body) { fixture("projects", project_name, "go.mod") }
+
+      it "raises a DependencyFileNotResolvable error" do
+        error_class = Dependabot::DependencyFileNotResolvable
+        expect { latest_resolvable_version }.
+          to raise_error(error_class) do |error|
+          expect(error.message).to include("web.archive.org/web/dependabot.com")
         end
       end
     end

--- a/go_modules/spec/fixtures/projects/missing_meta_tag/go.mod
+++ b/go_modules/spec/fixtures/projects/missing_meta_tag/go.mod
@@ -1,7 +1,7 @@
-module github.com/dependabot/vgotest
+module github.com/dependabot/test
 
 go 1.12
 
 require (
-	example.com/test/package v1.7.0
+	web.archive.org/web/dependabot.com v1.7.0
 )

--- a/go_modules/spec/fixtures/projects/missing_package/go.mod
+++ b/go_modules/spec/fixtures/projects/missing_package/go.mod
@@ -1,0 +1,7 @@
+module github.com/dependabot/vgotest
+
+go 1.12
+
+require (
+	example.com/test/package v1.7.0
+)


### PR DESCRIPTION
Add a spec for handling package url that don't include meta tags.

Both 404 and missing meta tag errors raised a error message starting
with `unrecognized import path`. I've split these out with two different
test cases.