### PR TITLE
Gradle Kotlin DSL: Add Support for Named URL Parameter in Maven Repository

### DIFF
--- a/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
@@ -19,7 +19,7 @@ module Dependabot
           /maven\s*\{[^\}]*\surl[\s\(]=?\s*['"](?<url>[^'"]+)['"]/.freeze
 
         KOTLIN_MAVEN_REPO_REGEX =
-          /maven\((url\=)?["](?<url>[^"]+)["]\)/.freeze
+          /maven\((url\s?\=\s?)?["](?<url>[^"]+)["]\)/.freeze
 
         MAVEN_REPO_REGEX =
           /(#{KOTLIN_MAVEN_REPO_REGEX}|#{GROOVY_MAVEN_REPO_REGEX})/.freeze

--- a/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
@@ -19,7 +19,7 @@ module Dependabot
           /maven\s*\{[^\}]*\surl[\s\(]=?\s*['"](?<url>[^'"]+)['"]/.freeze
 
         KOTLIN_MAVEN_REPO_REGEX =
-          /maven\(['"](?<url>[^'"]+)['"]\)/.freeze
+          /maven\((url\=)?["](?<url>[^"]+)["]\)/.freeze
 
         MAVEN_REPO_REGEX =
           /(#{KOTLIN_MAVEN_REPO_REGEX}|#{GROOVY_MAVEN_REPO_REGEX})/.freeze

--- a/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
             %w(
               https://jcenter.bintray.com
               https://dl.bintray.com/magnusja/maven
+              https://kotlin.bintray.com/kotlinx
               https://maven.google.com
             )
           )

--- a/gradle/spec/fixtures/buildfiles/root_build.gradle.kts
+++ b/gradle/spec/fixtures/buildfiles/root_build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
 
     repositories {
         jcenter()
-        maven("https://dl.bintray.com/magnusja/maven")
+        maven(url = "https://dl.bintray.com/magnusja/maven")
         google()
     }
     dependencies {

--- a/gradle/spec/fixtures/buildfiles/root_build.gradle.kts
+++ b/gradle/spec/fixtures/buildfiles/root_build.gradle.kts
@@ -17,6 +17,7 @@ buildscript {
     repositories {
         jcenter()
         maven(url = "https://dl.bintray.com/magnusja/maven")
+        maven("https://kotlin.bintray.com/kotlinx/")
         google()
     }
     dependencies {


### PR DESCRIPTION
In Kotlin, a function call can have named parameters and Strings are only allowed to begin with `"`.

````kotlin
repositories {
    maven("foo.com")
    maven(url = "bar.com") // equals to maven("bar.com")
    maven('baz.com') // invalid, does not compile
}
````

This PR adds the optional `url = ` String to the regex as well as removing `'` as String delimiter, which is not allowed in Kotlin.