### PR TITLE
common/spec_helper: tmp_repo return string

### DIFF
--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -1603,7 +1603,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
           end
 
           vendor_files =
-            Dir.entries(File.join(repo_contents_path + "vendor/cache"))
+            Dir.entries(Pathname.new(repo_contents_path).join("vendor/cache"))
 
           expect(file).to be_nil
           expect(vendor_files).to include("business-1.4.0.gem")
@@ -1626,7 +1626,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
             f.name == "vendor/cache/addressable-7.2.0.gem"
           end
           vendor_files =
-            Dir.entries(File.join(repo_contents_path + "vendor/cache"))
+            Dir.entries(Pathname.new(repo_contents_path).join("vendor/cache"))
 
           expect(file).to be_nil
           expect(vendor_files).to include("statesman-7.2.0.gem")

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Dependabot::SharedHelpers do
     let(:repo_contents_path) { build_tmp_repo(project_name) }
 
     it "runs inside the temporary repo directory" do
-      expect(in_a_temporary_repo_directory).to eq(repo_contents_path.to_s)
+      expect(in_a_temporary_repo_directory).to eq(repo_contents_path)
     end
 
     context "with a valid directory" do
@@ -54,7 +54,7 @@ RSpec.describe Dependabot::SharedHelpers do
 
       it "creates the missing directory " do
         expect(in_a_temporary_repo_directory).
-          to eq(repo_contents_path.join(directory).to_s)
+          to eq(Pathname.new(repo_contents_path).join(directory).to_s)
       end
     end
 

--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -86,7 +86,7 @@ def build_tmp_repo(project)
     Dependabot::SharedHelpers.run_shell_command("git commit -m init")
   end
 
-  tmp_repo_path
+  tmp_repo_path.to_s
 end
 
 def project_dependency_files(project)

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -268,7 +268,7 @@ module Dependabot
         end
 
         def module_pathname
-          @module_pathname ||= repo_contents_path.join(directory)
+          @module_pathname ||= Pathname.new(repo_contents_path).join(directory)
         end
 
         def substitute_all(substitutions)


### PR DESCRIPTION
This corrects the assumption that `repo_contents_path` is an instance of `Pathname`, which it only ever is when instantiated by the `build_tmp_repo` helper.
Since that helper already claims to return a`[String]`, correct it.

# Related
- #2848 