### PR TITLE
GoModUpdater: return updated go.mod directly

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -193,15 +193,6 @@ module Dependabot
           end
         end
 
-        def add_requirements(requirements)
-          requirements.each do |r|
-            escaped_req = Shellwords.escape("#{r['Path']}@#{r['Version']}")
-            command = "go mod edit -require #{escaped_req}"
-            _, stderr, status = Open3.capture3(ENVIRONMENT, command)
-            handle_subprocess_error(stderr) unless status.success?
-          end
-        end
-
         def in_repo_path(&block)
           SharedHelpers.
             in_a_temporary_repo_directory(directory, repo_contents_path) do

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -252,7 +252,7 @@ module Dependabot
         end
 
         def module_pathname
-          @module_pathname ||= Pathname.new(repo_contents_path).join(directory)
+          @module_pathname ||= Pathname.new(repo_contents_path).join(directory.sub(%r{^/}, ""))
         end
 
         def substitute_all(substitutions)

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -69,7 +69,7 @@ module Dependabot
           @updated_files ||= update_files
         end
 
-        def update_files
+        def update_files # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
           in_repo_path do
             # Map paths in local replace directives to path hashes
 
@@ -99,8 +99,8 @@ module Dependabot
             updated_go_mod = File.read("go.mod")
 
             # running "go get" may inject the current go version, remove it
-            original_go_version = original_go_mod.match(GO_MOD_VERSION)
-            updated_go_version = updated_go_mod.match(GO_MOD_VERSION)
+            original_go_version = original_go_mod.match(GO_MOD_VERSION)&.to_a&.first
+            updated_go_version = updated_go_mod.match(GO_MOD_VERSION)&.to_a&.first
             if original_go_version != updated_go_version
               go_mod_lines = updated_go_mod.lines
               go_mod_lines.each_with_index do |line, i|

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -481,9 +481,9 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
       end
     end
 
-    context "for a monorepo" do
+    context "for a monorepo directory" do
       let(:project_name) { "monorepo" }
-      let(:directory) { "cmd" }
+      let(:directory) { "/cmd" }
 
       let(:dependency_name) { "rsc.io/qr" }
       let(:dependency_version) { "v0.2.0" }
@@ -501,6 +501,36 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
         }]
       end
 
+      # updated and tidied
+      it { is_expected.to include(%(rsc.io/qr v0.2.0)) }
+      it { is_expected.not_to include(%(rsc.io/qr v0.1.0)) }
+      # module was not stubbed
+      it { is_expected.to include(%(rsc.io/quote v1.4.0)) }
+    end
+
+    context "for a monorepo root" do
+      let(:project_name) { "monorepo" }
+
+      let(:dependency_name) { "rsc.io/qr" }
+      let(:dependency_version) { "v0.2.0" }
+      let(:dependency_previous_version) { "v0.1.0" }
+      let(:requirements) { previous_requirements }
+      let(:previous_requirements) do
+        [{
+          file: "go.mod",
+          requirement: "v0.1.0",
+          groups: [],
+          source: {
+            type: "default",
+            source: "rsc.io/qr"
+          }
+        }]
+      end
+
+      # updated and tidied
+      it { is_expected.to include(%(rsc.io/qr v0.2.0)) }
+      it { is_expected.not_to include(%(rsc.io/qr v0.1.0)) }
+      # module was not stubbed
       it { is_expected.to include(%(rsc.io/quote v1.4.0)) }
     end
 

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -503,6 +503,30 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
 
       it { is_expected.to include(%(rsc.io/quote v1.4.0)) }
     end
+
+    context "for an external path replacement" do
+      let(:project_name) { "substituted" }
+
+      let(:dependency_name) { "rsc.io/qr" }
+      let(:dependency_version) { "v0.2.0" }
+      let(:dependency_previous_version) { "v0.1.0" }
+      let(:requirements) { previous_requirements }
+      let(:previous_requirements) do
+        [{
+          file: "go.mod",
+          requirement: "v0.1.0",
+          groups: [],
+          source: {
+            type: "default",
+            source: "rsc.io/qr"
+          }
+        }]
+      end
+
+      # Update is applied, stubbed indirect dependencies are not culled
+      it { is_expected.to include(%(rsc.io/qr v0.2.0)) }
+      it { is_expected.to include(%(rsc.io/quote v1.4.0)) }
+    end
   end
 
   describe "#handle_subprocess_error" do

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
           let(:project_name) { "go_1.11" }
 
           it { is_expected.to_not include("go 1.") }
+          it { is_expected.to include("module github.com/dependabot/vgotest\n\nrequire") }
         end
 
         context "for a go 1.12 go.mod" do

--- a/go_modules/spec/fixtures/projects/go_1.11/go.mod
+++ b/go_modules/spec/fixtures/projects/go_1.11/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fatih/Color v1.7.0
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
+	golang.org/x/sys v0.0.0-20201221093633-bc327ba9c2f0 // indirect
 	rsc.io/qr v0.1.0
 	rsc.io/quote v1.4.0
 )

--- a/go_modules/spec/fixtures/projects/go_1.11/main.go
+++ b/go_modules/spec/fixtures/projects/go_1.11/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	_ "github.com/fatih/Color"
+	_ "rsc.io/qr"
+	_ "rsc.io/quote"
+)
+
+func main() {
+}

--- a/go_modules/spec/fixtures/projects/monorepo/go.mod
+++ b/go_modules/spec/fixtures/projects/monorepo/go.mod
@@ -1,0 +1,10 @@
+module github.com/dependabot/vgotest/root
+
+go 1.15
+
+require (
+	github.com/dependabot/vgotest/common v1.0.0
+	rsc.io/qr v0.1.0
+)
+
+replace github.com/dependabot/vgotest/common => ./common

--- a/go_modules/spec/fixtures/projects/monorepo/go.sum
+++ b/go_modules/spec/fixtures/projects/monorepo/go.sum
@@ -1,0 +1,6 @@
+rsc.io/qr v0.1.0 h1:M/sAxsU2J5mlQ4W84Bxga2EgdQqOaAliipcjPmMUM5Q=
+rsc.io/qr v0.1.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=
+rsc.io/quote v1.4.0 h1:tYuJspOzwTRMUOX6qmSDRTEKFVV80GM0/l89OLZuVNg=
+rsc.io/quote v1.4.0/go.mod h1:S2vMDfxMfk+OGQ7xf1uNqJCSuSPCW5QC127LHYfOJmQ=
+rsc.io/sampler v1.0.0 h1:CZX0Ury6np11Lwls9Jja2rFf3YrNPeUPAWiEVrJ0u/4=
+rsc.io/sampler v1.0.0/go.mod h1:cqxpM3ZVz9VtirqxZPmrWzkQ+UkiNiGtkrN+B+i8kx8=

--- a/go_modules/spec/fixtures/projects/monorepo/main.go
+++ b/go_modules/spec/fixtures/projects/monorepo/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/dependabot/vgotest/common"
+	_ "rsc.io/qr"
+)
+
+func main() {
+	fmt.Println(common.Hello())
+}

--- a/go_modules/spec/fixtures/projects/substituted/go.mod
+++ b/go_modules/spec/fixtures/projects/substituted/go.mod
@@ -1,0 +1,12 @@
+module github.com/dependabot/vgotest/cmd
+
+go 1.15
+
+require (
+	github.com/dependabot/vgotest/common v1.0.0
+	rsc.io/qr v0.1.0
+)
+
+// valid on a checkout, but invalid to Dependabot
+replace github.com/dependabot/vgotest/common => ../monorepo/common
+

--- a/go_modules/spec/fixtures/projects/substituted/go.sum
+++ b/go_modules/spec/fixtures/projects/substituted/go.sum
@@ -1,0 +1,6 @@
+rsc.io/qr v0.1.0 h1:M/sAxsU2J5mlQ4W84Bxga2EgdQqOaAliipcjPmMUM5Q=
+rsc.io/qr v0.1.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=
+rsc.io/quote v1.4.0 h1:tYuJspOzwTRMUOX6qmSDRTEKFVV80GM0/l89OLZuVNg=
+rsc.io/quote v1.4.0/go.mod h1:S2vMDfxMfk+OGQ7xf1uNqJCSuSPCW5QC127LHYfOJmQ=
+rsc.io/sampler v1.0.0 h1:CZX0Ury6np11Lwls9Jja2rFf3YrNPeUPAWiEVrJ0u/4=
+rsc.io/sampler v1.0.0/go.mod h1:cqxpM3ZVz9VtirqxZPmrWzkQ+UkiNiGtkrN+B+i8kx8=

--- a/go_modules/spec/fixtures/projects/substituted/main.go
+++ b/go_modules/spec/fixtures/projects/substituted/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/dependabot/vgotest/common"
+	_ "rsc.io/qr"
+)
+
+func main() {
+	fmt.Println(common.Hello())
+}


### PR DESCRIPTION
Previously Dependabot would extract the changes detected in `go.mod`, then use `go mod edit -{drop,}require` to re-apply the updated paths on to the original `go.mod`.

This PR asserts that since Dependabot supports `go mod tidy`, customers expect `go.mod` to be tidied. That allows us to skip this additional complexity+compute of reapplying updates by returning the tidied contents directly.

Extra care is taken to ensure Dependabot won't inject a go language version (the `go` directive, e.g. `go 1.15`), to avoid regression. AFAICT this will be added by all versions since `go1.12 (released 2019/02/25)`. Meaning the potential for injection only affects modules that immediately upgrade to vgo when it became available, `go1.11 (released 2018/08/24)`, and haven't updated since. Likely rare.