### PR TITLE
Fix media types in Accept header for Docker Registry

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -14,16 +14,20 @@ module DockerRegistry2
     private
 
     # By default the Docker Registry client sets the Accept header to
-    # `application/vnd.docker.distribution.manifest.v2+json`
-    # This results in the digest of a specific platform to be returned, we
-    # want to override this header so we can fetch the generic digest
-    # associated with the given repo/tag.
+    # `application/vnd.docker.distribution.manifest.v2+json`. This is fine for
+    # most images, but for multi-architecture images, it fetches the digest of a
+    # specific architecture instead of the digest for the multi-architecture
+    # image. We override the header to tell the Docker API to vary its behavior
+    # depending on whether the image is a uses a traditional (non-list) manifest
+    # or a manifest list. If the image uses a traditional manifest, the API will
+    # return the manifest digest. If the image uses a manifest list, the API
+    # will return the manifest list digest.
     def headers(payload: nil, bearer_token: nil)
       headers = {}
       headers["Authorization"] = "Bearer #{bearer_token}" unless bearer_token.nil?
       if payload.nil?
         headers["Accept"] =
-          "application/vnd.docker.distribution.manifest.list.v2+json, application/json"
+          "application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/json"
       end
       headers["Content-Type"] = "application/vnd.docker.distribution.manifest.v2+json" unless payload.nil?
 

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -26,8 +26,11 @@ module DockerRegistry2
       headers = {}
       headers["Authorization"] = "Bearer #{bearer_token}" unless bearer_token.nil?
       if payload.nil?
-        headers["Accept"] =
-          "application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/json"
+        headers["Accept"] = %w(
+          application/vnd.docker.distribution.manifest.v2+json
+          application/vnd.docker.distribution.manifest.list.v2+json
+          application/json"
+        ).join(",")
       end
       headers["Content-Type"] = "application/vnd.docker.distribution.manifest.v2+json" unless payload.nil?
 


### PR DESCRIPTION
https://github.com/dependabot/dependabot-core/issues/2962 reported an problem with the pull requests that Dependabot was opening for the `python:slim` Docker image. The `python:slim` Docker image is a multi-architecture image and publishes a manifest _list_ (also known as a ["fat manifest"](https://docs.docker.com/registry/spec/manifest-v2-2/#image-manifest-version-2-schema-2)). With an image that uses a manifest _list_, the manifest list has a digest, and each architecture-specific image in the list has a digest as well. In https://github.com/dependabot/dependabot-core/issues/2962 we saw that when a Dockerfile depended on `python:slim` (which again is a multi-architecture image), Dependabot wrongly created a pull request to update the Dockerfile to use the `linux/amd64` version of the image. In other words, instead of referring to the digest of the `python:slim` manifest _list_, the Dockerfile was now referring to the digest of the `linux/amd64` `python:slim` manifest.

To fix this problem, https://github.com/dependabot/dependabot-core/pull/3060 added the `Accept` header used to indicate that we want to receive manifest lists back from the Docker API. In that PR, our `Accept` header changed as follows:

```diff
- application/vnd.docker.distribution.manifest.v2+json, application/json
+ application/vnd.docker.distribution.manifest.list.v2+json, application/json
```

This worked well for manifest lists, but we've recently learned that this broke the behavior for images that don't use manifest lists. (According to the Docker docs, [_most_ images don't use manifest lists](https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list)).

Because we're no longer telling the Docker API that we accept the `application/vnd.docker.distribution.manifest.v2+json` media type, when we ask for the manifest for an image that does _not_ use a list, the Docker API falls back to the old v1 media type: `application/vnd.docker.distribution.manifest.v1+prettyjws` and we end up with the wrong digest.

To resolve this problem, we instead need to tell the Docker API that we accept multiple media types:

    application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/json

With this ☝️ as our `Accept` header, the Docker API gives us the behavior we need for images that use manifest _and_ for images that use manifest lists. If the image uses a manifest, we get back the manifest. If an image uses a manifest list, we get back the manifest list. 😅

# Examples

Let's see this in action. To see how it works for an image that uses a plain ole manifest (non-list), we'll use a jenkins image. To see how it works for an image that uses a manifest list, we'll use a python image.

For starters, we'll pull each of these images using the docker CLI and note the digest that it returns. This is the digest that we want Dependabot to use, which means that it's the digest that we want to get back from the Docker REST API.

**Manifest (Non-list): Jenkins**

```
$ docker pull jenkins/jenkins:2.263.4-lts-alpine
2.263.4-lts-alpine: Pulling from jenkins/jenkins
Digest: sha256:6eec4f88e34bce5c8d016e790006f4d5545105491dd6e9f3096e06cc874fd19a
Status: Image is up to date for jenkins/jenkins:2.263.4-lts-alpine
docker.io/jenkins/jenkins:2.263.4-lts-alpine
```

To confirm that this image uses a plain manifest, and not a manifest list, we can check the media type:

```
$ docker buildx imagetools inspect jenkins/jenkins:2.263.4-lts-alpine
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
   ... snip
}
```

**Manifest List: Python**

```
$ docker pull python:slim
slim: Pulling from library/python
Digest: sha256:bf3ec573c0ae0d0c619c3f3e0e9490878432bf7a5c63a643b6c39c9878b51191
Status: Image is up to date for python:slim
docker.io/library/python:slim
```

To confirm that this image uses a manifest list, we can check the media type:

```
$ docker buildx imagetools inspect library/python:slim
Name:      docker.io/library/python:slim
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
...
```

## Fetching the digest with the Docker REST API

For these examples, we'll use the [`docker_registry2` gem](https://github.com/deitch/docker_registry2), since that's the Docker Registry client that dependabot-core uses.

```rb
# Create the client
reg = DockerRegistry2.connect("https://registry.hub.docker.com", { user: "jasonrudolph", password: "<redacted>" })
```

dependabot-core relies on the [`#digest` method](https://github.com/deitch/docker_registry2/blob/cfdb5bb1e4851516bf6a650ed63526f44810c12c/lib/registry/registry.rb#L128-L134) to get the digest for an image manifest. Under the hood, that method uses the Docker API endpoint for [pulling an image manifest](https://docs.docker.com/registry/spec/api/#pulling-an-image-manifest), so we'll use that API directly for demonstration purposes.

Let's fetch the digest for jenkins:

```rb
reg.dohead('/v2/jenkins/jenkins/manifests/2.263.4-lts-alpine').headers
# => {:content_length=>"3248", :content_type=>"application/vnd.docker.distribution.manifest.v2+json", :docker_content_digest=>"sha256:6eec4f88e34bce5c8d016e790006f4d5545105491dd6e9f3096e06cc874fd19a", :docker_distribution_api_version=>"registry/2.0", :etag=>"\"sha256:6eec4f88e34bce5c8d016e790006f4d5545105491dd6e9f3096e06cc874fd19a\"", :date=>"Wed, 10 Feb 2021 21:12:27 GMT", :strict_transport_security=>"max-age=31536000"}
```

✅ Note that the `docker_content_digest` is the same digest we got from `docker pull`. (Good!) And note that the content type is `application/vnd.docker.distribution.manifest.v2+json`, indicating a plain (non-list) manifest.

Let's fetch the digest for python:

```rb
reg.dohead('/v2/library/python/manifests/slim').headers
# => {:content_length=>"1370", :content_type=>"application/vnd.docker.distribution.manifest.v2+json", :docker_content_digest=>"sha256:c63c1906d81f84abbdc8b5af9e1e94f9860ee3f703c136629d6c322960ee08c5", :docker_distribution_api_version=>"registry/2.0", :etag=>"\"sha256:c63c1906d81f84abbdc8b5af9e1e94f9860ee3f703c136629d6c322960ee08c5\"", :date=>"Wed, 10 Feb 2021 21:19:02 GMT", :strict_transport_security=>"max-age=31536000"}
```

❌ Note that the `docker_content_digest` is **not** the digest we got from `docker pull`. And note that the content type is `application/vnd.docker.distribution.manifest.v2+json`, despite the fact that this image uses a manifest list.

## Now let's adjust the `Accept` header

Now let's change the `Accept` header like so:

```diff
- application/vnd.docker.distribution.manifest.v2+json, application/json
+ application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/json
```

Let's try fetching the digest for python again:

```rb
reg.dohead('/v2/library/python/manifests/slim').headers
# => {:content_length=>"1862", :content_type=>"application/vnd.docker.distribution.manifest.list.v2+json", :docker_content_digest=>"sha256:bf3ec573c0ae0d0c619c3f3e0e9490878432bf7a5c63a643b6c39c9878b51191", :docker_distribution_api_version=>"registry/2.0", :etag=>"\"sha256:bf3ec573c0ae0d0c619c3f3e0e9490878432bf7a5c63a643b6c39c9878b51191\"", :date=>"Wed, 10 Feb 2021 21:11:58 GMT", :strict_transport_security=>"max-age=31536000"}
```

✅ Now, note that the `docker_content_digest` is the same the digest we got from `docker pull`. 🕺 And note that the content type is `application/vnd.docker.distribution.manifest.list.v2+json`, indicating that the image uses a manifest list.

If we repeat the process for jenkins, we still get the correct results that we saw previously:

```rb
reg.dohead('/v2/jenkins/jenkins/manifests/2.263.4-lts-alpine').headers
# => {:content_length=>"3248", :content_type=>"application/vnd.docker.distribution.manifest.v2+json", :docker_content_digest=>"sha256:6eec4f88e34bce5c8d016e790006f4d5545105491dd6e9f3096e06cc874fd19a", :docker_distribution_api_version=>"registry/2.0", :etag=>"\"sha256:6eec4f88e34bce5c8d016e790006f4d5545105491dd6e9f3096e06cc874fd19a\"", :date=>"Wed, 10 Feb 2021 21:12:27 GMT", :strict_transport_security=>"max-age=31536000"}
```

## Put it to use in dependabot-core

To make sure this has the desired effect in dependabot-core, let's try a dry-run with each image. I created a test repo with a Dockerfile for the jenkins image and a Dockerfile for the python image. We'll perform a dry-run on each and verify that dependabot-core proposes an update to the same SHAs that we saw from `docker pull` above:

```
$ bin/dry-run.rb docker jasonrudolph/bug-free-system --dir jenkins

± Dockerfile
~~~
1c1
< FROM jenkins/jenkins:2.263.4-lts-alpine@sha256:fa0b0f06383944877c8105ad8e7edcac29f05583cef8b0d26cd8c9586e0cb667
---
> FROM jenkins/jenkins:2.263.4-lts-alpine@sha256:6eec4f88e34bce5c8d016e790006f4d5545105491dd6e9f3096e06cc874fd19a
~~~
```

```
± Dockerfile
~~~
1c1
< FROM python:slim@sha256:4d92968b26bb6b7b62d957244de86fc1054f03793577d49e85c00864eb03ca07
---
> FROM python:slim@sha256:bf3ec573c0ae0d0c619c3f3e0e9490878432bf7a5c63a643b6c39c9878b51191
~~~
```

And indeed, dependabot-core suggests updates to the same SHAs that we saw from `docker pull`.

# Why no tests?

Still reading? Whew! You're a trooper. If you're wondering why this pull request doesn't touch any tests, thanks for caring about our test suite! :bow: @jurre summarizes this for us in https://github.com/dependabot/dependabot-core/pull/3060#issue-565381434:

> The tests have remained unchanged in this PR, because (unfortunately) all the requests and responses are stubbed out.
