### PR TITLE
composer: fix check for platform deps in composer version detection

### DIFF
--- a/composer/lib/dependabot/composer/helpers.rb
+++ b/composer/lib/dependabot/composer/helpers.rb
@@ -7,6 +7,11 @@ module Dependabot
     module Helpers
       # From composers json-schema: https://getcomposer.org/schema.json
       COMPOSER_V2_NAME_REGEX = %r{^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$}.freeze
+      # From https://github.com/composer/composer/blob/b7d770659b4e3ef21423bd67ade935572913a4c1/src/Composer/Repository/PlatformRepository.php#L33
+      PLATFORM_PACKAGE_REGEX = /
+        ^(?:php(?:-64bit|-ipv6|-zts|-debug)?|hhvm|(?:ext|lib)-[a-z0-9](?:[_.-]?[a-z0-9]+)*
+        |composer-(?:plugin|runtime)-api)$
+      /x.freeze
 
       def self.composer_version(composer_json, parsed_lockfile = nil)
         return "v1" if composer_json["name"] && composer_json["name"] !~ COMPOSER_V2_NAME_REGEX
@@ -21,7 +26,7 @@ module Dependabot
         return false unless composer_json.key?("require")
 
         composer_json["require"].keys.any? do |key|
-          key != "php" && key !~ COMPOSER_V2_NAME_REGEX
+          key != "php" && key !~ PLATFORM_PACKAGE_REGEX && key !~ COMPOSER_V2_NAME_REGEX
         end
       end
       private_class_method :invalid_v2_requirement?

--- a/composer/lib/dependabot/composer/helpers.rb
+++ b/composer/lib/dependabot/composer/helpers.rb
@@ -14,19 +14,22 @@ module Dependabot
       /x.freeze
 
       def self.composer_version(composer_json, parsed_lockfile = nil)
-        return "v1" if composer_json["name"] && composer_json["name"] !~ COMPOSER_V2_NAME_REGEX
-        return "v1" if invalid_v2_requirement?(composer_json)
-        return "v2" unless parsed_lockfile && parsed_lockfile["plugin-api-version"]
+        if parsed_lockfile && parsed_lockfile["plugin-api-version"]
+          version = Composer::Version.new(parsed_lockfile["plugin-api-version"])
+          return version.canonical_segments.first == 1 ? "v1" : "v2"
+        else
+          return "v1" if composer_json["name"] && composer_json["name"] !~ COMPOSER_V2_NAME_REGEX
+          return "v1" if invalid_v2_requirement?(composer_json)
+        end
 
-        version = Composer::Version.new(parsed_lockfile["plugin-api-version"])
-        version.canonical_segments.first == 1 ? "v1" : "v2"
+        "v2"
       end
 
       def self.invalid_v2_requirement?(composer_json)
         return false unless composer_json.key?("require")
 
         composer_json["require"].keys.any? do |key|
-          key != "php" && key !~ PLATFORM_PACKAGE_REGEX && key !~ COMPOSER_V2_NAME_REGEX
+          key !~ PLATFORM_PACKAGE_REGEX && key !~ COMPOSER_V2_NAME_REGEX
         end
       end
       private_class_method :invalid_v2_requirement?

--- a/composer/spec/dependabot/composer/file_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater_spec.rb
@@ -131,5 +131,23 @@ RSpec.describe Dependabot::Composer::FileUpdater do
         expect(parsed_updated_lockfile_content["plugin-api-version"]).to eq("1.1.0")
       end
     end
+
+    context "with a project that specifies a platform package" do
+      let(:updated_lockfile_content) do
+        updated_files.find { |f| f.name == "composer.lock" }.content
+      end
+      let(:parsed_updated_lockfile_content) { JSON.parse(updated_lockfile_content) }
+      let(:updated_lockfile_entry) do
+        parsed_updated_lockfile_content["packages"].find do |package|
+          package["name"] == dependency.name
+        end
+      end
+      let(:project_name) { "platform_package" }
+
+      it "updates the dependency and does not downgrade the composer version" do
+        expect(updated_lockfile_entry["version"]).to eq("1.22.1")
+        expect(parsed_updated_lockfile_content["plugin-api-version"]).to eq("2.0.0")
+      end
+    end
   end
 end

--- a/composer/spec/dependabot/composer/helpers_spec.rb
+++ b/composer/spec/dependabot/composer/helpers_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/composer/helpers"
+
+RSpec.describe Dependabot::Composer::Helpers do
+  describe ".composer_version" do
+    let(:composer_v2_content) do
+      <<~JSON
+        {
+          "name": "valid/name",
+          "version": "3.1.7",
+          "dist": {
+            "url": "https://www.example.net/files/3.1.7.zip",
+            "type": "zip"
+          },
+          "require": {
+            "monolog/monolog" : "1.0.1",
+            "symfony/polyfill-mbstring": "1.0.1",
+            "php": "*",
+            "lib-foo": "*",
+            "ext-bar": "*"
+          }
+        }
+      JSON
+    end
+
+    let(:composer_v1_content) do
+      <<~JSON
+        {
+          "name": "valid/name",
+          "version": "3.1.7",
+          "dist": {
+            "url": "https://www.example.net/files/3.1.7.zip",
+            "type": "zip"
+          },
+          "require": {
+            "monolog/monolog" : "1.0.1",
+            "symfony/polyfill-mbstring": "1.0.1",
+            "php": "*",
+            "invalid-package-name": "*"
+          }
+        }
+      JSON
+    end
+
+    it "uses v2 for a manifest that specifies a platform dependency without lockfile" do
+      composer_json = JSON.parse(composer_v2_content)
+
+      expect(described_class.composer_version(composer_json)).to eq("v2")
+    end
+
+    it "uses v1 when one of the packages has an invalid name" do
+      composer_json = JSON.parse(composer_v1_content)
+
+      expect(described_class.composer_version(composer_json)).to eq("v1")
+    end
+  end
+end

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       it { is_expected.to eq(Dependabot::Composer::Version.new("1.25.1")) }
     end
 
-    context "with a name that is only valid in v1" do
+    context "with a dependency name that is only valid in v1" do
       let(:project_name) { "v1/invalid_v2_requirement" }
       let(:dependency_name) { "monolog/Monolog" }
       let(:latest_allowable_version) { Gem::Version.new("1.25.1") }

--- a/composer/spec/fixtures/projects/platform_package/composer.json
+++ b/composer/spec/fixtures/projects/platform_package/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "valid/name",
+  "version": "3.1.7",
+  "dist": {
+    "url": "https://www.example.net/files/3.1.7.zip",
+    "type": "zip"
+  },
+  "require": {
+    "monolog/monolog" : "1.0.1",
+    "symfony/polyfill-mbstring": "1.0.1",
+    "php": "*"
+  }
+}

--- a/composer/spec/fixtures/projects/platform_package/composer.lock
+++ b/composer/spec/fixtures/projects/platform_package/composer.lock
@@ -1,0 +1,125 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "11c76f56fea3bb5e14712bc2f292829c",
+    "packages": [
+        {
+            "name": "monolog/monolog",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "303b8a83c87d5c6d749926cf02620465a5dcd0f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/303b8a83c87d5c6d749926cf02620465a5dcd0f2",
+                "reference": "303b8a83c87d5c6d749926cf02620465a5dcd0f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Logging for PHP 5.3",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/1.0.1"
+            },
+            "time": "2011-08-25T20:42:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/49ff736bd5d41f45240cec77b44967d76e0c3d25",
+                "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/master"
+            },
+            "time": "2015-11-20T09:19:13+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "*"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
+}


### PR DESCRIPTION
Hi,
after https://github.com/dependabot/dependabot-core/pull/2970 Dependabot PRs reverted to using composer v1 in my repo. The reason is that I have `"ext-zip": "*"`and similar in the `require` section.

I tested this by checking the value returned by `composer_version`.