### PR TITLE
Bugfix for Elixir Code.eval_file

### DIFF
--- a/hex/lib/dependabot/hex/file_fetcher.rb
+++ b/hex/lib/dependabot/hex/file_fetcher.rb
@@ -68,7 +68,7 @@ module Dependabot
 
       def evaled_files
         mixfile.content.scan(EVAL_FILE).map do |eval_file_args|
-          path = Pathname.new(File.join(*eval_file_args.reverse)).
+          path = Pathname.new(File.join(*eval_file_args.compact.reverse)).
                  cleanpath.to_path
           fetch_file_from_host(path).tap { |f| f.support_file = true }
         end

--- a/hex/spec/dependabot/hex/file_fetcher_spec.rb
+++ b/hex/spec/dependabot/hex/file_fetcher_spec.rb
@@ -103,6 +103,33 @@ RSpec.describe Dependabot::Hex::FileFetcher do
     end
   end
 
+  context "with an evaled file without a relative directory" do
+    before do
+      stub_request(:get, url + "mix.exs?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body:
+            fixture("github", "contents_elixir_mixfile_with_eval_file_without_relative_dir.json"),
+          headers: json_header
+        )
+      stub_request(:get, url + "version?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body:
+            fixture("github", "contents_todo_txt.json"),
+          headers: json_header
+        )
+    end
+
+    it "fetches the evaled file" do
+      expect(file_fetcher_instance.files.count).to eq(3)
+      expect(file_fetcher_instance.files.map(&:name)).
+        to match_array(%w(mix.exs mix.lock version))
+    end
+  end
+
   context "with an umbrella app" do
     before do
       stub_request(:get, url + "?ref=sha").

--- a/hex/spec/fixtures/github/contents_elixir_mixfile_with_eval_file_without_relative_dir.json
+++ b/hex/spec/fixtures/github/contents_elixir_mixfile_with_eval_file_without_relative_dir.json
@@ -1,0 +1,18 @@
+{
+  "name": "mix.exs",
+  "path": "mix.exs",
+  "sha": "611c38ac024bbe16004d106167ac5d840a56523d",
+  "size": 2952,
+  "url": "https://api.github.com/repos/Accenture/reactive-interaction-gateway/contents/mix.exs?ref=master",
+  "html_url": "https://github.com/Accenture/reactive-interaction-gateway/blob/master/mix.exs",
+  "git_url": "https://api.github.com/repos/Accenture/reactive-interaction-gateway/git/blobs/611c38ac024bbe16004d106167ac5d840a56523d",
+  "download_url": "https://raw.githubusercontent.com/Accenture/reactive-interaction-gateway/master/mix.exs",
+  "type": "file",
+  "content": "ZGVmbW9kdWxlIERlcGVuZGFib3RUZXN0Lk1peGZpbGUgZG8KICB1c2UgTWl4LlByb2plY3QKCiAgZGVmIHByb2plY3QgZG8KICAgICV7ZWxpeGlyOiBlbGl4aXJfdmVyc2lvbn0gPSB2ZXJzaW9ucygpCiAgICBbCiAgICAgIGFwcDogOmRlcGVuZGFib3RfdGVzdCwKICAgICAgdmVyc2lvbjogIjAuMS4wIiwKICAgICAgZWxpeGlyOiBlbGl4aXJfdmVyc2lvbiwKICAgICAgc3RhcnRfcGVybWFuZW50OiBNaXguZW52ID09IDpwcm9kLAogICAgICBkZXBzOiBkZXBzKCkKICAgIF0KICBlbmQKCiAgZGVmcCB2ZXJzaW9ucyBkbwogICAge21hcCwgW119ID0gQ29kZS5ldmFsX2ZpbGUoInZlcnNpb24iKQogICAgbWFwCiAgZW5kCgogIGRlZiBhcHBsaWNhdGlvbiBkbwogICAgW2V4dHJhX2FwcGxpY2F0aW9uczogWzpsb2dnZXJdXQogIGVuZAoKICBkZWZwIGRlcHMgZG8KICAgIFsKICAgICAgezpwbHVnLCAiMS4zLjAifSwKICAgICAgezpwaG9lbml4LCAiPT0gMS4yLjEifQogICAgXQogIGVuZAplbmQK",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/Accenture/reactive-interaction-gateway/contents/mix.exs?ref=master",
+    "git": "https://api.github.com/repos/Accenture/reactive-interaction-gateway/git/blobs/611c38ac024bbe16004d106167ac5d840a56523d",
+    "html": "https://github.com/Accenture/reactive-interaction-gateway/blob/master/mix.exs"
+  }
+}


### PR DESCRIPTION
Currently there is a bug where if you use `Code.eval_file` in your mix.exs, then dependabot will error out because the second argument is nil. A simple compact solves this issue by removing any nils that the regex catches. I have added a test as well.