### PR TITLE
Composer: handle invalid version string

### DIFF
--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -254,9 +254,7 @@ module Dependabot
               error.message.match(/Failed to clone (?<url>.*?) via/).
               named_captures.fetch("url")
             raise Dependabot::GitDependenciesNotReachable, dependency_url
-          elsif error.message.start_with?("Could not parse version") ||
-                error.message.include?("does not allow connections to http://") ||
-                error.message.match?(/The `url` supplied for the path .* does not exist/)
+          elsif unresolvable_error?(error)
             raise Dependabot::DependencyFileNotResolvable, sanitized_message
           elsif error.message.match?(MISSING_EXPLICIT_PLATFORM_REQ_REGEX)
             # These errors occur when platform requirements declared explicitly
@@ -346,6 +344,13 @@ module Dependabot
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/CyclomaticComplexity
         # rubocop:enable Metrics/MethodLength
+
+        def unresolvable_error?(error)
+          error.message.start_with?("Could not parse version") ||
+            error.message.include?("does not allow connections to http://") ||
+            error.message.match?(/The `url` supplied for the path .* does not exist/) ||
+            error.message.start_with?("Invalid version string")
+        end
 
         def library?
           parsed_composer_file["type"] == "library"

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -219,6 +219,15 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       it { is_expected.to eq(Dependabot::Composer::Version.new("1.25.1")) }
     end
 
+    context "with an invalid version string" do
+      let(:project_name) { "invalid_version_string" }
+
+      it "raises a Dependabot::DependencyFileNotResolvable error" do
+        expect { resolver.latest_resolvable_version }.
+          to raise_error(Dependabot::DependencyFileNotResolvable)
+      end
+    end
+
     # This test is extremely slow, as it needs to wait for Composer to time out.
     # As a result we currently keep it commented out.
     # context "with an unreachable private registry" do

--- a/composer/spec/fixtures/projects/invalid_version_string/composer.json
+++ b/composer/spec/fixtures/projects/invalid_version_string/composer.json
@@ -1,0 +1,7 @@
+{
+  "name": "valid/name",
+  "version": "3.1.7",
+  "require": {
+    "monolog/monolog" : "^3.0|4.1.x-dev as 3.0.0"
+  }
+}


### PR DESCRIPTION
This would previously bubble up as an unknown error, but we should
inform the user their manifest file is not resolvable.

We handle a slightly different variant of this error already.