### PR TITLE
Fix dependabot-core-ci build by removing buildkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
           - omnibus
           - python
           - terraform
-    env:
-      DOCKER_BUILDKIT: 1
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -62,14 +60,13 @@ jobs:
             "$CORE_CI_IMAGE:latest" || true
       - name: Build dependabot-core image
         run: |
-          docker build \
+          DOCKER_BUILDKIT=1 docker build \
             -t "$CORE_IMAGE:latest" \
             -t "$CORE_CI_IMAGE:core--$BRANCH_REF" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --cache-from "$BASE_IMAGE" \
             --cache-from "$CORE_CI_IMAGE:core--$BRANCH_REF" \
             --cache-from "$CORE_IMAGE:latest" \
-            --memory 4g \
             .
       - name: Push dependabot-core image to Docker registry
         if: env.DOCKER_LOGGED_IN == 'true'
@@ -82,11 +79,8 @@ jobs:
             -t "$CORE_CI_IMAGE:latest" \
             -t "$CORE_CI_IMAGE:ci--$BRANCH_REF" \
             -f Dockerfile.ci \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from "$BASE_IMAGE" \
             --cache-from "$CORE_CI_IMAGE:latest" \
             --cache-from "$CORE_CI_IMAGE:ci--$BRANCH_REF" \
-            --memory 4g \
             .
       - name: Push dependabot-core-ci image to Docker registry
         if: env.DOCKER_LOGGED_IN == 'true'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,6 @@ jobs:
           docker build \
             -t "dependabot/dependabot-core:latest" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --memory 4g \
             .
       - name: Log in to the Docker registry
         run: |

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -28,6 +28,45 @@ RUN mkdir -p \
   ${CODE_DIR}/python \
   ${CODE_DIR}/terraform
 
+COPY common/lib/dependabot/version.rb ${CODE_DIR}/common/lib/dependabot/version.rb
+COPY common/Gemfile common/dependabot-common.gemspec ${CODE_DIR}/common/
+COPY bundler/Gemfile bundler/dependabot-bundler.gemspec ${CODE_DIR}/bundler/
+COPY cargo/Gemfile cargo/dependabot-cargo.gemspec ${CODE_DIR}/cargo/
+COPY composer/Gemfile composer/dependabot-composer.gemspec ${CODE_DIR}/composer/
+COPY dep/Gemfile dep/dependabot-dep.gemspec ${CODE_DIR}/dep/
+COPY docker/Gemfile docker/dependabot-docker.gemspec ${CODE_DIR}/docker/
+COPY elm/Gemfile elm/dependabot-elm.gemspec ${CODE_DIR}/elm/
+COPY git_submodules/Gemfile git_submodules/dependabot-git_submodules.gemspec ${CODE_DIR}/git_submodules/
+COPY github_actions/Gemfile github_actions/dependabot-github_actions.gemspec ${CODE_DIR}/github_actions/
+COPY go_modules/Gemfile go_modules/dependabot-go_modules.gemspec ${CODE_DIR}/go_modules/
+COPY gradle/Gemfile gradle/dependabot-gradle.gemspec ${CODE_DIR}/gradle/
+COPY hex/Gemfile hex/dependabot-hex.gemspec ${CODE_DIR}/hex/
+COPY maven/Gemfile maven/dependabot-maven.gemspec ${CODE_DIR}/maven/
+COPY npm_and_yarn/Gemfile npm_and_yarn/dependabot-npm_and_yarn.gemspec ${CODE_DIR}/npm_and_yarn/
+COPY nuget/Gemfile nuget/dependabot-nuget.gemspec ${CODE_DIR}/nuget/
+COPY python/Gemfile python/dependabot-python.gemspec ${CODE_DIR}/python/
+COPY terraform/Gemfile terraform/dependabot-terraform.gemspec ${CODE_DIR}/terraform/
+COPY omnibus/Gemfile omnibus/dependabot-omnibus.gemspec ${CODE_DIR}/omnibus/
+
+RUN cd common && bundle install
+RUN cd bundler && bundle install
+RUN cd cargo && bundle install
+RUN cd composer && bundle install
+RUN cd dep && bundle install
+RUN cd docker && bundle install
+RUN cd elm && bundle install
+RUN cd git_submodules && bundle install
+RUN cd github_actions && bundle install
+RUN cd go_modules && bundle install
+RUN cd gradle && bundle install
+RUN cd hex && bundle install
+RUN cd maven && bundle install
+RUN cd npm_and_yarn && bundle install
+RUN cd nuget && bundle install
+RUN cd python && bundle install
+RUN cd terraform && bundle install
+RUN cd omnibus && bundle install
+
 COPY common/ ${CODE_DIR}/common/
 COPY bundler/ ${CODE_DIR}/bundler/
 COPY cargo/ ${CODE_DIR}/cargo/
@@ -43,23 +82,8 @@ COPY hex/ ${CODE_DIR}/hex/
 COPY maven/ ${CODE_DIR}/maven/
 COPY npm_and_yarn/ ${CODE_DIR}/npm_and_yarn/
 COPY nuget/ ${CODE_DIR}/nuget/
-COPY omnibus/ ${CODE_DIR}/omnibus/
 COPY python/ ${CODE_DIR}/python/
 COPY terraform/ ${CODE_DIR}/terraform/
-
-RUN cd common && bundle install
-
-RUN GREEN='\033[0;32m'; NC='\033[0m'; \
-  for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
-    -not -path "${CODE_DIR}/omnibus/Gemfile" \
-    -not -path "${CODE_DIR}/common/Gemfile" \
-    -name 'Gemfile' | xargs dirname`; do \
-    echo && \
-    echo "---------------------------------------------------------------------------" && \
-    echo "Installing gems for ${GREEN}$(realpath --relative-to=${CODE_DIR} $d)${NC}..." && \
-    echo "---------------------------------------------------------------------------" && \
-    cd $d && bundle install; \
-  done
+COPY omnibus/ ${CODE_DIR}/omnibus/
 
 RUN git config --global user.name dependabot-ci && git config --global user.email no-reply@github.com
-RUN cd omnibus && bundle install


### PR DESCRIPTION
Running docker build for the dependabot-core-ci image was hanging at the
"exporting layers" step after running all the steps in the Dockerfile.

This seems to indicate that docker buildkit is doing a bunch of heavy
lifting/diffing/hashing of the content (lots of bundle files) which is
too memory intensive and causes the docker build command to exit 137
(probably OOM).
