### PR TITLE
Nuget: handle version ranges in VersionFinder

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -99,7 +99,7 @@ module Dependabot
         end
 
         def parse_requirement_string(string)
-          return string if string.match?(NUGET_RANGE_REGEX)
+          return [string] if string.match?(NUGET_RANGE_REGEX)
 
           string.split(",").map(&:strip)
         end

--- a/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
@@ -276,6 +276,16 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
 
       its([:version]) { is_expected.to eq(version_class.new("2.1.0")) }
     end
+
+    context "with a version range specified" do
+      let(:dependency_files) { project_dependency_files("version_range") }
+      let(:dependency_version) { "1.1.0" }
+      let(:dependency_requirements) do
+        [{ file: "my.csproj", requirement: "[1.1.0, 3.0.0)", groups: [], source: nil }]
+      end
+
+      its([:version]) { is_expected.to eq(version_class.new("2.1.0")) }
+    end
   end
 
   describe "#lowest_security_fix_version_details" do

--- a/nuget/spec/fixtures/projects/version_range/my.csproj
+++ b/nuget/spec/fixtures/projects/version_range/my.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="[1.1.0, 3.0.0)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Previously, a version specified as a range would result in a `undefined
method `any?' for "[5.1.0, 6.0.0)":String` error. This prevents that
from happening.