### PR TITLE
go_modules: only stub modules outside the current checkout

### DIFF
--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
         "password" => "token"
       }],
       repo_contents_path: repo_contents_path,
-      directory: "/",
+      directory: directory,
       options: { tidy: tidy, vendor: false }
     )
   end
@@ -25,6 +25,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
   let(:repo_contents_path) { build_tmp_repo(project_name) }
   let(:go_mod_content) { fixture("projects", project_name, "go.mod") }
   let(:tidy) { true }
+  let(:directory) { "/" }
 
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -477,6 +478,29 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
           it { is_expected.to include(%(rsc.io/quote v1.4.0)) }
         end
       end
+    end
+
+    context "for a monorepo" do
+      let(:project_name) { "monorepo" }
+      let(:directory) { "cmd" }
+
+      let(:dependency_name) { "rsc.io/qr" }
+      let(:dependency_version) { "v0.2.0" }
+      let(:dependency_previous_version) { "v0.1.0" }
+      let(:requirements) { previous_requirements }
+      let(:previous_requirements) do
+        [{
+          file: "go.mod",
+          requirement: "v0.1.0",
+          groups: [],
+          source: {
+            type: "default",
+            source: "rsc.io/qr"
+          }
+        }]
+      end
+
+      it { is_expected.to include(%(rsc.io/quote v1.4.0)) }
     end
   end
 end

--- a/go_modules/spec/fixtures/projects/monorepo/cmd/go.mod
+++ b/go_modules/spec/fixtures/projects/monorepo/cmd/go.mod
@@ -1,0 +1,10 @@
+module github.com/dependabot/vgotest/cmd
+
+go 1.15
+
+require (
+	github.com/dependabot/vgotest/common v1.0.0
+	rsc.io/qr v0.1.0
+)
+
+replace github.com/dependabot/vgotest/common => ../common

--- a/go_modules/spec/fixtures/projects/monorepo/cmd/go.sum
+++ b/go_modules/spec/fixtures/projects/monorepo/cmd/go.sum
@@ -1,0 +1,6 @@
+rsc.io/qr v0.1.0 h1:M/sAxsU2J5mlQ4W84Bxga2EgdQqOaAliipcjPmMUM5Q=
+rsc.io/qr v0.1.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=
+rsc.io/quote v1.4.0 h1:tYuJspOzwTRMUOX6qmSDRTEKFVV80GM0/l89OLZuVNg=
+rsc.io/quote v1.4.0/go.mod h1:S2vMDfxMfk+OGQ7xf1uNqJCSuSPCW5QC127LHYfOJmQ=
+rsc.io/sampler v1.0.0 h1:CZX0Ury6np11Lwls9Jja2rFf3YrNPeUPAWiEVrJ0u/4=
+rsc.io/sampler v1.0.0/go.mod h1:cqxpM3ZVz9VtirqxZPmrWzkQ+UkiNiGtkrN+B+i8kx8=

--- a/go_modules/spec/fixtures/projects/monorepo/cmd/main.go
+++ b/go_modules/spec/fixtures/projects/monorepo/cmd/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/dependabot/vgotest/common"
+	_ "rsc.io/qr"
+)
+
+func main() {
+	fmt.Println(common.Hello())
+}

--- a/go_modules/spec/fixtures/projects/monorepo/common/go.mod
+++ b/go_modules/spec/fixtures/projects/monorepo/common/go.mod
@@ -1,0 +1,5 @@
+module github.com/dependabot/vgotest/common
+
+go 1.15
+
+require rsc.io/quote v1.4.0

--- a/go_modules/spec/fixtures/projects/monorepo/common/go.sum
+++ b/go_modules/spec/fixtures/projects/monorepo/common/go.sum
@@ -1,0 +1,4 @@
+rsc.io/quote v1.4.0 h1:tYuJspOzwTRMUOX6qmSDRTEKFVV80GM0/l89OLZuVNg=
+rsc.io/quote v1.4.0/go.mod h1:S2vMDfxMfk+OGQ7xf1uNqJCSuSPCW5QC127LHYfOJmQ=
+rsc.io/sampler v1.0.0 h1:CZX0Ury6np11Lwls9Jja2rFf3YrNPeUPAWiEVrJ0u/4=
+rsc.io/sampler v1.0.0/go.mod h1:cqxpM3ZVz9VtirqxZPmrWzkQ+UkiNiGtkrN+B+i8kx8=

--- a/go_modules/spec/fixtures/projects/monorepo/common/lib.go
+++ b/go_modules/spec/fixtures/projects/monorepo/common/lib.go
@@ -1,0 +1,7 @@
+package common
+
+import "rsc.io/quote"
+
+func Hello() string {
+	return quote.Hello()
+}


### PR DESCRIPTION
Some users have multiple go modules within a single repository, and use `replace` directives to reference local modules on disk. [sample](https://github.com/thepwagner/dependagot/blob/master/go/modules/go.mod#L5).

Previous to this PR, Dependabot would replace all local `replace` directives with stubbed modules, under the assumption that they weren't available.

This assumption changed when Dependabot started cloning full Go repositories (a requirement for `go mod vendor` and `go mod tidy` support)! This PR adjusts the logic to only stub modules that are:
* absolute paths
* relative paths that escape the current checkout (e.g. `../foo` from the root)
* relative paths that do not exist

cc https://github.com/dependabot/dependabot-core/pull/2551#discussion_r494289784