### PR TITLE
v0.129.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.129.3, 5 January 2021
+
+- Bump eslint-plugin-prettier from 3.3.0 to 3.3.1 in /npm_and_yarn/helpers
+- Gradle: Handle missing required manifest file
+- Actions: Accept shortref hashes
+
 ## v0.129.2, 4 January 2021
 
 - go_modules: return tidied `go.mod` contents directly

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.129.2"
+  VERSION = "0.129.3"
 end


### PR DESCRIPTION
## v0.129.3, 5 January 2021

- Bump eslint-plugin-prettier from 3.3.0 to 3.3.1 in /npm_and_yarn/helpers
- Gradle: Handle missing required manifest file
- Actions: Accept shortref hashes