### PR TITLE
go_modules: GitDependenciesNotReachable.urls are repos, not module paths

### DIFF
--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -166,10 +166,10 @@ RSpec.describe Dependabot::GoModules::FileParser do
     end
 
     describe "a non-existent github.com versioned repository" do
-      let(:invalid_repo) { "github.com/dependabot-fixtures/must-never-exist/v2" }
+      let(:invalid_repo) { "github.com/dependabot-fixtures/must-never-exist" }
       let(:go_mod_content) do
         go_mod = fixture("go_mods", go_mod_fixture_name)
-        go_mod.sub("rsc.io/quote v1.4.0", "#{invalid_repo} v2.0.0")
+        go_mod.sub("rsc.io/quote v1.4.0", "#{invalid_repo}/v2 v2.0.0")
       end
 
       it "raises the correct error" do


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/2791 we added a test for unreachable dependencies that aren't located at the repository root. 

At the time it was assumed that since the user wrote `github.com/thepwagner/my-awesome-repo/v2` that was the best "dependency URL" to return with errors. Since introducing [updates from private GitHub repositories](https://github.blog/changelog/2020-12-02-dependabot-version-updates-from-private-github-repositories/) it has become clear that recording the problematic repository is a better solution than the exact path.

This PR adjusts the behaviour so only the base repository URL (e.g. `github.com/${owner}/${repo}`) is raised in the error for unreachable git dependencies.