### PR TITLE
v0.133.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.133.5, 19 February 2021
+
+- Python: Raise UnexpectedExternalCode if `reject_external_code: true`, regardless of the update involving external code
+- Hex: Raise UnexpectedExternalCode if `reject_external_code: true`, regardless of the update involving external code
+- JS: fix npm file updater spec
+
 ## v0.133.4, 18 February 2021
 
 - Elixir: support projects using Nerves extensions (@fhunleth and @cblavier)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.133.4"
+  VERSION = "0.133.5"
 end


### PR DESCRIPTION
Release [these commits](https://github.com/dependabot/dependabot-core/compare/v0.133.4...v0.133.5-release-notes)

These PRs:
* https://github.com/dependabot/dependabot-core/pull/3169
* https://github.com/dependabot/dependabot-core/commit/e1f0a0f051ed30e8ba16d4d07528d4e96fbcf24c (skipped PR, unreviewed)