### PR TITLE
go_modules: clean build cache

### DIFF
--- a/go_modules/helpers/build
+++ b/go_modules/helpers/build
@@ -24,3 +24,4 @@ os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 echo "building $install_dir/bin/helper"
 
 GO111MODULE=on GOOS="$os" GOARCH=amd64 go build -o "$install_dir/bin/helper" .
+go clean -cache -modcache


### PR DESCRIPTION
Invoke the [go clean](https://golang.org/pkg/cmd/go/internal/clean/) command after building modules, to remove the helper's dependency sources from the tree.

This frees 11MB from the final docker image, and reduces the files any subsequent [`chown`](https://github.com/dependabot/dependabot-core/blob/main/Dockerfile.development#L23) steps have to update.

<details><summary>pre-disk usage</summary>
<p>

```
[dependabot-core-dev] /opt/go/gopath $ du pkg/
12	pkg/mod/golang.org/x/xerrors@v0.0.0-20191011141410-1b5146add898/internal
116	pkg/mod/golang.org/x/xerrors@v0.0.0-20191011141410-1b5146add898
32	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/hkdf
148	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/ed25519/internal/edwards25519
156	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/ed25519/internal
60	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/ed25519/testdata
248	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/ed25519
48	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/blowfish
96	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/ssh/agent
72	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/ssh/terminal
76	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/ssh/test
36	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/ssh/knownhosts
28	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/ssh/testdata
772	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/ssh
28	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/bcrypt
32	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/twofish
172	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/blake2s
540	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/sha3/testdata
656	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/sha3
60	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/argon2
16	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/tea
16	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/pbkdf2
192	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/blake2b
12	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/cryptobyte/asn1
88	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/cryptobyte
28	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/acme/autocert/internal/acmetest
36	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/acme/autocert/internal
156	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/acme/autocert
24	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/acme/internal/acmeprobe
32	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/acme/internal
380	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/acme
84	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/ocsp
24	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/pkcs12/internal/rc2
32	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/pkcs12/internal
108	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/pkcs12
64	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/salsa20/salsa
80	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/salsa20
292	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/poly1305
24	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/xtea
28	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/scrypt
48	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/cast5
156	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/internal/chacha20
20	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/internal/subtle
184	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/internal
460	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/chacha20poly1305
80	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/otr
104	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/curve25519
80	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/bn256
240	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/openpgp/packet
16	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/openpgp/elgamal
12	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/openpgp/errors
32	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/openpgp/clearsign
24	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/openpgp/armor
20	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/openpgp/s2k
508	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/openpgp
24	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/ripemd160
28	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/xts
24	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/md4
16	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/nacl/sign
20	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/nacl/box
24	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/nacl/auth
24	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/nacl/secretbox
92	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550/nacl
5040	pkg/mod/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550
24	pkg/mod/golang.org/x/mod@v0.3.0/semver
52	pkg/mod/golang.org/x/mod@v0.3.0/sumdb/note
64	pkg/mod/golang.org/x/mod@v0.3.0/sumdb/tlog
16	pkg/mod/golang.org/x/mod@v0.3.0/sumdb/dirhash
24	pkg/mod/golang.org/x/mod@v0.3.0/sumdb/storage
220	pkg/mod/golang.org/x/mod@v0.3.0/sumdb
56	pkg/mod/golang.org/x/mod@v0.3.0/zip/testdata/create_from_dir
68	pkg/mod/golang.org/x/mod@v0.3.0/zip/testdata/unzip
68	pkg/mod/golang.org/x/mod@v0.3.0/zip/testdata/create
200	pkg/mod/golang.org/x/mod@v0.3.0/zip/testdata
272	pkg/mod/golang.org/x/mod@v0.3.0/zip
44	pkg/mod/golang.org/x/mod@v0.3.0/module
56	pkg/mod/golang.org/x/mod@v0.3.0/modfile/testdata
140	pkg/mod/golang.org/x/mod@v0.3.0/modfile
24	pkg/mod/golang.org/x/mod@v0.3.0/gosumcheck
12	pkg/mod/golang.org/x/mod@v0.3.0/internal/lazyregexp
20	pkg/mod/golang.org/x/mod@v0.3.0/internal
776	pkg/mod/golang.org/x/mod@v0.3.0
5940	pkg/mod/golang.org/x
5948	pkg/mod/golang.org
12	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/script
84	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/_internal_/objabi
28	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/_internal_/buildid
12	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/_internal_/browser
16	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/_internal_/sys
148	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/_internal_
52	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/modconv
184	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/modload
24	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/mvs
12	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/renameio
16	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/par
28	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/cfg
12	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/modinfo
32	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/web
24	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/robustio
28	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/search
72	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/modfetch/codehost
228	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/modfetch
16	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/str
16	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/auth
44	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/base
244	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/work
16	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/lockedfile/_internal_/filelock
24	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/lockedfile/_internal_
48	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/lockedfile
124	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/load
76	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/get
32	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/imports
40	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_/cache
1288	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go/_internal_
1296	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd/go
1456	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/cmd
48	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/_internal_/xcoff
12	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/_internal_/lazyregexp
12	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/_internal_/singleflight
12	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/_internal_/cfg
12	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/_internal_/goroot
12	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/_internal_/lazytemplate
120	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0/_internal_
1608	pkg/mod/github.com/dependabot/gomodules-extracted@v1.2.0
1616	pkg/mod/github.com/dependabot
180	pkg/mod/github.com/!masterminds/vcs@v1.13.1
180	pkg/mod/github.com/!masterminds/vcs@v1.12.0
368	pkg/mod/github.com/!masterminds
1992	pkg/mod/github.com
48	pkg/mod/cache/download/golang.org/x/xerrors/@v
56	pkg/mod/cache/download/golang.org/x/xerrors
1832	pkg/mod/cache/download/golang.org/x/crypto/@v
1840	pkg/mod/cache/download/golang.org/x/crypto
16	pkg/mod/cache/download/golang.org/x/tools/@v
24	pkg/mod/cache/download/golang.org/x/tools
152	pkg/mod/cache/download/golang.org/x/mod/@v
160	pkg/mod/cache/download/golang.org/x/mod
20	pkg/mod/cache/download/golang.org/x/sys/@v
28	pkg/mod/cache/download/golang.org/x/sys
16	pkg/mod/cache/download/golang.org/x/sync/@v
24	pkg/mod/cache/download/golang.org/x/sync
20	pkg/mod/cache/download/golang.org/x/net/@v
28	pkg/mod/cache/download/golang.org/x/net
16	pkg/mod/cache/download/golang.org/x/text/@v
24	pkg/mod/cache/download/golang.org/x/text
2192	pkg/mod/cache/download/golang.org/x
2200	pkg/mod/cache/download/golang.org
408	pkg/mod/cache/download/github.com/dependabot/gomodules-extracted/@v
416	pkg/mod/cache/download/github.com/dependabot/gomodules-extracted
424	pkg/mod/cache/download/github.com/dependabot
124	pkg/mod/cache/download/github.com/!masterminds/vcs/@v
132	pkg/mod/cache/download/github.com/!masterminds/vcs
140	pkg/mod/cache/download/github.com/!masterminds
572	pkg/mod/cache/download/github.com
2780	pkg/mod/cache/download
2788	pkg/mod/cache
10736	pkg/mod
10744	pkg/
```

</p>
</details> 