### PR TITLE
Add error message to dependency file not parseable

### DIFF
--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -173,8 +173,8 @@ module Dependabot
             PathGemspecFinder.new(gemfile: file).path_gemspec_paths
           end.uniq
         end
-      rescue ::Bundler::LockfileError
-        raise Dependabot::DependencyFileNotParseable, lockfile.path
+      rescue ::Bundler::LockfileError => e
+        raise Dependabot::DependencyFileNotParseable, lockfile.path, e.message
       rescue ::Bundler::Plugin::UnknownSourceError
         # Quietly ignore plugin errors - we'll raise a better error during
         # parsing

--- a/bundler/lib/dependabot/bundler/file_fetcher/child_gemfile_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher/child_gemfile_finder.rb
@@ -18,8 +18,8 @@ module Dependabot
         def child_gemfile_paths
           ast = Parser::CurrentRuby.parse(gemfile.content)
           find_child_gemfile_paths(ast)
-        rescue Parser::SyntaxError
-          raise Dependabot::DependencyFileNotParseable, gemfile.path
+        rescue Parser::SyntaxError => e
+          raise Dependabot::DependencyFileNotParseable, gemfile.path, e.message
         end
 
         private

--- a/bundler/lib/dependabot/bundler/file_fetcher/gemspec_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher/gemspec_finder.rb
@@ -18,8 +18,8 @@ module Dependabot
         def gemspec_directories
           ast = Parser::CurrentRuby.parse(gemfile.content)
           find_gemspec_paths(ast)
-        rescue Parser::SyntaxError
-          raise Dependabot::DependencyFileNotParseable, gemfile.path
+        rescue Parser::SyntaxError => e
+          raise Dependabot::DependencyFileNotParseable, gemfile.path, e.message
         end
 
         private

--- a/bundler/lib/dependabot/bundler/file_fetcher/path_gemspec_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher/path_gemspec_finder.rb
@@ -18,8 +18,8 @@ module Dependabot
         def path_gemspec_paths
           ast = Parser::CurrentRuby.parse(gemfile.content)
           find_path_gemspec_paths(ast)
-        rescue Parser::SyntaxError
-          raise Dependabot::DependencyFileNotParseable, gemfile.path
+        rescue Parser::SyntaxError => e
+          raise Dependabot::DependencyFileNotParseable, gemfile.path, e.message
         end
 
         private

--- a/bundler/lib/dependabot/bundler/file_fetcher/require_relative_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher/require_relative_finder.rb
@@ -18,8 +18,8 @@ module Dependabot
         def require_relative_paths
           ast = Parser::CurrentRuby.parse(file.content)
           find_require_relative_paths(ast)
-        rescue Parser::SyntaxError
-          raise Dependabot::DependencyFileNotParseable, file.path
+        rescue Parser::SyntaxError => e
+          raise Dependabot::DependencyFileNotParseable, file.path, e.message
         end
 
         private

--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -272,8 +272,8 @@ module Dependabot
 
       def parsed_file(file)
         TomlRB.parse(file.content)
-      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-        raise Dependabot::DependencyFileNotParseable, file.path
+      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+        raise Dependabot::DependencyFileNotParseable, file.path, e.message
       end
 
       def cargo_toml

--- a/cargo/lib/dependabot/cargo/file_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser.rb
@@ -207,8 +207,8 @@ module Dependabot
       def parsed_file(file)
         @parsed_file ||= {}
         @parsed_file[file.name] ||= TomlRB.parse(file.content)
-      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-        raise Dependabot::DependencyFileNotParseable, file.path
+      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+        raise Dependabot::DependencyFileNotParseable, file.path, e.message
       end
 
       def manifest_files

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -29,10 +29,10 @@ module Dependabot
     end
 
     def sanitize_source(source)
-      replace_capture_group(source, SOURCE_PATH_REGEX, "<redacted path>")
+      replace_capture_groups(source, SOURCE_PATH_REGEX, "<redacted path>")
     end
 
-    def replace_capture_group(string, regex, replacement)
+    def replace_capture_groups(string, regex, replacement)
       return string unless string.respond_to?(:scan)
 
       string.scan(regex).flatten.compact.reduce(string) do |original_msg, match|
@@ -42,7 +42,7 @@ module Dependabot
 
     def filter_sensitive_data(message)
       [HTTP_REGEX, BASIC_AUTH_REGEX].reduce(message) do |msg, regex|
-        replace_capture_group(msg, regex, "<redacted>")
+        replace_capture_groups(msg, regex, "<redacted>")
       end
     end
   end

--- a/common/spec/dependabot/errors_spec.rb
+++ b/common/spec/dependabot/errors_spec.rb
@@ -3,6 +3,51 @@
 require "spec_helper"
 require "dependabot/errors"
 
+RSpec.describe Dependabot::DependabotError do
+  let(:error) { described_class.new(message) }
+  let(:message) do
+    "some error"
+  end
+
+  describe "#message" do
+    subject { error.message }
+
+    it { is_expected.to eq("some error") }
+
+    context "with dependabot temp path" do
+      let(:message) do
+        "tmp/dependabot_123/path error"
+      end
+
+      it { is_expected.to eq("dependabot_tmp_dir/path error") }
+    end
+
+    context "with http basic auth" do
+      let(:message) do
+        "git://user:token@github.com error"
+      end
+
+      it { is_expected.to eq("git://<redacted>@github.com error") }
+    end
+
+    context "with escaped basic auth uri" do
+      let(:message) do
+        "git://user:token%40github.com error"
+      end
+
+      it { is_expected.to eq("git://<redacted>%40github.com error") }
+    end
+
+    context "with auth in url path" do
+      let(:message) do
+        "Something blew up https://domain.com/token/path error"
+      end
+
+      it { is_expected.to eq("Something blew up <redacted> error") }
+    end
+  end
+end
+
 RSpec.describe Dependabot::DependencyFileNotFound do
   let(:error) { described_class.new(file_path) }
   let(:file_path) { "path/to/Gemfile" }
@@ -29,6 +74,89 @@ RSpec.describe Dependabot::DependencyFileNotFound do
     context "with a nested file whose path starts with a slash" do
       let(:file_path) { "/path/to/Gemfile" }
       it { is_expected.to eq("/path/to") }
+    end
+  end
+end
+
+RSpec.describe Dependabot::PrivateSourceAuthenticationFailure do
+  let(:error) { described_class.new(source) }
+  let(:source) { "source" }
+
+  describe "#message" do
+    subject { error.message }
+
+    it do
+      is_expected.to eq(
+        "The following source could not be reached as it requires authentication (and any provided details were "\
+        "invalid or lacked the required permissions): source"
+      )
+    end
+
+    context "when source includes something that looks like a path" do
+      let(:source) do
+        "source.com/token123/path"
+      end
+
+      it do
+        is_expected.to eq(
+          "The following source could not be reached as it requires authentication (and any provided details were "\
+          "invalid or lacked the required permissions): source.com/<redacted path>"
+        )
+      end
+    end
+  end
+end
+
+RSpec.describe Dependabot::PrivateSourceTimedOut do
+  let(:error) { described_class.new(source) }
+  let(:source) { "source" }
+
+  describe "#message" do
+    subject { error.message }
+
+    it do
+      is_expected.to eq(
+        "The following source timed out: source"
+      )
+    end
+
+    context "when source includes something that looks like a path" do
+      let(:source) do
+        "source.com/token123/path"
+      end
+
+      it do
+        is_expected.to eq(
+          "The following source timed out: source.com/<redacted path>"
+        )
+      end
+    end
+  end
+end
+
+RSpec.describe Dependabot::PrivateSourceCertificateFailure do
+  let(:error) { described_class.new(source) }
+  let(:source) { "source" }
+
+  describe "#message" do
+    subject { error.message }
+
+    it do
+      is_expected.to eq(
+        "Could not verify the SSL certificate for source"
+      )
+    end
+
+    context "when source includes something that looks like a path" do
+      let(:source) do
+        "source.com/token123/path"
+      end
+
+      it do
+        is_expected.to eq(
+          "Could not verify the SSL certificate for source.com/<redacted path>"
+        )
+      end
     end
   end
 end

--- a/composer/lib/dependabot/composer/file_fetcher.rb
+++ b/composer/lib/dependabot/composer/file_fetcher.rb
@@ -124,8 +124,8 @@ module Dependabot
 
       def parsed_composer_json
         @parsed_composer_json ||= JSON.parse(composer_json.content)
-      rescue JSON::ParserError
-        raise Dependabot::DependencyFileNotParseable, composer_json.path
+      rescue JSON::ParserError => e
+        raise Dependabot::DependencyFileNotParseable, composer_json.path, e.message
       end
 
       def parsed_lockfile

--- a/composer/lib/dependabot/composer/file_parser.rb
+++ b/composer/lib/dependabot/composer/file_parser.rb
@@ -196,8 +196,8 @@ module Dependabot
 
       def parsed_composer_json
         @parsed_composer_json ||= JSON.parse(composer_json.content)
-      rescue JSON::ParserError
-        raise Dependabot::DependencyFileNotParseable, composer_json.path
+      rescue JSON::ParserError => e
+        raise Dependabot::DependencyFileNotParseable, composer_json.path, e.message
       end
 
       def composer_json

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -162,8 +162,8 @@ module Dependabot
               "password" => details["password"]
             }
           end
-        rescue JSON::ParserError
-          raise Dependabot::DependencyFileNotParseable, auth_json.path
+        rescue JSON::ParserError => e
+          raise Dependabot::DependencyFileNotParseable, auth_json.path, e.message
         end
 
         def composer_file

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -233,8 +233,6 @@ module Dependabot
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/MethodLength
         def handle_composer_errors(error)
-          sanitized_message = remove_url_credentials(error.message)
-
           # Special case for Laravel Nova, which will fall back to attempting
           # to close a private repo if given invalid (or no) credentials
           if error.message.include?("github.com/laravel/nova.git")
@@ -253,7 +251,7 @@ module Dependabot
             raise Dependabot::GitDependenciesNotReachable, dependency_url
           elsif error.message.start_with?("Could not parse version") ||
                 error.message.include?("does not allow connections to http://")
-            raise Dependabot::DependencyFileNotResolvable, sanitized_message
+            raise Dependabot::DependencyFileNotResolvable, error.message
           elsif error.message.match?(MISSING_EXPLICIT_PLATFORM_REQ_REGEX)
             # These errors occur when platform requirements declared explicitly
             # in the composer.json aren't met.
@@ -493,10 +491,6 @@ module Dependabot
           credentials.
             select { |cred| cred["type"] == "composer_repository" }.
             select { |cred| cred["password"] }
-        end
-
-        def remove_url_credentials(message)
-          message.gsub(%r{(?<=://)[^\s]*:[^\s]*(?=@)}, "****")
         end
       end
     end

--- a/dep/lib/dependabot/dep/file_parser.rb
+++ b/dep/lib/dependabot/dep/file_parser.rb
@@ -153,8 +153,8 @@ module Dependabot
       def parsed_file(file)
         @parsed_file ||= {}
         @parsed_file[file.name] ||= TomlRB.parse(file.content)
-      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-        raise Dependabot::DependencyFileNotParseable, file.path
+      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+        raise Dependabot::DependencyFileNotParseable, file.path, e.message
       end
 
       def manifest

--- a/elm/lib/dependabot/elm/file_parser.rb
+++ b/elm/lib/dependabot/elm/file_parser.rb
@@ -113,14 +113,14 @@ module Dependabot
 
       def parsed_package_file
         @parsed_package_file ||= JSON.parse(elm_package.content)
-      rescue JSON::ParserError
-        raise Dependabot::DependencyFileNotParseable, elm_package.path
+      rescue JSON::ParserError => e
+        raise Dependabot::DependencyFileNotParseable, elm_package.path, e.message
       end
 
       def parsed_elm_json
         @parsed_elm_json ||= JSON.parse(elm_json.content)
-      rescue JSON::ParserError
-        raise Dependabot::DependencyFileNotParseable, elm_json.path
+      rescue JSON::ParserError => e
+        raise Dependabot::DependencyFileNotParseable, elm_json.path, e.message
       end
 
       def elm_package

--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -47,8 +47,8 @@ module Dependabot
         end
 
         dependency_set
-      rescue Psych::SyntaxError, Psych::DisallowedClass, Psych::BadAlias
-        raise Dependabot::DependencyFileNotParseable, file.path
+      rescue Psych::SyntaxError, Psych::DisallowedClass, Psych::BadAlias => e
+        raise Dependabot::DependencyFileNotParseable, file.path, e.message
       end
 
       def build_github_dependency(file, string)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -198,8 +198,8 @@ module Dependabot
             path = File.join(current_dir, path) unless current_dir.nil?
             [name, Pathname.new(path).cleanpath.to_path]
           end
-      rescue JSON::ParserError
-        raise Dependabot::DependencyFileNotParseable, file.path
+      rescue JSON::ParserError => e
+        raise Dependabot::DependencyFileNotParseable, file.path, e.message
       end
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/PerceivedComplexity
@@ -318,8 +318,8 @@ module Dependabot
 
       def parsed_package_json
         JSON.parse(package_json.content)
-      rescue JSON::ParserError
-        raise Dependabot::DependencyFileNotParseable, package_json.path
+      rescue JSON::ParserError => e
+        raise Dependabot::DependencyFileNotParseable, package_json.path, e.message
       end
 
       def parsed_package_lock
@@ -362,8 +362,8 @@ module Dependabot
         return {} unless lerna_json
 
         JSON.parse(lerna_json.content)
-      rescue JSON::ParserError
-        raise Dependabot::DependencyFileNotParseable, lerna_json.path
+      rescue JSON::ParserError => e
+        raise Dependabot::DependencyFileNotParseable, lerna_json.path, e.message
       end
     end
   end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -171,16 +171,16 @@ module Dependabot
           @parse_package_lock ||= {}
           @parse_package_lock[package_lock.name] ||=
             JSON.parse(package_lock.content)
-        rescue JSON::ParserError
-          raise Dependabot::DependencyFileNotParseable, package_lock.path
+        rescue JSON::ParserError => e
+          raise Dependabot::DependencyFileNotParseable, package_lock.path, e.message
         end
 
         def parse_shrinkwrap(shrinkwrap)
           @parse_shrinkwrap ||= {}
           @parse_shrinkwrap[shrinkwrap.name] ||=
             JSON.parse(shrinkwrap.content)
-        rescue JSON::ParserError
-          raise Dependabot::DependencyFileNotParseable, shrinkwrap.path
+        rescue JSON::ParserError => e
+          raise Dependabot::DependencyFileNotParseable, shrinkwrap.path, e.message
         end
 
         def parse_yarn_lock(yarn_lock)
@@ -194,8 +194,8 @@ module Dependabot
                 function: "yarn:parseLockfile",
                 args: [Dir.pwd]
               )
-            rescue SharedHelpers::HelperSubprocessFailed
-              raise Dependabot::DependencyFileNotParseable, yarn_lock.path
+            rescue SharedHelpers::HelperSubprocessFailed => e
+              raise Dependabot::DependencyFileNotParseable, yarn_lock.path, e.message
             end
         end
 

--- a/nuget/lib/dependabot/nuget/file_parser/global_json_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/global_json_parser.rb
@@ -48,8 +48,8 @@ module Dependabot
 
         def parsed_global_json
           @parsed_global_json ||= JSON.parse(global_json.content)
-        rescue JSON::ParserError
-          raise Dependabot::DependencyFileNotParseable, global_json.path
+        rescue JSON::ParserError => e
+          raise Dependabot::DependencyFileNotParseable, global_json.path, e.message
         end
       end
     end

--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -144,16 +144,16 @@ module Dependabot
         raise "No Pipfile" unless pipfile
 
         @parsed_pipfile ||= TomlRB.parse(pipfile.content)
-      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-        raise Dependabot::DependencyFileNotParseable, pipfile.path
+      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+        raise Dependabot::DependencyFileNotParseable, pipfile.path, e.message
       end
 
       def parsed_pyproject
         raise "No pyproject.toml" unless pyproject
 
         @parsed_pyproject ||= TomlRB.parse(pyproject.content)
-      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-        raise Dependabot::DependencyFileNotParseable, pyproject.path
+      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+        raise Dependabot::DependencyFileNotParseable, pyproject.path, e.message
       end
 
       def req_txt_and_in_files

--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -221,8 +221,8 @@ module Dependabot
         return true if poetry_lock || pyproject_lock
 
         !TomlRB.parse(pyproject.content).dig("tool", "poetry").nil?
-      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-        raise Dependabot::DependencyFileNotParseable, pyproject.path
+      rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+        raise Dependabot::DependencyFileNotParseable, pyproject.path, e.message
       end
 
       def output_file_regex(filename)

--- a/python/lib/dependabot/python/file_parser/pipfile_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/pipfile_files_parser.rb
@@ -145,14 +145,14 @@ module Dependabot
 
         def parsed_pipfile
           @parsed_pipfile ||= TomlRB.parse(pipfile.content)
-        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-          raise Dependabot::DependencyFileNotParseable, pipfile.path
+        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+          raise Dependabot::DependencyFileNotParseable, pipfile.path, e.message
         end
 
         def parsed_pipfile_lock
           @parsed_pipfile_lock ||= JSON.parse(pipfile_lock.content)
-        rescue JSON::ParserError
-          raise Dependabot::DependencyFileNotParseable, pipfile_lock.path
+        rescue JSON::ParserError => e
+          raise Dependabot::DependencyFileNotParseable, pipfile_lock.path, e.message
         end
 
         def pipfile

--- a/python/lib/dependabot/python/file_parser/poetry_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/poetry_files_parser.rb
@@ -107,20 +107,20 @@ module Dependabot
 
         def parsed_pyproject
           @parsed_pyproject ||= TomlRB.parse(pyproject.content)
-        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-          raise Dependabot::DependencyFileNotParseable, pyproject.path
+        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+          raise Dependabot::DependencyFileNotParseable, pyproject.path, e.message
         end
 
         def parsed_pyproject_lock
           @parsed_pyproject_lock ||= TomlRB.parse(pyproject_lock.content)
-        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-          raise Dependabot::DependencyFileNotParseable, pyproject_lock.path
+        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+          raise Dependabot::DependencyFileNotParseable, pyproject_lock.path, e.message
         end
 
         def parsed_poetry_lock
           @parsed_poetry_lock ||= TomlRB.parse(poetry_lock.content)
-        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
-          raise Dependabot::DependencyFileNotParseable, poetry_lock.path
+        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError => e
+          raise Dependabot::DependencyFileNotParseable, poetry_lock.path, e.message
         end
 
         def pyproject

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -377,13 +377,10 @@ module Dependabot
 
         def clean_error_message(message)
           msg_lines = message.lines
-          msg = msg_lines.
-                take_while { |l| !l.start_with?("During handling of") }.
-                drop_while { |l| l.start_with?(*VERBOSE_ERROR_OUTPUT_LINES) }.
-                join.strip
-
-          # Redact any URLs, as they may include credentials
-          msg.gsub(/http.*?(?=\s)/, "<redacted>")
+          msg_lines.
+          take_while { |l| !l.start_with?("During handling of") }.
+          drop_while { |l| l.start_with?(*VERBOSE_ERROR_OUTPUT_LINES) }.
+          join.strip
         end
 
         def filenames_to_compile

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -250,20 +250,17 @@ module Dependabot
           # Pipenv outputs a lot of things to STDERR, so we need to clean
           # up the error message
           msg_lines = message.lines
-          msg = msg_lines.
-                take_while { |l| !l.start_with?("During handling of") }.
-                drop_while do |l|
-                  next false if l.start_with?("CRITICAL:")
-                  next false if l.start_with?("ERROR:")
-                  next false if l.start_with?("packaging.specifiers")
-                  next false if l.start_with?("pipenv.patched.notpip._internal")
-                  next false if l.include?("Max retries exceeded")
+          msg_lines.
+          take_while { |l| !l.start_with?("During handling of") }.
+          drop_while do |l|
+            next false if l.start_with?("CRITICAL:")
+            next false if l.start_with?("ERROR:")
+            next false if l.start_with?("packaging.specifiers")
+            next false if l.start_with?("pipenv.patched.notpip._internal")
+            next false if l.include?("Max retries exceeded")
 
-                  true
-                end.join.strip
-
-          # We also need to redact any URLs, as they may include credentials
-          msg.gsub(/http.*?(?=\s)/, "<redacted>")
+            true
+          end.join.strip
         end
 
         def handle_pipenv_installation_error(error_message)

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -159,15 +159,9 @@ module Dependabot
               raise unless e.message.include?("SolverProblemError") ||
                            e.message.include?("PackageNotFound")
 
-              msg = clean_error_message(e.message)
-              raise DependencyFileNotResolvable, msg
+              raise DependencyFileNotResolvable, e.message
             end
           end
-        end
-
-        def clean_error_message(message)
-          # Redact any URLs, as they may include credentials
-          message.gsub(/http.*?(?=\s)/, "<redacted>")
         end
 
         def write_temporary_dependency_files(updated_req: nil,

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -235,8 +235,7 @@ module Dependabot
             JSON.parse(stdout)
           end
       rescue SharedHelpers::HelperSubprocessFailed => e
-        msg = e.message.strip
-        raise Dependabot::DependencyFileNotParseable.new(file.path, msg)
+        raise Dependabot::DependencyFileNotParseable.new(file.path, e.message)
       end
 
       def terraform_parser_path


### PR DESCRIPTION
Adds the exception message to `DependencyFileNotParseable` errors and adds sanitisation on all `DependabotError` messages redacting anything that looks like a `http(s)` link, basic auth creds `//username:token@` and any path from private source exceptions.

We might end up redacting more than we want but seems ok to start strict and walk back changes if we get reports of error logs missing crucial debugging information.