### PR TITLE
Support reading files in Elixir supporting files like in mixfiles

### DIFF
--- a/hex/lib/dependabot/hex/file_parser.rb
+++ b/hex/lib/dependabot/hex/file_parser.rb
@@ -77,7 +77,7 @@ module Dependabot
         dependency_files.select(&:support_file).each do |file|
           path = file.name
           FileUtils.mkdir_p(Pathname.new(path).dirname)
-          File.write(path, file.content)
+          File.write(path, sanitize_mixfile(file.content))
         end
       end
 

--- a/hex/lib/dependabot/hex/file_parser.rb
+++ b/hex/lib/dependabot/hex/file_parser.rb
@@ -42,7 +42,7 @@ module Dependabot
       def dependency_details
         SharedHelpers.in_a_temporary_directory do
           write_sanitized_mixfiles
-          write_supporting_files
+          write_sanitized_supporting_files
           File.write("mix.lock", lockfile.content) if lockfile
           FileUtils.cp(elixir_helper_parse_deps_path, "parse_deps.exs")
 
@@ -73,7 +73,7 @@ module Dependabot
         end
       end
 
-      def write_supporting_files
+      def write_sanitized_supporting_files
         dependency_files.select(&:support_file).each do |file|
           path = file.name
           FileUtils.mkdir_p(Pathname.new(path).dirname)

--- a/hex/lib/dependabot/hex/file_updater/lockfile_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater/lockfile_updater.rb
@@ -66,7 +66,7 @@ module Dependabot
           dependency_files.select(&:support_file).each do |file|
             path = file.name
             FileUtils.mkdir_p(Pathname.new(path).dirname)
-            File.write(path, file.content)
+            File.write(path, sanitize_mixfile(file.content))
           end
         end
 

--- a/hex/lib/dependabot/hex/update_checker/version_resolver.rb
+++ b/hex/lib/dependabot/hex/update_checker/version_resolver.rb
@@ -133,12 +133,7 @@ module Dependabot
           files.each do |file|
             path = file.name
             FileUtils.mkdir_p(Pathname.new(path).dirname)
-
-            if file.name.end_with?("mix.exs")
-              File.write(path, sanitize_mixfile(file.content))
-            else
-              File.write(path, file.content)
-            end
+            File.write(path, sanitize_mixfile(file.content))
           end
         end
 

--- a/hex/lib/dependabot/hex/update_checker/version_resolver.rb
+++ b/hex/lib/dependabot/hex/update_checker/version_resolver.rb
@@ -31,7 +31,7 @@ module Dependabot
         def fetch_latest_resolvable_version
           latest_resolvable_version =
             SharedHelpers.in_a_temporary_directory do
-              write_temporary_dependency_files
+              write_temporary_sanitized_dependency_files
               FileUtils.cp(
                 elixir_helper_check_update_path,
                 "check_update.exs"
@@ -109,7 +109,7 @@ module Dependabot
 
         def check_original_requirements_resolvable
           SharedHelpers.in_a_temporary_directory do
-            write_temporary_dependency_files(prepared: false)
+            write_temporary_sanitized_dependency_files(prepared: false)
             FileUtils.cp(
               elixir_helper_check_update_path,
               "check_update.exs"
@@ -125,7 +125,7 @@ module Dependabot
           raise Dependabot::DependencyFileNotResolvable, e.message
         end
 
-        def write_temporary_dependency_files(prepared: true)
+        def write_temporary_sanitized_dependency_files(prepared: true)
           files = if prepared then prepared_dependency_files
                   else original_dependency_files
                   end

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -314,6 +314,21 @@ RSpec.describe Dependabot::Hex::FileParser do
       its(:length) { is_expected.to eq(2) }
     end
 
+    context "with a call to read a version file in a support file" do
+      let(:mixfile_fixture_name) { "loads_file_with_require" }
+      let(:lockfile_fixture_name) { "exact_version" }
+      let(:files) { [mixfile, lockfile, support_file] }
+      let(:support_file) do
+        Dependabot::DependencyFile.new(
+          name: "module_version.ex",
+          content: fixture("support_files", "module_version"),
+          support_file: true
+        )
+      end
+
+      its(:length) { is_expected.to eq(2) }
+    end
+
     context "with a call to eval a support file" do
       let(:mixfile_fixture_name) { "loads_file_with_eval" }
       let(:lockfile_fixture_name) { "exact_version" }

--- a/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
@@ -220,6 +220,26 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
       end
     end
 
+    context "with a mix.exs that opens another file in a required file" do
+      let(:mixfile_fixture_name) { "loads_file_with_require" }
+      let(:lockfile_fixture_name) { "exact_version" }
+      let(:files) { [mixfile, lockfile, support_file] }
+      let(:support_file) do
+        Dependabot::DependencyFile.new(
+          name: "module_version.ex",
+          content: fixture("support_files", "module_version"),
+          support_file: true
+        )
+      end
+
+      it "updates the dependency version in the lockfile" do
+        expect(updated_lockfile_content).to include %({:hex, :plug, "1.4.3")
+        expect(updated_lockfile_content).to include(
+          "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed"
+        )
+      end
+    end
+
     context "with an umbrella app" do
       let(:mixfile_fixture_name) { "umbrella" }
       let(:lockfile_fixture_name) { "umbrella" }

--- a/hex/spec/dependabot/hex/update_checker/version_resolver_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker/version_resolver_spec.rb
@@ -79,6 +79,23 @@ RSpec.describe Dependabot::Hex::UpdateChecker::VersionResolver do
       expect(latest_resolvable_version).to be < Gem::Version.new("1.4.0")
     end
 
+    context "with a call to read a version file in a support file" do
+      let(:mixfile_fixture_name) { "loads_file_with_require" }
+      let(:original_files) { [mixfile, lockfile, support_file] }
+      let(:prepared_files) { [sanitized_mixfile, lockfile, support_file] }
+      let(:support_file) do
+        Dependabot::DependencyFile.new(
+          name: "module_version.ex",
+          content: fixture("support_files", "module_version"),
+          support_file: true
+        )
+      end
+
+      it "still finds a resolvable version" do
+        expect(latest_resolvable_version).not_to be_nil
+      end
+    end
+
     context "with a dependency with a bad specification" do
       let(:mixfile_fixture_name) { "bad_spec" }
 

--- a/hex/spec/fixtures/mixfiles/loads_file_with_require
+++ b/hex/spec/fixtures/mixfiles/loads_file_with_require
@@ -1,0 +1,26 @@
+defmodule DependabotTest.Mixfile do
+  use Mix.Project
+
+  Code.require_file("./module_version.ex")
+
+  def project do
+    [
+      app: :dependabot_test,
+      version: DependabotTest.Version.version(),
+      elixir: "~> 1.5",
+      start_permanent: Mix.env == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:plug, "1.3.0"},
+      {:phoenix, "== 1.2.1"}
+    ]
+  end
+end

--- a/hex/spec/fixtures/support_files/module_version
+++ b/hex/spec/fixtures/support_files/module_version
@@ -1,0 +1,5 @@
+defmodule DependabotTest.Version do
+  def version() do
+    String.trim(File.read!("VERSION"))
+  end
+end


### PR DESCRIPTION
Currently you get an error if you try and read say a version file in a supporting file in an Elixir project. This is handled in the mixfile proper by stubbing out the call to read a file with just a standard string. This PR extends this behavior to supporting files as well. I have also added a test for this as well.