### PR TITLE
PackageJsonUpdater: use project based fixtures

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/package_json_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/package_json_updater_spec.rb
@@ -14,12 +14,10 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
   end
 
   let(:package_json) do
-    Dependabot::DependencyFile.new(
-      content: fixture("package_files", manifest_fixture_name),
-      name: "package.json"
-    )
+    project_dependency_files(project_name).find { |f| f.name == "package.json" }
   end
-  let(:manifest_fixture_name) { "package.json" }
+  let(:project_name) { "npm7/simple" }
+
   let(:dependencies) { [dependency] }
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -68,7 +66,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
           }]
         )
       end
-      let(:manifest_fixture_name) { "minor_version_specified.json" }
+      let(:project_name) { "npm7/minor_version_specified" }
 
       its(:content) { is_expected.to include '"fetch-factory": "0.2.x"' }
     end
@@ -93,10 +91,10 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
           }]
         )
       end
-      let(:manifest_fixture_name) { "minor_version_specified.json" }
+      let(:project_name) { "npm7/minor_version_specified" }
 
       its(:content) do
-        is_expected.to eq(fixture("package_files", manifest_fixture_name))
+        is_expected.to eq(fixture("projects", "npm7", "minor_version_specified", "package.json"))
       end
 
       context "except for the source" do
@@ -124,7 +122,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
         end
 
         its(:content) do
-          is_expected.to eq(fixture("package_files", manifest_fixture_name))
+          is_expected.to eq(fixture("projects", "npm7", "minor_version_specified", "package.json"))
         end
       end
     end
@@ -149,7 +147,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
           }]
         )
       end
-      let(:manifest_fixture_name) { "package.json" }
+      let(:project_name) { "npm7/simple" }
 
       it "updates the existing development declaration" do
         parsed_file = JSON.parse(updated_package_json.content)
@@ -159,7 +157,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
     end
 
     context "updating multiple dependencies" do
-      let(:manifest_fixture_name) { "package.json" }
+      let(:project_name) { "npm7/simple" }
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -237,7 +235,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
           }]
         )
       end
-      let(:manifest_fixture_name) { "duplicate.json" }
+      let(:project_name) { "npm6/duplicate" }
 
       it "updates both declarations" do
         parsed_file = JSON.parse(updated_package_json.content)
@@ -248,7 +246,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
       end
 
       context "with identical versions" do
-        let(:manifest_fixture_name) { "duplicate_identical.json" }
+        let(:project_name) { "npm7/duplicate_identical" }
 
         let(:dependency) do
           Dependabot::Dependency.new(
@@ -310,7 +308,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
           }]
         )
       end
-      let(:manifest_fixture_name) { "dev_and_peer_dependency.json" }
+      let(:project_name) { "npm7/dev_and_peer_dependency" }
 
       it "updates both declarations" do
         parsed_file = JSON.parse(updated_package_json.content)
@@ -322,7 +320,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
     end
 
     context "with a git dependency" do
-      let(:manifest_fixture_name) { "github_dependency.json" }
+      let(:project_name) { "npm7/github_dependency" }
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "is-number",
@@ -356,7 +354,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
       its(:content) { is_expected.to include("jonschlinkert/is-number#4.0.0") }
 
       context "that specifies a semver requirement" do
-        let(:manifest_fixture_name) { "github_dependency_semver.json" }
+        let(:project_name) { "npm7/github_dependency_semver" }
         let(:dependency) do
           Dependabot::Dependency.new(
             name: "is-number",
@@ -392,7 +390,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
         end
 
         context "without the `semver:` marker" do
-          let(:manifest_fixture_name) { "github_dependency_yarn_semver.json" }
+          let(:project_name) { "yarn/github_dependency_yarn_semver" }
 
           its(:content) do
             is_expected.to include('"jonschlinkert/is-number#^4.0.0"')
@@ -402,7 +400,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
     end
 
     context "with a path-based dependency" do
-      let(:manifest_fixture_name) { "path_dependency.json" }
+      let(:project_name) { "npm7/path_dependency" }
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "lodash",
@@ -430,7 +428,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
     end
 
     context "with non-standard whitespace" do
-      let(:manifest_fixture_name) { "non_standard_whitespace.json" }
+      let(:project_name) { "npm7/non_standard_whitespace" }
 
       its(:content) do
         is_expected.to include %("*.js": ["eslint --fix", "git add"])

--- a/npm_and_yarn/spec/fixtures/projects/npm7/dev_and_peer_dependency/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/dev_and_peer_dependency/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "{{ name }}",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+      "test": "echo \"Error: no\\ test\ specified\" && exit 1"
+  },
+  "repository": {
+      "type": "git",
+      "url": "git+https://github.com/waltfy/PROTO_TEST.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+      "url": "https://github.com/waltfy/PROTO_TEST/issues"
+  },
+  "homepage": "https://github.com/waltfy/PROTO_TEST#readme",
+  "dependencies": {
+    "fetch-factory": "^0.0.1"
+  },
+  "peerDependencies": {
+    "etag" : "^1.0.0"
+  },
+  "devDependencies": {
+    "etag" : "^1.0.0"
+  }}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/duplicate_identical/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/duplicate_identical/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+      "type": "git",
+      "url": "git+https://github.com/waltfy/PROTO_TEST.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+      "url": "https://github.com/waltfy/PROTO_TEST/issues"
+  },
+  "homepage": "https://github.com/waltfy/PROTO_TEST#readme",
+  "dependencies": {
+    "fetch-factory": "^0.1.0"
+  },
+  "devDependencies": {
+    "fetch-factory": "^0.1.0"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/minor_version_specified/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/minor_version_specified/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+      "type": "git",
+      "url": "git+https://github.com/waltfy/PROTO_TEST.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+      "url": "https://github.com/waltfy/PROTO_TEST/issues"
+  },
+  "homepage": "https://github.com/waltfy/PROTO_TEST#readme",
+  "dependencies": {
+    "fetch-factory": "0.1.x"
+  },
+  "devDependencies": {
+    "etag": "^1.0.0"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/non_standard_whitespace/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/non_standard_whitespace/package.json
@@ -4,8 +4,7 @@
     "description": "",
     "main": "index.js",
     "scripts": {
-        "test": "echo \"Error: no\\ test\ specified\" && exit 1",
-        "prettify": "prettier --write \"{{packages/*/src,examples,cypress,scripts}/**/,}*.{js,jsx,ts,tsx,css,md}\""
+        "test": "echo \"Error: no test specified\" && exit 1"
     },
     "repository": {
         "type": "git",
@@ -21,5 +20,8 @@
       "fetch-factory": "^0.0.1"
     },
     "devDependencies": {
-      "etag" : "^1.0.0"
+      "etag": "^1.0.0"
+    },
+    "lint-staged": {
+        "*.js": ["eslint --fix", "git add"]
     }}


### PR DESCRIPTION
Updating the `PackageJsonUpdater` specs to use project based spec
fixtures.