### PR TITLE
gradle: repository url by assignment

### DIFF
--- a/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
@@ -16,7 +16,7 @@ module Dependabot
         REPOSITORIES_BLOCK_START = /(?:^|\s)repositories\s*\{/.freeze
 
         GROOVY_MAVEN_REPO_REGEX =
-          /maven\s*\{[^\}]*\surl[\s\(]\s*['"](?<url>[^'"]+)['"]/.freeze
+          /maven\s*\{[^\}]*\surl[\s\(]=?\s*['"](?<url>[^'"]+)['"]/.freeze
 
         KOTLIN_MAVEN_REPO_REGEX =
           /maven\(['"](?<url>[^'"]+)['"]\)/.freeze

--- a/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
@@ -103,6 +103,19 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
         end
       end
 
+      context "that use an assignment operator" do
+        let(:buildfile_fixture_name) { "custom_repos_build_assignment.gradle" }
+
+        it "includes the additional declarations" do
+          expect(repository_urls).to match_array(
+            %w(
+              https://jcenter.bintray.com
+              https://hub.spigotmc.org/nexus/content/repositories/snapshots
+            )
+          )
+        end
+      end
+
       context "with kotlin" do
         let(:buildfile_fixture_name) { "root_build.gradle.kts" }
 

--- a/gradle/spec/fixtures/buildfiles/custom_repos_build_assignment.gradle
+++ b/gradle/spec/fixtures/buildfiles/custom_repos_build_assignment.gradle
@@ -1,0 +1,17 @@
+apply plugin: 'java'
+
+repositories {
+    jcenter()
+    maven {
+        name = 'Spigot'
+        url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/'
+        content {
+            includeGroup 'org.bukkit'
+            includeGroup 'org.spigotmc'
+        }
+    }
+}
+
+dependencies {
+    compile 'org.spigotmc:spigot-api:1.16.4-R0.1-SNAPSHOT'
+}


### PR DESCRIPTION
This pull request modifies the `Dependabot::Gradle::FileParser::RepositoriesFinder` to accept maven repositories where the URL field is assigned.

Includes a failing test case rooted on a valid project.

<details><summary>$ gradle classpath</summary>
<p>

```
$ gradle dependencies

&gt; Task :dependencies

------------------------------------------------------------
Root project 'gradle-foo'
------------------------------------------------------------

annotationProcessor - Annotation processors and their dependencies for source set 'main'.
No dependencies

apiElements - API elements for main. (n)
No dependencies

archives - Configuration for archive artifacts. (n)
No dependencies

compileClasspath - Compile classpath for source set 'main'.
\--- org.spigotmc:spigot-api:1.16.4-R0.1-SNAPSHOT
     +--- commons-lang:commons-lang:2.6
     +--- com.google.guava:guava:21.0
     +--- com.google.code.gson:gson:2.8.0
     +--- net.md-5:bungeecord-chat:1.16-R0.3
     |    +--- com.google.code.gson:gson:2.8.0
     |    \--- com.google.guava:guava:21.0
     \--- org.yaml:snakeyaml:1.26

compileOnly - Compile only dependencies for source set 'main'. (n)
No dependencies

default - Configuration for default artifacts. (n)
No dependencies

implementation - Implementation only dependencies for source set 'main'. (n)
No dependencies

runtimeClasspath - Runtime classpath of source set 'main'.
\--- org.spigotmc:spigot-api:1.16.4-R0.1-SNAPSHOT
     +--- commons-lang:commons-lang:2.6
     +--- com.google.guava:guava:21.0
     +--- com.google.code.gson:gson:2.8.0
     +--- net.md-5:bungeecord-chat:1.16-R0.3
     |    +--- com.google.code.gson:gson:2.8.0
     |    \--- com.google.guava:guava:21.0
     \--- org.yaml:snakeyaml:1.26

runtimeElements - Elements of runtime for main. (n)
No dependencies

runtimeOnly - Runtime only dependencies for source set 'main'. (n)
No dependencies

testAnnotationProcessor - Annotation processors and their dependencies for source set 'test'.
No dependencies

testCompileClasspath - Compile classpath for source set 'test'.
\--- org.spigotmc:spigot-api:1.16.4-R0.1-SNAPSHOT
     +--- commons-lang:commons-lang:2.6
     +--- com.google.guava:guava:21.0
     +--- com.google.code.gson:gson:2.8.0
     +--- net.md-5:bungeecord-chat:1.16-R0.3
     |    +--- com.google.code.gson:gson:2.8.0
     |    \--- com.google.guava:guava:21.0
     \--- org.yaml:snakeyaml:1.26

testCompileOnly - Compile only dependencies for source set 'test'. (n)
No dependencies

testImplementation - Implementation only dependencies for source set 'test'. (n)
No dependencies

testRuntimeClasspath - Runtime classpath of source set 'test'.
\--- org.spigotmc:spigot-api:1.16.4-R0.1-SNAPSHOT
     +--- commons-lang:commons-lang:2.6
     +--- com.google.guava:guava:21.0
     +--- com.google.code.gson:gson:2.8.0
     +--- net.md-5:bungeecord-chat:1.16-R0.3
     |    +--- com.google.code.gson:gson:2.8.0
     |    \--- com.google.guava:guava:21.0
     \--- org.yaml:snakeyaml:1.26

testRuntimeOnly - Runtime only dependencies for source set 'test'. (n)
No dependencies

(*) - dependencies omitted (listed previously)

A web-based, searchable dependency report is available by adding the --scan option.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2s
1 actionable task: 1 executed
```

</p>
</details> 

# Related
- Closes https://github.com/dependabot/dependabot-core/issues/2981