### PR TITLE
Go mod: handle major version mismatch

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -24,7 +24,9 @@ module Dependabot
           /module .* found \(.*\), but does not contain package/m.freeze,
           # Package does not exist, has been pulled or cannot be reached due to
           # auth problems with either git or the go proxy
-          /go: .*: unknown revision/m.freeze
+          /go: .*: unknown revision/m.freeze,
+          # Package version doesn't match the module major version
+          /go: .*: go.mod has post-v1 module path/m.freeze
         ].freeze
 
         MODULE_PATH_MISMATCH_REGEXES = [

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -364,6 +364,35 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
         end
       end
     end
+
+    context "when module major version doesn't match" do
+      let(:project_name) { "module_major_version_mismatch" }
+      let(:dependency_name) do
+        "github.com/dependabot-fixtures/go-major-mismatch"
+      end
+      let(:dependency_version) { "v1.0.5" }
+      let(:dependency_previous_version) { "v1.0.4" }
+      let(:requirements) do
+        [{
+          file: "go.mod",
+          requirement: "v1.0.1",
+          groups: [],
+          source: {
+            type: "default",
+            source: "github.com/dependabot-fixtures/go-major-mismatch"
+          }
+        }]
+      end
+      let(:previous_requirements) { [] }
+
+      it "raises the correct error" do
+        error_class = Dependabot::DependencyFileNotResolvable
+        expect { updater.updated_go_sum_content }.
+          to raise_error(error_class) do |error|
+          expect(error.message).to include("go.mod has post-v1 module path")
+        end
+      end
+    end
   end
 
   describe "#updated_go_sum_content" do

--- a/go_modules/spec/fixtures/projects/module_major_version_mismatch/go.mod
+++ b/go_modules/spec/fixtures/projects/module_major_version_mismatch/go.mod
@@ -1,0 +1,7 @@
+module github.com/dependabot/vgotest
+
+go 1.15
+
+require (
+  github.com/dependabot-fixtures/go-major-mismatch v1.0.4
+)

--- a/go_modules/spec/fixtures/projects/module_major_version_mismatch/go.sum
+++ b/go_modules/spec/fixtures/projects/module_major_version_mismatch/go.sum
@@ -1,0 +1,8 @@
+github.com/dependabot-fixtures/go-major-mismatch v1.0.4 h1:7oLmIm7OUUwB3ZkT+97S3mq0eBtPsFxvj84EnQlRX2s=
+github.com/dependabot-fixtures/go-major-mismatch v1.0.4/go.mod h1:bl5eQuaBLVXeu2xj7IXugzNnGWXeC9LlaAxavHfD35o=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:qgOY6WgZOaTkIIMiVjBQcw93ERBE4m30iBm00nkL0i8=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+rsc.io/quote v1.5.0 h1:mVjf/WMWxfIw299sOl/O3EXn5qEaaJPMDHMsv7DBDlw=
+rsc.io/quote v1.5.0/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
+rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/go_modules/spec/fixtures/projects/module_major_version_mismatch/main.go
+++ b/go_modules/spec/fixtures/projects/module_major_version_mismatch/main.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	_ "github.com/dependabot-fixtures/go-major-mismatch"
+)
+
+func main() {
+}


### PR DESCRIPTION
When updating a dependency to a v1 tag which includes a v2 module go mod
will complain that the major version doesn't match:

```
go: github.com/dependabot-fixtures/go-major-mismatch@v1.0.1:
  go.mod has post-v1 module path "github.com/dependabot-fixtures/go-major-mismatch/v2" at revision v1.0.1
```