### PR TITLE
v0.131.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.131.1, 4 February 2021
+
+- Composer: handle invalid version string
+- Composer: Don't raise when adding temp platform extensions
+- Composer: Handle version constraints with both caret and dev postfix
+- Docker: Use the correct Docker digest when checking for updates
+
 ## v0.131.0, 4 February 2021
 
 - Composer: handle unreachable path vcs source

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.131.0"
+  VERSION = "0.131.1"
 end


### PR DESCRIPTION
- Composer: handle invalid version string
- Composer: Don't raise when adding temp platform extensions
- Composer: Handle version constraints with both caret and dev postfix
- Docker: Use the correct Docker digest when checking for updates