### PR TITLE
Add rubocop config for each language

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           docker push "$CORE_CI_IMAGE:ci--$BRANCH_REF"
       - name: Run Rubocop linting
         run: |
-          docker run --rm "$CORE_CI_IMAGE" bash -c "cd /home/dependabot/dependabot-core/${{ matrix.suite }} && bundle exec rubocop . -c ../.rubocop.yml"
+          docker run --rm "$CORE_CI_IMAGE" bash -c "cd /home/dependabot/dependabot-core/${{ matrix.suite }} && bundle exec rubocop ."
       - name: Run js linting and tests
         if: matrix.suite == 'npm_and_yarn'
         run: |

--- a/bundler/.rubocop.yml
+++ b/bundler/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/cargo/.rubocop.yml
+++ b/cargo/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/common/.rubocop.yml
+++ b/common/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/composer/.rubocop.yml
+++ b/composer/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/dep/.rubocop.yml
+++ b/dep/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/docker/.rubocop.yml
+++ b/docker/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/elm/.rubocop.yml
+++ b/elm/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/git_submodules/.rubocop.yml
+++ b/git_submodules/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/github_actions/.rubocop.yml
+++ b/github_actions/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/go_modules/.rubocop.yml
+++ b/go_modules/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/gradle/.rubocop.yml
+++ b/gradle/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/hex/.rubocop.yml
+++ b/hex/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/maven/.rubocop.yml
+++ b/maven/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/npm_and_yarn/.rubocop.yml
+++ b/npm_and_yarn/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/nuget/.rubocop.yml
+++ b/nuget/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/omnibus/.rubocop.yml
+++ b/omnibus/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/python/.rubocop.yml
+++ b/python/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml

--- a/terraform/.rubocop.yml
+++ b/terraform/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ../.rubocop.yml


### PR DESCRIPTION
At some point rubocop removed support for finding configs in parent
directories and only loads the .rubocop.yml defined in the current
folder so we used to run CI lint with `-c ../.rubocop.yml` but this
breaks editors (e.g. vscode) support as it needs to run rubocop in the
package manager folder.