### PR TITLE
v0.133.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.133.2, 11 February 2021
+
+- Docker: Fix media types in Accept header for Docker Registry
+- Convert LockfileParserSpec to use project based fixtures
+
 ## v0.133.1, 10 February 2021
 
 - npm: fix npm 7 workspace bug when updating nested packages

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.133.1"
+  VERSION = "0.133.2"
 end


### PR DESCRIPTION
- Docker: Fix media types in Accept header for Docker Registry
- Convert LockfileParserSpec to use project based fixtures