### PR TITLE
v0.132.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.132.0, 8 February 2021
+
+- npm: Add support for updating npm 7 lockfiles
+
 ## v0.131.3, 8 February 2021
 
 - Nuget: handle version ranges in VersionFinder

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.131.3"
+  VERSION = "0.132.0"
 end


### PR DESCRIPTION
## v0.132.0, 8 February 2021

- npm: Add support for updating npm 7 lockfiles
