### PR TITLE
v0.129.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v0.129.2, 4 January 2021
+
+- go_modules: return tidied `go.mod` contents directly
+- go_modules: fix nested module detection from a monorepo root
+- go_modules: stop parsing indirect dependencies (previous: parsed but not updated)
+- gradle: fix whitespace matching in settings (@bountin)
+- Add token support for BitBucket (@iinuwa)
+- Add retries for Azure client (@GiriB)
+- CI: Add Python flake8 linting
+- Bundler: fix bundler gem when invoked as standalone gem
+- Bump friendsofphp/php-cs-fixer in /composer/helpers/v2
+- Bump friendsofphp/php-cs-fixer in /composer/helpers/v1
+- Bump node-notifier from 8.0.0 to 8.0.1 in /npm_and_yarn/helpers
+- Update rubocop requirement from ~> 1.6.0 to ~> 1.7.0 in /common
+- Update simplecov requirement from ~> 0.20.0 to ~> 0.21.0 in /common
+- Bump eslint from 7.16.0 to 7.17.0 in /npm_and_yarn/helpers
+- Bump phpstan/phpstan from 0.12.63 to 0.12.64 in /composer/helpers/v2
+- Bump phpstan/phpstan from 0.12.63 to 0.12.64 in /composer/helpers/v1
+
 ## v0.129.1, 21 December 2020
 
 - Bump phpstan/phpstan from 0.12.59 to 0.12.63

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.129.1"
+  VERSION = "0.129.2"
 end


### PR DESCRIPTION
Release will contain [these commits](https://github.com/dependabot/dependabot-core/compare/v0.129.1...2380e7c2719ab06a9fffcc3c4b5614e68e867525)

Release will contain these PRs:
* https://github.com/dependabot/dependabot-core/pull/2899
* https://github.com/dependabot/dependabot-core/pull/2903
* https://github.com/dependabot/dependabot-core/pull/2904
* https://github.com/dependabot/dependabot-core/pull/2892
* https://github.com/dependabot/dependabot-core/pull/2905
* https://github.com/dependabot/dependabot-core/pull/2901 
* https://github.com/dependabot/dependabot-core/pull/2900
* https://github.com/dependabot/dependabot-core/pull/2880
* https://github.com/dependabot/dependabot-core/pull/2908 / https://github.com/dependabot/dependabot-core/pull/2909
* https://github.com/dependabot/dependabot-core/pull/2913
* https://github.com/dependabot/dependabot-core/pull/2939
* https://github.com/dependabot/dependabot-core/pull/2916
* https://github.com/dependabot/dependabot-core/pull/2915
* https://github.com/dependabot/dependabot-core/pull/2938
* https://github.com/dependabot/dependabot-core/pull/2937
* https://github.com/dependabot/dependabot-core/pull/2931
* https://github.com/dependabot/dependabot-core/pull/2928
* https://github.com/dependabot/dependabot-core/pull/2922
* https://github.com/dependabot/dependabot-core/pull/2932
* https://github.com/dependabot/dependabot-core/pull/2918
* https://github.com/dependabot/dependabot-core/pull/2906

Notes drop internal changes (e.g. to address CI/development tooling).