### PR TITLE
Fix: Use consistent names

### DIFF
--- a/composer/spec/dependabot/composer/file_fetcher/path_dependency_builder_spec.rb
+++ b/composer/spec/dependabot/composer/file_fetcher/path_dependency_builder_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Dependabot::Composer::FileFetcher::PathDependencyBuilder do
     described_class.new(
       path: path,
       directory: directory,
-      lockfile: composer_lock
+      lockfile: lockfile
     )
   end
 
   let(:path) { "components/path_dep" }
   let(:directory) { "/" }
-  let(:composer_lock) do
+  let(:lockfile) do
     Dependabot::DependencyFile.new(
       name: "composer.lock",
       content: fixture("lockfiles", lockfile_fixture_name)
@@ -29,7 +29,7 @@ RSpec.describe Dependabot::Composer::FileFetcher::PathDependencyBuilder do
     subject(:dependency_file) { builder.dependency_file }
 
     context "with a lockfile" do
-      let(:composer_lock) do
+      let(:lockfile) do
         Dependabot::DependencyFile.new(
           name: "composer.lock",
           content: fixture("lockfiles", lockfile_fixture_name)
@@ -52,7 +52,7 @@ RSpec.describe Dependabot::Composer::FileFetcher::PathDependencyBuilder do
     end
 
     context "without a lockfile" do
-      let(:composer_lock) { nil }
+      let(:lockfile) { nil }
       it { is_expected.to be_nil }
     end
   end

--- a/composer/spec/dependabot/composer/file_parser_spec.rb
+++ b/composer/spec/dependabot/composer/file_parser_spec.rb
@@ -9,8 +9,8 @@ require_common_spec "file_parsers/shared_examples_for_file_parsers"
 RSpec.describe Dependabot::Composer::FileParser do
   it_behaves_like "a dependency file parser"
 
-  let(:files) { [composer_json, lockfile] }
-  let(:composer_json) do
+  let(:files) { [manifest, lockfile] }
+  let(:manifest) do
     Dependabot::DependencyFile.new(
       name: "composer.json",
       content: composer_json_body
@@ -23,10 +23,10 @@ RSpec.describe Dependabot::Composer::FileParser do
     )
   end
   let(:composer_json_body) do
-    fixture("composer_files", composer_json_fixture_name)
+    fixture("composer_files", manifest_fixture_name)
   end
   let(:lockfile_body) { fixture("lockfiles", lockfile_fixture_name) }
-  let(:composer_json_fixture_name) { "minor_version" }
+  let(:manifest_fixture_name) { "minor_version" }
   let(:lockfile_fixture_name) { "minor_version" }
   let(:parser) { described_class.new(dependency_files: files, source: source) }
   let(:source) do
@@ -71,7 +71,7 @@ RSpec.describe Dependabot::Composer::FileParser do
     end
 
     context "with an integer version" do
-      let(:composer_json_fixture_name) { "integer_version" }
+      let(:manifest_fixture_name) { "integer_version" }
       let(:lockfile_fixture_name) { "integer_version" }
 
       describe "the first dependency" do
@@ -86,7 +86,7 @@ RSpec.describe Dependabot::Composer::FileParser do
     end
 
     context "for development dependencies" do
-      let(:composer_json_fixture_name) { "development_dependencies" }
+      let(:manifest_fixture_name) { "development_dependencies" }
       let(:lockfile_fixture_name) { "development_dependencies" }
 
       it "includes development dependencies" do
@@ -116,7 +116,7 @@ RSpec.describe Dependabot::Composer::FileParser do
     end
 
     context "with the PHP version specified" do
-      let(:composer_json_fixture_name) { "php_specified" }
+      let(:manifest_fixture_name) { "php_specified" }
       let(:lockfile_fixture_name) { "php_specified" }
 
       its(:length) { is_expected.to eq(5) }
@@ -128,7 +128,7 @@ RSpec.describe Dependabot::Composer::FileParser do
     end
 
     context "with subdependencies" do
-      let(:composer_json_fixture_name) { "development_subdependencies" }
+      let(:manifest_fixture_name) { "development_subdependencies" }
       let(:lockfile_fixture_name) { "development_subdependencies" }
 
       its(:length) { is_expected.to eq(16) }
@@ -170,7 +170,7 @@ RSpec.describe Dependabot::Composer::FileParser do
     end
 
     context "with a git dependency" do
-      let(:composer_json_fixture_name) { "git_source" }
+      let(:manifest_fixture_name) { "git_source" }
       let(:lockfile_fixture_name) { "git_source" }
 
       it "includes the dependency" do
@@ -202,7 +202,7 @@ RSpec.describe Dependabot::Composer::FileParser do
         end
 
         context "specified as an alias" do
-          let(:composer_json_fixture_name) { "git_source_alias" }
+          let(:manifest_fixture_name) { "git_source_alias" }
 
           its(:requirements) do
             is_expected.to eq(
@@ -224,7 +224,7 @@ RSpec.describe Dependabot::Composer::FileParser do
         context "due to a stability flag" do
           subject { dependencies.last }
 
-          let(:composer_json_fixture_name) { "git_source_transitive" }
+          let(:manifest_fixture_name) { "git_source_transitive" }
           let(:lockfile_fixture_name) { "git_source_transitive" }
 
           its(:requirements) do
@@ -255,8 +255,8 @@ RSpec.describe Dependabot::Composer::FileParser do
     end
 
     context "with a path dependency" do
-      let(:files) { [composer_json, lockfile, path_dep] }
-      let(:composer_json_fixture_name) { "path_source" }
+      let(:files) { [manifest, lockfile, path_dep] }
+      let(:manifest_fixture_name) { "path_source" }
       let(:lockfile_fixture_name) { "path_source" }
       let(:path_dep) do
         Dependabot::DependencyFile.new(
@@ -285,7 +285,7 @@ RSpec.describe Dependabot::Composer::FileParser do
     end
 
     context "without a lockfile" do
-      let(:files) { [composer_json] }
+      let(:files) { [manifest] }
 
       its(:length) { is_expected.to eq(2) }
 
@@ -308,7 +308,7 @@ RSpec.describe Dependabot::Composer::FileParser do
       end
 
       context "for development dependencies" do
-        let(:composer_json_fixture_name) { "development_dependencies" }
+        let(:manifest_fixture_name) { "development_dependencies" }
 
         it "includes development dependencies" do
           expect(dependencies.length).to eq(2)
@@ -334,12 +334,12 @@ RSpec.describe Dependabot::Composer::FileParser do
       end
 
       context "with the PHP version specified" do
-        let(:composer_json_fixture_name) { "php_specified" }
+        let(:manifest_fixture_name) { "php_specified" }
         its(:length) { is_expected.to eq(2) }
       end
 
       context "with a git dependency" do
-        let(:composer_json_fixture_name) { "git_source" }
+        let(:manifest_fixture_name) { "git_source" }
 
         it "includes the dependency" do
           expect(dependencies.length).to eq(2)

--- a/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Dependabot::Composer::FileUpdater::LockfileUpdater do
       "password" => "token"
     }]
   end
-  let(:files) { [composer_json, lockfile] }
-  let(:composer_json) do
+  let(:files) { [manifest, lockfile] }
+  let(:manifest) do
     Dependabot::DependencyFile.new(
       name: "composer.json",
       content: fixture("composer_files", manifest_fixture_name)
@@ -280,7 +280,7 @@ RSpec.describe Dependabot::Composer::FileUpdater::LockfileUpdater do
     end
 
     context "with a path source" do
-      let(:files) { [composer_json, lockfile, path_dep] }
+      let(:files) { [manifest, lockfile, path_dep] }
       let(:manifest_fixture_name) { "path_source" }
       let(:lockfile_fixture_name) { "path_source" }
       let(:path_dep) do

--- a/composer/spec/dependabot/composer/file_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Dependabot::Composer::FileUpdater do
       "host" => "github.com"
     }]
   end
-  let(:files) { [composer_json, lockfile] }
-  let(:composer_json) do
+  let(:files) { [manifest, lockfile] }
+  let(:manifest) do
     Dependabot::DependencyFile.new(
       name: "composer.json",
       content: fixture("composer_files", manifest_fixture_name)
@@ -83,7 +83,7 @@ RSpec.describe Dependabot::Composer::FileUpdater do
     end
 
     describe "the updated composer_file" do
-      let(:files) { [composer_json] }
+      let(:files) { [manifest] }
       subject(:updated_manifest_content) do
         updated_files.find { |f| f.name == "composer.json" }.content
       end
@@ -101,7 +101,7 @@ RSpec.describe Dependabot::Composer::FileUpdater do
         it "includes the new requirement" do
           expect(described_class::ManifestUpdater).
             to receive(:new).
-            with(dependencies: [dependency], manifest: composer_json).
+            with(dependencies: [dependency], manifest: manifest).
             and_call_original
 
           expect(updated_manifest_content).

--- a/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
       "password" => "token"
     }]
   end
-  let(:files) { [composer_file, lockfile] }
-  let(:composer_file) do
+  let(:files) { [manifest, lockfile] }
+  let(:manifest) do
     Dependabot::DependencyFile.new(
       content: fixture("composer_files", manifest_fixture_name),
       name: "composer.json"
@@ -114,7 +114,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
     end
 
     context "without a lockfile" do
-      let(:files) { [composer_file] }
+      let(:files) { [manifest] }
       it { is_expected.to eq(Gem::Version.new("1.22.1")) }
 
       context "when using a pre-release" do
@@ -302,7 +302,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
               "password" => "token"
             }]
           end
-          let(:files) { [composer_file, lockfile, auth_json] }
+          let(:files) { [manifest, lockfile, auth_json] }
           let(:auth_json) do
             Dependabot::DependencyFile.new(
               content: fixture("auth_jsons", auth_json_fixture_name),

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
       "password" => "token"
     }]
   end
-  let(:files) { [composer_file, lockfile] }
-  let(:composer_file) do
+  let(:files) { [manifest, lockfile] }
+  let(:manifest) do
     Dependabot::DependencyFile.new(
       content: fixture("composer_files", manifest_fixture_name),
       name: "composer.json"
@@ -113,7 +113,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     end
 
     context "with a path source" do
-      let(:files) { [composer_file, lockfile, path_dep] }
+      let(:files) { [manifest, lockfile, path_dep] }
       let(:manifest_fixture_name) { "path_source" }
       let(:lockfile_fixture_name) { "path_source" }
       let(:path_dep) do
@@ -148,7 +148,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     end
 
     context "with a git dependency" do
-      let(:files) { [composer_file, lockfile] }
+      let(:files) { [manifest, lockfile] }
       let(:manifest_fixture_name) { "git_source" }
       let(:lockfile_fixture_name) { "git_source" }
 
@@ -236,7 +236,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     end
 
     context "without a lockfile" do
-      let(:files) { [composer_file] }
+      let(:files) { [manifest] }
       it { is_expected.to be >= Gem::Version.new("1.22.0") }
 
       context "when there are conflicts at the version specified" do
@@ -314,7 +314,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     end
 
     context "with a path source" do
-      let(:files) { [composer_file, lockfile, path_dep] }
+      let(:files) { [manifest, lockfile, path_dep] }
       let(:manifest_fixture_name) { "path_source" }
       let(:lockfile_fixture_name) { "path_source" }
       let(:path_dep) do
@@ -452,7 +452,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
 
     context "with a replaced direct dependency" do
       let(:manifest_fixture_name) { "replaced_direct_dependency" }
-      let(:files) { [composer_file] }
+      let(:files) { [manifest] }
       let(:dependency_name) { "neos/flow" }
       let(:dependency_version) { nil }
       let(:requirements) do
@@ -518,7 +518,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     end
 
     context "with a version conflict in the current files" do
-      let(:files) { [composer_file, lockfile] }
+      let(:files) { [manifest, lockfile] }
       let(:manifest_fixture_name) { "version_conflict" }
       let(:dependency_name) { "monolog/monolog" }
       let(:dependency_version) { "2.1.5" }
@@ -534,7 +534,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
       it { is_expected.to be_nil }
 
       context "and there is no lockfile" do
-        let(:files) { [composer_file] }
+        let(:files) { [manifest] }
 
         it "raises a resolvability error" do
           expect { latest_resolvable_version }.
@@ -544,7 +544,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     end
 
     context "with an update that can't resolve" do
-      let(:files) { [composer_file, lockfile] }
+      let(:files) { [manifest, lockfile] }
       let(:manifest_fixture_name) { "version_conflict_on_update" }
       let(:lockfile_fixture_name) { "version_conflict_on_update" }
       let(:dependency_name) { "longman/telegram-bot" }
@@ -561,13 +561,13 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
       it { is_expected.to be_nil }
 
       context "and there is no lockfile" do
-        let(:files) { [composer_file] }
+        let(:files) { [manifest] }
 
         it { is_expected.to be_nil }
 
         context "and the conflict comes from a loose PHP version" do
           let(:manifest_fixture_name) { "version_conflict_library" }
-          let(:files) { [composer_file] }
+          let(:files) { [manifest] }
 
           it { is_expected.to be_nil }
         end


### PR DESCRIPTION
This PR

* [x] uses consistent naming across specifications for `composer`

Related to #2741.

💁‍♂️ I believe using consistent naming here will make it easier to split out the scenarios - what do you think?