### PR TITLE
[Gradle] Fix not matched spaces in settings

### DIFF
--- a/gradle/lib/dependabot/gradle/file_fetcher/settings_file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher/settings_file_parser.rb
@@ -6,9 +6,6 @@ module Dependabot
   module Gradle
     class FileFetcher
       class SettingsFileParser
-        INCLUDE_ARGS_REGEX =
-          /(?:^|\s)include(?:\(|\s)(\s*[^\s,\)]+(?:,\s*[^\s,\)]+)*)/.freeze
-
         def initialize(settings_file:)
           @settings_file = settings_file
         end

--- a/gradle/lib/dependabot/gradle/file_fetcher/settings_file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher/settings_file_parser.rb
@@ -49,7 +49,7 @@ module Dependabot
 
         def function_regex(function_name)
           /
-            (?:^|\s)#{Regexp.quote(function_name)}(?:\(|\s)
+            (?:^|\s)#{Regexp.quote(function_name)}(?:\s*\(|\s)
             (?<args>\s*[^\s,\)]+(?:,\s*[^\s,\)]+)*)
           /mx
         end

--- a/gradle/spec/dependabot/gradle/file_fetcher/settings_file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_fetcher/settings_file_parser_spec.rb
@@ -26,6 +26,16 @@ RSpec.describe Dependabot::Gradle::FileFetcher::SettingsFileParser do
       end
     end
 
+    context "with various call styles" do
+      let(:fixture_name) { "call_style_settings.gradle" }
+
+      it "includes the additional declarations" do
+        expect(subproject_paths).to match_array(
+          %w(function_without_space function_with_space implicit implicit_with_many_spaces)
+        )
+      end
+    end
+
     context "when kotlin" do
       let(:settings_file) do
         Dependabot::DependencyFile.new(

--- a/gradle/spec/dependabot/gradle/file_fetcher/settings_file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_fetcher/settings_file_parser_spec.rb
@@ -24,19 +24,19 @@ RSpec.describe Dependabot::Gradle::FileFetcher::SettingsFileParser do
       it "includes the additional declarations" do
         expect(subproject_paths).to match_array(%w(app))
       end
+    end
 
-      context "when kotlin" do
-        let(:settings_file) do
-          Dependabot::DependencyFile.new(
-            name: "settings.gradle.kts",
-            content: fixture("settings_files", fixture_name)
-          )
-        end
-        let(:fixture_name) { "settings.gradle.kts" }
+    context "when kotlin" do
+      let(:settings_file) do
+        Dependabot::DependencyFile.new(
+          name: "settings.gradle.kts",
+          content: fixture("settings_files", fixture_name)
+        )
+      end
+      let(:fixture_name) { "settings.gradle.kts" }
 
-        it "includes the additional declarations" do
-          expect(subproject_paths).to match_array(%w(app))
-        end
+      it "includes the additional declarations" do
+        expect(subproject_paths).to match_array(%w(app))
       end
     end
 

--- a/gradle/spec/fixtures/settings_files/call_style_settings.gradle
+++ b/gradle/spec/fixtures/settings_files/call_style_settings.gradle
@@ -1,0 +1,4 @@
+include(':function_without_space')
+include (':function_with_space')
+include ':implicit'
+include   ":implicit_with_many_spaces"


### PR DESCRIPTION
I had a `settings.gradle.kts` where includes with a space in front of the opening parenthesis were not discovered.

This PR should fix that issue.