### PR TITLE
Use GITHUB_TOKEN as a test token to fix fork specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,7 @@ jobs:
           fi
       - name: Set test env credentials
         run: |
-          if [ -n "${{ secrets.PUBLIC_REPO_GITHUB_TOKEN }}" ]; then
-            echo "DEPENDABOT_TEST_ACCESS_TOKEN=${{ secrets.PUBLIC_REPO_GITHUB_TOKEN }}" >> $GITHUB_ENV
-          else
-            echo "No test credentials, skipping"
-          fi
+          echo "DEPENDABOT_TEST_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
       - name: Pull Docker base images & warm Docker cache
         run: |
           docker pull "$BASE_IMAGE"


### PR DESCRIPTION
It's used to authenticate composer github requests to get around api rate limits