### PR TITLE
v0.127.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.127.1, 14 December 2020
+
+- Bump wheel from 0.36.1 to 0.36.2 in /python/helpers
+- Bump eslint-plugin-prettier from 3.2.0 to 3.3.0 in /npm_and_yarn/helpers
+- Bump @npmcli/arborist from 2.0.0 to 2.0.1 in /npm_and_yarn/helpers
+
 ## v0.127.0, 11 December 2020
 
 - go_modules: raise Dependabot::OutOfDisk error when we're fairly sure that the failure occurred due to running out of disk space

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.127.0"
+  VERSION = "0.127.1"
 end


### PR DESCRIPTION
## v0.127.1, 14 December 2020

- Bump wheel from 0.36.1 to 0.36.2 in /python/helpers
- Bump eslint-plugin-prettier from 3.2.0 to 3.3.0 in /npm_and_yarn/helpers
- Bump @npmcli/arborist from 2.0.0 to 2.0.1 in /npm_and_yarn/helpers

## Notes

- This is a patch version to clear some library upgrades off master ahead of a minor version to add kotlin support to gradle: https://github.com/dependabot/dependabot-core/pull/2680