### PR TITLE
go-1.15.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,8 +136,8 @@ RUN add-apt-repository ppa:ondrej/php \
 ### GO
 
 # Install Go and dep
-ARG GOLANG_VERSION=1.15.2
-ARG GOLANG_CHECKSUM=b49fda1ca29a1946d6bb2a5a6982cf07ccd2aba849289508ee0f9918f6bb4552
+ARG GOLANG_VERSION=1.15.7
+ARG GOLANG_CHECKSUM=0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3
 RUN curl -o go.tar.gz https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz \
   && echo "$GOLANG_CHECKSUM go.tar.gz" | sha256sum -c - \
   && tar -xzf go.tar.gz -C /opt \


### PR DESCRIPTION
This pull request bumps the bundled version of Golang from `1.15.3` to `1.15.7`.

This mitigates CVE-2021-3115 , per https://groups.google.com/g/golang-announce/c/mperVMGa98w:

> The go command may execute arbitrary code at build time when cgo is in use on Windows. This may occur when running “go get”, or any other command that builds code. Only users who build untrusted code (and don’t execute it) are affected.
> In addition to Windows users, this can also affect Unix users who have “.” listed explicitly in their PATH and are running “go get” or build commands outside of a module or with module mode disabled.

