### PR TITLE
fix CI: pin parseconfig <1.1.0

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri", "~> 1.8"
   spec.add_dependency "octokit", "~> 4.6"
   spec.add_dependency "pandoc-ruby", "~> 2.0"
-  spec.add_dependency "parseconfig", "~> 1.0"
   spec.add_dependency "parser", "~> 2.5"
   spec.add_dependency "toml-rb", ">= 1.1.2", "< 3.0"
 

--- a/git_submodules/dependabot-git_submodules.gemspec
+++ b/git_submodules/dependabot-git_submodules.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = common_gemspec.required_ruby_version
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
+  spec.add_dependency "parseconfig", "~> 1.0", "< 1.1.0"
 
   common_gemspec.development_dependencies.each do |dep|
     spec.add_development_dependency dep.name, dep.requirement.to_s


### PR DESCRIPTION
[parseconfig](https://rubygems.org/gems/parseconfig/versions/1.1.0) released `v1.1.0` on `2021-01-06` (today).
Per its [changelog](https://github.com/datafolklabs/ruby-parseconfig/blob/master/Changelog), this release changes the behaviour of value parsing to introduce additional features.

This change causes a regression in the `git_submodules` tests: when an invalid `.gitmodules` file is parsed, the returned value is different.

* Modify gemspec to not upgrade `parseconfig` past `1.1.0`
* As `parseconfig` is used exclusively by the `git_submodules` plugin, only declare it there

# Related
- Discovered/blocked https://github.com/dependabot/dependabot-core/pull/2951
- Blocks https://github.com/dependabot/dependabot-core/pull/2952