### PR TITLE
Sanitize mentions more aggressively

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -45,9 +45,13 @@ module Dependabot
 
         def sanitize_mentions(doc)
           doc.walk do |node|
-            if !parent_node_link?(node) && node.type == :text &&
+            if node.type == :text &&
                node.string_content.match?(MENTION_REGEX)
-              nodes = build_mention_nodes(node.string_content)
+              nodes = if !parent_node_link?(node)
+                        build_mention_nodes(node.string_content)
+                      else
+                        build_mention_link_text_nodes(node.string_content)
+                      end
 
               nodes.each do |n|
                 node.insert_before(n)
@@ -111,6 +115,12 @@ module Dependabot
           end
 
           nodes
+        end
+
+        def build_mention_link_text_nodes(text)
+          code_node = CommonMarker::Node.new(:code)
+          code_node.string_content = text
+          [code_node]
         end
 
         def create_link_node(url, text)

--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -115,10 +115,10 @@ module Dependabot
 
         def create_link_node(url, text)
           link_node = CommonMarker::Node.new(:link)
-          text_node = CommonMarker::Node.new(:text)
+          code_node = CommonMarker::Node.new(:code)
           link_node.url = url
-          text_node.string_content = text
-          link_node.append_child(text_node)
+          code_node.string_content = text
+          link_node.append_child(code_node)
           link_node
         end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
       it "sanitizes the text" do
         expect(sanitize_links_and_mentions).
           to eq("<p>Great work <a href=\"https://github.com/greysteil\">"\
-            "@greysteil</a>!</p>\n")
+            "<code>@greysteil</code></a>!</p>\n")
       end
 
       context "that includes a dash" do
@@ -31,7 +31,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         it "sanitizes the text" do
           expect(sanitize_links_and_mentions).to eq(
             "<p>Great work <a href=\"https://github.com/greysteil-work\">"\
-            "@greysteil-work</a>!</p>\n"
+            "<code>@greysteil-work</code></a>!</p>\n"
           )
         end
       end
@@ -47,7 +47,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         it "sanitizes the text" do
           expect(sanitize_links_and_mentions).to eq(
             "<p>The team (by <a href=\"https://github.com/greysteil\">"\
-            "@greysteil</a>) etc.</p>\n"
+            "<code>@greysteil</code></a>) etc.</p>\n"
           )
         end
       end
@@ -57,7 +57,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
         it "sanitizes the text" do
           expect(sanitize_links_and_mentions).to eq(
-            "<p>[<a href=\"https://github.com/hmarr\">@hmarr</a>]</p>\n"
+            "<p>[<a href=\"https://github.com/hmarr\"><code>@hmarr</code></a>]</p>\n"
           )
         end
       end
@@ -68,7 +68,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         it "sanitizes the mention" do
           expect(sanitize_links_and_mentions).to eq(
             "<p><a href=\"https://github.com/hmarr\"><em>@hmarr</em></a> "\
-            "<a href=\"https://github.com/feelepxyz\">@feelepxyz</a></p>\n"
+            "<a href=\"https://github.com/feelepxyz\"><code>@feelepxyz</code></a></p>\n"
           )
         end
       end
@@ -87,7 +87,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         let(:text) { fixture("changelogs", "sentry.md") }
         it do
           is_expected.to include(
-            "<a href=\"https://github.com/halkeye\">@halkeye</a>"
+            "<a href=\"https://github.com/halkeye\"><code>@halkeye</code></a>"
           )
         end
       end
@@ -113,9 +113,9 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
           it "sanitizes the text" do
             expect(sanitize_links_and_mentions).to eq(
-              "<p><a href=\"https://github.com/greysteil\">@greysteil</a> "\
+              "<p><a href=\"https://github.com/greysteil\"><code>@greysteil</code></a> "\
               "wrote this:</p>\n<pre><code> @model ||= 123\n</code></pre>\n<p>"\
-              "Review by <a href=\"https://github.com/hmarr\">@hmarr</a>!"\
+              "Review by <a href=\"https://github.com/hmarr\"><code>@hmarr</code></a>!"\
               "</p>\n"
             )
           end
@@ -129,9 +129,9 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
           it "sanitizes the mention" do
             expect(sanitize_links_and_mentions).to eq(
               "<p><code>@command</code>\nThanks to "\
-              "<a href=\"https://github.com/feelepxyz\">@feelepxyz</a>"\
+              "<a href=\"https://github.com/feelepxyz\"><code>@feelepxyz</code></a>"\
               "<code>@other</code> <a href=\"https://github.com/escape\">"\
-              "@escape</a></p>\n"
+              "<code>@escape</code></a></p>\n"
             )
           end
         end
@@ -142,7 +142,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
           it "sanitizes the mention" do
             expect(sanitize_links_and_mentions).to eq(
               "<p><code>@command </code>\n<code> @test</code> "\
-              "<a href=\"https://github.com/feelepxyz\">@feelepxyz</a></p>\n"
+              "<a href=\"https://github.com/feelepxyz\"><code>@feelepxyz</code></a></p>\n"
             )
           end
         end
@@ -170,7 +170,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
               expect(sanitize_links_and_mentions).to eq(
                 "<p>Take a look at this code: <code>@not-a-mention "\
                 "```@not-a-mention```</code> This is a "\
-                "<a href=\"https://github.com/mention\">@mention</a>!</p>\n"
+                "<a href=\"https://github.com/mention\"><code>@mention</code></a>!</p>\n"
               )
             end
           end
@@ -183,7 +183,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
             expect(sanitize_links_and_mentions).to eq(
               "<p><code>@command </code></p>\n<pre><code>@test\n"\
               "</code></pre>\n"\
-              "<p><a href=\"https://github.com/feelepxyz\">@feelepxyz</a></p>\n"
+              "<p><a href=\"https://github.com/feelepxyz\"><code>@feelepxyz</code></a></p>\n"
             )
           end
         end
@@ -193,9 +193,9 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
           it "sanitizes the mentions" do
             expect(sanitize_links_and_mentions).to eq(
-              "<p><a href=\"https://github.com/command\">@command</a> "\
+              "<p><a href=\"https://github.com/command\"><code>@command</code></a> "\
               "``` <a href=\"https://github.com/feelepxyz\">"\
-              "@feelepxyz</a></p>\n"
+              "<code>@feelepxyz</code></a></p>\n"
             )
           end
         end

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
         it "sanitizes the mention" do
           expect(sanitize_links_and_mentions).to eq(
-            "<p><a href=\"https://github.com/hmarr\"><em>@hmarr</em></a> "\
+            "<p><a href=\"https://github.com/hmarr\"><em><code>@hmarr</code></em></a> "\
             "<a href=\"https://github.com/feelepxyz\"><code>@feelepxyz</code></a></p>\n"
           )
         end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1194,8 +1194,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 "<blockquote>\n"\
                 "<h2>v1.6.0</h2>\n"\
                 "<p>Mad props to <a href=\"https://github.com/greysteil\">"\
-                "@greysteil</a> and <a href=\"https://github.com/hmarr\">"\
-                "@hmarr</a> for the "\
+                "<code>@greysteil</code></a> and <a href=\"https://github.com/hmarr\">"\
+                "<code>@hmarr</code></a> for the "\
                 "@angular/scope work - see <a href=\"https://github.com/"\
                 "gocardless/business/blob/HEAD/CHANGELOG.md\">changelog</a>."\
                 "</p>\n"\


### PR DESCRIPTION
The current sanitization works well when directly creating PRs, however,
when a user replies to an email notification containing that content, some
of the markup of the original message will be stripped out (either by
GitHub, or by email providers), which can result in a link like 
`<a href="https://github.com/jurre>@jurre</a>` being turned into just
`@jurre`, which will consequently mention theuser when that email reply 
is rendered.

This wraps the inner mention in a codeblock, which should prevent this
from happening. It looks _slightly_ funny:

<a href="https://github.com/jurre"><code>@jurre</code></a>

But I think this is worth it, getting unexpected mentions by Dependabot
is a source of frustration for users, and by showing that the mention is
wrapped in a codeblock, this should make it easier to spot if it was an
actual mention or not.

Alternatively we could insert some no-space character between the `@`
and the user login, but I personally prefer this more explicit approach.

Fixes https://github.com/dependabot/dependabot-core/issues/2820