### PR TITLE
update ci jobs env variable assignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,15 @@ jobs:
         uses: actions/checkout@v2
       - name: Prepare environment variables
         run: |
-          echo ::set-env name=BRANCH_REF::"$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')"
-          echo ::set-env name=BASE_IMAGE::ubuntu:18.04
-          echo ::set-env name=CORE_IMAGE::dependabot/dependabot-core
-          echo ::set-env name=CORE_CI_IMAGE::dependabot/dependabot-core-ci
+          echo "BRANCH_REF=$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')" >> $GITHUB_ENV
+          echo "BASE_IMAGE=ubuntu:18.04" >> $GITHUB_ENV
+          echo "CORE_IMAGE=dependabot/dependabot-core" >> $GITHUB_ENV
+          echo "CORE_CI_IMAGE=dependabot/dependabot-core-ci" >> $GITHUB_ENV
       - name: Log in to Docker registry
         run: |
           if [ -n "${{ secrets.DOCKER_USERNAME }}" ] && [ -n "${{ secrets.DOCKER_PASSWORD }}" ]; then
             echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-            echo ::set-env name=DOCKER_LOGGED_IN::true
+            echo "DOCKER_LOGGED_IN=true" >> $GITHUB_ENV
           else
             echo "No Docker credentials, skipping login"
           fi


### PR DESCRIPTION
I noticed that there were some github action warnings on the ci build of my previous PRs. I've made another PR to fix these warnings, as it appears they will break your CI on Monday.

the warnings (https://github.com/dependabot/dependabot-core/actions/runs/357182402): 
```The `set-env` command is deprecated and will be disabled on November 16th. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/```