### PR TITLE
composer: increase Dependabot::OutOfMemory

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -108,7 +108,8 @@ module Dependabot
         args: args,
         time_taken: time_taken,
         stderr_output: stderr ? stderr[0..50_000] : "", # Truncate to ~100kb
-        process_exit_value: process.to_s
+        process_exit_value: process.to_s,
+        process_termsig: process.termsig
       }
 
       response = JSON.parse(stdout)

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -19,6 +19,7 @@ module Dependabot
                  "#{Excon::USER_AGENT} ruby/#{RUBY_VERSION} "\
                  "(#{RUBY_PLATFORM}) "\
                  "(+https://github.com/dependabot/dependabot-core)"
+    SIGKILL = 9
 
     class ChildProcessFailed < StandardError
       attr_reader :error_class, :error_message, :error_backtrace

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -150,6 +150,19 @@ RSpec.describe Dependabot::SharedHelpers do
           to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
       end
     end
+
+    context "when the subprocess is killed" do
+      let(:function) { "killed" }
+
+      it "raises a HelperSubprocessFailed error" do
+        expect { run_subprocess }.
+          to(raise_error do |error|
+            expect(error).
+              to be_a(Dependabot::SharedHelpers::HelperSubprocessFailed)
+            expect(error.error_context[:process_termsig]).to eq(9)
+          end)
+      end
+    end
   end
 
   describe ".escape_command" do

--- a/common/spec/helpers/test/run.rb
+++ b/common/spec/helpers/test/run.rb
@@ -13,6 +13,9 @@ when "useful_error"
 when "hard_error"
   puts "Oh no!"
   exit 0
+when "killed"
+  # SIGKILL the helper, which is what the kernel OOMKiller might do.
+  Process.kill("KILL", Process.pid)
 else
   $stdout.write(JSON.dump(result: request))
 end

--- a/composer/helpers/bin/run
+++ b/composer/helpers/bin/run
@@ -11,25 +11,25 @@ require __DIR__ . '/../vendor/autoload.php';
 // and an `args` method, as passed in by UpdateCheckers::Php
 $request = json_decode(file_get_contents('php://stdin'), true);
 
+function memoryInBytes($value) {
+    $unit = strtolower(substr($value, -1, 1));
+    $value = (int) $value;
+    if ($unit == 'g') {
+        $value *= (1024 * 1024 * 1024);
+    } elseif ($unit == 'm') {
+        $value *= (1024 * 1024);
+    } elseif ($unit == 'k') {
+        $value *= 1024;
+    }
+
+    return $value;
+}
+
 // Increase the default memory limit the same way Composer does (but clearer)
 if (function_exists('ini_set')) {
-    $memoryInBytes = function ($value) {
-        $unit = strtolower(substr($value, -1, 1));
-        $value = (int) $value;
-        if ($unit == 'g') {
-            $value *= (1024 * 1024 * 1024);
-        } elseif ($unit == 'm') {
-            $value *= (1024 * 1024);
-        } elseif ($unit == 'k') {
-            $value *= 1024;
-        }
-
-        return $value;
-    };
-
     $memoryLimit = trim(ini_get('memory_limit'));
     // Increase memory_limit if it is lower than 1900MB
-    if ($memoryLimit != -1 && $memoryInBytes($memoryLimit) < 1024 * 1024 * 1900) {
+    if ($memoryLimit != -1 && memoryInBytes($memoryLimit) < 1024 * 1024 * 1900) {
         @ini_set('memory_limit', '1900M');
     }
 
@@ -53,6 +53,10 @@ register_shutdown_function(function (): void {
         fwrite(STDOUT, json_encode(['error' => $error['message']]));
     }
 });
+
+if ($memoryAlloc = getenv('DEPENDABOT_TEST_MEMORY_ALLOCATION')) {
+    str_repeat('*', memoryInBytes($memoryAlloc));
+}
 
 try {
     switch ($request['function']) {

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -320,6 +320,9 @@ module Dependabot
           elsif error.message.start_with?("Allowed memory size") ||
                 error.message.start_with?("Out of memory")
             raise Dependabot::OutOfMemory
+          elsif error.error_context[:process_termsig] == 9
+            # If the helper was SIGKILL-ed, assume the OOMKiller did it
+            raise Dependabot::OutOfMemory
           elsif error.message.start_with?("Package not found in updated") &&
                 !dependency.top_level?
             # If we can't find the dependency in the composer.lock after an

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -320,7 +320,8 @@ module Dependabot
           elsif error.message.start_with?("Allowed memory size") ||
                 error.message.start_with?("Out of memory")
             raise Dependabot::OutOfMemory
-          elsif error.error_context[:process_termsig] == 9
+          elsif error.error_context[:process_termsig] ==
+                Dependabot::SharedHelpers::SIGKILL
             # If the helper was SIGKILL-ed, assume the OOMKiller did it
             raise Dependabot::OutOfMemory
           elsif error.message.start_with?("Package not found in updated") &&

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -199,6 +199,22 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       end
     end
 
+    context "with a forced oom error" do
+      let(:manifest_fixture_name) { "php_specified_in_library" }
+      let(:dependency_files) { [manifest] }
+      let(:dependency_name) { "phpdocumentor/reflection-docblock" }
+      let(:dependency_version) { "2.0.4" }
+      let(:string_req) { "2.0.4" }
+
+      before { ENV["DEPENDABOT_TEST_MEMORY_ALLOCATION"] = "16G" }
+      after { ENV.delete("DEPENDABOT_TEST_MEMORY_ALLOCATION") }
+
+      it "raises a Dependabot::OutOfMemory error" do
+        expect { resolver.latest_resolvable_version }.
+          to raise_error(Dependabot::OutOfMemory)
+      end
+    end
+
     # This test is extremely slow, as it needs to wait for Composer to time out.
     # As a result we currently keep it commented out.
     # context "with an unreachable private registry" do


### PR DESCRIPTION
This aims to improve the behaviour of the `composer` updater while under memory pressure:

Composer updates shell to a helper process implemented in PHP, depending on the project this helper process might end up using several GB of memory.
Previously, there was some code to [enforce memory limits](https://github.com/dependabot/dependabot-core/blob/main/composer/helpers/bin/run#L45-L46) in PHP, that I don't think is used as we always run without specifying the [limit](https://github.com/dependabot/dependabot-core/search?q=memory_limit).

In practice, we're at the whims of the Linux Out of Memory (OOM) Killer, whose algorithm is roughly described [here](https://github.com/torvalds/linux/blob/7c2a69f610e64c8dec6a06a66e721f4ce1dd783a/Documentation/filesystems/proc.rst#31-procpidoom_adj--procpidoom_score_adj--adjust-the-oom-killer-score).
TLDR: since the helper process is likely using more memory than `dependabot-core`'s host process, it's the most likely to be killed. It would be nice to `oom_score_adjust` to encourage the oomkiller to target the helper, but that's not worth adding the permissions to make that possible (e.g. `SYS_RESOURCE` capability and running (at least initially) as root).

To address the OOM killer reality, I've made two adjustments:
* `Dependabot::SharedHelpers::ChildProcessFailed.error_context` has an added `termsig` field, forwarding [`Process::Status#termsig`](https://ruby-doc.org/core-2.7.2/Process/Status.html#method-i-termsig)
* If composer detects the helper process _was_ killed, assume it was the kernel's OOM killer and raise a more appropriate exception
