### PR TITLE
go_modules: don't raise error for go mod tidy

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -122,8 +122,11 @@ module Dependabot
           # https://github.com/golang/go/commit/3aa09489ab3aa13a3ac78b1ff012b148ffffe367
           command = "go mod tidy"
 
-          _, stderr, status = Open3.capture3(ENVIRONMENT, command)
-          handle_subprocess_error(stderr, true) unless status.success?
+          # we explicitly don't raise an error for 'go mod tidy' and silently
+          # continue here. `go mod tidy` shouldn't block updating versions
+          # because there are some edge cases where it's OK to fail (such as
+          # generated files not available yet to us). 
+          Open3.capture3(ENVIRONMENT, command)
         end
 
         def run_go_vendor
@@ -246,7 +249,7 @@ module Dependabot
           write_go_mod(body)
         end
 
-        def handle_subprocess_error(stderr, istidy=false)
+        def handle_subprocess_error(stderr)
           stderr = stderr.gsub(Dir.getwd, "")
 
           error_regex = RESOLVABILITY_ERROR_REGEXES.find { |r| stderr =~ r }
@@ -261,12 +264,6 @@ module Dependabot
             raise Dependabot::GoModulePathMismatch.
               new(go_mod_path, match[1], match[2])
           end
-
-          # we explicitly don't raise an error for 'go mod tidy' and silently
-          # continue here. `go mod tidy` shouldn't block updating versions
-          # because there are some edge cases where it's ok to fail (such as
-          # generated files not available yet to us). 
-          return if istidy
 
           # We don't know what happened so we raise a generic error
           msg = stderr.lines.last(10).join.strip

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -125,7 +125,7 @@ module Dependabot
           # we explicitly don't raise an error for 'go mod tidy' and silently
           # continue here. `go mod tidy` shouldn't block updating versions
           # because there are some edge cases where it's OK to fail (such as
-          # generated files not available yet to us). 
+          # generated files not available yet to us).
           Open3.capture3(ENVIRONMENT, command)
         end
 

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -230,6 +230,10 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
               expect { updater.updated_go_sum_content }.
                 to_not raise_error(error_class) do |error|
                 expect(error.message).to include("googleapis/gnostic/OpenAPIv2")
+              it "updates the go.mod" do
+                expect(updater.updated_go_mod_content).to include(
+                  %(github.com/googleapis/gnostic v0.5.1\n)
+                )
               end
             end
           end

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -230,11 +230,13 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
               expect { updater.updated_go_sum_content }.
                 to_not raise_error(error_class) do |error|
                 expect(error.message).to include("googleapis/gnostic/OpenAPIv2")
-              it "updates the go.mod" do
-                expect(updater.updated_go_mod_content).to include(
-                  %(github.com/googleapis/gnostic v0.5.1\n)
-                )
               end
+            end
+
+            it "updates the go.mod" do
+              expect(updater.updated_go_mod_content).to include(
+                %(github.com/googleapis/gnostic v0.5.1 // indirect\n)
+              )
             end
           end
         end

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -225,10 +225,10 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
             # OpenAPIV2 has been renamed to openapiv2 in this version
             let(:dependency_version) { "v0.5.1" }
 
-            it "raises a DependencyFileNotResolvable error" do
+            it "does not raises a DependencyFileNotResolvable error" do
               error_class = Dependabot::DependencyFileNotResolvable
               expect { updater.updated_go_sum_content }.
-                to raise_error(error_class) do |error|
+                to_not raise_error(error_class) do |error|
                 expect(error.message).to include("googleapis/gnostic/OpenAPIv2")
               end
             end

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -225,12 +225,10 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
             # OpenAPIV2 has been renamed to openapiv2 in this version
             let(:dependency_version) { "v0.5.1" }
 
+            # NOTE: We explitly don't want to raise a resolvability error from go mod tidy
             it "does not raises a DependencyFileNotResolvable error" do
-              error_class = Dependabot::DependencyFileNotResolvable
               expect { updater.updated_go_sum_content }.
-                to_not raise_error(error_class) do |error|
-                expect(error.message).to include("googleapis/gnostic/OpenAPIv2")
-              end
+                to_not raise_error(Dependabot::DependencyFileNotResolvable)
             end
 
             it "updates the go.mod" do


### PR DESCRIPTION
`go mod tidy` makes sure that go.mod matches the source code in a Go
module. This also means that `dependabot` is doing a quassi linting on
the code, which prevents updating versions in a go.mod if the source
code doesn't got build. One particular use case is when a project is
missing generated files. Sometimes people don't submit and commit the
generated files of a code generator (i.e: `protobuf`) and do it in
pre-script in the CI. Because `dependabot` is not aware of this
pre-script, it'll run `go mod tidy` and fail for the user.

We should silently continue if `go mod tidy` fails and not raise an
error. This will allow dependabot still to run `go mod tidy`, but will
not block users for these kind of edge cases.