### PR TITLE
Don't raise when adding temp platform extensions

### DIFF
--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -159,7 +159,7 @@ module Dependabot
           json = JSON.parse(content)
 
           composer_platform_extensions.each do |extension, requirements|
-            raise "No matching version for #{requirements}!" unless version_for_reqs(requirements)
+            next unless version_for_reqs(requirements)
 
             json["config"] ||= {}
             json["config"]["platform"] ||= {}

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -210,6 +210,15 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       end
     end
 
+    context "with a platform extension that cannot be added" do
+      let(:project_name) { "unaddable_platform_req" }
+      let(:dependency_name) { "monolog/monolog" }
+      let(:latest_allowable_version) { Gem::Version.new("1.25.1") }
+      let(:dependency_version) { "1.0.2" }
+
+      it { is_expected.to eq(Dependabot::Composer::Version.new("1.25.1")) }
+    end
+
     # This test is extremely slow, as it needs to wait for Composer to time out.
     # As a result we currently keep it commented out.
     # context "with an unreachable private registry" do

--- a/composer/spec/fixtures/projects/unaddable_platform_req/composer.json
+++ b/composer/spec/fixtures/projects/unaddable_platform_req/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "valid/name",
+  "type": "library",
+  "require": {
+    "php": ">=5.3.0",
+    "monolog/monolog" : "1.0.1"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^4.0 || ^8.0"
+  }
+}


### PR DESCRIPTION
It's not clear to me why we need to raise in this scenario, those errors
are not handled. It seems better to attempt the update without adding
the extensions, for some cases that I've tried locally that seems to
update dependencies just fine.

Maybe this behavior was improved with composer 2?