### PR TITLE
fix incorrect spec and mixfile fixture

### DIFF
--- a/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
@@ -199,10 +199,8 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
     end
 
     context "with a mix.exs that evals another file" do
-      let(:mixfile_body) do
-        fixture("mixfiles", "loads_file_with_eval")
-      end
-      let(:lockfile_body) { fixture("lockfiles", "exact_version") }
+      let(:mixfile_fixture_name) { "loads_file_with_eval" }
+      let(:lockfile_fixture_name) { "exact_version" }
       let(:files) { [mixfile, lockfile, support_file] }
       let(:support_file) do
         Dependabot::DependencyFile.new(

--- a/hex/spec/fixtures/mixfiles/diverging_environments
+++ b/hex/spec/fixtures/mixfiles/diverging_environments
@@ -18,7 +18,7 @@ defmodule DependabotTest.Mixfile do
   defp deps do
     [
       {:poison, "~> 3.0", only: :test},
-      {:credo, "~> 0.6", "< 0.10.0", only: [:dev, :test]}
+      {:credo, ">= 0.6.0 and < 0.10.0", only: [:dev, :test]}
     ]
   end
 end


### PR DESCRIPTION
I came across this spec that was setting the wrong let variables, and thus wasn't being run properly.

The mixfile was syntactically invalid, so I fixed it.