### PR TITLE
[azure] Add retries for Azure client

### DIFF
--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -7,7 +7,9 @@ module Dependabot
   module Clients
     class Azure
       class NotFound < StandardError; end
+      class ServiceNotAvailaible < StandardError; end
 
+      RETRYABLE_ERRORS = [Dependabot::Clients::Azure::ServiceNotAvailaible].freeze
       MAX_PR_DESCRIPTION_LENGTH = 3999
 
       #######################
@@ -175,15 +177,21 @@ module Dependabot
       # rubocop:enable Metrics/ParameterLists
 
       def get(url)
-        response = Excon.get(
-          url,
-          user: credentials&.fetch("username", nil),
-          password: credentials&.fetch("password", nil),
-          idempotent: true,
-          **SharedHelpers.excon_defaults(
-            headers: auth_header
-          )
-        )
+        response = nil
+        retry_connection_failures do
+          response = Excon.get(
+                  url,
+                  user: credentials&.fetch("username", nil),
+                  password: credentials&.fetch("password", nil),
+                  idempotent: true,
+                  **SharedHelpers.excon_defaults(
+                    headers: auth_header
+                  )
+                )
+          
+          raise ServiceNotAvailaible if response.status == 500
+        end
+      
         raise NotFound if response.status == 404
 
         response
@@ -210,6 +218,17 @@ module Dependabot
       end
 
       private
+      
+      def retry_connection_failures
+        retry_attempt = 0
+
+        begin
+          yield
+        rescue *RETRYABLE_ERRORS
+          retry_attempt += 1
+          retry_attempt <= @max_retries ? retry : raise
+        end
+      end
 
       def auth_header_for(token)
         return {} unless token

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -7,9 +7,15 @@ module Dependabot
   module Clients
     class Azure
       class NotFound < StandardError; end
+
+      class InternalServerError < StandardError; end
+
       class ServiceNotAvailaible < StandardError; end
 
-      RETRYABLE_ERRORS = [Dependabot::Clients::Azure::ServiceNotAvailaible].freeze
+      class BadGateway < StandardError; end
+
+      RETRYABLE_ERRORS = [InternalServerError, BadGateway, ServiceNotAvailaible].freeze
+
       MAX_PR_DESCRIPTION_LENGTH = 3999
 
       #######################
@@ -29,10 +35,11 @@ module Dependabot
       # Client #
       ##########
 
-      def initialize(source, credentials)
+      def initialize(source, credentials, max_retries: 3)
         @source = source
         @credentials = credentials
         @auth_header = auth_header_for(credentials&.fetch("token", nil))
+        @max_retries = max_retries || 3
       end
 
       def fetch_commit(_repo, branch)
@@ -178,20 +185,23 @@ module Dependabot
 
       def get(url)
         response = nil
+
         retry_connection_failures do
           response = Excon.get(
-                  url,
-                  user: credentials&.fetch("username", nil),
-                  password: credentials&.fetch("password", nil),
-                  idempotent: true,
-                  **SharedHelpers.excon_defaults(
-                    headers: auth_header
-                  )
-                )
-          
-          raise ServiceNotAvailaible if response.status == 500
+            url,
+            user: credentials&.fetch("username", nil),
+            password: credentials&.fetch("password", nil),
+            idempotent: true,
+            **SharedHelpers.excon_defaults(
+              headers: auth_header
+            )
+          )
+
+          raise InternalServerError if response.status == 500
+          raise BadGateway if response.status == 502
+          raise ServiceNotAvailaible if response.status == 503
         end
-      
+
         raise NotFound if response.status == 404
 
         response
@@ -218,7 +228,7 @@ module Dependabot
       end
 
       private
-      
+
       def retry_connection_failures
         retry_attempt = 0
 

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -185,8 +185,8 @@ RSpec.describe Dependabot::Clients::Azure do
         expect(response.status).to eq(200)
       end
 
-      it "with failure count > max_retries rasie error" do
-        #  Request fails (503) multiple times and exceeds max_retry limimt
+      it "with failure count > max_retries raises error" do
+        #  Request fails (503) multiple times and exceeds max_retry limit
         stub_request(:get, base_url).
           with(basic_auth: [username, password]).
           to_return({ status: 503 }, { status: 503 }, { status: 503 })


### PR DESCRIPTION
Azure client today doesn't implement any retries. When working with bigger repos, we see (transient) ServiceUnavailable often. This PR adds retries for the standard 500, 502 and 503 errors. 