### PR TITLE
v0.129.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.129.4, 6 January 2021
 
 - go_modules: raise Dependabot::GitDependenciesNotReachable for dependencies missing from github.com
+- go_modules: fix regression when parsing go.mod files without dependencies
 - Bitbucket: support for PR creation (@iinuwa)
 
 ## v0.129.3, 5 January 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.129.4, 6 January 2021
+
+- go_modules: raise Dependabot::GitDependenciesNotReachable for dependencies missing from github.com
+- Bitbucket: support for PR creation (@iinuwa)
+
 ## v0.129.3, 5 January 2021
 
 - Bump eslint-plugin-prettier from 3.3.0 to 3.3.1 in /npm_and_yarn/helpers
@@ -99,7 +104,7 @@
 
 ## v0.125.6, 27 November 2020
 
-- Pip compile: raise DependencyFileNotRqesolvable error when initial manifest
+- Pip compile: raise DependencyFileNotResolvable error when initial manifest
   files are unresolvable
 - JS: Handle rate limited npm package requests
 - Go mod: verify Dependabot::GitDependenciesNotReachable from versioned

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.129.3"
+  VERSION = "0.129.4"
 end


### PR DESCRIPTION
Release [these commits](https://github.com/dependabot/dependabot-core/compare/v0.129.3...v0.129.4-release-notes)

These PRS:
* https://github.com/dependabot/dependabot-core/pull/2923
* https://github.com/dependabot/dependabot-core/pull/2949
* https://github.com/dependabot/dependabot-core/pull/2952
* https://github.com/dependabot/dependabot-core/pull/2953
