### PR TITLE
pipenv: handle installs with missing system deps

### DIFF
--- a/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
@@ -469,6 +469,35 @@ RSpec.describe namespace::PipenvVersionResolver do
           end
       end
     end
+
+    context "with a missing system libary" do
+      # NOTE: Attempt to update an unrelated dependency (tensorflow) to cause
+      # resolution to fail for rtree which has a system dependency on
+      # libspatialindex which isn't installed in dependabot-core's Dockerfile.
+      let(:dependency_files) do
+        project_dependency_files("pipenv/missing-system-library")
+      end
+      let(:updated_requirement) { "==2.3.1" }
+      let(:dependency_name) { "tensorflow" }
+      let(:dependency_version) { "2.1.0" }
+      let(:dependency_requirements) do
+        [{
+          file: "Pipfile",
+          requirement: "==2.1.0",
+          groups: ["default"],
+          source: nil
+        }]
+      end
+
+      it "raises a helpful error" do
+        expect { subject }.
+          to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
+            expect(error.message).to include(
+              "Pipenv failed to install \"rtree\""
+            )
+          end
+      end
+    end
   end
 
   describe "#resolvable?" do

--- a/python/spec/fixtures/projects/pipenv/missing-system-library/Pipfile
+++ b/python/spec/fixtures/projects/pipenv/missing-system-library/Pipfile
@@ -1,0 +1,8 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+rtree = "==0.9.3"
+tensorflow = "==2.1.0"

--- a/python/spec/fixtures/projects/pipenv/missing-system-library/Pipfile.lock
+++ b/python/spec/fixtures/projects/pipenv/missing-system-library/Pipfile.lock
@@ -1,0 +1,41 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "e98725a3545acb9f6a84023a297838e6edf163ef50824694b0ebeb0d372ca0f5"
+        },
+        "pipfile-spec": 6,
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "rtree": {
+            "hashes": [
+                "sha256:cae327e2c03b3da4ea40d0fdf68f3e55fe9f302c56b9f31e1bfeb36dbea73f44"
+            ],
+            "index": "pypi",
+            "version": "==0.9.3"
+        },
+        "tensorflow": {
+            "hashes": [
+                "sha256:1cf129ccda0aea616b122f34b0c4bc39da959d34c4a4d8c23ed944555c5e47ab",
+                "sha256:2e8fc9764b7ea87687a4c80c2fbde69aeeb459a536eb5a591938d7931ab004c2",
+                "sha256:33e4b16e8f8905ee088bf8f413dcce2820b777fdf7f799009b3a47f354ebb23f",
+                "sha256:513d48dd751e0076d1b1e5e498e3522891305bedd2840f3cb4b1c57ffcb7d97d",
+                "sha256:5cfa729fc71f6f2dca0ea77ebe768ea293e723e22ecb086a0b3ab26cc1776e37",
+                "sha256:7bad8ea686a1f33d9dac13eb578c4597346789d4f826980c8bbcfbd08e7dc921",
+                "sha256:8c0fae0f9f772ed7e3370f1b286f88c27debbcf09468e5036670ea2c67e239ec",
+                "sha256:92c4f1c939de438fbe484d011e5eebe059fc8e5244cfe32a81c6891b3357d109",
+                "sha256:c420e70d4127c2ac00054aece54cf04a1a43d5d4f25de90267f247873f1bd5a8",
+                "sha256:e631f55cf30054fee3230c89a7f998fd08748aa3045651a5a760cec2c5b9f9d6",
+                "sha256:e877fbf373d5be42fb118269df1670b8d3c0df9be223904a2584a8f8ed23b082"
+            ],
+            "index": "pypi",
+            "version": "==2.1.0"
+        }
+    }
+}


### PR DESCRIPTION
Raise a `DependencyFileNotResolvable` error when pipenv fails to install
dependencies require missing system level dependenceis.

The error message parsing is pretty gnarly as the only reference of the
offending dependency is in a tmp build path in the error message.

In the test case pipenv failed to install `rtree` because it requires a
system level dependency: `libspatialindex`.

We don't want to install this in our ever growning dockerfile so attempt
to explain the error to users.

The underlying cause might be obscured by this open issue in pipenv:
https://github.com/pypa/pipenv/issues/2791

Similarly, there's an open issue to fix the system requirement in rtree:
https://github.com/Toblerity/rtree/issues/147

This is the error pipenv raises:

```
pipenv.patched.notpip._internal.exceptions.InstallationError: Command "python setup.py egg_info" failed with error code 1 in /tmp/tmp8jk2atvgbuild/rtree/
File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/resolver.py", line 126, in <module>
    main()
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/resolver.py", line 118, in main
    _main(parsed.pre, parsed.clear, parsed.verbose, parsed.system,
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/resolver.py", line 78, in _main
    results = resolve(
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/resolver.py", line 61, in resolve
    return resolve_deps(
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/utils.py", line 718, in resolve_deps
    resolved_tree, hashes, markers_lookup, resolver = actually_resolve_deps(
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/utils.py", line 480, in actually_resolve_deps
    resolved_tree = resolver.resolve()
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/utils.py", line 385, in resolve
    results = self.resolver.resolve(max_rounds=environments.PIPENV_MAX_ROUNDS)
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/patched/piptools/resolver.py", line 102, in resolve
    has_changed, best_matches = self._resolve_one_round()
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/patched/piptools/resolver.py", line 206, in _resolve_one_round
    for dep in self._iter_dependencies(best_match):
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/patched/piptools/resolver.py", line 301, in _iter_dependencies
    dependencies = self.repository.get_dependencies(ireq)
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/patched/piptools/repositories/pypi.py", line 234, in get_dependencies
    legacy_results = self.get_legacy_dependencies(ireq)
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/patched/piptools/repositories/pypi.py", line 426, in get_legacy_dependencies
    results, ireq = self.resolve_reqs(download_dir, ireq, wheel_cache)
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/patched/piptools/repositories/pypi.py", line 297, in resolve_reqs
    results = resolver._resolve_one(reqset, ireq)
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/patched/notpip/_internal/resolve.py", line 260, in _resolve_one
    abstract_dist = self._get_abstract_dist_for(req_to_install)
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/patched/notpip/_internal/resolve.py", line 211, in _get_abstract_dist_for
    abstract_dist = self.preparer.prepare_linked_requirement(
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/patched/notpip/_internal/operations/prepare.py", line 294, in prepare_linked_
    abstract_dist.prep_for_dist(finder, self.build_isolation)
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/patched/notpip/_internal/operations/prepare.py", line 127, in prep_for_dist
    self.req.run_egg_info()
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/patched/notpip/_internal/req/req_install.py", line 470, in run_egg_info
    call_subprocess(
  File "/usr/local/.pyenv/versions/3.9.0/lib/python3.9/site-packages/pipenv/patched/notpip/_internal/utils/misc.py", line 703, in call_subprocess
    raise InstallationError(
pipenv.patched.notpip._internal.exceptions.InstallationError: Command "python setup.py egg_info" failed with error code 1 in /tmp/tmp8jk2atvgbuild/rtree/
```