### PR TITLE
go_modules: FileParser accept go.mod without dependencies

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -77,7 +77,7 @@ module Dependabot
 
             stdout, stderr, status = Open3.capture3(env, command)
             handle_parser_error(path, stderr) unless status.success?
-            JSON.parse(stdout)["Require"]
+            JSON.parse(stdout)["Require"] || []
           rescue Dependabot::DependencyFileNotResolvable
             # We sometimes see this error if a host times out.
             # In such cases, retrying (a maximum of 3 times) may fix it.

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -264,6 +264,18 @@ RSpec.describe Dependabot::GoModules::FileParser do
       end
     end
 
+    describe "without any dependencies" do
+      let(:go_mod_content) do
+        fixture("projects", "no_dependencies", "go.mod")
+      end
+
+      subject(:dependencies) do
+        parser.parse
+      end
+
+      its(:length) { is_expected.to eq(0) }
+    end
+
     context "that is not resolvable" do
       let(:go_mod_content) do
         fixture("projects", "unknown_vcs", "go.mod")

--- a/go_modules/spec/fixtures/projects/no_dependencies/go.mod
+++ b/go_modules/spec/fixtures/projects/no_dependencies/go.mod
@@ -1,0 +1,4 @@
+module github.com/dependabot/vgotest
+
+go 1.12
+

--- a/go_modules/spec/fixtures/projects/no_dependencies/main.go
+++ b/go_modules/spec/fixtures/projects/no_dependencies/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("yo")
+}


### PR DESCRIPTION
It's valid to declare a `go.mod` file that doesn't define any dependencies; when that happens `go mod edit -json` will return:

```
dependabot-core/go_modules/spec/fixtures/projects/no_dependencies $ go mod edit -json
{
	"Module": {
		"Path": "github.com/dependabot/vgotest"
	},
	"Go": "1.12",
	"Require": null,
	"Exclude": null,
	"Replace": null
}
```

This PR modifies the `FileParser` to return an empty array in this case, instead of the nil value.

# Related
- https://github.com/dependabot/dependabot-core/pull/2880