### PR TITLE
v0.125.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.125.1, 5 November 2020
+
+- Escape `SharedHelpers.run_shell_command` with shellwords
+
 ## v0.125.0, 5 November 2020
 
 - Bundler: Explain why security update was not possible

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.125.0"
+  VERSION = "0.125.1"
 end


### PR DESCRIPTION
Escape `SharedHelpers.run_shell_command` with shellwords