### PR TITLE
gomod: Do not attempt to parse transitive dependencies

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -17,7 +17,7 @@ module Dependabot
         dependency_set = Dependabot::FileParsers::Base::DependencySet.new
 
         required_packages.each do |dep|
-          dependency_set << dependency_from_details(dep)
+          dependency_set << dependency_from_details(dep) unless dep["Indirect"]
         end
 
         dependency_set.dependencies

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -60,7 +60,7 @@ module Dependabot
         @required_packages ||=
           SharedHelpers.in_a_temporary_directory do |path|
             # Create a fake empty module for each local module so that
-            # `go list` works, even if some modules have been `replace`d with
+            # `go mod edit` works, even if some modules have been `replace`d with
             # a local module that we don't have access to.
             local_replacements.each do |_, stub_path|
               Dir.mkdir(stub_path) unless Dir.exist?(stub_path)

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Dependabot::GoModules::FileParser do
   describe "parse" do
     subject(:dependencies) { parser.parse }
 
-    its(:length) { is_expected.to eq(6) }
+    its(:length) { is_expected.to eq(5) }
 
     describe "top level dependencies" do
       subject(:dependencies) do

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Dependabot::GoModules::FileParser do
   describe "parse" do
     subject(:dependencies) { parser.parse }
 
-    its(:length) { is_expected.to eq(5) }
+    its(:length) { is_expected.to eq(3) }
 
     describe "top level dependencies" do
       subject(:dependencies) do

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -144,9 +144,8 @@ RSpec.describe Dependabot::GoModules::FileParser do
         go_mod.sub("rsc.io/quote", "example.com/not-a-repo")
       end
 
-      it "raises the correct error" do
-        expect { parser.parse }.
-          to raise_error(Dependabot::DependencyFileNotResolvable)
+      it "does not raise an error" do
+        expect { parser.parse }.not_to raise_error
       end
     end
 
@@ -157,11 +156,8 @@ RSpec.describe Dependabot::GoModules::FileParser do
         go_mod.sub("rsc.io/quote", invalid_repo)
       end
 
-      it "raises the correct error" do
-        expect { parser.parse }.
-          to raise_error(Dependabot::GitDependenciesNotReachable) do |error|
-            expect(error.dependency_urls).to contain_exactly(invalid_repo)
-          end
+      it "does not raise an error" do
+        expect { parser.parse }.not_to raise_error
       end
     end
 
@@ -172,11 +168,8 @@ RSpec.describe Dependabot::GoModules::FileParser do
         go_mod.sub("rsc.io/quote v1.4.0", "#{invalid_repo}/v2 v2.0.0")
       end
 
-      it "raises the correct error" do
-        expect { parser.parse }.
-          to raise_error(Dependabot::GitDependenciesNotReachable) do |error|
-            expect(error.dependency_urls).to contain_exactly(invalid_repo)
-          end
+      it "does not raise an error" do
+        expect { parser.parse }.not_to raise_error
       end
     end
 
@@ -186,9 +179,8 @@ RSpec.describe Dependabot::GoModules::FileParser do
         go_mod.sub("github.com/mattn/go-colorable v0.0.9", "github.com/mattn/go-colorable v0.1234.4321")
       end
 
-      it "raises the correct error" do
-        expect { parser.parse }.
-          to raise_error(Dependabot::DependencyFileNotResolvable)
+      it "does not raise an error" do
+        expect { parser.parse }.not_to raise_error
       end
     end
 
@@ -197,10 +189,7 @@ RSpec.describe Dependabot::GoModules::FileParser do
       let(:go_mod_fixture_name) { "parent_module.mod" }
 
       it "raises the correct error" do
-        expect { parser.parse }.
-          to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
-            expect(error.message).to include("hmarr/404")
-          end
+        expect { parser.parse }.not_to raise_error
       end
     end
 
@@ -210,9 +199,8 @@ RSpec.describe Dependabot::GoModules::FileParser do
         go_mod.sub("rsc.io/quote v1.4.0", "rsc.io/quote v1.321.0")
       end
 
-      it "raises the correct error" do
-        expect { parser.parse }.
-          to raise_error(Dependabot::DependencyFileNotResolvable)
+      it "does not raise an error" do
+        expect { parser.parse }.not_to raise_error
       end
     end
 
@@ -223,11 +211,8 @@ RSpec.describe Dependabot::GoModules::FileParser do
                    "github.com/hmarr/404 v0.0.0-20181216014959-b89dc648a159")
       end
 
-      it "raises the correct error" do
-        expect { parser.parse }.
-          to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
-            expect(error.message).to include("hmarr/404")
-          end
+      it "does not raise an error" do
+        expect { parser.parse }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
Previously we would run `go list -m -json all` to generate a list of
dependencies to attempt to update.

The way that this is implemented, it causes _every_ transitive
dependency to be listed, even if they are not required by this project.

This can happen when a module defines several packages, but only a
subset of those packages is used by the current repository.

It will also verify that each of those transitive dependencies is
available, and this causes issues when we rely on a dependency with
private transitive dependencies. We run into the scenario where we have
access to any of the transitive dependencies that are used, but since we
do not have access to an _unused_ transitive dependency, we run into a
`dependency_file_not_resolvable` error.

This is especially unfortunate, since we won't attempt to update _any_
indirect dependencies for go_modules anyway.

By using `go mod edit -json` instead, we get an easier to parse list of
dependencies, and we grab just the direct ones.

In order to replicate the previous behavior of raising a
`DependencyFileNotResolvable` error when some of the packages are not
available, we now also run a `go get`, but it's debatable if we even
need to do this, since this error will be raised in subsequent steps (in
the `FileUpdater`), and not raising it here means that we can
consolidate our error handling for this scenario in one place.

Co-authored-by: Fatih Arslan <fatih@github.com>