### PR TITLE
v0.130.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.130.3, 25 January 2021
+
+- Extract yarn/npm lockfile updater specs from FileUpdater specs
+- Bump @npmcli/arborist from 2.0.5 to 2.0.6 in /npm_and_yarn/helpers
+- Gomod: go-1.15.7
+- Composer: Check for explicit composer plugin version before invalid plugins
+- Update eslint prettier extension
+- Fix JS debugging in vscode
+
 ## v0.130.2, 19 January 2021
 
 - gradle: repository url by assignment

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.130.2"
+  VERSION = "0.130.3"
 end


### PR DESCRIPTION
## v0.130.3, 25 January 2021

- Extract yarn/npm lockfile updater specs from FileUpdater specs
- Bump @npmcli/arborist from 2.0.5 to 2.0.6 in /npm_and_yarn/helpers
- Gomod: go-1.15.7
- Composer: Check for explicit composer plugin version before invalid plugins
- Update eslint prettier extension
- Fix JS debugging in vscode