### PR TITLE
V0.128.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.128.0, 14 December 2020
+
+- Gradle: Support kotlin manifest files (thanks, @shakhar!)
+
 ## v0.127.1, 14 December 2020
 
 - Bump wheel from 0.36.1 to 0.36.2 in /python/helpers

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.127.1"
+  VERSION = "0.128.0"
 end


### PR DESCRIPTION
## v0.128.0, 14 December 2020

- Gradle: Support kotlin manifest files (thanks, @shakhar!)