### PR TITLE
v0.131.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v0.131.0, 4 February 2021
+
+- Composer: handle unreachable path vcs source
+- Nuget: Parse floating notation when used in range
+- Nuget: Ignore `Remove` ProjectReferences
+- Gradle Kotlin DSL: Add Support for Named URL Parameter in Maven Repository (@hfhbd)
+- Python: Add python 3.8.7 (@Parnassius)
+- npm: Refactor specs to use project based fixtures
+- Bump composer/composer from 1.10.19 to 1.10.20 in /composer/helpers/v1
+- Bump composer/composer from 2.0.8 to 2.0.9 in /composer/helpers/v2
+- Bump phpstan/phpstan from 0.12.68 to 0.12.71 in /composer/helpers/v1 and /composer/helpers/v2
+- Bump friendsofphp/php-cs-fixer in /composer/helpers/v2 and /composer/helpers/v1
+- Update simplecov-console requirement from ~> 0.8.0 to ~> 0.9.1
+- Bump @npmcli/arborist from 2.0.6 to 2.1.1 in /npm_and_yarn/helpers
+- Update rubocop requirement from ~> 1.8.0 to ~> 1.9.0 in /common
+
 ## v0.130.3, 25 January 2021
 
 - Extract yarn/npm lockfile updater specs from FileUpdater specs

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.130.3"
+  VERSION = "0.131.0"
 end


### PR DESCRIPTION
## v0.131.0, 4 February 2021

- Composer: handle unreachable path vcs source
- Nuget: Parse floating notation when used in range
- Nuget: Ignore `Remove` ProjectReferences
- Gradle Kotlin DSL: Add Support for Named URL Parameter in Maven Repository (@hfhbd)
- Python: Add python 3.8.7 (@Parnassius)
- npm: Refactor specs to use project based fixtures
- Bump composer/composer from 1.10.19 to 1.10.20 in /composer/helpers/v1
- Bump composer/composer from 2.0.8 to 2.0.9 in /composer/helpers/v2
- Bump phpstan/phpstan from 0.12.68 to 0.12.71 in /composer/helpers/v1 and /composer/helpers/v2
- Bump friendsofphp/php-cs-fixer in /composer/helpers/v2 and /composer/helpers/v1
- Update simplecov-console requirement from ~> 0.8.0 to ~> 0.9.1
- Bump @npmcli/arborist from 2.0.6 to 2.1.1 in /npm_and_yarn/helpers
- Update rubocop requirement from ~> 1.8.0 to ~> 1.9.0 in /common