### PR TITLE
Nuget: Parse floating notation when used in range

### DIFF
--- a/nuget/lib/dependabot/nuget/requirement.rb
+++ b/nuget/lib/dependabot/nuget/requirement.rb
@@ -49,13 +49,18 @@ module Dependabot
         return convert_dotnet_range_to_ruby_range(req_string) if req_string&.start_with?("(", "[")
 
         return req_string.split(",").map(&:strip) if req_string.include?(",")
+
         return req_string unless req_string.include?("*")
 
         convert_wildcard_req(req_string)
       end
 
       def convert_dotnet_range_to_ruby_range(req_string)
-        lower_b, upper_b = req_string.split(",").map(&:strip)
+        lower_b, upper_b = req_string.split(",").map(&:strip).map do |bound|
+          next convert_range_wildcard_req(bound) if bound.include?("*")
+
+          bound
+        end
 
         lower_b =
           if ["(", "["].include?(lower_b) then nil
@@ -70,6 +75,14 @@ module Dependabot
           end
 
         [lower_b, upper_b].compact
+      end
+
+      def convert_range_wildcard_req(req_string)
+        range_end = req_string[-1]
+        defined_part = req_string.split("*").first
+        version = defined_part + "0"
+        version += range_end if [")", "]"].include?(range_end)
+        version
       end
 
       def convert_wildcard_req(req_string)

--- a/nuget/spec/dependabot/nuget/requirement_spec.rb
+++ b/nuget/spec/dependabot/nuget/requirement_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe Dependabot::Nuget::Requirement do
         let(:requirement_string) { ">= 1.0.0, < 2.0.0" }
         it { is_expected.to eq(Gem::Requirement.new(">= 1.0.0", "< 2.0.0")) }
       end
+
+      context "which includes a * in the lower bound" do
+        let(:requirement_string) { "[2.1.*,3.0.0)" }
+        it { is_expected.to eq(Gem::Requirement.new(">= 2.1.0", "< 3.0.0")) }
+      end
+
+      context "which includes a * in the upper bound" do
+        let(:requirement_string) { "[2.1,3.0.*)" }
+        it { is_expected.to eq(Gem::Requirement.new(">= 2.1", "< 3.0.0")) }
+      end
     end
   end
 end


### PR DESCRIPTION
Typically you’d define a Nuget range as `[2.0, 3.0)` which translates to: "higher than
or equal to 2.0 but lower than 3.0". You can also say `2.0.*` which means any
patch version of 2.0.

However, it's valid to combine these like `[2.1.*,3.0.0)`.

The floating notation (`*`) seems like it’s redundant in this case,
as the `3.0.0)` bit would allow 2.2 to be installed.

I could not find any documentation on this, so I made a best guess
effort to do what seems right, previously a notation like this would
fail and cause the update to error. I've verified that this resolves
those errors when dry-running.