### PR TITLE
npm: fix npm workspace bug

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -117,11 +117,11 @@ module Dependabot
       end
 
       def package_lock_changed?(package_lock)
-        package_lock.content != updated_package_lock_content(package_lock)
+        package_lock.content != updated_lockfile_content(package_lock)
       end
 
       def shrinkwrap_changed?(shrinkwrap)
-        shrinkwrap.content != updated_package_lock_content(shrinkwrap)
+        shrinkwrap.content != updated_lockfile_content(shrinkwrap)
       end
 
       def updated_manifest_files
@@ -150,7 +150,7 @@ module Dependabot
 
           updated_files << updated_file(
             file: package_lock,
-            content: updated_package_lock_content(package_lock)
+            content: updated_lockfile_content(package_lock)
           )
         end
 
@@ -159,7 +159,7 @@ module Dependabot
 
           updated_files << updated_file(
             file: shrinkwrap,
-            content: updated_shrinkwrap_content(shrinkwrap)
+            content: updated_lockfile_content(shrinkwrap)
           )
         end
 
@@ -181,25 +181,15 @@ module Dependabot
           )
       end
 
-      def updated_package_lock_content(package_lock)
-        @updated_package_lock_content ||= {}
-        @updated_package_lock_content[package_lock.name] ||=
-          npm_lockfile_updater.updated_lockfile_content(package_lock)
-      end
-
-      def updated_shrinkwrap_content(shrinkwrap)
-        @updated_shrinkwrap_content ||= {}
-        @updated_shrinkwrap_content[shrinkwrap.name] ||=
-          npm_lockfile_updater.updated_lockfile_content(shrinkwrap)
-      end
-
-      def npm_lockfile_updater
-        @npm_lockfile_updater ||=
+      def updated_lockfile_content(file)
+        @updated_lockfile_content ||= {}
+        @updated_lockfile_content[file.name] ||=
           NpmLockfileUpdater.new(
+            lockfile: file,
             dependencies: dependencies,
             dependency_files: dependency_files,
             credentials: credentials
-          )
+          ).updated_lockfile.content
       end
 
       def updated_package_json_content(file)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -17,35 +17,22 @@ module Dependabot
         require_relative "npmrc_builder"
         require_relative "package_json_updater"
 
-        def initialize(dependencies:, dependency_files:, credentials:)
+        def initialize(lockfile:, dependencies:, dependency_files:, credentials:)
+          @lockfile = lockfile
           @dependencies = dependencies
           @dependency_files = dependency_files
           @credentials = credentials
         end
 
-        def updated_lockfile_content(lockfile)
-          return lockfile.content if npmrc_disables_lockfile?
-          return lockfile.content if updatable_dependencies(lockfile).empty?
-
-          @updated_lockfile_content ||= {}
-          @updated_lockfile_content[lockfile.name] ||=
-            SharedHelpers.in_a_temporary_directory do
-              path = Pathname.new(lockfile.name).dirname.to_s
-              lockfile_name = Pathname.new(lockfile.name).basename.to_s
-              write_temporary_dependency_files(lockfile.name)
-              updated_files = Dir.chdir(path) do
-                run_current_npm_update(lockfile_name: lockfile_name, lockfile_content: lockfile.content)
-              end
-              updated_content = updated_files.fetch(lockfile_name)
-              post_process_npm_lockfile(lockfile.content, updated_content, lockfile.name)
-            end
-        rescue SharedHelpers::HelperSubprocessFailed => e
-          handle_npm_updater_error(e, lockfile)
+        def updated_lockfile
+          updated_file = lockfile.dup
+          updated_file.content = updated_lockfile_content
+          updated_file
         end
 
         private
 
-        attr_reader :dependencies, :dependency_files, :credentials
+        attr_reader :lockfile, :dependencies, :dependency_files, :credentials
 
         UNREACHABLE_GIT = /fatal: repository '(?<url>.*)' not found/.freeze
         FORBIDDEN_GIT = /fatal: Authentication failed for '(?<url>.*)'/.freeze
@@ -63,6 +50,21 @@ module Dependabot
         NPM7_MISSING_GIT_REF = /already exists and is not an empty directory/.freeze
         NPM6_MISSING_GIT_REF = /did not match any file\(s\) known to git/.freeze
 
+        def updated_lockfile_content
+          return lockfile.content if npmrc_disables_lockfile?
+          return lockfile.content unless updatable_dependencies.any?
+
+          @updated_lockfile_content ||=
+            SharedHelpers.in_a_temporary_directory do
+              write_temporary_dependency_files
+              updated_files = Dir.chdir(lockfile_directory) { run_current_npm_update }
+              updated_lockfile_content = updated_files.fetch(lockfile_basename)
+              post_process_npm_lockfile(updated_lockfile_content)
+            end
+        rescue SharedHelpers::HelperSubprocessFailed => e
+          handle_npm_updater_error(e)
+        end
+
         def top_level_dependencies
           dependencies.select(&:top_level?)
         end
@@ -71,16 +73,14 @@ module Dependabot
           dependencies.reject(&:top_level?)
         end
 
-        def updatable_dependencies(lockfile)
+        def updatable_dependencies
           dependencies.reject do |dependency|
-            dependency_up_to_date?(lockfile, dependency) ||
-              top_level_dependency_update_not_required?(dependency, lockfile)
+            dependency_up_to_date?(dependency) || top_level_dependency_update_not_required?(dependency)
           end
         end
 
-        def lockfile_dependencies(lockfile)
-          @lockfile_dependencies ||= {}
-          @lockfile_dependencies[lockfile.name] ||=
+        def lockfile_dependencies
+          @lockfile_dependencies ||=
             NpmAndYarn::FileParser.new(
               dependency_files: [lockfile, *package_files],
               source: nil,
@@ -88,9 +88,8 @@ module Dependabot
             ).parse
         end
 
-        def dependency_up_to_date?(lockfile, dependency)
-          existing_dep = lockfile_dependencies(lockfile).
-                         find { |dep| dep.name == dependency.name }
+        def dependency_up_to_date?(dependency)
+          existing_dep = lockfile_dependencies.find { |dep| dep.name == dependency.name }
 
           # If the dependency is missing but top level it should be treated as
           # not up to date
@@ -106,93 +105,81 @@ module Dependabot
         # proj). npm 7 introduces workspace support so we explitly want to
         # update the root lockfile and check if the dependency is in the
         # lockfile
-        def top_level_dependency_update_not_required?(dependency, lockfile)
-          lockfile_dir = Pathname.new(lockfile.name).dirname.to_s
-
-          requirements_for_path = dependency.requirements.select do |req|
-            req_dir = Pathname.new(req[:file]).dirname.to_s
-            req_dir == lockfile_dir
-          end
-
-          dependency_in_lockfile = lockfile_dependencies(lockfile).any? do |dep|
-            dep.name == dependency.name
-          end
-
-          dependency.top_level? && requirements_for_path.empty? && !dependency_in_lockfile
+        def top_level_dependency_update_not_required?(dependency)
+          dependency.top_level? &&
+            !dependency_in_package_json?(dependency) &&
+            !dependency_in_lockfile?(dependency)
         end
 
-        def run_current_npm_update(lockfile_name:, lockfile_content:)
-          top_level_dependency_updates = top_level_dependencies.map do |d|
-            { name: d.name, version: d.version, requirements: d.requirements }
-          end
-
-          run_npm_updater(
-            lockfile_name: lockfile_name,
-            top_level_dependency_updates: top_level_dependency_updates,
-            lockfile_content: lockfile_content
-          )
+        def run_current_npm_update
+          run_npm_updater(top_level_dependencies: top_level_dependencies)
         end
 
-        def run_previous_npm_update(lockfile_name:, lockfile_content:)
+        def run_previous_npm_update
           previous_top_level_dependencies = top_level_dependencies.map do |d|
-            {
+            Dependabot::Dependency.new(
               name: d.name,
+              package_manager: d.package_manager,
               version: d.previous_version,
-              requirements: d.previous_requirements
-            }
+              previous_version: d.previous_version,
+              requirements: d.previous_requirements,
+              previous_requirements: d.previous_requirements
+            )
           end
 
-          run_npm_updater(
-            lockfile_name: lockfile_name,
-            top_level_dependency_updates: previous_top_level_dependencies,
-            lockfile_content: lockfile_content
-          )
+          run_npm_updater(top_level_dependencies: previous_top_level_dependencies)
         end
 
-        def run_npm_updater(lockfile_name:, top_level_dependency_updates:, lockfile_content:)
+        def run_npm_updater(top_level_dependencies:)
           SharedHelpers.with_git_configured(credentials: credentials) do
-            if top_level_dependency_updates.any?
-              run_npm_top_level_updater(
-                lockfile_name: lockfile_name,
-                top_level_dependency_updates: top_level_dependency_updates,
-                lockfile_content: lockfile_content
-              )
+            if top_level_dependencies.any?
+              run_npm_top_level_updater(top_level_dependencies: top_level_dependencies)
             else
-              run_npm_subdependency_updater(lockfile_name: lockfile_name, lockfile_content: lockfile_content)
+              run_npm_subdependency_updater
             end
           end
         end
 
-        def run_npm_top_level_updater(lockfile_name:, top_level_dependency_updates:, lockfile_content:)
-          if npm7?(lockfile_content)
-            run_npm_7_top_level_updater(
-              lockfile_name: lockfile_name,
-              top_level_dependency_updates: top_level_dependency_updates
-            )
+        def run_npm_top_level_updater(top_level_dependencies:)
+          if npm7?
+            run_npm_7_top_level_updater(top_level_dependencies: top_level_dependencies)
           else
             SharedHelpers.run_helper_subprocess(
               command: NativeHelpers.helper_path,
               function: "npm6:update",
               args: [
                 Dir.pwd,
-                lockfile_name,
-                top_level_dependency_updates
+                lockfile_basename,
+                top_level_dependencies.map(&:to_h)
               ]
             )
           end
         end
 
-        def run_npm_7_top_level_updater(lockfile_name:, top_level_dependency_updates:)
-          # - `--dry-run=false` the updater sets a global .npmrc with dry-run: true to
-          #   work around an issue in npm 6, we don't want that here
+        def run_npm_7_top_level_updater(top_level_dependencies:)
+          is_dependency_in_current_package_json = top_level_dependencies.any? do |dependency|
+            dependency_in_package_json?(dependency)
+          end
+
+          # NOTE: When updating a dependency in a nested workspace project we
+          # need to run `npm install` without any arguments to update the root
+          # level lockfile after having updated the nested packages package.json
+          # requirement, otherwise npm will add the dependency as a new
+          # top-level dependency to the root lockfile.
+          install_args = ""
+          if is_dependency_in_current_package_json
+            # TODO: Update the npm 6 updater to use these args as we currently
+            # do the same in the js updater helper, we've kept it seperate for
+            # the npm 7 rollout
+            install_args = top_level_dependencies.map { |dependency| npm_install_args(dependency) }
+          end
+
+          # NOTE: npm options
           # - `--force` ignores checks for platform (os, cpu) and engines
-          # - `--ignore-scripts` disables prepare and prepack scripts which are run
-          #   when installing git dependencies
-          flattenend_manifest_dependencies = flattenend_manifest_dependencies_for_lockfile_name(lockfile_name)
-          install_args = npm_top_level_updater_args(
-            top_level_dependency_updates: top_level_dependency_updates,
-            flattenend_manifest_dependencies: flattenend_manifest_dependencies
-          )
+          # - `--dry-run=false` the updater sets a global .npmrc with dry-run:
+          #   true to work around an issue in npm 6, we don't want that here
+          # - `--ignore-scripts` disables prepare and prepack scripts which are
+          #   run when installing git dependencies
           command = [
             "npm",
             "install",
@@ -204,26 +191,27 @@ module Dependabot
             "--package-lock-only"
           ].join(" ")
           SharedHelpers.run_shell_command(command)
-          { lockfile_name => File.read(lockfile_name) }
+          { lockfile_basename => File.read(lockfile_basename) }
         end
 
-        def run_npm_subdependency_updater(lockfile_name:, lockfile_content:)
-          if npm7?(lockfile_content)
-            run_npm_7_subdependency_updater(lockfile_name: lockfile_name)
+        def run_npm_subdependency_updater
+          if npm7?
+            run_npm_7_subdependency_updater
           else
             SharedHelpers.run_helper_subprocess(
               command: NativeHelpers.helper_path,
               function: "npm6:updateSubdependency",
-              args: [Dir.pwd, lockfile_name, sub_dependencies.map(&:to_h)]
+              args: [Dir.pwd, lockfile_basename, sub_dependencies.map(&:to_h)]
             )
           end
         end
 
-        def run_npm_7_subdependency_updater(lockfile_name:)
+        def run_npm_7_subdependency_updater
           dependency_names = sub_dependencies.map(&:name)
+          # NOTE: npm options
+          # - `--force` ignores checks for platform (os, cpu) and engines
           # - `--dry-run=false` the updater sets a global .npmrc with dry-run: true to
           #   work around an issue in npm 6, we don't want that here
-          # - `--force` ignores checks for platform (os, cpu) and engines
           # - `--ignore-scripts` disables prepare and prepack scripts which are run
           #   when installing git dependencies
           command = [
@@ -237,59 +225,64 @@ module Dependabot
             "--package-lock-only"
           ].join(" ")
           SharedHelpers.run_shell_command(command)
-          { lockfile_name => File.read(lockfile_name) }
+          { lockfile_basename => File.read(lockfile_basename) }
         end
 
-        # TODO: Update the npm 6 updater to use these args as we currently do
-        # the same in the js updater helper, we've kept it seperate for the npm
-        # 7 rollout
-        def npm_top_level_updater_args(top_level_dependency_updates:, flattenend_manifest_dependencies:)
-          top_level_dependency_updates.map do |dependency|
+        def updated_version_requirement_for_dependency(dependency)
+          flattenend_manifest_dependencies[dependency.name]
+        end
+
+        # TODO: Add the raw updated requirement to the Dependency instance
+        # instead of fishing it out of the updated package json, we need to do
+        # this because we don't store the same requirement in
+        # Dependency#requirements for git dependencies - see PackageJsonUpdater
+        def flattenend_manifest_dependencies
+          return @flattenend_manifest_dependencies if defined?(@flattenend_manifest_dependencies)
+
+          @flattenend_manifest_dependencies =
+            NpmAndYarn::FileParser::DEPENDENCY_TYPES.inject({}) do |deps, type|
+              deps.merge(parsed_package_json[type] || {})
+            end
+        end
+
+        def npm_install_args(dependency)
+          git_requirement = dependency.requirements.find { |req| req[:source] && req[:source][:type] == "git" }
+
+          if git_requirement
             # NOTE: For git dependencies we loose some information about the
             # requirement that's only available in the package.json, e.g. when
             # specifying a semver tag:
             # `dependabot/depeendabot-core#semver:^0.1` - this is required to
             # pass the correct install argument to `npm install`
-            existing_version_requirement = flattenend_manifest_dependencies[dependency.fetch(:name)]
-            npm_install_args(
-              dependency.fetch(:name),
-              dependency.fetch(:version),
-              dependency.fetch(:requirements),
-              existing_version_requirement
-            )
-          end
-        end
-
-        def flattenend_manifest_dependencies_for_lockfile_name(lockfile_name)
-          package_json_content = updated_package_json_content_for_lockfile_name(lockfile_name)
-          return {} unless package_json_content
-
-          parsed_package = JSON.parse(package_json_content)
-          NpmAndYarn::FileParser::DEPENDENCY_TYPES.inject({}) do |deps, type|
-            deps.merge(parsed_package[type] || {})
-          end
-        end
-
-        def npm_install_args(dep_name, desired_version, requirements, existing_version_requirement)
-          git_requirement = requirements.find { |req| req[:source] && req[:source][:type] == "git" }
-
-          if git_requirement
-            existing_version_requirement ||= git_requirement[:source][:url]
+            updated_version_requirement = updated_version_requirement_for_dependency(dependency)
+            updated_version_requirement ||= git_requirement[:source][:url]
 
             # NOTE: Git is configured to auth over https while updating
-            existing_version_requirement = existing_version_requirement.gsub(
+            updated_version_requirement = updated_version_requirement.gsub(
               %r{git\+ssh://git@(.*?)[:/]}, 'https://\1/'
             )
 
             # NOTE: Keep any semver range that has already been updated by the
             # PackageJsonUpdater when installing the new version
-            if existing_version_requirement.include?(desired_version)
-              "#{dep_name}@#{existing_version_requirement}"
+            if updated_version_requirement.include?(dependency.version)
+              "#{dependency.name}@#{updated_version_requirement}"
             else
-              "#{dep_name}@#{existing_version_requirement.sub(/#.*/, '')}##{desired_version}"
+              "#{dependency.name}@#{updated_version_requirement.sub(/#.*/, '')}##{dependency.version}"
             end
           else
-            "#{dep_name}@#{desired_version}"
+            "#{dependency.name}@#{dependency.version}"
+          end
+        end
+
+        def dependency_in_package_json?(dependency)
+          dependency.requirements.any? do |req|
+            req[:file] == package_json.name
+          end
+        end
+
+        def dependency_in_lockfile?(dependency)
+          lockfile_dependencies.any? do |dep|
+            dep.name == dependency.name
           end
         end
 
@@ -297,14 +290,14 @@ module Dependabot
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/PerceivedComplexity
         # rubocop:disable Metrics/MethodLength
-        def handle_npm_updater_error(error, lockfile)
+        def handle_npm_updater_error(error)
           error_message = error.message
           if error_message.match?(MISSING_PACKAGE)
             package_name = error_message.match(MISSING_PACKAGE).
                            named_captures["package_req"]
             sanitized_name = sanitize_package_name(package_name)
             sanitized_error = error_message.gsub(package_name, sanitized_name)
-            handle_missing_package(sanitized_name, sanitized_error, lockfile)
+            handle_missing_package(sanitized_name, sanitized_error)
           end
 
           # Invalid package: When the package.json doesn't include a name or
@@ -316,7 +309,7 @@ module Dependabot
           if error_message.match?(INVALID_PACKAGE) ||
              error_message.include?("Invalid package name") ||
              error_message.include?(sub_dep_local_path_error)
-            raise_resolvability_error(error_message, lockfile)
+            raise_resolvability_error(error_message)
           end
 
           # TODO: Move this logic to the version resolver and check if a new
@@ -340,7 +333,7 @@ module Dependabot
           # queries
           if error_message.include?("No matching vers") &&
              dependencies_in_error_message?(error_message) &&
-             resolvable_before_update?(lockfile)
+             resolvable_before_update?
 
             # Raise a bespoke error so we can capture and ignore it if
             # we're trying to create a new PR (which will be created
@@ -353,7 +346,7 @@ module Dependabot
                            named_captures["package_req"]
             sanitized_name = sanitize_package_name(package_name)
             sanitized_error = error_message.gsub(package_name, sanitized_name)
-            handle_missing_package(sanitized_name, sanitized_error, lockfile)
+            handle_missing_package(sanitized_name, sanitized_error)
           end
 
           # Some private registries return a 403 when the user is readonly
@@ -362,7 +355,7 @@ module Dependabot
                            named_captures["package_req"]
             sanitized_name = sanitize_package_name(package_name)
             sanitized_error = error_message.gsub(package_name, sanitized_name)
-            handle_missing_package(sanitized_name, sanitized_error, lockfile)
+            handle_missing_package(sanitized_name, sanitized_error)
           end
 
           if (git_error = error_message.match(UNREACHABLE_GIT) || error_message.match(FORBIDDEN_GIT))
@@ -379,9 +372,8 @@ module Dependabot
           # people to re-generate their lockfiles (Future feature idea: add a
           # way to click-to-fix the lockfile from the issue)
           if error_message.include?("Cannot read property 'match' of ") &&
-             !resolvable_before_update?(lockfile)
-            raise_missing_lockfile_version_resolvability_error(error_message,
-                                                               lockfile)
+             !resolvable_before_update?
+            raise_missing_lockfile_version_resolvability_error(error_message)
           end
 
           if (error_message.include?("No matching vers") ||
@@ -390,8 +382,8 @@ module Dependabot
              error_message.include?("Invalid tag name") ||
              error_message.match?(NPM6_MISSING_GIT_REF) ||
              error_message.match?(NPM7_MISSING_GIT_REF)) &&
-             !resolvable_before_update?(lockfile)
-            raise_resolvability_error(error_message, lockfile)
+             !resolvable_before_update?
+            raise_resolvability_error(error_message)
           end
 
           # NOTE: This check was introduced in npm7/arborist
@@ -407,17 +399,15 @@ module Dependabot
         # rubocop:enable Metrics/PerceivedComplexity
         # rubocop:enable Metrics/MethodLength
 
-        def raise_resolvability_error(error_message, lockfile)
+        def raise_resolvability_error(error_message)
           dependency_names = dependencies.map(&:name).join(", ")
           msg = "Error whilst updating #{dependency_names} in "\
                 "#{lockfile.path}:\n#{error_message}"
           raise Dependabot::DependencyFileNotResolvable, msg
         end
 
-        def raise_missing_lockfile_version_resolvability_error(error_message,
-                                                               lockfile)
-          lockfile_dir = Pathname.new(lockfile.name).dirname
-          modules_path = lockfile_dir.join("node_modules")
+        def raise_missing_lockfile_version_resolvability_error(error_message)
+          modules_path = File.join(lockfile_directory, "node_modules")
           # NOTE: don't include the dependency names to prevent opening
           # multiple issues for each dependency that fails because we unique
           # issues on the error message (issue detail) on the backend
@@ -432,11 +422,10 @@ module Dependabot
           raise Dependabot::DependencyFileNotResolvable, msg
         end
 
-        def handle_missing_package(package_name, error_message, lockfile)
-          missing_dep = lockfile_dependencies(lockfile).
-                        find { |dep| dep.name == package_name }
+        def handle_missing_package(package_name, error_message)
+          missing_dep = lockfile_dependencies.find { |dep| dep.name == package_name }
 
-          raise_resolvability_error(error_message, lockfile) unless missing_dep
+          raise_resolvability_error(error_message) unless missing_dep
 
           reg = NpmAndYarn::UpdateChecker::RegistryFinder.new(
             dependency: missing_dep,
@@ -458,23 +447,14 @@ module Dependabot
           end
         end
 
-        def resolvable_before_update?(lockfile)
-          @resolvable_before_update ||= {}
-          return @resolvable_before_update[lockfile.name] if @resolvable_before_update.key?(lockfile.name)
+        def resolvable_before_update?
+          return @resolvable_before_update if defined?(@resolvable_before_update)
 
-          @resolvable_before_update[lockfile.name] =
+          @resolvable_before_update =
             begin
               SharedHelpers.in_a_temporary_directory do
-                write_temporary_dependency_files(
-                  lockfile.name,
-                  update_package_json: false
-                )
-
-                lockfile_name = Pathname.new(lockfile.name).basename.to_s
-                path = Pathname.new(lockfile.name).dirname.to_s
-                Dir.chdir(path) do
-                  run_previous_npm_update(lockfile_name: lockfile_name, lockfile_content: lockfile.content)
-                end
+                write_temporary_dependency_files(update_package_json: false)
+                Dir.chdir(lockfile_directory) { run_previous_npm_update }
               end
 
               true
@@ -492,12 +472,10 @@ module Dependabot
           end
         end
 
-        def write_temporary_dependency_files(lockfile_name,
-                                             update_package_json: true)
-          write_lockfiles(lockfile_name)
+        def write_temporary_dependency_files(update_package_json: true)
+          write_lockfiles
 
-          dir = Pathname.new(lockfile_name).dirname
-          File.write(File.join(dir, ".npmrc"), npmrc_content)
+          File.write(File.join(lockfile_directory, ".npmrc"), npmrc_content)
 
           package_files.each do |file|
             path = file.name
@@ -524,9 +502,9 @@ module Dependabot
           end
         end
 
-        def write_lockfiles(lockfile_name)
+        def write_lockfiles
           excluded_lock =
-            case lockfile_name
+            case lockfile.name
             when "package-lock.json" then "npm-shrinkwrap.json"
             when "npm-shrinkwrap.json" then "package-lock.json"
             end
@@ -627,22 +605,86 @@ module Dependabot
           @git_ssh_requirements_to_swap
         end
 
-        def post_process_npm_lockfile(original_content, updated_content, lockfile_name)
-          updated_content = replace_project_metadata(updated_content, original_content)
-
+        def post_process_npm_lockfile(updated_lockfile_content)
           # Switch SSH requirements back for git dependencies
-          updated_content = replace_swapped_git_ssh_requirements(updated_content)
+          updated_lockfile_content = replace_swapped_git_ssh_requirements(updated_lockfile_content)
 
           # Switch from details back for git dependencies (they will have
           # changed because we locked them)
-          updated_content = replace_locked_git_dependencies(updated_content)
+          updated_lockfile_content = replace_locked_git_dependencies(updated_lockfile_content)
+
+          parsed_updated_lockfile_content = JSON.parse(updated_lockfile_content)
+
+          # Restore lockfile name attribute from the original lockfile
+          updated_lockfile_content = replace_project_name(updated_lockfile_content, parsed_updated_lockfile_content)
+
+          # Restore npm 7 "packages" "name" entry from package.json if previously set
+          updated_lockfile_content = restore_packages_name(updated_lockfile_content, parsed_updated_lockfile_content)
 
           # Switch back npm 7 lockfile "pacakages" requirements from the package.json
-          updated_content = restore_locked_package_dependencies(lockfile_name, updated_content)
+          updated_lockfile_content = restore_locked_package_dependencies(
+            updated_lockfile_content, parsed_updated_lockfile_content
+          )
 
           # Switch back the protocol of tarball resolutions if they've changed
           # (fixes an npm bug, which appears to be applied inconsistently)
-          replace_tarball_urls(updated_content)
+          replace_tarball_urls(updated_lockfile_content)
+        end
+
+        def replace_project_name(updated_lockfile_content, parsed_updated_lockfile_content)
+          current_name = parsed_updated_lockfile_content["name"]
+          original_name = parsed_lockfile["name"]
+          if original_name
+            updated_lockfile_content = replace_lockfile_name_attribute(
+              current_name, original_name, updated_lockfile_content
+            )
+          end
+          updated_lockfile_content
+        end
+
+        def restore_packages_name(updated_lockfile_content, parsed_updated_lockfile_content)
+          return updated_lockfile_content unless npm7?
+
+          current_name = parsed_updated_lockfile_content.dig("packages", "", "name")
+          original_name = parsed_lockfile.dig("packages", "", "name")
+
+          # TODO: Submit a patch to npm fixing this issue making `npm install`
+          # consistent with `npm install --package-lock-only`
+          #
+          # NOTE: This is a workaround for npm adding a `name` attribute to the
+          # packages section in the lockfile because we install using
+          # `--package-lock-only`
+          if !original_name
+            updated_lockfile_content = remove_lockfile_packages_name_attribute(
+              current_name, updated_lockfile_content
+            )
+          elsif original_name && original_name != current_name
+            updated_lockfile_content = replace_lockfile_packages_name_attribute(
+              current_name, original_name, updated_lockfile_content
+            )
+          end
+
+          updated_lockfile_content
+        end
+
+        def replace_lockfile_name_attribute(current_name, original_name, updated_lockfile_content)
+          updated_lockfile_content.sub(
+            /"name":\s"#{current_name}"/,
+            "\"name\": \"#{original_name}\""
+          )
+        end
+
+        def replace_lockfile_packages_name_attribute(current_name, original_name, updated_lockfile_content)
+          packages_key_line = '"": {'
+          updated_lockfile_content.sub(
+            /(#{packages_key_line}[\n\s]+"name":\s)"#{current_name}"/,
+            '\1"' + original_name + '"'
+          )
+        end
+
+        def remove_lockfile_packages_name_attribute(current_name, updated_lockfile_content)
+          packages_key_line = '"": {'
+          updated_lockfile_content.gsub(/(#{packages_key_line})[\n\s]+"name":\s"#{current_name}",/, '\1')
         end
 
         # NOTE: This is a workaround to "sync" what's in package.json
@@ -654,43 +696,38 @@ module Dependabot
         # `package.json` requirement for eslint at `^1.0.0`, in which case we
         # need to copy this from the manifest to the lockfile after the update
         # has finished.
-        def restore_locked_package_dependencies(lockfile_name, lockfile_content)
-          return lockfile_content unless npm7?(lockfile_content)
+        def restore_locked_package_dependencies(updated_lockfile_content, parsed_updated_lockfile_content)
+          return updated_lockfile_content unless npm7?
 
-          original_package = updated_package_json_content_for_lockfile_name(lockfile_name)
-          return lockfile_content unless original_package
-
-          parsed_package = JSON.parse(original_package)
-          parsed_lockfile = JSON.parse(lockfile_content)
           dependency_names_to_restore = (dependencies.map(&:name) + git_dependencies_to_lock.keys).uniq
 
           NpmAndYarn::FileParser::DEPENDENCY_TYPES.each do |type|
-            parsed_package.fetch(type, {}).each do |dependency_name, original_requirement|
+            parsed_package_json.fetch(type, {}).each do |dependency_name, original_requirement|
               next unless dependency_names_to_restore.include?(dependency_name)
 
-              locked_requirement = parsed_lockfile.dig("packages", "", type, dependency_name)
+              locked_requirement = parsed_updated_lockfile_content.dig("packages", "", type, dependency_name)
               next unless locked_requirement
 
               locked_req = %("#{dependency_name}": "#{locked_requirement}")
               original_req = %("#{dependency_name}": "#{original_requirement}")
-              lockfile_content = lockfile_content.gsub(locked_req, original_req)
+              updated_lockfile_content = updated_lockfile_content.gsub(locked_req, original_req)
             end
           end
 
-          lockfile_content
+          updated_lockfile_content
         end
 
-        def replace_swapped_git_ssh_requirements(lockfile_content)
+        def replace_swapped_git_ssh_requirements(updated_lockfile_content)
           git_ssh_requirements_to_swap.each do |req|
             new_r = req.gsub(%r{git\+ssh://git@(.*?)[:/]}, 'git+https://\1/')
             old_r = req.gsub(%r{git@(.*?)[:/]}, 'git@\1/')
-            lockfile_content = lockfile_content.gsub(new_r, old_r)
+            updated_lockfile_content = updated_lockfile_content.gsub(new_r, old_r)
           end
 
-          lockfile_content
+          updated_lockfile_content
         end
 
-        def replace_locked_git_dependencies(lockfile_content)
+        def replace_locked_git_dependencies(updated_lockfile_content)
           # Switch from details back for git dependencies (they will have
           # changed because we locked them)
           git_dependencies_to_lock.each do |dependency_name, details|
@@ -701,44 +738,33 @@ module Dependabot
             # updates the lockfile "from" field to the new git commit when we
             # run npm install
             original_from = %("from": "#{details[:from]}")
-            if npm7?(lockfile_content)
+            if npm7?
               # NOTE: The `from` syntax has changed in npm 7 to inclued the dependency name
               npm7_locked_from = %("from": "#{dependency_name}@#{details[:version]}")
-              lockfile_content = lockfile_content.gsub(npm7_locked_from, original_from)
+              updated_lockfile_content = updated_lockfile_content.gsub(npm7_locked_from, original_from)
             else
               npm6_locked_from = %("from": "#{details[:version]}")
-              lockfile_content = lockfile_content.gsub(npm6_locked_from, original_from)
+              updated_lockfile_content = updated_lockfile_content.gsub(npm6_locked_from, original_from)
             end
           end
 
-          lockfile_content
+          updated_lockfile_content
         end
 
-        def replace_tarball_urls(lockfile_content)
+        def replace_tarball_urls(updated_lockfile_content)
           tarball_urls.each do |url|
             trimmed_url = url.gsub(/(\d+\.)*tgz$/, "")
             incorrect_url = if url.start_with?("https")
                               trimmed_url.gsub(/^https:/, "http:")
                             else trimmed_url.gsub(/^http:/, "https:")
                             end
-            lockfile_content = lockfile_content.gsub(
+            updated_lockfile_content = updated_lockfile_content.gsub(
               /#{Regexp.quote(incorrect_url)}(?=(\d+\.)*tgz")/,
               trimmed_url
             )
           end
 
-          lockfile_content
-        end
-
-        def replace_project_metadata(new_content, old_content)
-          old_name = old_content.match(/(?<="name": ").*(?=",)/)&.to_s
-
-          if old_name
-            new_content = new_content.
-                          sub(/(?<="name": ").*(?=",)/, old_name)
-          end
-
-          new_content
+          updated_lockfile_content
         end
 
         def tarball_urls
@@ -765,15 +791,6 @@ module Dependabot
           ).npmrc_content
         end
 
-        def updated_package_json_content_for_lockfile_name(lockfile_name)
-          lockfile_basename = Pathname.new(lockfile_name).basename.to_s
-          package_name = lockfile_name.sub(lockfile_basename, "package.json")
-          package_json = package_files.find { |f| f.name == package_name }
-          return unless package_json
-
-          updated_package_json_content(package_json)
-        end
-
         def updated_package_json_content(file)
           @updated_package_json_content ||= {}
           @updated_package_json_content[file.name] ||=
@@ -787,8 +804,10 @@ module Dependabot
           npmrc_content.match?(/^package-lock\s*=\s*false/)
         end
 
-        def npm7?(lockfile_content)
-          Dependabot::NpmAndYarn::Helpers.npm_version(lockfile_content) == "npm7"
+        def npm7?
+          return @npm7 if defined?(@npm7)
+
+          @npm7 = Dependabot::NpmAndYarn::Helpers.npm_version(lockfile.content) == "npm7"
         end
 
         def sanitized_package_json_content(content)
@@ -800,6 +819,30 @@ module Dependabot
 
         def sanitize_package_name(package_name)
           package_name.gsub("%2f", "/").gsub("%2F", "/")
+        end
+
+        def lockfile_directory
+          Pathname.new(lockfile.name).dirname.to_s
+        end
+
+        def lockfile_basename
+          Pathname.new(lockfile.name).basename.to_s
+        end
+
+        def parsed_lockfile
+          @parsed_lockfile ||= JSON.parse(lockfile.content)
+        end
+
+        def parsed_package_json
+          return {} unless package_json
+          return @parsed_package_json if defined?(@parsed_package_json)
+
+          @parsed_package_json = JSON.parse(updated_package_json_content(package_json))
+        end
+
+        def package_json
+          package_name = lockfile.name.sub(lockfile_basename, "package.json")
+          package_files.find { |f| f.name == package_name }
         end
 
         def package_locks

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -157,7 +157,7 @@ module Dependabot
         end
 
         def run_npm_7_top_level_updater(top_level_dependencies:)
-          is_dependency_in_current_package_json = top_level_dependencies.any? do |dependency|
+          dependencies_in_current_package_json = top_level_dependencies.any? do |dependency|
             dependency_in_package_json?(dependency)
           end
 
@@ -167,7 +167,7 @@ module Dependabot
           # requirement, otherwise npm will add the dependency as a new
           # top-level dependency to the root lockfile.
           install_args = ""
-          if is_dependency_in_current_package_json
+          if dependencies_in_current_package_json
             # TODO: Update the npm 6 updater to use these args as we currently
             # do the same in the js updater helper, we've kept it seperate for
             # the npm 7 rollout

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -2099,6 +2099,11 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           let(:previous_version) { "1.8.0" }
           let(:requirements) do
             [{
+              file: "other_package/package.json",
+              requirement: "^1.8.1",
+              groups: ["devDependencies"],
+              source: nil
+            }, {
               file: "packages/package1/package.json",
               requirement: "^1.8.1",
               groups: ["devDependencies"],
@@ -2107,6 +2112,11 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           end
           let(:previous_requirements) do
             [{
+              file: "other_package/package.json",
+              requirement: "^1.0.0",
+              groups: ["devDependencies"],
+              source: nil
+            }, {
               file: "packages/package1/package.json",
               requirement: "^1.1.0",
               groups: ["devDependencies"],
@@ -2115,22 +2125,30 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           end
 
           it "updates the right file" do
-            root_lockfile = updated_files.find { |f| f.name == "package-lock.json" }
-            parsed_root_lockfile = JSON.parse(root_lockfile.content)
+            updated_npm_lock_content = updated_files.find { |f| f.name == "package-lock.json" }
+            expected_updated_npm_lock_content = fixture(
+              "updated_projects", "npm7", "workspaces_dev", "package-lock.json"
+            )
+            parsed_npm_lockfile = JSON.parse(updated_npm_lock_content.content)
             expect(updated_files.map(&:name)).
-              to match_array(%w(package-lock.json packages/package1/package.json))
-            expect(parsed_root_lockfile.dig("dependencies", "etag", "version")).to eq("1.8.1")
-            # Doesn't install etag as a top-level dependency
-            expect(parsed_root_lockfile.dig("packages", "", "dependencies", "etag")).to be_nil
+              to match_array(%w(package-lock.json other_package/package.json packages/package1/package.json))
+            expect(parsed_npm_lockfile.dig("dependencies", "etag", "version")).to eq("1.8.1")
+            expect(updated_npm_lock.content).to eq(expected_updated_npm_lock_content)
           end
 
           it "updates the existing development declaration" do
-            file = updated_files.find do |f|
+            package1 = updated_files.find do |f|
               f.name == "packages/package1/package.json"
             end
-            parsed_file = JSON.parse(file.content)
-            expect(parsed_file.dig("dependencies", "etag")).to be_nil
-            expect(parsed_file.dig("devDependencies", "etag")).to eq("^1.8.1")
+            other_package = updated_files.find do |f|
+              f.name == "other_package/package.json"
+            end
+            parsed_package1 = JSON.parse(package1.content)
+            parsed_other_package = JSON.parse(other_package.content)
+            expect(parsed_package1.dig("dependencies", "etag")).to be_nil
+            expect(parsed_package1.dig("devDependencies", "etag")).to eq("^1.8.1")
+            expect(parsed_other_package.dig("dependencies", "etag")).to be_nil
+            expect(parsed_other_package.dig("devDependencies", "etag")).to eq("^1.8.1")
           end
         end
       end

--- a/npm_and_yarn/spec/fixtures/npm_lockfiles/npm7_subdependency_update_preserved_indentation.json
+++ b/npm_and_yarn/spec/fixtures/npm_lockfiles/npm7_subdependency_update_preserved_indentation.json
@@ -5,7 +5,6 @@
 		"requires": true,
 		"packages": {
 				"": {
-						"name": "npm-sub-dep-test",
 						"version": "1.0.0",
 						"license": "ISC",
 						"dependencies": {

--- a/npm_and_yarn/spec/fixtures/projects/npm7/packages_name_missing/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/packages_name_missing/package-lock.json
@@ -1,0 +1,29 @@
+{
+    "name": "package-name",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "version": "1.0.0",
+            "dependencies": {
+                "etag": "^1.0.0"
+            }
+        },
+        "node_modules/etag": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+            "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        }
+    },
+    "dependencies": {
+        "etag": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+            "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
+        }
+    }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/packages_name_missing/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/packages_name_missing/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "package-name",
+    "version": "1.0.0",
+    "description": "",
+    "dependencies": {
+        "etag": "^1.0.0"
+    }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/packages_name_outdated/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/packages_name_outdated/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "package-name",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+      "": {
+          "name": "old-name",
+          "version": "1.0.0",
+          "dependencies": {
+              "etag": "^1.0.0"
+          }
+      },
+      "node_modules/etag": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+          "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
+          "engines": {
+              "node": ">= 0.6"
+          }
+      }
+  },
+  "dependencies": {
+      "etag": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+          "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
+      }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/packages_name_outdated/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/packages_name_outdated/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-name",
+  "version": "1.0.0",
+  "description": "",
+  "dependencies": {
+      "etag": "^1.0.0"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/simple/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/simple/package.json
@@ -1,25 +1,13 @@
 {
-    "name": "{{ name }}",
-    "version": "1.0.0",
-    "description": "",
-    "main": "index.js",
-    "scripts": {
-        "test": "echo \"Error: no\\ test\ specified\" && exit 1",
-        "prettify": "prettier --write \"{{packages/*/src,examples,cypress,scripts}/**/,}*.{js,jsx,ts,tsx,css,md}\""
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/waltfy/PROTO_TEST.git"
-    },
-    "author": "",
-    "license": "ISC",
-    "bugs": {
-        "url": "https://github.com/waltfy/PROTO_TEST/issues"
-    },
-    "homepage": "https://github.com/waltfy/PROTO_TEST#readme",
-    "dependencies": {
+  "name": "{{ name }}",
+  "version": "1.0.0",
+  "description": "description",
+  "author": "author",
+  "license": "ISC",
+  "dependencies": {
       "fetch-factory": "^0.0.1"
-    },
-    "devDependencies": {
-      "etag" : "^1.0.0"
-    }}
+  },
+  "devDependencies": {
+      "etag": "^1.0.0"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/subdependency_update/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/subdependency_update/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "example",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/npm_and_yarn/spec/fixtures/projects/npm7/subdependency_update_tab_indentation/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/subdependency_update_tab_indentation/package-lock.json
@@ -5,7 +5,6 @@
 		"requires": true,
 		"packages": {
 				"": {
-						"name": "npm-sub-dep-test",
 						"version": "1.0.0",
 						"license": "ISC",
 						"dependencies": {

--- a/npm_and_yarn/spec/fixtures/projects/npm7/workspaces_incorrect_version/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/workspaces_incorrect_version/package-lock.json
@@ -1,0 +1,838 @@
+{
+  "name": "bump-test",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "0.0.1",
+      "license": "ISC",
+      "workspaces": [
+        "package"
+      ],
+      "dependencies": {
+        "showdown": "1.9.1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package": {
+      "resolved": "package",
+      "link": true
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "node_modules/showdown": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
+      "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
+      "dependencies": {
+        "yargs": "^14.2"
+      },
+      "bin": {
+        "showdown": "bin/showdown.js"
+      }
+    },
+    "node_modules/showdown/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/showdown/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/showdown/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/showdown/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/showdown/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/showdown/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/showdown/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/showdown/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/showdown/node_modules/yargs": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+      "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^15.0.1"
+      }
+    },
+    "node_modules/showdown/node_modules/yargs-parser": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+      "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
+    },
+    "package": {
+      "version": "0.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "yargs": "^16.2.0"
+      }
+    },
+    "package/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "package/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "package/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "package/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "package/node_modules/string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "package/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "package/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "package/node_modules/y18n": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "package/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "package/node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  },
+  "dependencies": {
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "package": {
+      "version": "file:package",
+      "requires": {
+        "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+        }
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "showdown": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
+      "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
+      "requires": {
+        "yargs": "^14.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "y18n": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/workspaces_incorrect_version/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/workspaces_incorrect_version/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "bump-test",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gocardless/bump-test.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/gocardless/bump-test/issues"
+  },
+  "homepage": "https://github.com/gocardless/bump-test#readme",
+  "dependencies": {
+    "showdown": "1.9.1"
+  },
+  "workspaces": [
+    "package"
+  ]
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/workspaces_incorrect_version/package/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/workspaces_incorrect_version/package/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "package",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gocardless/bump-test.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/gocardless/bump-test/issues"
+  },
+  "homepage": "https://github.com/gocardless/bump-test#readme",
+  "dependencies": {
+    "yargs": "^16.2.0"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm7/packages_name_missing/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm7/packages_name_missing/package-lock.json
@@ -1,0 +1,29 @@
+{
+    "name": "package-name",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "version": "1.0.0",
+            "dependencies": {
+                "etag": "^1.8.1"
+            }
+        },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        }
+    },
+    "dependencies": {
+        "etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+        }
+    }
+}

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm7/packages_name_missing/package.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm7/packages_name_missing/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "package-name",
+    "version": "1.0.0",
+    "description": "",
+    "dependencies": {
+        "etag": "^1.8.1"
+    }
+}

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm7/packages_name_outdated/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm7/packages_name_outdated/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "package-name",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "old-name",
+      "version": "1.0.0",
+      "dependencies": {
+        "etag": "^1.8.1"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "dependencies": {
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm7/packages_name_outdated/package.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm7/packages_name_outdated/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-name",
+  "version": "1.0.0",
+  "description": "",
+  "dependencies": {
+    "etag": "^1.8.1"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm7/simple/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm7/simple/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "fetch-factory": "^0.0.1"
+                "fetch-factory": "^0.0.2"
             },
             "devDependencies": {
                 "etag": "^1.0.0"
@@ -38,13 +38,13 @@
             }
         },
         "node_modules/fetch-factory": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.1.tgz",
-            "integrity": "sha1-4AdgWb2zHjFHx1s7jAQTO6jH4HE=",
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.2.tgz",
+            "integrity": "sha1-7h380QJIZAv+MOXD2Jiie3Ysh6w=",
             "dependencies": {
-                "es6-promise": "3.3.1",
-                "isomorphic-fetch": "2.2.1",
-                "lodash": "3.10.1"
+                "es6-promise": "^3.0.2",
+                "isomorphic-fetch": "^2.1.1",
+                "lodash": "^3.10.1"
             }
         },
         "node_modules/iconv-lite": {
@@ -113,13 +113,13 @@
             "dev": true
         },
         "fetch-factory": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.1.tgz",
-            "integrity": "sha1-4AdgWb2zHjFHx1s7jAQTO6jH4HE=",
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.2.tgz",
+            "integrity": "sha1-7h380QJIZAv+MOXD2Jiie3Ysh6w=",
             "requires": {
-                "es6-promise": "3.3.1",
-                "isomorphic-fetch": "2.2.1",
-                "lodash": "3.10.1"
+                "es6-promise": "^3.0.2",
+                "isomorphic-fetch": "^2.1.1",
+                "lodash": "^3.10.1"
             }
         },
         "iconv-lite": {

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm7/simple/package.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm7/simple/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "{{ name }}",
+    "version": "1.0.0",
+    "description": "description",
+    "author": "author",
+    "license": "ISC",
+    "dependencies": {
+        "fetch-factory": "^0.0.2"
+    },
+    "devDependencies": {
+        "etag": "^1.0.0"
+    }
+}

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm7/workspaces_dev/other_package/package.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm7/workspaces_dev/other_package/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "other_package",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gocardless/bump-test.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/gocardless/bump-test/issues"
+  },
+  "homepage": "https://github.com/gocardless/bump-test#readme",
+  "dependencies": {
+    "lodash": "^1.2.1"
+  },
+  "devDependencies": {
+    "etag": "^1.8.1"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm7/workspaces_dev/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm7/workspaces_dev/package-lock.json
@@ -1,0 +1,174 @@
+{
+  "name": "bump-test",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bump-test",
+      "version": "0.0.1",
+      "license": "ISC",
+      "workspaces": [
+        "./packages/*",
+        "other_package"
+      ],
+      "dependencies": {
+        "lodash": "1.2.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.2.0.tgz",
+      "integrity": "sha1-NZq0sV3NZLptdHNLcsNjYKmvLBk=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
+      "integrity": "sha1-HJhDdzfxGZ68wdTEj9Qbn5yOjyM=",
+      "dependencies": {
+        "ansi-styles": "~0.2.0",
+        "has-color": "~0.1.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.2.0.tgz",
+      "integrity": "sha1-XxajMYqzv2gMe0G1u2Mn6eEIbsQ=",
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/other_package": {
+      "resolved": "other_package",
+      "link": true
+    },
+    "node_modules/package1": {
+      "resolved": "packages/package1",
+      "link": true
+    },
+    "other_package": {
+      "version": "0.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "lodash": "^1.2.1"
+      },
+      "devDependencies": {
+        "etag": "^1.8.1"
+      }
+    },
+    "other_package/node_modules/lodash": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+      "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A=",
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "packages/package1": {
+      "version": "0.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "0.3.0",
+        "lodash": "^1.2.1"
+      },
+      "devDependencies": {
+        "etag": "^1.8.1"
+      }
+    },
+    "packages/package1/node_modules/lodash": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+      "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A=",
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    }
+  },
+  "dependencies": {
+    "ansi-styles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.2.0.tgz",
+      "integrity": "sha1-NZq0sV3NZLptdHNLcsNjYKmvLBk="
+    },
+    "chalk": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
+      "integrity": "sha1-HJhDdzfxGZ68wdTEj9Qbn5yOjyM=",
+      "requires": {
+        "ansi-styles": "~0.2.0",
+        "has-color": "~0.1.0"
+      }
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
+    "has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+    },
+    "lodash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.2.0.tgz",
+      "integrity": "sha1-XxajMYqzv2gMe0G1u2Mn6eEIbsQ="
+    },
+    "other_package": {
+      "version": "file:other_package",
+      "requires": {
+        "etag": "^1.8.1",
+        "lodash": "^1.2.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+          "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A="
+        }
+      }
+    },
+    "package1": {
+      "version": "file:packages/package1",
+      "requires": {
+        "chalk": "0.3.0",
+        "etag": "^1.8.1",
+        "lodash": "^1.2.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+          "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A="
+        }
+      }
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm7/workspaces_dev/package.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm7/workspaces_dev/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "bump-test",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gocardless/bump-test.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/gocardless/bump-test/issues"
+  },
+  "homepage": "https://github.com/gocardless/bump-test#readme",
+  "dependencies": {
+    "lodash": "1.2.0"
+  },
+  "workspaces": [
+    "./packages/*",
+    "other_package"
+  ]
+}

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm7/workspaces_dev/packages/package1/package.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm7/workspaces_dev/packages/package1/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "package1",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gocardless/bump-test.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/gocardless/bump-test/issues"
+  },
+  "homepage": "https://github.com/gocardless/bump-test#readme",
+  "dependencies": {
+    "chalk": "0.3.0",
+    "lodash": "^1.2.1"
+  },
+  "devDependencies": {
+    "etag": "^1.8.1"
+  }
+}


### PR DESCRIPTION
Fixes one of the bugs discovered in this update:
https://github.com/AviVahl/ts-tools/pull/152

This particular update no raises when dry-running: `bin/dry-run.rb npm_and_yarn AviVahl/ts-tools --cache files --dep yargs` - we'll need to do some further work in the file parser and update checker to not attempt this update in the first place.

Dependabot will no longer attempt to add the nested dependency to the root level lockfile when doing updates to npm workspace projects.

This is done by checking if the dependency being updated is defined in a `package.json` in the same folder as the lockfile being updated. If it's a nested package we run `npm install` without any package@version arguments letting npm update the nested package references which have already been updated in the package.json by the `PackageJsonUpdater`.

Additionally, I've added a workaround to stop adding the `name` attribute to the lockfile `packages.""` section when running `npm install` with `--package-lock-only`. This seems to be a bug with npm but without this fix dependabot will always add this attribute and it will most likely never exist in a users repo so adding confusion about why it's added.

We also sanitize invalid `package.json` names, e.g. `{{ name }}` to `something` during the update, we don't want this to bleed into the updated lockfile.

TODO
- [x] Add more specs covering these cases