### PR TITLE
Add option to profile dry-run using Stackprof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Run Python flake8 linting
         if: matrix.suite == 'python'
         run: |
-          docker run --rm "$CORE_CI_IMAGE" bash -c "pyenv exec flake8 . --count --exclude=./.*,./python/spec/fixtures --show-source --statistics"
+          docker run --rm "$CORE_CI_IMAGE" bash -c "pyenv exec flake8 python/helpers/. --count --exclude=./.*,./python/spec/fixtures --show-source --statistics"
       - name: Run Ruby Rubocop linting
         run: |
           docker run --rm "$CORE_CI_IMAGE" bash -c "cd /home/dependabot/dependabot-core/${{ matrix.suite }} && bundle exec rubocop ."

--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ This is a "meta" gem, that simply depends on all the others. If you want to
 automatically include support for all languages, you can just include this gem
 and you'll get all you need.
 
+## Profiling
+
+You can profile a dry-run by passing the `--profile` flag when running it. This
+will generate a `stackprof-<datetime>.dump` file in the `tmp/` folder, and you
+can generate a flamegraph from this by running:
+`stackprof --d3-flamegraph tmp/stackprof-<datetime>.dump > tmp/flamegraph.html`.
+
 ## Why is this public?
 
 As the name suggests, Dependabot Core is the core of Dependabot (the rest of the

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -167,6 +167,7 @@ docker run --rm -ti \
   -v "$(pwd)/omnibus/dependabot-omnibus.gemspec:$CODE_DIR/omnibus/dependabot-omnibus.gemspec" \
   -v "$(pwd)/omnibus/lib:$CODE_DIR/omnibus/lib" \
   -v "$(pwd)/omnibus/spec:$CODE_DIR/omnibus/spec" \
+  -v "$(pwd)/tmp:/$CODE_DIR/tmp" \
   --name "$CONTAINER_NAME" \
   "${DOCKER_OPTS[@]}" \
   --cap-add=SYS_PTRACE \

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 1.9.0"
   spec.add_development_dependency "simplecov", "~> 0.21.0"
   spec.add_development_dependency "simplecov-console", "~> 0.9.1"
+  spec.add_development_dependency "stackprof", "~> 0.2.16"
   spec.add_development_dependency "vcr", "6.0.0"
   spec.add_development_dependency "webmock", "~> 3.4"
 


### PR DESCRIPTION
This makes it easy to figure out performance bottlenecks by analyzing
where time is spent in a run. The trace can be visualized by running
`stackprof --d3-flamegraph tmp/stackprof-2021-02-15-13:00.dump > tmp/flamegraph.html`
and viewing that in a browser. For some reason the built in viewer did
not work on my machine, but the d3-generated flamegraph has been clear
enough for me.