### PR TITLE
Fix go_modules flaky spec accessing archive.org

### DIFF
--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
       let(:project_name) { "missing_meta_tag" }
       let(:repo_contents_path) { build_tmp_repo(project_name) }
 
-      let(:dependency_name) { "web.archive.org/web/dependabot.com" }
+      let(:dependency_name) { "example.com/web/dependabot.com" }
       let(:dependency_version) { "1.7.0" }
 
       let(:go_mod) do
@@ -174,7 +174,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
         error_class = Dependabot::DependencyFileNotResolvable
         expect { latest_resolvable_version }.
           to raise_error(error_class) do |error|
-          expect(error.message).to include("web.archive.org/web/dependabot.com")
+          expect(error.message).to include("example.com/web/dependabot.com")
         end
       end
     end

--- a/go_modules/spec/fixtures/projects/missing_meta_tag/go.mod
+++ b/go_modules/spec/fixtures/projects/missing_meta_tag/go.mod
@@ -3,5 +3,5 @@ module github.com/dependabot/test
 go 1.12
 
 require (
-	web.archive.org/web/dependabot.com v1.7.0
+	example.com/web/dependabot.com v1.7.0
 )


### PR DESCRIPTION
Spotted this spec has been flaking: https://github.com/dependabot/dependabot-core/pull/3138/checks?check_run_id=1903505156

Looks like archive.org is intermittently failing to serve the request.