### PR TITLE
Bump pip-tools from 5.4.0 to 5.5.0 in /python/helpers and update test spec

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -1,5 +1,5 @@
 pip==20.3.3
-pip-tools==5.4.0
+pip-tools==5.5.0
 flake8==3.8.4
 hashin==0.15.0
 pipenv==2018.11.26

--- a/python/spec/dependabot/python/file_updater/pip_compile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pip_compile_file_updater_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
       expect(updated_files.count).to eq(1)
       expect(updated_files.first.content).to include("attrs==18.1.0")
       expect(updated_files.first.content).
-        to include("pbr==4.0.2                # via mock")
+        to include("pbr==4.0.2\n    # via mock")
       expect(updated_files.first.content).to include("# This file is autogen")
       expect(updated_files.first.content).to_not include("--hash=sha")
     end
@@ -95,7 +95,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
         expect(updated_files.count).to eq(1)
         expect(updated_files.first.content).to include("attrs==18.1.0")
         expect(updated_files.first.content).
-          to include("pbr==4.0.2                # via mock")
+          to include("pbr==4.0.2\n    # via mock")
         expect(updated_files.first.content).to include("# This file is autogen")
         expect(updated_files.first.content).to_not include("--hash=sha")
       end
@@ -241,7 +241,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
           to include("-e file:///Users/greysteil/code/python-test")
         expect(updated_files.first.content).to_not include("tmp/dependabot")
         expect(updated_files.first.content).
-          to include("pbr==4.0.2                # via mock")
+          to include("pbr==4.0.2\n    # via mock")
         expect(updated_files.first.content).to include("# This file is autogen")
         expect(updated_files.first.content).to_not include("--hash=sha")
       end
@@ -279,7 +279,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
       it "updates the requirements.txt" do
         expect(updated_files.count).to eq(1)
         expect(updated_files.first.content).
-          to include("pbr==4.2.0                # via mock")
+          to include("pbr==4.2.0\n    # via mock")
       end
 
       context "with an uncompiled requirement file, too" do
@@ -312,7 +312,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
         it "updates the requirements.txt" do
           expect(updated_files.count).to eq(2)
           expect(updated_files.first.content).
-            to include("pbr==4.2.0                # via mock")
+            to include("pbr==4.2.0\n    # via mock")
           expect(updated_files.last.content).to include("pbr==4.2.0")
         end
       end
@@ -325,7 +325,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipCompileFileUpdater do
         expect(updated_files.count).to eq(1)
         expect(updated_files.first.content).to include("attrs==17.4.0")
         expect(updated_files.first.content).
-          to include("pbr==4.0.2                # via mock")
+          to include("pbr==4.0.2\n    # via mock")
         expect(updated_files.first.content).to include("# This file is autogen")
         expect(updated_files.first.content).to_not include("--hash=sha")
       end


### PR DESCRIPTION
As of pip-tools 5.5, the output format changed to always put `via` comments on separate lines, and no longer include a trailing `\` when using `--generate-hashes`.

so it changed from this output:
```
#
# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile --output-file requirements/test.txt requirements/test.in
#
apipkg==1.4               # via execnet
attrs==18.1.0             # via -r requirements/test.in, pytest
execnet==1.5.0            # via pytest-xdist
flaky==3.4.0              # via -r requirements/test.in
mock==2.0.0               # via -r requirements/test.in
more-itertools==4.1.0     # via pytest
pbr==4.0.2                # via mock
pluggy==0.6.0             # via pytest
py==1.5.3                 # via pytest
pytest-forked==0.2        # via pytest-xdist
pytest-xdist==1.22.2      # via -r requirements/test.in
pytest==3.5.1             # via -r requirements/test.in, pytest-forked, pytest-xdist
six==1.11.0               # via mock, more-itertools, pytest
```
to this output:
```
#
# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile --output-file requirements/test.txt requirements/test.in
#
apipkg==1.4
    # via execnet
attrs==20.3.0
    # via
    #   -r requirements/test.in
    #   pytest
execnet==1.5.0
    # via pytest-xdist
flaky==3.4.0
    # via -r requirements/test.in
mock==2.0.0
    # via -r requirements/test.in
more-itertools==4.1.0
    # via pytest
pbr==4.2.0
    # via mock
pluggy==0.6.0
    # via pytest
py==1.5.3
    # via pytest
pytest-forked==0.2
    # via pytest-xdist
pytest-xdist==1.22.2
    # via -r requirements/test.in
pytest==3.5.1
    # via
    #   -r requirements/test.in
    #   pytest-forked
    #   pytest-xdist
six==1.11.0
    # via
    #   mock
    #   more-itertools
    #   pytest
```