### PR TITLE
Add OutOfDisk error and use it in go_modules ecosystem

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -23,6 +23,7 @@ module Dependabot
   end
 
   class OutOfDisk < DependabotError; end
+
   class OutOfMemory < DependabotError; end
 
   #####################

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -22,6 +22,7 @@ module Dependabot
     end
   end
 
+  class OutOfDisk < DependabotError; end
   class OutOfMemory < DependabotError; end
 
   #####################

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -36,7 +36,8 @@ module Dependabot
         ].freeze
 
         OUT_OF_DISK_REGEXES = [
-          %r{input/output error}.freeze
+          %r{input/output error}.freeze,
+          /no space left on device/.freeze
         ].freeze
 
         def initialize(dependencies:, credentials:, repo_contents_path:,

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -479,4 +479,27 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
       end
     end
   end
+
+  describe "#handle_subprocess_error" do
+    context "for a error caused by running out of disk space" do
+      let(:dependency_name) { "rsc.io/quote" }
+      let(:dependency_version) { "v1.5.2" }
+      let(:dependency_previous_version) { "v1.4.0" }
+      let(:requirements) { previous_requirements }
+      let(:previous_requirements) { [] }
+
+      it "raises an OutOfDisk error" do
+        stderr = <<~ERROR
+          rsc.io/quote imports
+            rsc.io/quote/v3 imports
+            rsc.io/sampler imports
+            golang.org/x/text/language: write /tmp/go-codehost-014108053: input/output error
+        ERROR
+
+        expect { updater.send(:handle_subprocess_error, stderr) }.to raise_error(Dependabot::OutOfDisk) do |error|
+          expect(error.message).to include("write /tmp/go-codehost-014108053: input/output error")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Similar to the introduction of the `OutOfMemory` error type in 61e79897c8c79ef0fb2e2c3c23ca8050fcf02754, this pull request introduces an `OutOfDisk` error type.

Incorporating new error types typically requires teaching each ecosystem to make use of the error type. Instead of one long-running pull request to update every ecosystem, this pull request incorporates the `OutOfDisk` error type into the go_modules ecosystem, and paves the way for future pull requests to add it to other ecosystems.

To date, I've seen two stack traces for out of disk errors in the go_modules ecosystem. One includes STDERR content like this:

    rsc.io/sampler imports
    write /opt/go/gopath/pkg/mod/cache/vcs/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/info/attributes: no space left on device

And the other includes STDERR content like this:

    rsc.io/sampler imports
    golang.org/x/text/language: write /tmp/go-codehost-014108053: input/output error

So, when a subprocess errors out, the changes in this pull request will look for those sorts of patterns in STDERR and will raise a `Dependabot::OutOfDisk` error.

Prior to this change, we would instead raise a generic `Dependabot::DependabotError` in this situation. By raising a more specific error type, we can more easily help developers understand exactly why an update failed, and we can instrument this error type to track how frequently it's occurring.