### PR TITLE
go_modules: fix test warning 🩹 

### DIFF
--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
             # NOTE: We explitly don't want to raise a resolvability error from go mod tidy
             it "does not raises a DependencyFileNotResolvable error" do
               expect { updater.updated_go_sum_content }.
-                to_not raise_error(Dependabot::DependencyFileNotResolvable)
+                to_not raise_error
             end
 
             it "updates the go.mod" do


### PR DESCRIPTION
Don't `expect().not_to raise_error(SpecificError)`, since that masks all other potential errors.