### PR TITLE
dockerignore helpers/helpers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@
 /helpers
 /spec
 gitignored
+/bundler/helpers/helpers/
+/python/helpers/helpers/


### PR DESCRIPTION
These directories are created by the setup in [`bin/docker-dev-shell`](https://github.com/dependabot/dependabot-core/blob/f66290a0e341e656784fd1dae0d7e80ea913ebac/bin/docker-dev-shell#L164-L165),
and [cache-bust the docker build](https://github.com/dependabot/dependabot-core/blob/f66290a0e341e656784fd1dae0d7e80ea913ebac/Dockerfile#L182).

They're already `.gitignore`-ed, by `.dockerignore`-ing we can have docker 
cache hits for `bin/docker-dev-shell --rebuild` 🩹 🎉 .

This has no affect outside local development experience.