### PR TITLE
v0.130.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.130.1, 14 January 2021
+
+- npm: detect npm v7 lockfiles
+- npm: Install npm v7 (unused) alongside npm v6
+- JS: Upgrade node to v14.15.4
+- Common: Added require "set" to utils.rb (@JohannesEH)
+- Sanitize `@mentions` by wrapping them in codeblocks preventing notifications when replying to PR email notifications
+
 ## v0.130.0, 13 January 2021
 
 - npm: Support GitLab format npm registry (@danoe)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.130.0"
+  VERSION = "0.130.1"
 end


### PR DESCRIPTION
## v0.130.1, 14 January 2021

- npm: detect npm v7 lockfiles
- npm: Install npm v7 (unused) alongside npm v6
- JS: Upgrade node to v14.15.4
- Common: Added require "set" to utils.rb (@JohannesEH)
- Sanitize `@mentions` by wrapping them in codeblocks preventing notifications when replying to PR email notifications
