### PR TITLE
Nuget: Ignore `Remove` ProjectReferences

### DIFF
--- a/nuget/lib/dependabot/nuget/file_fetcher/import_paths_finder.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher/import_paths_finder.rb
@@ -26,11 +26,16 @@ module Dependabot
         def project_reference_paths
           doc = Nokogiri::XML(project_file.content)
           doc.remove_namespaces!
-          doc.xpath("/Project/ItemGroup/ProjectReference").map do |node|
-            path = node.attribute("Include").value.strip.tr("\\", "/")
+          nodes = doc.xpath("/Project/ItemGroup/ProjectReference").map do |node|
+            attribute = node.attribute("Include")
+            next unless attribute
+
+            path = attribute.value.strip.tr("\\", "/")
             path = File.join(current_dir, path) unless current_dir.nil?
             Pathname.new(path).cleanpath.to_path
           end
+
+          nodes.compact
         end
 
         private

--- a/nuget/spec/dependabot/nuget/file_fetcher/import_paths_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_fetcher/import_paths_finder_spec.rb
@@ -45,5 +45,11 @@ RSpec.describe Dependabot::Nuget::FileFetcher::ImportPathsFinder do
       let(:csproj_name) { "nested/my.csproj" }
       it { is_expected.to eq(["ref/another.csproj"]) }
     end
+
+    context "when the file references another project via a Remove attribute" do
+      let(:fixture_name) { "project_reference_remove.csproj" }
+      let(:csproj_name) { "nested/my.csproj" }
+      it { is_expected.to eq([]) }
+    end
   end
 end

--- a/nuget/spec/fixtures/csproj/project_reference_remove.csproj
+++ b/nuget/spec/fixtures/csproj/project_reference_remove.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Remove="..\ref\another.csproj">
+      <SupportedFramework>net461;netcoreapp2.0;$(AllXamarinFrameworks)</SupportedFramework>
+    </ProjectReference>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Nuget allows us to reference nested projects using the
`<ProjectReference Include="some\project.csproc">` notation. You can
also explicitly remove references as shown in the fixture added in this
PR.

In that case we used to error, now we just ignore that reference
instead.