### PR TITLE
pin faraday for octokit

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "commonmarker", ">= 0.20.1", "< 0.22.0"
   spec.add_dependency "docker_registry2", "~> 1.7", ">= 1.7.1"
   spec.add_dependency "excon", "~> 0.75"
+  # TODO https://github.com/octokit/octokit.rb/issues/1315
+  spec.add_dependency "faraday", "< 1.2.0"
   spec.add_dependency "gitlab", "4.17.0"
   spec.add_dependency "nokogiri", "~> 1.8"
   spec.add_dependency "octokit", "~> 4.6"

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "commonmarker", ">= 0.20.1", "< 0.22.0"
   spec.add_dependency "docker_registry2", "~> 1.7", ">= 1.7.1"
   spec.add_dependency "excon", "~> 0.75"
-  # TODO https://github.com/octokit/octokit.rb/issues/1315
+  # TODO: https://github.com/octokit/octokit.rb/issues/1315
   spec.add_dependency "faraday", "< 1.2.0"
   spec.add_dependency "gitlab", "4.17.0"
   spec.add_dependency "nokogiri", "~> 1.8"


### PR DESCRIPTION
Per https://github.com/octokit/octokit.rb/issues/1315

[faraday-1.2.0](https://github.com/lostisland/faraday/releases/tag/v1.2.0) released recently, breaking Dependabot CI.
Specifically, errors are being returned as resources instead of raised as exceptions like `Octokit::NotFound`.

🩹 CI by pinning faraday to the previous version.

# Related
- discovered https://github.com/dependabot/dependabot-core/pull/2911
- discovered https://github.com/dependabot/dependabot-core/pull/2912