### PR TITLE
actions: accept shortref hashes

### DIFF
--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -28,6 +28,7 @@ module Dependabot
         updated = updated_source
         return dependency.requirements if updated == previous
 
+        # Maintain a short git hash only if it matches the latest
         if previous[:type] == "git" &&
            previous[:url] == updated[:url] &&
            updated[:ref]&.match?(/^[0-9a-f]{6,40}$/) &&

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -23,10 +23,20 @@ module Dependabot
         dependency.version
       end
 
-      def updated_requirements
-        return dependency.requirements if updated_source == dependency_source_details
+      def updated_requirements # rubocop:disable Metrics/PerceivedComplexity
+        previous = dependency_source_details
+        updated = updated_source
+        return dependency.requirements if updated == previous
 
-        dependency.requirements.map { |req| req.merge(source: updated_source) }
+        if previous[:type] == "git" &&
+           previous[:url] == updated[:url] &&
+           updated[:ref]&.match?(/^[0-9a-f]{6,40}$/) &&
+           previous[:ref]&.match?(/^[0-9a-f]{6,40}$/) &&
+           updated[:ref]&.start_with?(previous[:ref])
+          return dependency.requirements
+        end
+
+        dependency.requirements.map { |req| req.merge(source: updated) }
       end
 
       private

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 require "dependabot/dependency"
 require "dependabot/github_actions/update_checker"
+require "dependabot/github_actions/metadata_finder"
 require_common_spec "update_checkers/shared_examples_for_update_checkers"
 
 RSpec.describe Dependabot::GithubActions::UpdateChecker do
@@ -297,6 +298,27 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
                 type: "git",
                 url: "https://github.com/actions/setup-node",
                 ref: "fc9ff49b90869a686df00e922af871c12215986a",
+                branch: nil
+              },
+              metadata: { declaration_string: "actions/setup-node@master" }
+            }]
+          end
+
+          it { is_expected.to eq(expected_requirements) }
+        end
+
+        context "and the previous version is a short SHA" do
+          let(:reference) { "5273d0df" }
+          let(:comparison_url) { repo_url + "/compare/v1.1.0...5273d0df" }
+          let(:expected_requirements) do
+            [{
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              source: {
+                type: "git",
+                url: "https://github.com/actions/setup-node",
+                ref: "5273d0df",
                 branch: nil
               },
               metadata: { declaration_string: "actions/setup-node@master" }


### PR DESCRIPTION
When dependabot updates an Actions workflow file, it prefers to replace versions with full length commit SHAs.
This is a great practice, reinforced by [Actions's best practices](https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions).

This has an unfortunate side effect when the Action is already pinned to the short version of the SHA: Dependabot will propose an "upgrade" to the full SHA.
That's _is_ a good idea from a security standpoint, but not an expected feature of Dependabot. Customers only expect PRs for dependency updates.

This PR adjusts the `Actions` comparison so that short refs are considered equal to full refs when considering upgrades.
That means customers will be upgraded (to full SHAs) as new releases become available, but Dependabot won't open a PR that only replaces a short ref with the expanded full ref.