### PR TITLE
v0.125.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.125.5, 25 November 2020
+
+- go_modules: raise Dependabot::GitDependenciesNotReachable for dependencies missing from github.com
+- JS: Prefer the npm conflicting dependency parser
+- Clean go_modules build cache in dependabot/dependabot-core docker image
+- Check Azure PR description against utf-16 encoded length
+- Bump @npmcli/arborist from 1.0.10 to 1.0.12 in /npm_and_yarn/helpers
+- Bump npm from 6.14.8 to 6.14.9 in /npm_and_yarn/helpers
+- Bump eslint from 7.12.1 to 7.14.0 in /npm_and_yarn/helpers
+
 ## v0.125.4, 17 November 2020
 
 - Yarn: Explain conflicting top-level dependency

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.125.4"
+  VERSION = "0.125.5"
 end


### PR DESCRIPTION
Release notes for `v0.125.5`.

Included:
* https://github.com/dependabot/dependabot-core/pull/2775
* https://github.com/dependabot/dependabot-core/pull/2752
* https://github.com/dependabot/dependabot-core/pull/2781
* https://github.com/dependabot/dependabot-core/pull/2782
* https://github.com/dependabot/dependabot-core/pull/2780
* https://github.com/dependabot/dependabot-core/pull/2788

Full diff: https://github.com/dependabot/dependabot-core/compare/v0.125.4...v0.125.5-release-notes