### PR TITLE
Insert zero-width space in @mentions

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -119,7 +119,7 @@ module Dependabot
 
         def build_mention_link_text_nodes(text)
           code_node = CommonMarker::Node.new(:code)
-          code_node.string_content = text
+          code_node.string_content = insert_zero_width_space_in_mention(text)
           [code_node]
         end
 
@@ -127,9 +127,17 @@ module Dependabot
           link_node = CommonMarker::Node.new(:link)
           code_node = CommonMarker::Node.new(:code)
           link_node.url = url
-          code_node.string_content = text
+          code_node.string_content = insert_zero_width_space_in_mention(text)
           link_node.append_child(code_node)
           link_node
+        end
+
+        # NOTE: Add a zero-width space between the @ and the username to prevent
+        # email replies on dependabot pull requests triggering notifications to
+        # users who've been mentioned in changelogs etc. PR email replies parse
+        # the content of the pull request body in plain text.
+        def insert_zero_width_space_in_mention(mention)
+          mention.sub("@", "@\u200B").encode("utf-8")
         end
 
         def parent_node_link?(node)

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
       it "sanitizes the text" do
         expect(sanitize_links_and_mentions).
           to eq("<p>Great work <a href=\"https://github.com/greysteil\">"\
-            "<code>@greysteil</code></a>!</p>\n")
+            "<code>@\u200Bgreysteil</code></a>!</p>\n")
       end
 
       context "that includes a dash" do
@@ -31,7 +31,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         it "sanitizes the text" do
           expect(sanitize_links_and_mentions).to eq(
             "<p>Great work <a href=\"https://github.com/greysteil-work\">"\
-            "<code>@greysteil-work</code></a>!</p>\n"
+            "<code>@\u200Bgreysteil-work</code></a>!</p>\n"
           )
         end
       end
@@ -47,7 +47,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         it "sanitizes the text" do
           expect(sanitize_links_and_mentions).to eq(
             "<p>The team (by <a href=\"https://github.com/greysteil\">"\
-            "<code>@greysteil</code></a>) etc.</p>\n"
+            "<code>@\u200Bgreysteil</code></a>) etc.</p>\n"
           )
         end
       end
@@ -57,7 +57,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
         it "sanitizes the text" do
           expect(sanitize_links_and_mentions).to eq(
-            "<p>[<a href=\"https://github.com/hmarr\"><code>@hmarr</code></a>]</p>\n"
+            "<p>[<a href=\"https://github.com/hmarr\"><code>@\u200Bhmarr</code></a>]</p>\n"
           )
         end
       end
@@ -67,8 +67,8 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
         it "sanitizes the mention" do
           expect(sanitize_links_and_mentions).to eq(
-            "<p><a href=\"https://github.com/hmarr\"><em><code>@hmarr</code></em></a> "\
-            "<a href=\"https://github.com/feelepxyz\"><code>@feelepxyz</code></a></p>\n"
+            "<p><a href=\"https://github.com/hmarr\"><em><code>@\u200Bhmarr</code></em></a> "\
+            "<a href=\"https://github.com/feelepxyz\"><code>@\u200Bfeelepxyz</code></a></p>\n"
           )
         end
       end
@@ -87,7 +87,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         let(:text) { fixture("changelogs", "sentry.md") }
         it do
           is_expected.to include(
-            "<a href=\"https://github.com/halkeye\"><code>@halkeye</code></a>"
+            "<a href=\"https://github.com/halkeye\"><code>@\u200Bhalkeye</code></a>"
           )
         end
       end
@@ -113,9 +113,9 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
           it "sanitizes the text" do
             expect(sanitize_links_and_mentions).to eq(
-              "<p><a href=\"https://github.com/greysteil\"><code>@greysteil</code></a> "\
+              "<p><a href=\"https://github.com/greysteil\"><code>@\u200Bgreysteil</code></a> "\
               "wrote this:</p>\n<pre><code> @model ||= 123\n</code></pre>\n<p>"\
-              "Review by <a href=\"https://github.com/hmarr\"><code>@hmarr</code></a>!"\
+              "Review by <a href=\"https://github.com/hmarr\"><code>@\u200Bhmarr</code></a>!"\
               "</p>\n"
             )
           end
@@ -129,9 +129,9 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
           it "sanitizes the mention" do
             expect(sanitize_links_and_mentions).to eq(
               "<p><code>@command</code>\nThanks to "\
-              "<a href=\"https://github.com/feelepxyz\"><code>@feelepxyz</code></a>"\
+              "<a href=\"https://github.com/feelepxyz\"><code>@\u200Bfeelepxyz</code></a>"\
               "<code>@other</code> <a href=\"https://github.com/escape\">"\
-              "<code>@escape</code></a></p>\n"
+              "<code>@\u200Bescape</code></a></p>\n"
             )
           end
         end
@@ -142,7 +142,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
           it "sanitizes the mention" do
             expect(sanitize_links_and_mentions).to eq(
               "<p><code>@command </code>\n<code> @test</code> "\
-              "<a href=\"https://github.com/feelepxyz\"><code>@feelepxyz</code></a></p>\n"
+              "<a href=\"https://github.com/feelepxyz\"><code>@\u200Bfeelepxyz</code></a></p>\n"
             )
           end
         end
@@ -170,7 +170,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
               expect(sanitize_links_and_mentions).to eq(
                 "<p>Take a look at this code: <code>@not-a-mention "\
                 "```@not-a-mention```</code> This is a "\
-                "<a href=\"https://github.com/mention\"><code>@mention</code></a>!</p>\n"
+                "<a href=\"https://github.com/mention\"><code>@\u200Bmention</code></a>!</p>\n"
               )
             end
           end
@@ -183,7 +183,7 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
             expect(sanitize_links_and_mentions).to eq(
               "<p><code>@command </code></p>\n<pre><code>@test\n"\
               "</code></pre>\n"\
-              "<p><a href=\"https://github.com/feelepxyz\"><code>@feelepxyz</code></a></p>\n"
+              "<p><a href=\"https://github.com/feelepxyz\"><code>@\u200Bfeelepxyz</code></a></p>\n"
             )
           end
         end
@@ -193,9 +193,9 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
           it "sanitizes the mentions" do
             expect(sanitize_links_and_mentions).to eq(
-              "<p><a href=\"https://github.com/command\"><code>@command</code></a> "\
+              "<p><a href=\"https://github.com/command\"><code>@\u200Bcommand</code></a> "\
               "``` <a href=\"https://github.com/feelepxyz\">"\
-              "<code>@feelepxyz</code></a></p>\n"
+              "<code>@\u200Bfeelepxyz</code></a></p>\n"
             )
           end
         end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1194,8 +1194,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 "<blockquote>\n"\
                 "<h2>v1.6.0</h2>\n"\
                 "<p>Mad props to <a href=\"https://github.com/greysteil\">"\
-                "<code>@greysteil</code></a> and <a href=\"https://github.com/hmarr\">"\
-                "<code>@hmarr</code></a> for the "\
+                "<code>@\u200Bgreysteil</code></a> and <a href=\"https://github.com/hmarr\">"\
+                "<code>@\u200Bhmarr</code></a> for the "\
                 "@angular/scope work - see <a href=\"https://github.com/"\
                 "gocardless/business/blob/HEAD/CHANGELOG.md\">changelog</a>."\
                 "</p>\n"\


### PR DESCRIPTION
Insert zero-width space in @mentions to prevent sending notifications to
users tagged in changelogs and release notes when email-replying to pull
requests from dependabot.

When sending an email reply to a pull request from dependabot the
contents of the pull request description including changelogs can be
included in the body of the email causing notifications to be sent to
the @mentioned users.

We've previously attempted to fix this by changing @mentions into code
blocks but it seems like the email content is treated as plain text
removing any formatting before detecting usernames.

Ref: https://github.com/dependabot/dependabot-core/pull/2982