### PR TITLE
Sanitize creds from DependabotError

### DIFF
--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
   let(:previous_requirements) do
     [{ file: "Gemfile", requirement: "~> 1.4.0", groups: [], source: nil }]
   end
-  let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
+  let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
   let(:repo_contents_path) { nil }
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
@@ -946,9 +946,9 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
           it "does not change the original path" do
             expect(file.content).to include "remote: plugins/example"
             expect(file.content).
-              not_to include Dependabot::SharedHelpers::BUMP_TMP_FILE_PREFIX
+              not_to include Dependabot::Utils::BUMP_TMP_FILE_PREFIX
             expect(file.content).
-              not_to include Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH
+              not_to include Dependabot::Utils::BUMP_TMP_DIR_PATH
           end
 
           context "as a .specification" do

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       context "that we have bad authentication details for" do
         let(:error_message) do
           <<~ERR
-            Bad username or password for https://SECRET_CODES@repo.fury.io/greysteil/.
+            Bad username or password for https://user:secret@repo.fury.io/greysteil/.
             Please double-check your credentials and correct them.
           ERR
         end
@@ -346,7 +346,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
             to raise_error do |error|
               expect(error).to be_a(error_class)
               expect(error.source).
-                to eq("https://SECRET_CODES@repo.fury.io/greysteil/")
+                to eq("https://repo.fury.io/<redacted>")
             end
         end
       end
@@ -378,7 +378,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
             to raise_error do |error|
               expect(error).to be_a(Dependabot::PrivateSourceTimedOut)
               expect(error.source).
-                to eq("https://repo.fury.io/greysteil/")
+                to eq("https://repo.fury.io/<redacted>")
             end
         end
       end

--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
   let(:previous_requirements) do
     [{ file: "Cargo.toml", requirement: "0.1.12", groups: [], source: nil }]
   end
-  let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
+  let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 

--- a/cargo/spec/dependabot/cargo/file_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater do
   let(:previous_requirements) do
     [{ file: "Cargo.toml", requirement: "0.1.12", groups: [], source: nil }]
   end
-  let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
+  let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -1,24 +1,45 @@
 # frozen_string_literal: true
 
-require "dependabot/shared_helpers"
+require "dependabot/utils"
 
 module Dependabot
   class DependabotError < StandardError
-    def initialize(msg = nil)
-      msg = sanitize_message(msg)
-      super(msg)
+    BASIC_AUTH_REGEX = %r{://(?<auth>[^:]*:[^@%\s]+(@|%40))}.freeze
+    # Remove any path segment from fury.io sources
+    FURY_IO_PATH_REGEX = %r{fury\.io/(?<path>.+)}.freeze
+
+    def initialize(message = nil)
+      super(sanitize_message(message))
     end
 
     private
 
     def sanitize_message(message)
-      return unless message
+      return message unless message.is_a?(String)
 
       path_regex =
-        Regexp.escape(SharedHelpers::BUMP_TMP_DIR_PATH) + "\/" +
-        Regexp.escape(SharedHelpers::BUMP_TMP_FILE_PREFIX) + "[^/]*"
+        Regexp.escape(Utils::BUMP_TMP_DIR_PATH) + "\/" +
+        Regexp.escape(Utils::BUMP_TMP_FILE_PREFIX) + "[a-zA-Z0-9-]*"
 
-      message.gsub(/#{path_regex}/, "dependabot_tmp_dir")
+      message = message.gsub(/#{path_regex}/, "dependabot_tmp_dir").strip
+      filter_sensitive_data(message)
+    end
+
+    def filter_sensitive_data(message)
+      replace_capture_groups(message, BASIC_AUTH_REGEX, "")
+    end
+
+    def sanitize_source(source)
+      source = filter_sensitive_data(source)
+      replace_capture_groups(source, FURY_IO_PATH_REGEX, "<redacted>")
+    end
+
+    def replace_capture_groups(string, regex, replacement)
+      return string unless string.is_a?(String)
+
+      string.scan(regex).flatten.compact.reduce(string) do |original_msg, match|
+        original_msg.gsub(match, replacement)
+      end
     end
   end
 
@@ -35,7 +56,6 @@ module Dependabot
 
     def initialize(branch_name, msg = nil)
       @branch_name = branch_name
-      msg = sanitize_message(msg)
       super(msg)
     end
   end
@@ -101,10 +121,10 @@ module Dependabot
     attr_reader :source
 
     def initialize(source)
-      @source = source.gsub(%r{(?<=\.fury\.io)/[A-Za-z0-9]{20}(?=/)}, "")
+      @source = sanitize_source(source)
       msg = "The following source could not be reached as it requires "\
             "authentication (and any provided details were invalid or lacked "\
-            "the required permissions): #{source}"
+            "the required permissions): #{@source}"
       super(msg)
     end
   end
@@ -113,8 +133,8 @@ module Dependabot
     attr_reader :source
 
     def initialize(source)
-      @source = source.gsub(%r{(?<=\.fury\.io)/[A-Za-z0-9]{20}(?=/)}, "")
-      super("The following source timed out: #{source}")
+      @source = sanitize_source(source)
+      super("The following source timed out: #{@source}")
     end
   end
 
@@ -122,8 +142,8 @@ module Dependabot
     attr_reader :source
 
     def initialize(source)
-      @source = source.gsub(%r{(?<=\.fury\.io)/[A-Za-z0-9]{20}(?=/)}, "")
-      super("Could not verify the SSL certificate for #{source}")
+      @source = sanitize_source(source)
+      super("Could not verify the SSL certificate for #{@source}")
     end
   end
 
@@ -132,7 +152,7 @@ module Dependabot
 
     def initialize(environment_variable)
       @environment_variable = environment_variable
-      super("Missing environment variable #{environment_variable}")
+      super("Missing environment variable #{@environment_variable}")
     end
   end
 
@@ -149,10 +169,10 @@ module Dependabot
 
     def initialize(*dependency_urls)
       @dependency_urls =
-        dependency_urls.flatten.map { |uri| uri.gsub(/x-access-token.*?@/, "") }
+        dependency_urls.flatten.map { |uri| filter_sensitive_data(uri) }
 
       msg = "The following git URLs could not be retrieved: "\
-            "#{dependency_urls.join(', ')}"
+            "#{@dependency_urls.join(', ')}"
       super(msg)
     end
   end
@@ -163,7 +183,7 @@ module Dependabot
     def initialize(dependency)
       @dependency = dependency
 
-      msg = "The branch or reference specified for #{dependency} could not "\
+      msg = "The branch or reference specified for #{@dependency} could not "\
             "be retrieved"
       super(msg)
     end
@@ -175,7 +195,7 @@ module Dependabot
     def initialize(*dependencies)
       @dependencies = dependencies.flatten
       msg = "The following path based dependencies could not be retrieved: "\
-            "#{dependencies.join(', ')}"
+            "#{@dependencies.join(', ')}"
       super(msg)
     end
   end
@@ -188,8 +208,8 @@ module Dependabot
       @declared_path = declared_path
       @discovered_path = discovered_path
 
-      msg = "The module path '#{declared_path}' found in #{go_mod} doesn't "\
-            "match the actual path '#{discovered_path}' in the dependency's "\
+      msg = "The module path '#{@declared_path}' found in #{@go_mod} doesn't "\
+            "match the actual path '#{@discovered_path}' in the dependency's "\
             "go.mod"
       super(msg)
     end

--- a/common/lib/dependabot/utils.rb
+++ b/common/lib/dependabot/utils.rb
@@ -4,6 +4,9 @@
 #       dependabot-core.
 module Dependabot
   module Utils
+    BUMP_TMP_FILE_PREFIX = "dependabot_"
+    BUMP_TMP_DIR_PATH = "tmp"
+
     @version_classes = {}
 
     def self.version_class_for_package_manager(package_manager)

--- a/common/spec/dependabot/errors_spec.rb
+++ b/common/spec/dependabot/errors_spec.rb
@@ -3,6 +3,73 @@
 require "spec_helper"
 require "dependabot/errors"
 
+RSpec.describe Dependabot::DependabotError do
+  let(:error) { described_class.new(message) }
+  let(:message) do
+    "some error"
+  end
+
+  describe "#message" do
+    subject { error.message }
+
+    it { is_expected.to eq("some error") }
+
+    context "with dependabot temp path" do
+      let(:message) do
+        "tmp/dependabot_20201218-14100-y0d218/path error"
+      end
+
+      it { is_expected.to eq("dependabot_tmp_dir/path error") }
+    end
+
+    context "with dependabot temp path" do
+      let(:message) do
+        "Error (/Users/x/code/dependabot-core/cargo/tmp/dependabot_20201218-14100-y0d218) "\
+        "failed to load https://github.com/dependabot"
+      end
+
+      it do
+        is_expected.to eq(
+          "Error (/Users/x/code/dependabot-core/cargo/dependabot_tmp_dir) "\
+          "failed to load https://github.com/dependabot"
+        )
+      end
+    end
+
+    context "without http basic auth token" do
+      let(:message) do
+        "git://user@github.com error"
+      end
+
+      it { is_expected.to eq("git://user@github.com error") }
+    end
+
+    context "with http basic auth missing username" do
+      let(:message) do
+        "git://:token@github.com error"
+      end
+
+      it { is_expected.to eq("git://github.com error") }
+    end
+
+    context "with http basic auth" do
+      let(:message) do
+        "git://user:token@github.com error"
+      end
+
+      it { is_expected.to eq("git://github.com error") }
+    end
+
+    context "with escaped basic auth uri" do
+      let(:message) do
+        "git://user:token%40github.com error"
+      end
+
+      it { is_expected.to eq("git://github.com error") }
+    end
+  end
+end
+
 RSpec.describe Dependabot::DependencyFileNotFound do
   let(:error) { described_class.new(file_path) }
   let(:file_path) { "path/to/Gemfile" }
@@ -29,6 +96,107 @@ RSpec.describe Dependabot::DependencyFileNotFound do
     context "with a nested file whose path starts with a slash" do
       let(:file_path) { "/path/to/Gemfile" }
       it { is_expected.to eq("/path/to") }
+    end
+  end
+end
+
+RSpec.describe Dependabot::PrivateSourceAuthenticationFailure do
+  let(:error) { described_class.new(source) }
+  let(:source) { "source" }
+
+  describe "#message" do
+    subject { error.message }
+
+    it do
+      is_expected.to eq(
+        "The following source could not be reached as it requires authentication (and any provided details were "\
+        "invalid or lacked the required permissions): source"
+      )
+    end
+
+    context "when source includes something that looks like a path" do
+      let(:source) do
+        "npm.fury.io/token123/path"
+      end
+
+      it do
+        is_expected.to eq(
+          "The following source could not be reached as it requires authentication (and any provided details were "\
+          "invalid or lacked the required permissions): npm.fury.io/<redacted>"
+        )
+      end
+    end
+  end
+end
+
+RSpec.describe Dependabot::PrivateSourceTimedOut do
+  let(:error) { described_class.new(source) }
+  let(:source) { "source" }
+
+  describe "#message" do
+    subject { error.message }
+
+    it do
+      is_expected.to eq(
+        "The following source timed out: source"
+      )
+    end
+
+    context "when source includes something that looks like a path" do
+      let(:source) do
+        "npm.fury.io/token123/path"
+      end
+
+      it do
+        is_expected.to eq(
+          "The following source timed out: npm.fury.io/<redacted>"
+        )
+      end
+    end
+  end
+end
+
+RSpec.describe Dependabot::PrivateSourceCertificateFailure do
+  let(:error) { described_class.new(source) }
+  let(:source) { "source" }
+
+  describe "#message" do
+    subject { error.message }
+
+    it do
+      is_expected.to eq(
+        "Could not verify the SSL certificate for source"
+      )
+    end
+
+    context "when source includes something that looks like a path" do
+      let(:source) do
+        "npm.fury.io/token123/path"
+      end
+
+      it do
+        is_expected.to eq(
+          "Could not verify the SSL certificate for npm.fury.io/<redacted>"
+        )
+      end
+    end
+  end
+end
+
+RSpec.describe Dependabot::GitDependenciesNotReachable do
+  let(:error) { described_class.new(dependency_url) }
+  let(:dependency_url) do
+    "https://x-access-token:token@bitbucket.org/gocardless/"
+  end
+
+  describe "#message" do
+    subject { error.message }
+
+    it do
+      is_expected.to eq(
+        "The following git URLs could not be retrieved: "\
+        "https://bitbucket.org/gocardless/"
+      )
     end
   end
 end

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -143,6 +143,17 @@ RSpec.describe Dependabot::SharedHelpers do
       end
     end
 
+    context "when the subprocess fails gracefully with sensitive data" do
+      let(:function) { "sensitive_error" }
+
+      it "raises a HelperSubprocessFailed error" do
+        expect { run_subprocess }.
+          to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed) do |error|
+            expect(error.message).to eq("Something went wrong: https://www.example.com")
+          end
+      end
+    end
+
     context "when the subprocess fails ungracefully" do
       let(:function) { "hard_error" }
 

--- a/common/spec/helpers/test/run.rb
+++ b/common/spec/helpers/test/run.rb
@@ -7,6 +7,9 @@ case request["function"]
 when "error"
   $stdout.write(JSON.dump(error: "Something went wrong"))
   exit 1
+when "sensitive_error"
+  $stdout.write(JSON.dump(error: "Something went wrong: https://username:secret@www.example.com"))
+  exit 1
 when "useful_error"
   $stderr.write("Some useful error")
   exit 1

--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -71,8 +71,8 @@ end
 def build_tmp_repo(project)
   project_path = File.expand_path(File.join("spec/fixtures/projects", project))
 
-  tmp_dir = Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH
-  prefix = Dependabot::SharedHelpers::BUMP_TMP_FILE_PREFIX
+  tmp_dir = Dependabot::Utils::BUMP_TMP_DIR_PATH
+  prefix = Dependabot::Utils::BUMP_TMP_FILE_PREFIX
   Dir.mkdir(tmp_dir) unless Dir.exist?(tmp_dir)
   tmp_repo = Dir.mktmpdir(prefix, tmp_dir)
   tmp_repo_path = Pathname.new(tmp_repo).expand_path

--- a/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Dependabot::Composer::FileUpdater::LockfileUpdater do
       source: nil
     }]
   end
-  let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
+  let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 

--- a/composer/spec/dependabot/composer/file_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Dependabot::Composer::FileUpdater do
       source: nil
     }]
   end
-  let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
+  let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 

--- a/dep/spec/dependabot/dep/file_updater_spec.rb
+++ b/dep/spec/dependabot/dep/file_updater_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Dependabot::Dep::FileUpdater do
       }
     }]
   end
-  let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
+  let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 

--- a/elm/spec/dependabot/elm/file_updater_spec.rb
+++ b/elm/spec/dependabot/elm/file_updater_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Dependabot::Elm::FileUpdater do
       package_manager: "elm"
     )
   end
-  let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
+  let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 

--- a/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
       package_manager: "hex"
     )
   end
-  let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
+  let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 

--- a/hex/spec/dependabot/hex/file_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Dependabot::Hex::FileUpdater do
       package_manager: "hex"
     )
   end
-  let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
+  let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     }]
   end
 
-  let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
+  let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 
@@ -1831,7 +1831,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
                 to raise_error do |error|
                   expect(error).
                     to be_a(Dependabot::PrivateSourceAuthenticationFailure)
-                  expect(error.source).to eq("npm-proxy.fury.io/dependabot")
+                  expect(error.source).to eq("npm-proxy.fury.io/<redacted>")
                 end
             end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
         it "raises a to Dependabot::PrivateSourceTimedOut error" do
           expect { version_finder.latest_version_from_registry }.
             to raise_error(Dependabot::PrivateSourceTimedOut) do |error|
-              expect(error.source).to eq("npm.fury.io/dependabot")
+              expect(error.source).to eq("npm.fury.io/<redacted>")
             end
         end
 
@@ -434,7 +434,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
           error_class = Dependabot::PrivateSourceAuthenticationFailure
           expect { version_finder.latest_version_from_registry }.
             to raise_error(error_class) do |error|
-              expect(error.source).to eq("npm.fury.io/dependabot")
+              expect(error.source).to eq("npm.fury.io/<redacted>")
             end
         end
       end
@@ -584,7 +584,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
           error_class = Dependabot::PrivateSourceAuthenticationFailure
           expect { version_finder.latest_version_from_registry }.
             to raise_error(error_class) do |error|
-              expect(error.source).to eq("npm.fury.io/dependabot")
+              expect(error.source).to eq("npm.fury.io/<redacted>")
             end
         end
 
@@ -611,7 +611,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
               error_class = Dependabot::PrivateSourceAuthenticationFailure
               expect { version_finder.latest_version_from_registry }.
                 to raise_error(error_class) do |error|
-                  expect(error.source).to eq("npm.fury.io/dependabot")
+                  expect(error.source).to eq("npm.fury.io/<redacted>")
                 end
             end
           end

--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -6,6 +6,7 @@ require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
 require "dependabot/python/requirement_parser"
 require "dependabot/errors"
+
 module Dependabot
   module Python
     class FileFetcher < Dependabot::FileFetchers::Base

--- a/python/spec/dependabot/python/file_updater/pip_compile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pip_compile_file_updater_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
       "password" => "token"
     }]
   end
-  let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
+  let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 

--- a/python/spec/dependabot/python/file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Dependabot::Python::FileUpdater do
       "password" => "token"
     }]
   end
-  let(:tmp_path) { Dependabot::SharedHelpers::BUMP_TMP_DIR_PATH }
+  let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
 
   before { Dir.mkdir(tmp_path) unless Dir.exist?(tmp_path) }
 


### PR DESCRIPTION
All errors now inherit from `DependabotError` and sanitize the message from http basic creds in urls.