### PR TITLE
JS: Prefer the npm conflicting dependency parser

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/conflicting_dependency_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/conflicting_dependency_resolver.rb
@@ -36,16 +36,22 @@ module Dependabot
             )
             dependency_files_builder.write_temporary_dependency_files
 
-            if dependency_files_builder.yarn_locks.any?
+            # TODO: Look into using npm/arborist for parsing yarn lockfiles (there's currently partial yarn support)
+            #
+            # Prefer the npm conflicting dependency parser if there's both a npm lockfile and a yarn.lock file as the
+            # npm parser handles edge cases where the package.json is out of sync with the lockfile, something the yarn
+            # parser doesn't deal with at the moment.
+            if dependency_files_builder.package_locks.any? ||
+               dependency_files_builder.shrinkwraps.any?
               SharedHelpers.run_helper_subprocess(
                 command: NativeHelpers.helper_path,
-                function: "yarn:findConflictingDependencies",
+                function: "npm:findConflictingDependencies",
                 args: [Dir.pwd, dependency.name, target_version.to_s]
               )
             else
               SharedHelpers.run_helper_subprocess(
                 command: NativeHelpers.helper_path,
-                function: "npm:findConflictingDependencies",
+                function: "yarn:findConflictingDependencies",
                 args: [Dir.pwd, dependency.name, target_version.to_s]
               )
             end


### PR DESCRIPTION
Prefer the npm conflicting dependency parser when there's both a yarn.lock and a package-lock.json file.

The npm parser handles edge cases where the package.json is out of sync with the lockfile, something the yarn parser doesn't deal with at the moment.