### PR TITLE
v0.129.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## v0.129.1, 21 December 2020
+
+- Bump phpstan/phpstan from 0.12.59 to 0.12.63
+- Bump friendsofphp/php-cs-fixer
+- Composer: Verify if composer name is compatible with v2
+- Python: Upgrade Python version to 3.9.1 (@ulgens)
+- Bump npm from 6.14.9 to 6.14.10 in /npm_and_yarn/helpers
+- Bump eslint from 7.15.0 to 7.16.0 in /npm_and_yarn/helpers
+- Sanitize creds from DependabotError
+- Bump composer/composer from 1.10.16 to 1.10.19 in /composer/helpers/v1
+- Bump pip from 20.3.1 to 20.3.3 in /python/helpers
+- Bump @npmcli/arborist from 2.0.1 to 2.0.2 in /npm_and_yarn/helpers
+- go_modules: limit GitDeps to repo
+- go_modules: fix test warning
+
 ## v0.129.0, 15 December 2020
 
 - Composer: Support composer v2 alongside v1 (Thanks for helping out @WyriHaximus)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.129.0"
+  VERSION = "0.129.1"
 end


### PR DESCRIPTION
- Bump phpstan/phpstan from 0.12.62 to 0.12.63 in /composer/helpers/v2
- Bump friendsofphp/php-cs-fixer in /composer/helpers/v2
- Composer: Verify if composer name is compatible with v2
- Python: Upgrade Python version to 3.9.1 (@ulgens)
- Bump npm from 6.14.9 to 6.14.10 in /npm_and_yarn/helpers
- Bump eslint from 7.15.0 to 7.16.0 in /npm_and_yarn/helpers
- Bump friendsofphp/php-cs-fixer in /composer/helpers/v1
- Sanitize creds from DependabotError
- Bump composer/composer from 1.10.16 to 1.10.19 in /composer/helpers/v1
- Bump phpstan/phpstan from 0.12.62 to 0.12.63 in /composer/helpers/v1
- Bump pip from 20.3.1 to 20.3.3 in /python/helpers
- Bump @npmcli/arborist from 2.0.1 to 2.0.2 in /npm_and_yarn/helpers
- go_modules: limit GitDeps to repo
- go_modules: fix test warning
- Bump phpstan/phpstan from 0.12.59 to 0.12.62 in /composer/helpers/v2
- Bump friendsofphp/php-cs-fixer in /composer/helpers/v1
- Bump phpstan/phpstan from 0.12.59 to 0.12.62 in /composer/helpers/v1
