### PR TITLE
elixir: support projects using Nerves extensions

### DIFF
--- a/hex/helpers/build
+++ b/hex/helpers/build
@@ -11,6 +11,7 @@ fi
 mkdir -p $install_dir
 
 mix local.hex --force
+mix archive.install hex nerves_bootstrap --force
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -416,5 +416,24 @@ RSpec.describe Dependabot::Hex::FileParser do
         )
       end
     end
+
+    context "with a nerves project" do
+      let(:mixfile_fixture_name) { "nerves" }
+
+      it "parses the dependencies correctly" do
+        expect(dependencies).to include(
+          Dependabot::Dependency.new(
+            name: "nerves",
+            requirements: [{
+              requirement: "~> 1.7.4",
+              file: "mix.exs",
+              groups: [],
+              source: nil
+            }],
+            package_manager: "hex"
+          )
+        )
+      end
+    end
   end
 end

--- a/hex/spec/fixtures/mixfiles/nerves
+++ b/hex/spec/fixtures/mixfiles/nerves
@@ -1,0 +1,67 @@
+defmodule NervesApp.MixProject do
+  use Mix.Project
+
+  @app :nerves_app
+  @version "0.1.0"
+  @all_targets [:rpi, :rpi0, :rpi2, :rpi3, :rpi3a, :rpi4, :bbb, :osd32mp1, :x86_64]
+
+  def project do
+    [
+      app: @app,
+      version: @version,
+      elixir: "~> 1.9",
+      archives: [nerves_bootstrap: "~> 1.10"],
+      start_permanent: Mix.env() == :prod,
+      build_embedded: true,
+      deps: deps(),
+      releases: [{@app, release()}],
+      preferred_cli_target: [run: :host, test: :host]
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      mod: {NervesApp.Application, []},
+      extra_applications: [:logger, :runtime_tools]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # Dependencies for all targets
+      {:nerves, "~> 1.7.4", runtime: false},
+      {:shoehorn, "~> 0.7.0"},
+      {:ring_logger, "~> 0.8.1"},
+      {:toolshed, "~> 0.2.13"},
+
+      # Dependencies for all targets except :host
+      {:nerves_runtime, "~> 0.11.3", targets: @all_targets},
+      {:nerves_pack, "~> 0.4.0", targets: @all_targets},
+
+      # Dependencies for specific targets
+      {:nerves_system_rpi, "~> 1.13", runtime: false, targets: :rpi},
+      {:nerves_system_rpi0, "~> 1.13", runtime: false, targets: :rpi0},
+      {:nerves_system_rpi2, "~> 1.13", runtime: false, targets: :rpi2},
+      {:nerves_system_rpi3, "~> 1.13", runtime: false, targets: :rpi3},
+      {:nerves_system_rpi3a, "~> 1.13", runtime: false, targets: :rpi3a},
+      {:nerves_system_rpi4, "~> 1.13", runtime: false, targets: :rpi4},
+      {:nerves_system_bbb, "~> 2.8", runtime: false, targets: :bbb},
+      {:nerves_system_osd32mp1, "~> 0.4", runtime: false, targets: :osd32mp1},
+      {:nerves_system_x86_64, "~> 1.13", runtime: false, targets: :x86_64}
+    ]
+  end
+
+  def release do
+    [
+      overwrite: true,
+      # Erlang distribution is not started automatically.
+      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
+      cookie: "#{@app}_cookie",
+      include_erts: &Nerves.Release.erts/0,
+      steps: [&Nerves.Release.init/1, :assemble],
+      strip_beams: Mix.env() == :prod or [keep: ["Docs"]]
+    ]
+  end
+end


### PR DESCRIPTION
Nerves provides tooling for using Elixir in embedded systems. Using
Dependabot on these projects currently fails with the following error
message:

```
Dependabot can't evaluate your Elixir dependency files.
As a result, Dependabot couldn't check whether any of your dependencies
are out-of-date.

The error Dependabot encountered was:
** (Mix) Archive "nerves_bootstrap" could not be found. Please make sure the archive is installed locally.
```

Adding the `nerves_bootstrap.archive` fixes this issue. This does not
affect projects that do not use the Nerves tooling since the code in the
archive is not called in those cases.
