### PR TITLE
python+hex reject_untrusted_code

### DIFF
--- a/hex/lib/dependabot/hex/file_parser.rb
+++ b/hex/lib/dependabot/hex/file_parser.rb
@@ -15,6 +15,9 @@ module Dependabot
       require "dependabot/file_parsers/base/dependency_set"
 
       def parse
+        # TODO: git sourced dependency's mixfiles are evaluated. Provide guards before removing this.
+        raise ::Dependabot::UnexpectedExternalCode if @reject_external_code
+
         dependency_set = DependencySet.new
 
         dependency_details.each do |dep|

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -24,7 +24,13 @@ RSpec.describe Dependabot::Hex::FileParser do
   end
   let(:mixfile_fixture_name) { "minor_version" }
   let(:lockfile_fixture_name) { "minor_version" }
-  let(:parser) { described_class.new(dependency_files: files, source: source) }
+  let(:parser) do
+    described_class.new(
+      dependency_files: files,
+      source: source,
+      reject_external_code: reject_external_code
+    )
+  end
   let(:source) do
     Dependabot::Source.new(
       provider: "github",
@@ -32,6 +38,7 @@ RSpec.describe Dependabot::Hex::FileParser do
       directory: "/"
     )
   end
+  let(:reject_external_code) { false }
 
   describe "parse" do
     subject(:dependencies) { parser.parse }
@@ -433,6 +440,14 @@ RSpec.describe Dependabot::Hex::FileParser do
             package_manager: "hex"
           )
         )
+      end
+    end
+
+    context "with reject_external_code" do
+      let(:reject_external_code) { true }
+
+      it "raises UnexpectedExternalCode" do
+        expect { dependencies }.to raise_error(Dependabot::UnexpectedExternalCode)
       end
     end
   end

--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -36,6 +36,9 @@ module Dependabot
       ).freeze
 
       def parse
+        # TODO: setup.py from external dependencies is evaluated. Provide guards before removing this.
+        raise Dependabot::UnexpectedExternalCode if @reject_external_code
+
         dependency_set = DependencySet.new
 
         dependency_set += pipenv_dependencies if pipfile

--- a/python/spec/dependabot/python/file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser_spec.rb
@@ -9,7 +9,13 @@ require_common_spec "file_parsers/shared_examples_for_file_parsers"
 RSpec.describe Dependabot::Python::FileParser do
   it_behaves_like "a dependency file parser"
 
-  let(:parser) { described_class.new(dependency_files: files, source: source) }
+  let(:parser) do
+    described_class.new(
+      dependency_files: files,
+      source: source,
+      reject_external_code: reject_external_code
+    )
+  end
   let(:source) do
     Dependabot::Source.new(
       provider: "github",
@@ -17,6 +23,7 @@ RSpec.describe Dependabot::Python::FileParser do
       directory: "/"
     )
   end
+  let(:reject_external_code) { false }
 
   let(:files) { [requirements] }
   let(:requirements) do
@@ -1220,6 +1227,14 @@ RSpec.describe Dependabot::Python::FileParser do
             )
           end
         end
+      end
+    end
+
+    context "with reject_external_code" do
+      let(:reject_external_code) { true }
+
+      it "raises UnexpectedExternalCode" do
+        expect { dependencies }.to raise_error(Dependabot::UnexpectedExternalCode)
       end
     end
   end


### PR DESCRIPTION
This PR propagates the `reject_external_code` setting and `UnexpectedExternalCode` exceptions to other ecosystems that may execute external/third party code as part of the update process:
* `python`, due to `setup.py` being evaluated
* `hex`, due to `mix.exs` being evaluated from git-sourced dependencies

Unlike `bundler`, there is no attempt at verifying these ecosystems will not execute external code: the exception is always raised if the flag is set.
We intend to improve this on a per-ecosystem basis in follow-up PRs.