### PR TITLE
Maven: handle invalid pom references

### DIFF
--- a/maven/lib/dependabot/maven/file_parser/property_value_finder.rb
+++ b/maven/lib/dependabot/maven/file_parser/property_value_finder.rb
@@ -39,6 +39,9 @@ module Dependabot
               break unless nm.match?(DOT_SEPARATOR_REGEX)
 
               nm = nm.sub(DOT_SEPARATOR_REGEX, "/")
+
+            rescue Nokogiri::XML::XPath::SyntaxError => e
+              raise DependencyFileNotEvaluatable, e.message
             end
 
           # If we found a property, return it

--- a/maven/spec/dependabot/maven/file_parser/property_value_finder_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser/property_value_finder_spec.rb
@@ -152,5 +152,17 @@ RSpec.describe Dependabot::Maven::FileParser::PropertyValueFinder do
         its([:value]) { is_expected.to eq("2.7") }
       end
     end
+
+    context "with a pom that contains invalid xml" do
+      let(:dependency_files) { project_dependency_files("invalid_version_ref") }
+      let(:property_name) { "guava.version`" }
+      let(:callsite_pom) { dependency_files.find { |f| f.name == "pom.xml" } }
+
+      it "raises a helpful error" do
+        expect { subject }.to raise_error(Dependabot::DependencyFileNotEvaluatable) do |error|
+          expect(error.message).to eq("ERROR: Invalid expression: /project/guava.version`")
+        end
+      end
+    end
   end
 end

--- a/maven/spec/fixtures/projects/invalid_version_ref/pom.xml
+++ b/maven/spec/fixtures/projects/invalid_version_ref/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.dependabot</groupId>
+  <artifactId>basic-pom</artifactId>
+  <version>0.0.1-RELEASE</version>
+  <name>Dependabot Basic POM</name>
+
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+        <version>${guava.version`}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.3</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.mockk</groupId>
+      <artifactId>mockk</artifactId>
+      <version>1.0.0</version>
+      <classifier>sources</classifier>
+    </dependency>
+  </dependencies>
+
+  <guava.version>23.3-jre</guava.version>
+</project>


### PR DESCRIPTION
When a version ref is invalid, we should raise a
DependencyFileNotEvaluatable. This can potentially be handled in the
`FileParser` if other dependencies _can_ be found.