### PR TITLE
Support Elixir Code.require_file

### DIFF
--- a/hex/lib/dependabot/hex/file_fetcher.rb
+++ b/hex/lib/dependabot/hex/file_fetcher.rb
@@ -8,9 +8,8 @@ module Dependabot
     class FileFetcher < Dependabot::FileFetchers::Base
       APPS_PATH_REGEX = /apps_path:\s*"(?<path>.*?)"/m.freeze
       STRING_ARG = %{(?:["'](.*?)["'])}
-      EVAL_FILE = /Code\.eval_file\(#{STRING_ARG}(?:\s*,\s*#{STRING_ARG})?\)/.
-                  freeze
-      REQUIRE_FILE = /Code\.require_file\(#{STRING_ARG}(?:\s*,\s*#{STRING_ARG})?\)/.
+      SUPPORTED_METHODS = %w(eval_file require_file).join("|").freeze
+      SUPPORT_FILE = /Code\.(?:#{SUPPORTED_METHODS})\(#{STRING_ARG}(?:\s*,\s*#{STRING_ARG})?\)/.
                      freeze
 
       def self.required_files_in?(filenames)
@@ -28,8 +27,7 @@ module Dependabot
         fetched_files << mixfile
         fetched_files << lockfile if lockfile
         fetched_files += subapp_mixfiles
-        fetched_files += evaled_files
-        fetched_files += required_files
+        fetched_files += support_files
         fetched_files
       end
 
@@ -69,17 +67,9 @@ module Dependabot
         []
       end
 
-      def evaled_files
-        mixfile.content.scan(EVAL_FILE).map do |eval_file_args|
-          path = Pathname.new(File.join(*eval_file_args.compact.reverse)).
-                 cleanpath.to_path
-          fetch_file_from_host(path).tap { |f| f.support_file = true }
-        end
-      end
-
-      def required_files
-        mixfile.content.scan(REQUIRE_FILE).map do |require_file_args|
-          path = Pathname.new(File.join(*require_file_args.compact.reverse)).
+      def support_files
+        mixfile.content.scan(SUPPORT_FILE).map do |support_file_args|
+          path = Pathname.new(File.join(*support_file_args.compact.reverse)).
                  cleanpath.to_path
           fetch_file_from_host(path).tap { |f| f.support_file = true }
         end

--- a/hex/spec/dependabot/hex/file_fetcher_spec.rb
+++ b/hex/spec/dependabot/hex/file_fetcher_spec.rb
@@ -130,6 +130,60 @@ RSpec.describe Dependabot::Hex::FileFetcher do
     end
   end
 
+  context "with a required file" do
+    before do
+      stub_request(:get, url + "mix.exs?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body:
+            fixture("github", "contents_elixir_mixfile_with_require_file.json"),
+          headers: json_header
+        )
+      stub_request(:get, url + "rel/releases.ex?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body:
+            fixture("github", "contents_todo_txt.json"),
+          headers: json_header
+        )
+    end
+
+    it "fetches the required file" do
+      expect(file_fetcher_instance.files.count).to eq(3)
+      expect(file_fetcher_instance.files.map(&:name)).
+        to match_array(%w(mix.exs mix.lock rel/releases.ex))
+    end
+  end
+
+  context "with a required file without a relative directory" do
+    before do
+      stub_request(:get, url + "mix.exs?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body:
+            fixture("github", "contents_elixir_mixfile_with_require_file_without_relative_dir.json"),
+          headers: json_header
+        )
+      stub_request(:get, url + "rel/releases.ex?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body:
+            fixture("github", "contents_todo_txt.json"),
+          headers: json_header
+        )
+    end
+
+    it "fetches the required file" do
+      expect(file_fetcher_instance.files.count).to eq(3)
+      expect(file_fetcher_instance.files.map(&:name)).
+        to match_array(%w(mix.exs mix.lock rel/releases.ex))
+    end
+  end
+
   context "with an umbrella app" do
     before do
       stub_request(:get, url + "?ref=sha").

--- a/hex/spec/fixtures/github/contents_elixir_mixfile_with_require_file.json
+++ b/hex/spec/fixtures/github/contents_elixir_mixfile_with_require_file.json
@@ -1,0 +1,18 @@
+{
+  "name": "mix.exs",
+  "path": "mix.exs",
+  "sha": "611c38ac024bbe16004d106167ac5d840a56523d",
+  "size": 2952,
+  "url": "https://api.github.com/repos/Accenture/reactive-interaction-gateway/contents/mix.exs?ref=master",
+  "html_url": "https://github.com/Accenture/reactive-interaction-gateway/blob/master/mix.exs",
+  "git_url": "https://api.github.com/repos/Accenture/reactive-interaction-gateway/git/blobs/611c38ac024bbe16004d106167ac5d840a56523d",
+  "download_url": "https://raw.githubusercontent.com/Accenture/reactive-interaction-gateway/master/mix.exs",
+  "type": "file",
+  "content": "ZGVmbW9kdWxlIERlcGVuZGFib3RUZXN0Lk1peGZpbGUgZG8KICB1c2UgTWl4LlByb2plY3QKCiAgQ29kZS5yZXF1aXJlX2ZpbGUoIi4vcmVsL3JlbGVhc2VzLmV4IiwgIi4vIikKCiAgZGVmIHByb2plY3QgZG8KICAgIFsKICAgICAgYXBwOiA6ZGVwZW5kYWJvdF90ZXN0LAogICAgICB2ZXJzaW9uOiAiMC4xLjAiLAogICAgICBlbGl4aXI6ICJ+PiAxLjgiLAogICAgICBzdGFydF9wZXJtYW5lbnQ6IE1peC5lbnYgPT0gOnByb2QsCiAgICAgIGRlcHM6IGRlcHMoKSwKICAgICAgcmVsZWFzZXM6IERlcGVuZGFib3RUZXN0LlJlbGVhc2VzLnJlbGVhc2VzKCkKICAgIF0KICBlbmQKCiAgZGVmIGFwcGxpY2F0aW9uIGRvCiAgICBbZXh0cmFfYXBwbGljYXRpb25zOiBbOmxvZ2dlcl1dCiAgZW5kCgogIGRlZnAgZGVwcyBkbwogICAgWwogICAgICB7OnBsdWcsICIxLjMuMCJ9LAogICAgICB7OnBob2VuaXgsICI9PSAxLjIuMSJ9CiAgICBdCiAgZW5kCmVuZAo=",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/Accenture/reactive-interaction-gateway/contents/mix.exs?ref=master",
+    "git": "https://api.github.com/repos/Accenture/reactive-interaction-gateway/git/blobs/611c38ac024bbe16004d106167ac5d840a56523d",
+    "html": "https://github.com/Accenture/reactive-interaction-gateway/blob/master/mix.exs"
+  }
+}

--- a/hex/spec/fixtures/github/contents_elixir_mixfile_with_require_file_without_relative_dir.json
+++ b/hex/spec/fixtures/github/contents_elixir_mixfile_with_require_file_without_relative_dir.json
@@ -1,0 +1,18 @@
+{
+  "name": "mix.exs",
+  "path": "mix.exs",
+  "sha": "611c38ac024bbe16004d106167ac5d840a56523d",
+  "size": 2952,
+  "url": "https://api.github.com/repos/Accenture/reactive-interaction-gateway/contents/mix.exs?ref=master",
+  "html_url": "https://github.com/Accenture/reactive-interaction-gateway/blob/master/mix.exs",
+  "git_url": "https://api.github.com/repos/Accenture/reactive-interaction-gateway/git/blobs/611c38ac024bbe16004d106167ac5d840a56523d",
+  "download_url": "https://raw.githubusercontent.com/Accenture/reactive-interaction-gateway/master/mix.exs",
+  "type": "file",
+  "content": "ZGVmbW9kdWxlIERlcGVuZGFib3RUZXN0Lk1peGZpbGUgZG8KICB1c2UgTWl4LlByb2plY3QKCiAgQ29kZS5yZXF1aXJlX2ZpbGUoIi4vcmVsL3JlbGVhc2VzLmV4IikKCiAgZGVmIHByb2plY3QgZG8KICAgIFsKICAgICAgYXBwOiA6ZGVwZW5kYWJvdF90ZXN0LAogICAgICB2ZXJzaW9uOiAiMC4xLjAiLAogICAgICBlbGl4aXI6ICJ+PiAxLjgiLAogICAgICBzdGFydF9wZXJtYW5lbnQ6IE1peC5lbnYgPT0gOnByb2QsCiAgICAgIGRlcHM6IGRlcHMoKSwKICAgICAgcmVsZWFzZXM6IERlcGVuZGFib3RUZXN0LlJlbGVhc2VzLnJlbGVhc2VzKCkKICAgIF0KICBlbmQKCiAgZGVmIGFwcGxpY2F0aW9uIGRvCiAgICBbZXh0cmFfYXBwbGljYXRpb25zOiBbOmxvZ2dlcl1dCiAgZW5kCgogIGRlZnAgZGVwcyBkbwogICAgWwogICAgICB7OnBsdWcsICIxLjMuMCJ9LAogICAgICB7OnBob2VuaXgsICI9PSAxLjIuMSJ9CiAgICBdCiAgZW5kCmVuZAo=",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/Accenture/reactive-interaction-gateway/contents/mix.exs?ref=master",
+    "git": "https://api.github.com/repos/Accenture/reactive-interaction-gateway/git/blobs/611c38ac024bbe16004d106167ac5d840a56523d",
+    "html": "https://github.com/Accenture/reactive-interaction-gateway/blob/master/mix.exs"
+  }
+}


### PR DESCRIPTION
I have a project that requires another file as part of our mix.exs, and dependabot fails due to it not being able to find the required file when upgrading dependencies. This PR adds this functionality by adding another regex similar to how `Code.eval_file` is handled. I have also included tests fo this as well.