### PR TITLE
Raise Azure::NotFound error when branch does not exist

### DIFF
--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -48,11 +48,9 @@ module Dependabot
           "/_apis/git/repositories/" + source.unscoped_repo +
           "/stats/branches?name=" + branch)
 
-        commit = JSON.parse(response.body).fetch("commit", nil)
+        raise NotFound if response.status == 400
 
-        raise NotFound unless commit
-
-        commit.fetch("commitId")
+        JSON.parse(response.body).fetch("commit").fetch("commitId")
       end
 
       def fetch_default_branch(_repo)

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -48,7 +48,11 @@ module Dependabot
           "/_apis/git/repositories/" + source.unscoped_repo +
           "/stats/branches?name=" + branch)
 
-        JSON.parse(response.body).fetch("commit").fetch("commitId")
+        commit = JSON.parse(response.body).fetch("commit", nil)
+
+        raise NotFound unless commit
+
+        commit.fetch("commitId")
       end
 
       def fetch_default_branch(_repo)

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -70,12 +70,12 @@ RSpec.describe Dependabot::Clients::Azure do
     context "when response body does not contain commit details" do
       before do
         stub_request(:get, branch_url).
-        with(basic_auth: [username, password]).
-        to_return(status: 400, body: fixture("azure", "branch_not_found.json"))
+          with(basic_auth: [username, password]).
+          to_return(status: 400, body: fixture("azure", "branch_not_found.json"))
       end
 
       it "raises a helpful error" do
-        expect {subject}.to raise_error(Dependabot::Clients::Azure::NotFound)
+        expect { subject }.to raise_error(Dependabot::Clients::Azure::NotFound)
       end
     end
   end

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -67,11 +67,11 @@ RSpec.describe Dependabot::Clients::Azure do
       end
     end
 
-    context "when response body does not contain commit details" do
+    context "when response is 400" do
       before do
         stub_request(:get, branch_url).
           with(basic_auth: [username, password]).
-          to_return(status: 400, body: fixture("azure", "branch_not_found.json"))
+          to_return(status: 400)
       end
 
       it "raises a helpful error" do

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe Dependabot::Clients::Azure do
         expect { subject }.to raise_error(Dependabot::Clients::Azure::NotFound)
       end
     end
+
+    context "when response body does not contain commit details" do
+      before do
+        stub_request(:get, branch_url).
+        with(basic_auth: [username, password]).
+        to_return(status: 400, body: fixture("azure", "branch_not_found.json"))
+      end
+
+      it "raises a helpful error" do
+        expect {subject}.to raise_error(Dependabot::Clients::Azure::NotFound)
+      end
+    end
   end
 
   describe "#create_commit" do


### PR DESCRIPTION
## Issue
Currently for fetch_commit function in azure_client, if the given branch does not exist, then dependabot-core raises error KeyError: Key not found 'commit' instead of Azure::NotFound error.

## Cause
The ADO api used to fetch branch details returns a status code of 400(Bad Request) instead of 404 because of which it does not raise a Azure::NotFound error.

## Solution
Added logic in fetch_commit method in Azure client class to raise Azure::NotFound whenever the incoming response is missing commit details.

## Testing
Tested this locally. Added unit test to verify this behaviour