### PR TITLE
v0.133.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.133.3, 16 February 2021
+
+- common: when detecting changes in vendored dependencies, assume resources are binary
+- Bump phpstan/phpstan from 0.12.74 to 0.12.76 in /composer/helpers/v2
+- Bump eslint from 7.19.0 to 7.20.0 in /npm_and_yarn/helpers
+- Bump @npmcli/arborist from 2.2.1 to 2.2.2 in /npm_and_yarn/helpers
+- Only run flake8 on python helpers folder
+- Add option to profile dry-run using Stackprof
+- Fix go_modules flaky spec accessing archive.org
+- Restore npm6/7 yanked version spec
+- npm: Convert FileParser specs to project fixtures
+
 ## v0.133.2, 11 February 2021
 
 - Docker: Fix media types in Accept header for Docker Registry

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.133.2"
+  VERSION = "0.133.3"
 end


### PR DESCRIPTION
Release [these commits](https://github.com/dependabot/dependabot-core/compare/v0.133.2...v0.133.3-release-notes)

These PRs:
* https://github.com/dependabot/dependabot-core/pull/3124
* https://github.com/dependabot/dependabot-core/pull/3138
* https://github.com/dependabot/dependabot-core/pull/3123 (test debt)
* https://github.com/dependabot/dependabot-core/pull/3133
* https://github.com/dependabot/dependabot-core/pull/3134
* https://github.com/dependabot/dependabot-core/pull/3135
* https://github.com/dependabot/dependabot-core/pull/3140 (test debt)
* https://github.com/dependabot/dependabot-core/pull/3141 (dev tooling)
