### PR TITLE
v0.133.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.133.1, 10 February 2021
+
+- npm: fix npm 7 workspace bug when updating nested packages
+- npm: correctly parse npm 7 version from package dependencies
+- npm: Refactor NpmLockfileUpdater
+- Update npm from 7.5.2 to 7.5.3
+- Bump @npmcli/arborist from 2.2.0 to 2.2.1 in /npm_and_yarn/helpers
+- Bump phpstan/phpstan from 0.12.71 to 0.12.74 in /composer/helpers/v2
+- Bump phpstan/phpstan from 0.12.71 to 0.12.74 in /composer/helpers/v1
+
 ## v0.133.0, 9 February 2021
 
 - Bundler: Raise UnexpectedExternalCode if `reject_external_code: true` and the update involves external code

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.133.0"
+  VERSION = "0.133.1"
 end


### PR DESCRIPTION
## v0.133.1, 10 February 2021

- npm: fix npm 7 workspace bug when updating nested packages
- npm: correctly parse npm 7 version from package dependencies
- npm: Refactor NpmLockfileUpdater
- Update npm from 7.5.2 to 7.5.3
- Bump @npmcli/arborist from 2.2.0 to 2.2.1 in /npm_and_yarn/helpers
- Bump phpstan/phpstan from 0.12.71 to 0.12.74 in /composer/helpers/v2
- Bump phpstan/phpstan from 0.12.71 to 0.12.74 in /composer/helpers/v1
