### PR TITLE
Resolve Python undefined name `hass_const`

### DIFF
--- a/python/spec/fixtures/setup_files/unparseable_python_requires.py
+++ b/python/spec/fixtures/setup_files/unparseable_python_requires.py
@@ -1,3 +1,4 @@
+import homeassistant.const as hass_const
 from setuptools import setup, find_packages
 
 MIN_PY_VERSION = '.'.join(map(str, hass_const.REQUIRED_PYTHON_VER))


### PR DESCRIPTION
@feelepxyz `import homeassistant.const as hass_const` as discussed in #1376

Also related to #2892

https://github.com/home-assistant/core/blob/dev/setup.py#L7 -->
https://github.com/home-assistant/core/blob/dev/homeassistant/const.py#L7