### PR TITLE
Upgrade node to v14.15.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,8 +76,8 @@ RUN git clone https://github.com/pyenv/pyenv.git /usr/local/.pyenv \
 
 ### JAVASCRIPT
 
-# Install Node 10.0 and Yarn
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+# Install Node 14.0 and Yarn
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
   && apt-get install -y nodejs \
   && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
This upgrades node from v12.x (contrary to what the comment said) to v14.x, which is the latest long-term supported version.