### PR TITLE
docker-dev-shell: exclude dry-run files

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -167,7 +167,6 @@ docker run --rm -ti \
   -v "$(pwd)/omnibus/dependabot-omnibus.gemspec:$CODE_DIR/omnibus/dependabot-omnibus.gemspec" \
   -v "$(pwd)/omnibus/lib:$CODE_DIR/omnibus/lib" \
   -v "$(pwd)/omnibus/spec:$CODE_DIR/omnibus/spec" \
-  -v "$(pwd)/dry-run:$CODE_DIR/dry-run" \
   --name "$CONTAINER_NAME" \
   "${DOCKER_OPTS[@]}" \
   --cap-add=SYS_PTRACE \


### PR DESCRIPTION
Don't persist the `dry-run/` path across container restarts.

This might be a performance regression for some workflows, but avoids the potential for private manifests used in testing (e.g. with [`LOCAL_GITHUB_ACCESS_TOKEN`](https://github.com/dependabot/dependabot-core/blob/0c3f58f3a33c93036a7e346f2ff42bb629d99e8e/bin/dry-run.rb#L109-L116)) to stick around on the host system.

Note that ecosystems that clone by default (e.g. `go_modules`) do not use the `dry-run/` path for clones: they use `/tmp`, which is already not persisted.