### PR TITLE
Composer: handle unreachable path vcs source

### DIFF
--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -255,7 +255,8 @@ module Dependabot
               named_captures.fetch("url")
             raise Dependabot::GitDependenciesNotReachable, dependency_url
           elsif error.message.start_with?("Could not parse version") ||
-                error.message.include?("does not allow connections to http://")
+                error.message.include?("does not allow connections to http://") ||
+                error.message.match?(/The `url` supplied for the path .* does not exist/)
             raise Dependabot::DependencyFileNotResolvable, sanitized_message
           elsif error.message.match?(MISSING_EXPLICIT_PLATFORM_REQ_REGEX)
             # These errors occur when platform requirements declared explicitly

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -201,6 +201,15 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       it { is_expected.to eq(Dependabot::Composer::Version.new("1.25.1")) }
     end
 
+    context "with an unresolvable path VCS source" do
+      let(:project_name) { "unreachable_path_vcs_source" }
+
+      it "raises a Dependabot::DependencyFileNotResolvable error" do
+        expect { resolver.latest_resolvable_version }.
+          to raise_error(Dependabot::DependencyFileNotResolvable)
+      end
+    end
+
     # This test is extremely slow, as it needs to wait for Composer to time out.
     # As a result we currently keep it commented out.
     # context "with an unreachable private registry" do

--- a/composer/spec/fixtures/projects/unreachable_path_vcs_source/composer.json
+++ b/composer/spec/fixtures/projects/unreachable_path_vcs_source/composer.json
@@ -1,0 +1,17 @@
+{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../foo",
+            "options": {
+                "symlink": true
+            }
+        },
+        {
+            "packagist.org": false
+        }
+    ],
+    "require": {
+        "dependabot/dummy-pkg-a": "*"
+    }
+}


### PR DESCRIPTION
When a Composer repository is specified as a local path source which is
not available we should raise a DependencyFileNotResolvable error.