### PR TITLE
Fix JS debugging in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,55 @@
         "${input:package_manager}",
         "${input:repository}"
       ]
-    }
+    },
+    {
+      "type": "node",
+      "name": "vscode-jest-tests",
+      "request": "launch",
+      "program": "${workspaceFolder}/npm_and_yarn/helpers/node_modules/jest/bin/jest.js",
+      "args": [
+        "--runInBand",
+        "-c",
+        "${workspaceFolder}/npm_and_yarn/helpers/jest.config.js"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true
+    },
+    {
+      "type": "node",
+      "name": "Run jest tests (watch)",
+      "request": "launch",
+      "program": "${workspaceFolder}/npm_and_yarn/helpers/node_modules/jest/bin/jest.js",
+      "args": [
+        "--runInBand",
+        "--watchAll",
+        "-c",
+        "${workspaceFolder}/npm_and_yarn/helpers/jest.config.js"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true
+    },
+    {
+      "type": "node",
+      "name": "Run jest tests on opened file (watch)",
+      "request": "launch",
+      "program": "${workspaceFolder}/npm_and_yarn/helpers/node_modules/jest/bin/jest.js",
+      "args": [
+        "${fileBasenameNoExtension}",
+        "--runInBand",
+        "--watchAll",
+        "-c",
+        "${workspaceFolder}/npm_and_yarn/helpers/jest.config.js"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true
+    },
   ],
   "inputs": [
     {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "files.associations": {
     "Dockerfile.*": "dockerfile"
-  }
+  },
+  "jest.pathToJest": "${workspaceFolder}/npm_and_yarn/helpers/node_modules/.bin/jest",
+  "jest.pathToConfig": "${workspaceFolder}/npm_and_yarn/helpers/jest.config.js"
 }

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -62,6 +62,9 @@ require "optparse"
 require "json"
 require "byebug"
 require "logger"
+require "dependabot/logger"
+
+Dependabot.logger = Logger.new($stdout)
 
 require "dependabot/file_fetchers"
 require "dependabot/file_parsers"
@@ -85,8 +88,6 @@ require "dependabot/npm_and_yarn"
 require "dependabot/nuget"
 require "dependabot/python"
 require "dependabot/terraform"
-
-Dependabot.logger = Logger.new($stdout)
 
 # GitHub credentials with write permission to the repo you want to update
 # (so that you can create a new branch, commit and pull request).

--- a/npm_and_yarn/helpers/.eslintrc
+++ b/npm_and_yarn/helpers/.eslintrc
@@ -1,10 +1,7 @@
 {
-  "plugins": [
+  "extends": [
     "prettier"
   ],
-  "rules": {
-    "prettier/prettier": "error"
-  },
   "env": {
     "node": true
   },

--- a/npm_and_yarn/helpers/build
+++ b/npm_and_yarn/helpers/build
@@ -14,6 +14,7 @@ cp -r \
   "$helpers_dir/test" \
   "$helpers_dir/run.js" \
   "$helpers_dir/.eslintrc" \
+  "$helpers_dir/jest.config.js" \
   "$helpers_dir/package.json" \
   "$helpers_dir/yarn.lock" \
   "$install_dir"

--- a/npm_and_yarn/helpers/jest.config.js
+++ b/npm_and_yarn/helpers/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  verbose: true,
+  testEnvironment: "node",
+};

--- a/npm_and_yarn/helpers/package.json
+++ b/npm_and_yarn/helpers/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "eslint": "^7.18.0",
-    "eslint-plugin-prettier": "^3.3.1",
+    "eslint-config-prettier": "^7.2.0",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2"

--- a/npm_and_yarn/helpers/yarn.lock
+++ b/npm_and_yarn/helpers/yarn.lock
@@ -2263,12 +2263,10 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-plugin-prettier@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz#7079cfa2497078905011e6f82e8dd8453d1371b7"
-  integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
+eslint-config-prettier@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz#f4a4bd2832e810e8cc7c1411ec85b3e85c0c53f9"
+  integrity sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==
 
 eslint-scope@^5.1.1:
   version "5.1.1"
@@ -2535,11 +2533,6 @@ fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -6105,13 +6098,6 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 prettier@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
This adds a couple launch scripts to debug npm and yarn tests when
running then using jest.

The launch scripts complained about a missing config file so added this
and changed the default env from jsdom to node as this is what we use.

Changed `eslint-plugin-prettier` to `eslint-config-prettier` as this
seems like the recommended extension now when using prettier with
eslint: https://prettier.io/docs/en/integrating-with-linters.html

This extracts these changes from the npm 7 branch:
#3011
