### PR TITLE
Add native javascript test for npm helper

### DIFF
--- a/npm_and_yarn/helpers/test/npm/conflicting-dependency-parser.test.js
+++ b/npm_and_yarn/helpers/test/npm/conflicting-dependency-parser.test.js
@@ -1,0 +1,29 @@
+const path = require("path");
+const os = require("os");
+const fs = require("fs");
+const rimraf = require("rimraf");
+const {
+  findConflictingDependencies,
+} = require("../../lib/npm/conflicting-dependency-parser");
+const helpers = require("./helpers");
+
+describe("findConflictingDependencies", () => {
+  let tempDir;
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(os.tmpdir() + path.sep);
+  });
+  afterEach(() => rimraf.sync(tempDir));
+
+  it("finds conflicting dependencies", async () => {
+    helpers.copyDependencies("conflicting-dependency-parser", tempDir);
+
+    const result = await findConflictingDependencies(tempDir, "abind", "2.0.0");
+    expect(result).toEqual([
+      {
+        name: "objnest",
+        version: "4.1.2",
+        requirement: "^1.0.0",
+      },
+    ]);
+  });
+});

--- a/npm_and_yarn/helpers/test/npm/fixtures/conflicting-dependency-parser/package-lock.json
+++ b/npm_and_yarn/helpers/test/npm/fixtures/conflicting-dependency-parser/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abind": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/abind/-/abind-1.0.5.tgz",
+      "integrity": "sha512-dbaEZphdPje0ihqSdWg36Sb8S20TuqQomiz2593oIx+enQ9Q4vDZRjIzhnkWltGRKVKqC28kTribkgRLBexWVQ=="
+    },
+    "extend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+      "integrity": "sha512-5mYyg57hpD+sFaJmgNL9BidQ5C7dmJE3U5vzlRWbuqG+8dytvYEoxvKs6Tj5cm3LpMsFvRt20qz1ckezmsOUgQ=="
+    },
+    "objnest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/objnest/-/objnest-4.1.2.tgz",
+      "integrity": "sha512-VLMIu6RjSrHyesMnlLZBTbNlzrfBEjkcBdq5NM763AG+BLRJm27H43GUTLv3XrtlNn0Ofs+em4G84T7kkXA+1A==",
+      "requires": {
+        "abind": "^1.0.0",
+        "extend": "^3.0.0"
+      }
+    }
+  }
+}

--- a/npm_and_yarn/helpers/test/npm/fixtures/conflicting-dependency-parser/package.json
+++ b/npm_and_yarn/helpers/test/npm/fixtures/conflicting-dependency-parser/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "objnest": "^4.1.2"
+  }
+}

--- a/npm_and_yarn/helpers/test/npm/helpers.js
+++ b/npm_and_yarn/helpers/test/npm/helpers.js
@@ -4,4 +4,18 @@ const fs = require("fs");
 module.exports = {
   loadFixture: (fixturePath) =>
     fs.readFileSync(path.join(__dirname, "fixtures", fixturePath)).toString(),
+
+  copyDependencies: (sourceDir, destDir) => {
+    const srcPackageJson = path.join(
+      __dirname,
+      `fixtures/${sourceDir}/package.json`
+    );
+    fs.copyFileSync(srcPackageJson, `${destDir}/package.json`);
+
+    const srcLockfile = path.join(
+      __dirname,
+      `fixtures/${sourceDir}/package-lock.json`
+    );
+    fs.copyFileSync(srcLockfile, `${destDir}/package-lock.json`);
+  },
 };

--- a/npm_and_yarn/helpers/test/npm/updater.test.js
+++ b/npm_and_yarn/helpers/test/npm/updater.test.js
@@ -12,22 +12,8 @@ describe("updater", () => {
   });
   afterEach(() => rimraf.sync(tempDir));
 
-  function copyDependencies(sourceDir, destDir) {
-    const srcPackageJson = path.join(
-      __dirname,
-      `fixtures/updater/${sourceDir}/package.json`
-    );
-    fs.copyFileSync(srcPackageJson, `${destDir}/package.json`);
-
-    const srcLockfile = path.join(
-      __dirname,
-      `fixtures/updater/${sourceDir}/package-lock.json`
-    );
-    fs.copyFileSync(srcLockfile, `${destDir}/package-lock.json`);
-  }
-
   it("generates an updated package-lock.json", async () => {
-    copyDependencies("original", tempDir);
+    helpers.copyDependencies("updater/original", tempDir);
 
     const result = await updateDependencyFiles(tempDir, "package-lock.json", [
       {


### PR DESCRIPTION
By writing tests for this helper in the native language, it makes it a lot easier to iterate on the code.