### PR TITLE
Do not run peerDependencyChecker when version has no peer deps

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -138,8 +138,11 @@ module Dependabot
         end
 
         def filter_lower_versions(versions_array)
-          versions_array.
-            select { |version| version > version_class.new(dependency.version) }
+          versions_array.select do |version|
+            next true if dependency.version.nil?
+
+            version > version_class.new(dependency.version)
+          end
         end
 
         def version_from_dist_tags


### PR DESCRIPTION
For each version of each dependency that we consider upgrading, we
currently perform a fairly expensive check to see if that would result
in any peer dependency conflicts.

However, in the majority of the cases this check is not needed, as the
dependency in question has no peer dependencies.

We can run `npm info react-dom@1.0.0 peerDependencies` to figure out
which peer-dependencies the given dependency@version has. If there are
none, the command will simply return nothing.

If we _do_ have any peer dependencies, we still perform the recursive
check to figure out if the peer-dep requirements are met.

This roughly cuts the time it takes to check a `package.json` with 14
dependencies in half when running locally.