### PR TITLE
JS: Handle rate limited npm package requests

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -361,7 +361,9 @@ module Dependabot
               idempotent: true,
               **SharedHelpers.excon_defaults
             )
-            return web_response.body.include?("Forgot password?")
+            # Note: returns 429 when the login page is rate limited
+            return web_response.body.include?("Forgot password?") ||
+                   web_response.status == 429
           end
 
           true

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
@@ -267,7 +267,31 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
             to_return(status: 200, body: login_form)
         end
 
-        it "raises a to Dependabot::PrivateSourceAuthenticationFailure error" do
+        it "raises a Dependabot::PrivateSourceAuthenticationFailure error" do
+          error_class = Dependabot::PrivateSourceAuthenticationFailure
+          expect { version_finder.latest_version_from_registry }.
+            to raise_error(error_class) do |error|
+              expect(error.source).to eq("registry.npmjs.org")
+            end
+        end
+      end
+
+      context "when the login page is rate limited" do
+        let(:credentials) do
+          [{
+            "type" => "git_source",
+            "host" => "github.com",
+            "username" => "x-access-token",
+            "password" => "token"
+          }]
+        end
+
+        before do
+          stub_request(:get, "https://www.npmjs.com/package/@blep/blep").
+            to_return(status: 429, body: "")
+        end
+
+        it "raises a Dependabot::PrivateSourceAuthenticationFailure error" do
           error_class = Dependabot::PrivateSourceAuthenticationFailure
           expect { version_finder.latest_version_from_registry }.
             to raise_error(error_class) do |error|


### PR DESCRIPTION
When checking if a package is private dependabot makes a request to the
package url, e.g. https://www.npmjs.com/package/express and if this
redirects to the login page it is assumed it is private so we show a
custom PrivateSourceAuthenticationFailure. This request can become rate
limited in which case it returns a 429.