### PR TITLE
go_modules raise GitDependenciesNotReachable

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -268,6 +268,7 @@ module Dependabot
 
           error_regex = RESOLVABILITY_ERROR_REGEXES.find { |r| stderr =~ r }
           if error_regex
+            # TODO: handle_resolvability_error here
             lines = stderr.lines.drop_while { |l| error_regex !~ l }
             raise Dependabot::DependencyFileNotResolvable.new, lines.join
           end

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -268,9 +268,8 @@ module Dependabot
 
           error_regex = RESOLVABILITY_ERROR_REGEXES.find { |r| stderr =~ r }
           if error_regex
-            # TODO: handle_resolvability_error here
             lines = stderr.lines.drop_while { |l| error_regex !~ l }
-            raise Dependabot::DependencyFileNotResolvable.new, lines.join
+            ResolvabilityErrors.handle(lines.join, credentials: credentials)
           end
 
           path_regex = MODULE_PATH_MISMATCH_REGEXES.find { |r| stderr =~ r }

--- a/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
+++ b/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
@@ -7,9 +7,7 @@ module Dependabot
 
       def self.handle(message, credentials:)
         mod_path = message.scan(GITHUB_REPO_REGEX).first
-        unless mod_path
-          raise Dependabot::DependencyFileNotResolvable, message
-        end
+        raise Dependabot::DependencyFileNotResolvable, message unless mod_path
 
         # Module not found on github.com - query for _any_ version to know if it
         # doesn't exist (or is private) or we were just given a bad revision by this manifest
@@ -19,7 +17,7 @@ module Dependabot
 
             env = { "GOPRIVATE" => "*" }
             _, _, status = Open3.capture3(env, SharedHelpers.escape_command("go get #{mod_path}"))
-            raise Dependabot::DependencyFileNotResolvable, line if status.success?
+            raise Dependabot::DependencyFileNotResolvable, message if status.success?
 
             mod_split = mod_path.split("/")
             repo_path = if mod_split.size > 3

--- a/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
+++ b/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
@@ -5,10 +5,10 @@ module Dependabot
     module ResolvabilityErrors
       GITHUB_REPO_REGEX = %r{github.com/[^:@]*}.freeze
 
-      def self.handle(error, credentials:)
-        mod_path = error.message.scan(GITHUB_REPO_REGEX).first
+      def self.handle(message, credentials:)
+        mod_path = message.scan(GITHUB_REPO_REGEX).first
         unless mod_path
-          raise Dependabot::DependencyFileNotResolvable, error.message
+          raise Dependabot::DependencyFileNotResolvable, message
         end
 
         # Module not found on github.com - query for _any_ version to know if it

--- a/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
+++ b/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Dependabot
+  module GoModules
+    module ResolvabilityErrors
+      GITHUB_REPO_REGEX = %r{github.com/[^:@]*}.freeze
+
+      def self.handle(error, credentials:)
+        mod_path = error.message.scan(GITHUB_REPO_REGEX).first
+        unless mod_path
+          raise Dependabot::DependencyFileNotResolvable, error.message
+        end
+
+        # Module not found on github.com - query for _any_ version to know if it
+        # doesn't exist (or is private) or we were just given a bad revision by this manifest
+        SharedHelpers.in_a_temporary_directory do
+          SharedHelpers.with_git_configured(credentials: credentials) do
+            File.write("go.mod", "module dummy\n")
+
+            env = { "GOPRIVATE" => "*" }
+            _, _, status = Open3.capture3(env, SharedHelpers.escape_command("go get #{mod_path}"))
+            raise Dependabot::DependencyFileNotResolvable, line if status.success?
+
+            mod_split = mod_path.split("/")
+            repo_path = if mod_split.size > 3
+                          mod_split[0..2].join("/")
+                        else
+                          mod_path
+                        end
+            raise Dependabot::GitDependenciesNotReachable, [repo_path]
+          end
+        end
+      end
+    end
+  end
+end

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -88,7 +88,7 @@ module Dependabot
 
       def handle_subprocess_error(error)
         if RESOLVABILITY_ERROR_REGEXES.any? { |rgx| error.message =~ rgx }
-          ResolvabilityErrors.handle(error, credentials: credentials)
+          ResolvabilityErrors.handle(error.message, credentials: credentials)
         end
 
         raise

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -16,7 +16,7 @@ module Dependabot
         /no go-import meta tags/,
         # Package url 404s
         /404 Not Found/,
-        /Repository not found/,
+        /Repository not found/
       ].freeze
 
       def latest_resolvable_version

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -5,6 +5,7 @@ require "dependabot/update_checkers/base"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/go_modules/native_helpers"
+require "dependabot/go_modules/resolvability_errors"
 require "dependabot/go_modules/version"
 
 module Dependabot
@@ -85,33 +86,9 @@ module Dependabot
         handle_subprocess_error(e)
       end
 
-      GITHUB_REPO_REGEX = %r{github.com/[^:@]*}.freeze
       def handle_subprocess_error(error)
         if RESOLVABILITY_ERROR_REGEXES.any? { |rgx| error.message =~ rgx }
-          mod_path = error.message.scan(GITHUB_REPO_REGEX).first
-          unless mod_path
-            raise Dependabot::DependencyFileNotResolvable, error.message
-          end
-
-          # Module not found on github.com - query for _any_ version to know if it
-          # doesn't exist (or is private)	or we were just given a bad revision by this manifest
-          SharedHelpers.in_a_temporary_directory do
-            SharedHelpers.with_git_configured(credentials: credentials) do
-              File.write("go.mod", "module dummy\n")
-
-              env = { "GOPRIVATE" => "*" }
-              _, _, status = Open3.capture3(env, SharedHelpers.escape_command("go get #{mod_path}"))
-              raise Dependabot::DependencyFileNotResolvable, line if status.success?
-
-              mod_split = mod_path.split("/")
-              repo_path = if mod_split.size > 3
-                            mod_split[0..2].join("/")
-                          else
-                            mod_path
-                          end
-              raise Dependabot::GitDependenciesNotReachable, [repo_path]
-            end
-          end
+          ResolvabilityErrors.handle(error, credentials: credentials)
         end
 
         raise

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -14,7 +14,8 @@ module Dependabot
         # Package url/proxy doesn't include any redirect meta tags
         /no go-import meta tags/,
         # Package url 404s
-        /404 Not Found/
+        /404 Not Found/,
+        /Repository not found/,
       ].freeze
 
       def latest_resolvable_version
@@ -84,9 +85,33 @@ module Dependabot
         handle_subprocess_error(e)
       end
 
+      GITHUB_REPO_REGEX = %r{github.com/[^:@]*}.freeze
       def handle_subprocess_error(error)
         if RESOLVABILITY_ERROR_REGEXES.any? { |rgx| error.message =~ rgx }
-          raise Dependabot::DependencyFileNotResolvable, error.message
+          mod_path = error.message.scan(GITHUB_REPO_REGEX).first
+          unless mod_path
+            raise Dependabot::DependencyFileNotResolvable, error.message
+          end
+
+          # Module not found on github.com - query for _any_ version to know if it
+          # doesn't exist (or is private)	or we were just given a bad revision by this manifest
+          SharedHelpers.in_a_temporary_directory do
+            SharedHelpers.with_git_configured(credentials: credentials) do
+              File.write("go.mod", "module dummy\n")
+
+              env = { "GOPRIVATE" => "*" }
+              _, _, status = Open3.capture3(env, SharedHelpers.escape_command("go get #{mod_path}"))
+              raise Dependabot::DependencyFileNotResolvable, line if status.success?
+
+              mod_split = mod_path.split("/")
+              repo_path = if mod_split.size > 3
+                            mod_split[0..2].join("/")
+                          else
+                            mod_path
+                          end
+              raise Dependabot::GitDependenciesNotReachable, [repo_path]
+            end
+          end
         end
 
         raise

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -150,10 +150,12 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
             let(:project_name) { "non_existent_dependency" }
 
             it "raises the correct error" do
-              error_class = Dependabot::DependencyFileNotResolvable
+              error_class = Dependabot::GitDependenciesNotReachable
               expect { updater.updated_go_sum_content }.
                 to raise_error(error_class) do |error|
                   expect(error.message).to include("hmarr/404")
+                  expect(error.dependency_urls).
+                    to eq(["github.com/hmarr/404"])
                 end
             end
           end


### PR DESCRIPTION
This PR restores the functionality introduced by https://github.com/dependabot/dependabot-core/pull/2780 , which was reverted by https://github.com/dependabot/dependabot-core/pull/2880 .

If Dependabot encounters a go module on `github.com` that can not be accessed, it should raise a `GitDependenciesNotReachable` error with details about the requested repositories.
Raising a `GitDependenciesNotReachable` is important as this is used by GitHub.com to recover from the error - https://github.blog/changelog/2020-12-02-dependabot-version-updates-from-private-github-repositories/

Since we no longer `go get` in the `FileParser`, there are two possible places this might be raised:
* In the `UpdateChecker`, if the private repository is a direct dependency
* In the `FlleUpdater`, if the private repository is an indirect dependency