### PR TITLE
Composer: Handle version constraints with both caret and dev postfix

### DIFF
--- a/composer/lib/dependabot/composer/requirement.rb
+++ b/composer/lib/dependabot/composer/requirement.rb
@@ -44,9 +44,9 @@ module Dependabot
 
         if req_string.start_with?("*", "x") then ">= 0"
         elsif req_string.include?("*") then convert_wildcard_req(req_string)
-        elsif req_string.include?(".x") then convert_wildcard_req(req_string)
-        elsif req_string.match?(/^~[^>]/) then convert_tilde_req(req_string)
         elsif req_string.start_with?("^") then convert_caret_req(req_string)
+        elsif req_string.match?(/^~[^>]/) then convert_tilde_req(req_string)
+        elsif req_string.include?(".x") then convert_wildcard_req(req_string)
         elsif req_string.match?(/\s-\s/) then convert_hyphen_req(req_string)
         else req_string
         end
@@ -68,7 +68,7 @@ module Dependabot
       end
 
       def convert_caret_req(req_string)
-        version = req_string.gsub(/^\^/, "")
+        version = req_string.gsub(/^\^/, "").gsub("x-dev", "0")
         parts = version.split(".")
         first_non_zero = parts.find { |d| d != "0" }
         first_non_zero_index =

--- a/composer/spec/dependabot/composer/requirement_spec.rb
+++ b/composer/spec/dependabot/composer/requirement_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe Dependabot::Composer::Requirement do
       it { is_expected.to eq(described_class.new(">= 1.0.0", "< 2.0.0")) }
     end
 
+    context "with a caret version and dev postfix" do
+      let(:requirement_string) { "^7.x-dev" }
+      it { is_expected.to eq(described_class.new(">= 7.0", "< 8.0")) }
+    end
+
     context "with a ~ version specified" do
       let(:requirement_string) { "~1.5.1" }
       it { is_expected.to eq(described_class.new("~> 1.5.1")) }


### PR DESCRIPTION
The `.x-dev` postfix is a way to tell composer to check out a branch
instead of a tag. For the purpose of defining the version range, we can
ignore this notation and replace it with a `0` to ensure we match the
right range.