### PR TITLE
hmarr dotfiles branch rename

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -27,7 +27,7 @@ RUN git config --global user.name dependabot-ci && git config --global user.emai
 
 ARG CODE_DIR=/home/$USERNAME/dependabot-core
 
-RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/master/vimrc-vanilla.vim && \
+RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/main/vimrc-vanilla.vim && \
   echo 'export PS1="[dependabot-core-dev] \w \[$(tput setaf 4)\]$ \[$(tput sgr 0)\]"' >> ~/.bashrc
 
 RUN mkdir -p ${CODE_DIR}/common/lib/dependabot


### PR DESCRIPTION
The default branch of https://github.com/hmarr/dotfiles was renamed, follow it.

This is only for development, where `.vimrc` is loaded.

<details><summary>fails like</summary>
<p>

```
E492: Not an editor command:               You can always update your selection by clicking <span class="text-bold">Cookie Preferences</span> at the bottom of the page.
line  730:
E492: Not an editor command:               For more information, see our <a href="https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-privacy-statement">Privacy Statement</a>.
line  731:
```

770 total errors!
</p>
</details> 