### PR TITLE
Dependabot::UnexpectedExternalCode

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -103,6 +103,7 @@ $options = {
   write: false,
   clone: false,
   lockfile_only: false,
+  reject_external_code: false,
   requirements_update_strategy: nil,
   commit: nil,
   updater_options: {},
@@ -165,6 +166,10 @@ option_parse = OptionParser.new do |opts|
 
   opts.on("--lockfile-only", "Only update the lockfile") do |_value|
     $options[:lockfile_only] = true
+  end
+
+  opts.on("--reject-external-code", "Reject external code") do |_value|
+    $options[:reject_external_code] = true
   end
 
   opts_req_desc = "Options: auto, widen_ranges, bump_versions or "\
@@ -454,7 +459,8 @@ parser = Dependabot::FileParsers.for_package_manager($package_manager).new(
   dependency_files: $files,
   repo_contents_path: $repo_contents_path,
   source: source,
-  credentials: $options[:credentials]
+  credentials: $options[:credentials],
+  reject_external_code: $options[:reject_external_code],
 )
 
 dependencies = cached_read("dependencies") { parser.parse }

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -217,4 +217,7 @@ module Dependabot
 
   # Raised by UpdateChecker if all candidate updates are ignored
   class AllVersionsIgnored < DependabotError; end
+
+  # Raised by FileParser if processing may execute external code in the update context
+  class UnexpectedExternalCode < DependabotError; end
 end

--- a/common/lib/dependabot/file_parsers/base.rb
+++ b/common/lib/dependabot/file_parsers/base.rb
@@ -6,11 +6,12 @@ module Dependabot
       attr_reader :dependency_files, :repo_contents_path, :credentials, :source
 
       def initialize(dependency_files:, repo_contents_path: nil, source:,
-                     credentials: [])
+                     credentials: [], reject_external_code: false)
         @dependency_files = dependency_files
         @repo_contents_path = repo_contents_path
         @credentials = credentials
         @source = source
+        @reject_external_code = reject_external_code
 
         check_required_files
       end


### PR DESCRIPTION
This introduces `Dependabot::UnexpectedExternalCode` as a new error, to be raised when Dependabot
determines it may need to evaluate external code to update a dependency.

This exception will be part of an **opt-in** hardening, to
be used in conjunction with features that extend the resources
accessible to Dependabot (e.g. private packages and sources).

The included sample and test cases centre around the Bundler ecosystem,
where Git sources which may result in a evaluating the Ruby code contained in the the dependency's
`.gemspec`, e.g. https://github.com/dependabot/dependabot-core/blob/main/common/dependabot-common.gemspec
