### PR TITLE
Cargo: handle caret version requirements

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
@@ -100,8 +100,9 @@ module Dependabot
           if simple_declaration
             simple_declaration_regex =
               /(?:^|["'])#{Regexp.escape(simple_declaration)}/
+            old_req_escaped = Regexp.escape(old_req)
             content.gsub(simple_declaration_regex) do |line|
-              line.gsub(/.+=.*\K(#{old_req})/, new_req)
+              line.gsub(/.+=.*\K(#{old_req_escaped})/, new_req)
             end
           elsif content.match?(feature_declaration_version_regex(dep))
             content.gsub(feature_declaration_version_regex(dep)) do |part|

--- a/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
@@ -264,6 +264,30 @@ RSpec.describe Dependabot::Cargo::FileUpdater::ManifestUpdater do
             to include(%([dependencies.pango]\nversion = "0.3.0"\n))
         end
       end
+
+      context "with a version requirement" do
+        context "with a target-specific dependency" do
+          let(:manifest_fixture_name) { "version_requirement" }
+          let(:previous_requirements) do
+            [{
+              file: "Cargo.toml",
+              requirement: "^0.1.38",
+              groups: [],
+              source: nil
+            }]
+          end
+          let(:requirements) do
+            [{
+              file: "Cargo.toml",
+              requirement: "^0.1.40",
+              groups: [],
+              source: nil
+            }]
+          end
+
+          it { is_expected.to include(%(time = "^0.1.40")) }
+        end
+      end
     end
   end
 end

--- a/cargo/spec/fixtures/manifests/version_requirement
+++ b/cargo/spec/fixtures/manifests/version_requirement
@@ -1,0 +1,8 @@
+[package]
+name = "dependabot" # the name of the package
+version = "0.1.0"    # the current version, obeying semver
+authors = ["support@dependabot.com"]
+default-run = "viewer"
+
+[dependencies]
+time = "^0.1.38"


### PR DESCRIPTION
Handle `^` version requirements by escaping the previous requirement.

The old requirement (e.g. `^1.0.0`) was interpolated unescaped inside a
regex match so the caret `^` broke the match.