### PR TITLE
Include native helpers in bundler gem

### DIFF
--- a/bundler/dependabot-bundler.gemspec
+++ b/bundler/dependabot-bundler.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   next unless File.directory?("lib")
 
   prefix = "/" + File.basename(File.expand_path(__dir__)) + "/"
-  Find.find("lib") do |path|
+  Find.find("lib", "helpers") do |path|
     if ignores.any? { |i| File.fnmatch(i, prefix + path, File::FNM_DOTMATCH) }
       Find.prune
     else


### PR DESCRIPTION
When we moved this code out into native helpers, those were not included
in the gem that we build.

This has historically not really been an issue for us, since we run
Dependabot in the Docker environment where these helpers are manually
copied over. But for people using the gem as a standalone, this means it
no longer works.

Fixes #2885