### PR TITLE
Verify if composer name is compatible with v2

### DIFF
--- a/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
@@ -7,6 +7,7 @@ require "dependabot/composer/file_updater"
 require "dependabot/composer/version"
 require "dependabot/composer/requirement"
 require "dependabot/composer/native_helpers"
+require "dependabot/composer/helpers"
 
 # rubocop:disable Metrics/ClassLength
 module Dependabot
@@ -448,13 +449,7 @@ module Dependabot
         end
 
         def composer_version
-          @composer_version ||=
-            begin
-              return "v2" unless parsed_lockfile["plugin-api-version"]
-
-              version = Version.new(parsed_lockfile["plugin-api-version"])
-              version.canonical_segments.first == 1 ? "v1" : "v2"
-            end
+          @composer_version ||= Helpers.composer_version(parsed_composer_json, parsed_lockfile)
         end
 
         def credentials_env

--- a/composer/lib/dependabot/composer/helpers.rb
+++ b/composer/lib/dependabot/composer/helpers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "dependabot/composer/version"
+
+module Dependabot
+  module Composer
+    module Helpers
+      # From composers json-schema: https://getcomposer.org/schema.json
+      COMPOSER_V2_NAME_REGEX = %r{^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$}.freeze
+
+      def self.composer_version(composer_json, parsed_lockfile = nil)
+        return "v1" if composer_json["name"] && composer_json["name"] !~ COMPOSER_V2_NAME_REGEX
+        return "v2" unless parsed_lockfile && parsed_lockfile["plugin-api-version"]
+
+        version = Composer::Version.new(parsed_lockfile["plugin-api-version"])
+        version.canonical_segments.first == 1 ? "v1" : "v2"
+      end
+    end
+  end
+end

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -8,6 +8,8 @@ require "dependabot/composer/version"
 require "dependabot/composer/requirement"
 require "dependabot/composer/native_helpers"
 require "dependabot/composer/file_parser"
+require "dependabot/composer/helpers"
+
 module Dependabot
   module Composer
     class UpdateChecker
@@ -433,13 +435,8 @@ module Dependabot
         end
 
         def composer_version
-          @composer_version ||=
-            begin
-              return "v2" unless lockfile && parsed_lockfile["plugin-api-version"]
-
-              version = Version.new(parsed_lockfile["plugin-api-version"])
-              version.canonical_segments.first == 1 ? "v1" : "v2"
-            end
+          parsed_lockfile_or_nil = lockfile ? parsed_lockfile : nil
+          @composer_version ||= Helpers.composer_version(parsed_composer_file, parsed_lockfile_or_nil)
         end
 
         def initial_platform

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -190,6 +190,15 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       end
     end
 
+    context "with a name that is only valid in v1" do
+      let(:project_name) { "v1/invalid_v2_name" }
+      let(:dependency_name) { "monolog/monolog" }
+      let(:latest_allowable_version) { Gem::Version.new("1.25.1") }
+      let(:dependency_version) { "1.0.2" }
+
+      it { is_expected.to eq(Dependabot::Composer::Version.new("1.25.1")) }
+    end
+
     # This test is extremely slow, as it needs to wait for Composer to time out.
     # As a result we currently keep it commented out.
     # context "with an unreachable private registry" do

--- a/composer/spec/fixtures/projects/v1/invalid_v2_name/composer.json
+++ b/composer/spec/fixtures/projects/v1/invalid_v2_name/composer.json
@@ -1,0 +1,12 @@
+{
+  "name": "this name is no longer valid in composerv2",
+  "version": "3.1.7",
+  "dist": {
+    "url": "https://www.example.net/files/3.1.7.zip",
+    "type": "zip"
+  },
+  "require": {
+    "monolog/monolog" : "1.0.1",
+    "symfony/polyfill-mbstring": "1.0.1"
+  }
+}


### PR DESCRIPTION
Composer v2 introduced a check on package names, and when no lockfile is
present to validate the plugin-api-version this causes us to attempt the
update with v2, which will fail because of this invalid name.

This includes an extra check to make sure the name is compatible with
the constraints of composer v2.