### PR TITLE
Support GitLab format npm registry

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -295,7 +295,9 @@ module Dependabot
           elsif resolved_url.include?("/#{name}/-/#{name}")
             # MyGet / Bintray format
             resolved_url.split("/#{name}/-/#{name}").first.
-              gsub("dl.bintray.com//", "api.bintray.com/npm/")
+              gsub("dl.bintray.com//", "api.bintray.com/npm/").
+              # GitLab format
+              gsub(/\/projects\/\d+/, '')
           elsif resolved_url.include?("/#{name}/-/#{name.split('/').last}")
             # Sonatype Nexus / Artifactory JFrog format
             resolved_url.split("/#{name}/-/#{name.split('/').last}").first

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -297,7 +297,7 @@ module Dependabot
             resolved_url.split("/#{name}/-/#{name}").first.
               gsub("dl.bintray.com//", "api.bintray.com/npm/").
               # GitLab format
-              gsub(/\/projects\/\d+/, '')
+              gsub(%r{\/projects\/\d+}, "")
           elsif resolved_url.include?("/#{name}/-/#{name.split('/').last}")
             # Sonatype Nexus / Artifactory JFrog format
             resolved_url.split("/#{name}/-/#{name.split('/').last}").first

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -276,8 +276,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           end
 
           describe "the scoped gitlab dependency" do
-
-
             subject { top_level_dependencies[6] }
 
             it { is_expected.to be_a(Dependabot::Dependency) }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           let(:package_json_fixture_name) { "private_source.json" }
           let(:npm_lock_fixture_name) { "private_source.json" }
 
-          its(:length) { is_expected.to eq(6) }
+          its(:length) { is_expected.to eq(7) }
 
           describe "the first private dependency" do
             subject { top_level_dependencies[1] }
@@ -269,6 +269,30 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   source: {
                     type: "private_registry",
                     url: "https://npm.pkg.github.com"
+                  }
+                }]
+              )
+            end
+          end
+
+          describe "the scoped gitlab dependency" do
+
+
+            subject { top_level_dependencies[6] }
+
+            it { is_expected.to be_a(Dependabot::Dependency) }
+            its(:name) { is_expected.to eq("@dependabot/pack-core-4") }
+            its(:version) { is_expected.to eq("2.0.14") }
+            its(:requirements) do
+              is_expected.to eq(
+                [{
+                  requirement: "^2.0.1",
+                  file: "package.json",
+                  groups: ["devDependencies"],
+                  source: {
+                    type: "private_registry",
+                    url: "https://gitlab.mydomain.com/api/v4/"\
+                         "packages/npm"
                   }
                 }]
               )
@@ -970,7 +994,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           let(:package_json_fixture_name) { "private_source.json" }
           let(:yarn_lock_fixture_name) { "private_source.lock" }
 
-          its(:length) { is_expected.to eq(6) }
+          its(:length) { is_expected.to eq(7) }
 
           describe "the second dependency" do
             subject { top_level_dependencies[1] }

--- a/npm_and_yarn/spec/fixtures/npm_lockfiles/private_source.json
+++ b/npm_and_yarn/spec/fixtures/npm_lockfiles/private_source.json
@@ -47,6 +47,11 @@
             "resolved": "https://npm.pkg.github.com/download/@dependabot/pack-core-3/2.0.14/55a2db17e0946313e6d150d2d63d5e9539458e4fcaf3fe928c320a7dd1b7f90b",
             "integrity": "sha1-/HizFb1hVT38sBYgsMHMF2qMbC8="
         },
+        "@dependabot/pack-core-4": {
+            "version": "2.0.14",
+            "resolved": "https://gitlab.mydomain.com/api/v4/projects/229/packages/npm/@dependabot/pack-core-4/-/@dependabot/pack-core-4-2.0.14.tgz",
+            "integrity": "sha1-/HizFb1hVT38sBYgsMHMF2qMbC8="
+        },
         "fetch-factory": {
             "version": "0.0.1",
             "resolved": "https://artifactory01.mydomain.com/artifactory/api/npm/my-repo/fetch-factory/-/fetch-factory-0.0.1.tgz",

--- a/npm_and_yarn/spec/fixtures/package_files/private_source.json
+++ b/npm_and_yarn/spec/fixtures/package_files/private_source.json
@@ -24,6 +24,7 @@
       "@dependabot/etag": "^1.0.0",
       "@dependabot/pack-core": "^2.0.1",
       "@dependabot/pack-core-2": "^2.0.1",
-      "@dependabot/pack-core-3": "^2.0.1"
+      "@dependabot/pack-core-3": "^2.0.1",
+      "@dependabot/pack-core-4": "^2.0.1"
     }
 }

--- a/npm_and_yarn/spec/fixtures/yarn_lockfiles/private_source.lock
+++ b/npm_and_yarn/spec/fixtures/yarn_lockfiles/private_source.lock
@@ -31,3 +31,9 @@ chalk@^2.0.0:
   resolved "https://npm.pkg.github.com/download/@dependabot/pack-core-3/2.0.14/55a2db17e0946313e6d150d2d63d5e9539458e4fcaf3fe928c320a7dd1b7f90b"
   dependencies:
     "@dependabot/etag" "^2.0.0"
+
+"@dependabot/pack-core-4@^2.0.1", "@dependabot/pack-core-4@^2.0.2":
+  version "2.0.14"
+  resolved "https://gitlab.mydomain.com/api/v4/projects/229/packages/npm/@dependabot/pack-core-4/-/@dependabot/pack-core-4-2.0.14.tgz"
+  dependencies:
+    "@dependabot/etag" "^2.0.0"


### PR DESCRIPTION
Currently it will try to call `/api/v4/projects/229/packages/npm/@prefix%2Fpackage-name`
Which will return: HTTP/1.1 404 Not Found

The correct api endpoint for the package meta data is located at: `/api/v4/packages/npm/@prefix%2Fpackage-name`
While the endpoint for the tar.gz is `api/v4/projects/229/packages/npm/@prefix/package-name/-/@prefix/package-name-0.4.0.tgz`

