### PR TITLE
Use composer v1 when any of the requirements are invalid on v2

### DIFF
--- a/composer/lib/dependabot/composer/helpers.rb
+++ b/composer/lib/dependabot/composer/helpers.rb
@@ -10,11 +10,21 @@ module Dependabot
 
       def self.composer_version(composer_json, parsed_lockfile = nil)
         return "v1" if composer_json["name"] && composer_json["name"] !~ COMPOSER_V2_NAME_REGEX
+        return "v1" if invalid_v2_requirement?(composer_json)
         return "v2" unless parsed_lockfile && parsed_lockfile["plugin-api-version"]
 
         version = Composer::Version.new(parsed_lockfile["plugin-api-version"])
         version.canonical_segments.first == 1 ? "v1" : "v2"
       end
+
+      def self.invalid_v2_requirement?(composer_json)
+        return false unless composer_json.key?("require")
+
+        composer_json["require"].keys.any? do |key|
+          key != "php" && key !~ COMPOSER_V2_NAME_REGEX
+        end
+      end
+      private_class_method :invalid_v2_requirement?
     end
   end
 end

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -192,6 +192,15 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       it { is_expected.to eq(Dependabot::Composer::Version.new("1.25.1")) }
     end
 
+    context "with a name that is only valid in v1" do
+      let(:project_name) { "v1/invalid_v2_requirement" }
+      let(:dependency_name) { "monolog/Monolog" }
+      let(:latest_allowable_version) { Gem::Version.new("1.25.1") }
+      let(:dependency_version) { "1.0.2" }
+
+      it { is_expected.to eq(Dependabot::Composer::Version.new("1.25.1")) }
+    end
+
     # This test is extremely slow, as it needs to wait for Composer to time out.
     # As a result we currently keep it commented out.
     # context "with an unreachable private registry" do

--- a/composer/spec/fixtures/projects/v1/invalid_v2_requirement/composer.json
+++ b/composer/spec/fixtures/projects/v1/invalid_v2_requirement/composer.json
@@ -1,0 +1,12 @@
+{
+  "name": "valid/name",
+  "version": "3.1.7",
+  "dist": {
+    "url": "https://www.example.net/files/3.1.7.zip",
+    "type": "zip"
+  },
+  "require": {
+    "monolog/Monolog" : "1.0.1",
+    "symfony/polyfill-mbstring": "1.0.1"
+  }
+}


### PR DESCRIPTION
Composer v2 has added some restrictions on package names. We already
validate that name for the package name itself, but v2 will _also_ raise
an error when any of the names listed in the require map are invalid.

We particularly notice this happens for invalid casing (v2 requires the
full name to be downcased), so that's what we're testing for here.