### PR TITLE
Restore npm6/7 yanked version spec

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -469,6 +469,35 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
             to raise_error(Dependabot::DependencyFileNotResolvable)
         end
       end
+
+      context "with a dependency version that can't be found" do
+        let(:files) { project_dependency_files("#{npm_version}/yanked_version") }
+
+        let(:dependency_name) { "etag" }
+        let(:version) { "1.8.0" }
+        let(:previous_version) { "1.0.0" }
+        let(:requirements) do
+          [{
+            file: "package.json",
+            requirement: "^1.0.0",
+            groups: ["dependencies"],
+            source: nil
+          }]
+        end
+        let(:previous_requirements) do
+          [{
+            file: "package.json",
+            requirement: "^1.0.0",
+            groups: ["dependencies"],
+            source: nil
+          }]
+        end
+
+        it "raises a helpful error" do
+          expect { updated_npm_lock_content }.
+            to raise_error(Dependabot::DependencyFileNotResolvable)
+        end
+      end
     end
   end
 end

--- a/npm_and_yarn/spec/fixtures/projects/npm6/yanked_version/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/yanked_version/package-lock.json
@@ -1,0 +1,17 @@
+{
+    "name": "yanked",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "etag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.0.0.tgz"
+        },
+        "lodash": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+            "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A="
+        }
+    }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm6/yanked_version/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/yanked_version/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "yanked",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "etag": "^1.0.0",
+    "lodash": "^99.0.0"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/yanked_version/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/yanked_version/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "yanked",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "yanked",
+      "version": "1.0.0",
+      "dependencies": {
+        "etag": "^1.0.0",
+        "lodash": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+      "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A=",
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    }
+  },
+  "dependencies": {
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "lodash": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+      "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/yanked_version/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/yanked_version/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "yanked",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "etag": "^1.0.0",
+    "lodash": "^99.0.0"
+  }
+}


### PR DESCRIPTION
This was previously not working for npm 7 using arborist so we removed
the spec but seems to be working as expected using the cli.