### PR TITLE
common: assume vendored resources are binary

### DIFF
--- a/common/lib/dependabot/file_updaters/vendor_updater.rb
+++ b/common/lib/dependabot/file_updaters/vendor_updater.rb
@@ -53,7 +53,7 @@ module Dependabot
 
       private
 
-      BINARY_ENCODINGS = %w(application/x-tarbinary binary).freeze
+      TEXT_ENCODINGS = %w(us-ascii utf-8).freeze
 
       attr_reader :repo_contents_path, :vendor_dir
 
@@ -62,7 +62,7 @@ module Dependabot
 
         encoding = `file -b --mime-encoding #{path}`.strip
 
-        BINARY_ENCODINGS.include?(encoding)
+        !TEXT_ENCODINGS.include?(encoding)
       end
     end
   end

--- a/common/spec/dependabot/file_updaters/vendor_updater_spec.rb
+++ b/common/spec/dependabot/file_updaters/vendor_updater_spec.rb
@@ -89,6 +89,31 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
       )
     end
 
+    context "with iso-8859 files" do
+      before do
+        in_cloned_repository(repo_contents_path) do
+          File.write("vendor/cache/utf8.txt", "special ü".encode("utf-8"))
+          File.write("vendor/cache/iso8859.txt", "special ü".encode("iso-8859-1"))
+        end
+      end
+
+      it "marks binary files as such" do
+        file = updated_files.find do |f|
+          f.name == "vendor/cache/iso8859.txt"
+        end
+
+        expect(file.binary?).to be_truthy
+      end
+
+      it "does not mark all files as binary" do
+        file = updated_files.find do |f|
+          f.name == "vendor/cache/utf8.txt"
+        end
+
+        expect(file.binary?).to be_falsy
+      end
+    end
+
     context "in a directory" do
       let(:project_name) { "nested_vendor_gems" }
       let(:directory) { "nested" }


### PR DESCRIPTION
Previously Dependabot included a list of binary mime types and encoded
only binary files.
Invert to include a list of acceptable text mime types to leave
un-encoded.

Per the included test, the edge case here is `iso-8859-1` strings, which
aren't binary but also aren't valid `utf-8`.

# Related
- Closes https://github.com/dependabot/dependabot-core/issues/3074