### PR TITLE
Use release version of pyenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN apt-get install -y software-properties-common \
 ENV PYENV_ROOT=/usr/local/.pyenv \
   PATH="/usr/local/.pyenv/bin:$PATH"
 RUN git clone https://github.com/pyenv/pyenv.git /usr/local/.pyenv \
-  && cd /usr/local/.pyenv && git checkout 2bf6111fa0bad10b78c3130dfab497c8c3dcd2b6 && cd - \
+  && cd /usr/local/.pyenv && git checkout v1.2.22 && cd - \
   && pyenv install 3.9.1 \
   && pyenv install 2.7.18 \
   && pyenv global 3.9.1


### PR DESCRIPTION
pyenv released a new version with Python 3.9.1 https://github.com/pyenv/pyenv/releases/tag/v1.2.22