### PR TITLE
v0.130.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.130.2, 19 January 2021
+
+- gradle: repository url by assignment
+- Bump pip-tools from 5.4.0 to 5.5.0
+- Bump eslint from 7.17.0 to 7.18.0 in /npm_and_yarn/helpers
+- Bump golang.org/x/mod from 0.4.0 to 0.4.1 in /go_modules/helpers
+- Bump @npmcli/arborist from 2.0.3 to 2.0.5 in /npm_and_yarn/helpers
+- Bump phpstan/phpstan from 0.12.66 to 0.12.68 in /composer/helpers/v2
+- Bump phpstan/phpstan from 0.12.66 to 0.12.68 in /composer/helpers/v1
+
 ## v0.130.1, 14 January 2021
 
 - npm: detect npm v7 lockfiles

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.130.1"
+  VERSION = "0.130.2"
 end


### PR DESCRIPTION
## v0.130.2, 19 January 2021

- gradle: repository url by assignment
- Bump pip-tools from 5.4.0 to 5.5.0
- Bump eslint from 7.17.0 to 7.18.0 in /npm_and_yarn/helpers
- Bump golang.org/x/mod from 0.4.0 to 0.4.1 in /go_modules/helpers
- Bump @npmcli/arborist from 2.0.3 to 2.0.5 in /npm_and_yarn/helpers
- Bump phpstan/phpstan from 0.12.66 to 0.12.68 in /composer/helpers/v2
- Bump phpstan/phpstan from 0.12.66 to 0.12.68 in /composer/helpers/v1