### PR TITLE
revert faraday restriction

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -27,8 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "commonmarker", ">= 0.20.1", "< 0.22.0"
   spec.add_dependency "docker_registry2", "~> 1.7", ">= 1.7.1"
   spec.add_dependency "excon", "~> 0.75"
-  # TODO: https://github.com/octokit/octokit.rb/issues/1315
-  spec.add_dependency "faraday", "< 1.2.0"
   spec.add_dependency "gitlab", "4.17.0"
   spec.add_dependency "nokogiri", "~> 1.8"
   spec.add_dependency "octokit", "~> 4.6"


### PR DESCRIPTION
This reverts https://github.com/dependabot/dependabot-core/pull/2913 , as https://github.com/octokit/octokit.rb/releases/tag/v4.20.0 was released to address the underlying issue, https://github.com/octokit/octokit.rb/issues/1315

# Related
- Reverts https://github.com/dependabot/dependabot-core/pull/2913
- Closes https://github.com/dependabot/dependabot-core/pull/2914