### PR TITLE
v0.125.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v0.125.7, 30 November 2020
+
+- Bump jest from 26.6.2 to 26.6.3 in /npm_and_yarn/helpers
+- Bump prettier from 2.1.2 to 2.2.1 in /npm_and_yarn/helpers
+- Bump @npmcli/arborist from 1.0.12 to 1.0.13 in /npm_and_yarn/helpers
+- Bump phpstan/phpstan from 0.12.53 to 0.12.58 in /composer/helpers
+- Bump pip-tools from 5.3.1 to 5.4.0 in /python/helpers
+- Update rubocop requirement from ~> 0.93.0 to ~> 1.4.2 in /common
+- Update simplecov requirement from ~> 0.19.0 to ~> 0.20.0 in /common
+- Update gitlab requirement from = 4.16.1 to = 4.17.0 in /common
+- Bundler: filter relevant credentials for all native helpers @baseballlover723
+- CI: Fix dependabot-core-ci build by removing buildkit caching
+
 ## v0.125.6, 27 November 2020
 
 - Pip compile: raise DependencyFileNotRqesolvable error when initial manifest

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.125.6"
+  VERSION = "0.125.7"
 end


### PR DESCRIPTION
## v0.125.7, 30 November 2020

- Bump jest from 26.6.2 to 26.6.3 in /npm_and_yarn/helpers
- Bump prettier from 2.1.2 to 2.2.1 in /npm_and_yarn/helpers
- Bump @npmcli/arborist from 1.0.12 to 1.0.13 in /npm_and_yarn/helpers
- Bump phpstan/phpstan from 0.12.53 to 0.12.58 in /composer/helpers
- Bump pip-tools from 5.3.1 to 5.4.0 in /python/helpers
- Update rubocop requirement from ~> 0.93.0 to ~> 1.4.2 in /common
- Update simplecov requirement from ~> 0.19.0 to ~> 0.20.0 in /common
- Update gitlab requirement from = 4.16.1 to = 4.17.0 in /common
- Bundler: filter relevant credentials for all native helpers `@baseballlover723`
- CI: Fix dependabot-core-ci build by removing buildkit caching
