### PR TITLE
Composer: use github token in test env 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,13 @@ jobs:
           else
             echo "No Docker credentials, skipping login"
           fi
+      - name: Set test env credentials
+        run: |
+          if [ -n "${{ secrets.PUBLIC_REPO_GITHUB_TOKEN }}" ]; then
+            echo "DEPENDABOT_TEST_ACCESS_TOKEN=${{ secrets.PUBLIC_REPO_GITHUB_TOKEN }}" >> $GITHUB_ENV
+          else
+            echo "No test credentials, skipping"
+          fi
       - name: Pull Docker base images & warm Docker cache
         run: |
           docker pull "$BASE_IMAGE"
@@ -97,6 +104,5 @@ jobs:
           docker run --rm "$CORE_CI_IMAGE" bash -c "cd /opt/npm_and_yarn && yarn test"
       - name: Run ${{ matrix.suite }} tests with rspec
         run: |
-          docker run --env "CI=true" --rm "$CORE_CI_IMAGE" bash -c \
-            "cd /home/dependabot/dependabot-core/${{ matrix.suite }} && \
-            bundle exec rspec spec"
+          docker run --env "CI=true" --env "DEPENDABOT_TEST_ACCESS_TOKEN=$DEPENDABOT_TEST_ACCESS_TOKEN" --rm "$CORE_CI_IMAGE" bash -c \
+            "cd /home/dependabot/dependabot-core/${{ matrix.suite }} && bundle exec rspec spec"

--- a/composer/spec/dependabot/composer/file_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater_spec.rb
@@ -17,12 +17,7 @@ RSpec.describe Dependabot::Composer::FileUpdater do
     )
   end
 
-  let(:credentials) do
-    [{
-      "type" => "git_source",
-      "host" => "github.com"
-    }]
-  end
+  let(:credentials) { github_credentials }
   let(:files) { project_dependency_files(project_name) }
   let(:project_name) { "exact_version" }
 

--- a/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
@@ -33,14 +33,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
   let(:requirements) do
     [{ file: "composer.json", requirement: "1.0.*", groups: [], source: nil }]
   end
-  let(:credentials) do
-    [{
-      "type" => "git_source",
-      "host" => "github.com",
-      "username" => "x-access-token",
-      "password" => "token"
-    }]
-  end
+  let(:credentials) { github_credentials }
   let(:files) { project_dependency_files(project_name) }
   let(:project_name) { "exact_version" }
 

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -16,14 +16,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
     )
   end
 
-  let(:credentials) do
-    [{
-      "type" => "git_source",
-      "host" => "github.com",
-      "username" => "x-access-token",
-      "password" => "token"
-    }]
-  end
+  let(:credentials) { github_credentials }
   let(:requirements_to_unlock) { :own }
   let(:dependency_files) { project_dependency_files(project_name) }
 


### PR DESCRIPTION
Fixes flaky test failures where composer runs into gh rate limits:
`Could not authenticate against github.com`

Requires `DEPENDABOT_TEST_ACCESS_TOKEN` to be set in CI.

Flattened the git specs as they where pretty hard to reason about with
lots of nested lets.