### PR TITLE
Add dependency names and count to dry run

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -450,16 +450,18 @@ def security_fix?(dependency)
   end
 end
 
-puts "=> updating #{dependencies.count} dependencies"
+puts "=> updating #{dependencies.count} dependencies: #{dependencies.map(&:name).join(", ")}"
 
 # rubocop:disable Metrics/BlockLength
+checker_count = 0
 dependencies.each do |dep|
+  checker_count += 1
   checker = update_checker_for(dep)
   name_version = "\n=== #{dep.name} (#{dep.version})"
   vulnerable = checker.vulnerable? ? " (vulnerable 🚨)" : ""
   puts name_version + vulnerable
 
-  puts " => checking for updates"
+  puts " => checking for updates #{checker_count}/#{dependencies.count}"
   puts " => latest available version is #{checker.latest_version}"
 
   if $options[:security_updates_only] && !checker.vulnerable?

--- a/bundler/helpers/lib/functions/force_updater.rb
+++ b/bundler/helpers/lib/functions/force_updater.rb
@@ -19,14 +19,14 @@ module Functions
         true
       )
 
-      other_updates = []
+      dependencies_to_unlock = []
 
       begin
-        definition = build_definition(other_updates: other_updates)
+        definition = build_definition(dependencies_to_unlock: dependencies_to_unlock)
         definition.resolve_remotely!
         specs = definition.resolve
         updates = [{ name: dependency_name }] +
-                  other_updates.map { |dep| { name: dep.name } }
+                  dependencies_to_unlock.map { |dep| { name: dep.name } }
         specs = specs.map do |dep|
           {
             name: dep.name,
@@ -41,12 +41,12 @@ module Functions
         new_dependencies_to_unlock =
           new_dependencies_to_unlock_from(
             error: e,
-            already_unlocked: other_updates
+            already_unlocked: dependencies_to_unlock
           )
 
         raise if new_dependencies_to_unlock.none?
 
-        other_updates += new_dependencies_to_unlock
+        dependencies_to_unlock += new_dependencies_to_unlock
         retry
       end
     end
@@ -98,8 +98,8 @@ module Functions
         end
     end
 
-    def build_definition(other_updates:)
-      gems_to_unlock = other_updates.map(&:name) + [dependency_name]
+    def build_definition(dependencies_to_unlock:)
+      gems_to_unlock = dependencies_to_unlock.map(&:name) + [dependency_name]
       definition = Bundler::Definition.build(
         gemfile_name,
         lockfile_name,


### PR DESCRIPTION
Add dependency names and count to dry run:

```
=> updating 4 dependencies: aws-sdk, vcr, webdrivers, webmock
=== aws-sdk (2.1.0)
 => checking for updates 1/4
...
```

Renamed a variable in the bundler force updater to clarify intent.