### PR TITLE
dry-run: configurable source provider

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -91,6 +91,7 @@ require "dependabot/terraform"
 
 $options = {
   credentials: [],
+  provider: "github",
   directory: "/",
   dependency_names: nil,
   branch: nil,
@@ -132,6 +133,10 @@ end
 
 option_parse = OptionParser.new do |opts|
   opts.banner = "usage: ruby bin/dry-run.rb [OPTIONS] PACKAGE_MANAGER REPO"
+
+  opts.on("--provider PROVIDER", "SCM provider e.g. github, azure, bitbucket") do |value|
+    $options[:provider] = value
+  end
 
   opts.on("--dir DIRECTORY", "Dependency file directory") do |value|
     $options[:directory] = value
@@ -413,7 +418,7 @@ def handle_dependabot_error(error:, dependency:)
 end
 
 source = Dependabot::Source.new(
-  provider: "github",
+  provider: $options[:provider],
   repo: $repo_name,
   directory: $options[:directory],
   branch: $options[:branch],


### PR DESCRIPTION
This modifies the `bin/dry-run.rb` testing script to accept a `--provider PROVIDER` argument, which can be used to select from [any available source providers](https://github.com/dependabot/dependabot-core/blob/f66290a0e341e656784fd1dae0d7e80ea913ebac/common/lib/dependabot/file_fetchers/base.rb#L200-L212).
This makes functionally testing authentication changes like #2918 easier.

To verify this change use a public repository. I searched `package.json site:bitbucket.org` and found [atlassian/atlasboard](https://bitbucket.org/atlassian/atlasboard/src/master/package.json):
```
bin/dry-run.rb --provider bitbucket npm_and_yarn atlassian/atlasboard
```