### PR TITLE
Convert version resolver specs to projects

### DIFF
--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
       latest_allowable_version: latest_allowable_version
     )
   end
-  let(:dependency_files) { [gemfile, lockfile] }
   let(:ignored_versions) { [] }
   let(:latest_allowable_version) { nil }
   let(:unlock_requirement) { false }
@@ -47,28 +46,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
   end
   let(:source) { nil }
   let(:requirement_string) { ">= 0" }
-
-  let(:gemfile) do
-    Dependabot::DependencyFile.new(
-      content: fixture("ruby", "gemfiles", gemfile_fixture_name),
-      name: "Gemfile"
-    )
-  end
-  let(:lockfile) do
-    Dependabot::DependencyFile.new(
-      content: fixture("ruby", "lockfiles", lockfile_fixture_name),
-      name: "Gemfile.lock"
-    )
-  end
-  let(:gemspec) do
-    Dependabot::DependencyFile.new(
-      content: fixture("ruby", "gemspecs", gemspec_fixture_name),
-      name: "example.gemspec"
-    )
-  end
-  let(:gemfile_fixture_name) { "Gemfile" }
-  let(:lockfile_fixture_name) { "Gemfile.lock" }
-  let(:gemspec_fixture_name) { "example" }
   let(:rubygems_url) { "https://index.rubygems.org/api/v1/" }
 
   describe "#latest_resolvable_version_details" do
@@ -76,39 +53,35 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
     context "with a rubygems source" do
       context "with a ~> version specified constraining the update" do
-        let(:gemfile_fixture_name) { "Gemfile" }
-        let(:lockfile_fixture_name) { "Gemfile.lock" }
         let(:requirement_string) { "~> 1.4.0" }
 
+        let(:dependency_files) { project_dependency_files("bundler1/gemfile") }
         its([:version]) { is_expected.to eq(Gem::Version.new("1.4.0")) }
       end
 
       context "with a minor version specified that can update" do
-        let(:gemfile_fixture_name) { "minor_version_specified" }
-        let(:lockfile_fixture_name) { "Gemfile.lock" }
         let(:requirement_string) { "~> 1.4" }
 
+        let(:dependency_files) { project_dependency_files("bundler1/minor_version_specified_gemfile") }
         its([:version]) { is_expected.to eq(Gem::Version.new("1.18.0")) }
       end
 
       context "when updating a dep blocked by a sub-dep" do
-        let(:gemfile_fixture_name) { "blocked_by_subdep" }
-        let(:lockfile_fixture_name) { "blocked_by_subdep.lock" }
         let(:dependency_name) { "dummy-pkg-a" }
         let(:current_version) { "1.0.1" }
         let(:requirements) do
           [{ file: "Gemfile", requirement: ">= 0", groups: [], source: nil }]
         end
 
+        let(:dependency_files) { project_dependency_files("bundler1/blocked_by_subdep") }
         its([:version]) { is_expected.to eq(Gem::Version.new("1.1.0")) }
       end
 
       context "that only appears in the lockfile" do
-        let(:gemfile_fixture_name) { "subdependency" }
-        let(:lockfile_fixture_name) { "subdependency.lock" }
         let(:dependency_name) { "i18n" }
         let(:requirements) { [] }
 
+        let(:dependency_files) { project_dependency_files("bundler1/subdependency") }
         its([:version]) { is_expected.to eq(Gem::Version.new("0.7.0")) }
 
         # TODO: https://github.com/dependabot/dependabot-core/issues/2364
@@ -125,20 +98,22 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
       end
 
       context "with a Bundler version specified" do
-        let(:gemfile_fixture_name) { "bundler_specified" }
-        let(:lockfile_fixture_name) { "bundler_specified.lock" }
         let(:requirement_string) { "~> 1.4.0" }
 
+        let(:dependency_files) { project_dependency_files("bundler1/bundler_specified") }
         its([:version]) { is_expected.to eq(Gem::Version.new("1.4.0")) }
 
         context "attempting to update Bundler" do
           let(:dependency_name) { "bundler" }
           include_context "stub rubygems versions api"
 
+          let(:dependency_files) { project_dependency_files("bundler1/bundler_specified") }
           its([:version]) { is_expected.to eq(Gem::Version.new("1.16.3")) }
 
           context "when wrapped in a source block" do
-            let(:gemfile_fixture_name) { "bundler_specified_in_source" }
+            let(:dependency_files) do
+              project_dependency_files("bundler1/bundler_specified_in_source_bundler_specified")
+            end
             its([:version]) { is_expected.to eq(Gem::Version.new("1.16.3")) }
           end
 
@@ -155,36 +130,22 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
       end
 
       context "with a default gem specified" do
-        let(:gemfile_fixture_name) { "default_gem_specified" }
-        let(:lockfile_fixture_name) { "default_gem_specified.lock" }
         let(:requirement_string) { "~> 1.4" }
 
+        let(:dependency_files) { project_dependency_files("bundler1/default_gem_specified") }
         its([:version]) { is_expected.to eq(Gem::Version.new("1.18.0")) }
       end
 
       context "with a version conflict at the latest version" do
-        let(:gemfile_fixture_name) { "version_conflict_no_req_change" }
-        let(:lockfile_fixture_name) { "version_conflict_no_req_change.lock" }
         let(:dependency_name) { "ibandit" }
         let(:requirement_string) { "~> 0.1" }
 
         # The latest version of ibandit is 0.8.5, but 0.11.28 is the latest
         # version compatible with the version of i18n in the Gemfile.lock.
+        let(:dependency_files) { project_dependency_files("bundler1/version_conflict_no_req_change") }
         its([:version]) { is_expected.to eq(Gem::Version.new("0.11.28")) }
 
         context "with a gems.rb and gems.locked" do
-          let(:gemfile) do
-            Dependabot::DependencyFile.new(
-              content: fixture("ruby", "gemfiles", gemfile_fixture_name),
-              name: "gems.rb"
-            )
-          end
-          let(:lockfile) do
-            Dependabot::DependencyFile.new(
-              content: fixture("ruby", "lockfiles", lockfile_fixture_name),
-              name: "gems.locked"
-            )
-          end
           let(:requirements) do
             [{
               file: "gems.rb",
@@ -194,32 +155,30 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
             }]
           end
 
+          let(:dependency_files) { project_dependency_files("bundler1/version_conflict_no_req_change_gems_rb") }
           its([:version]) { is_expected.to eq(Gem::Version.new("0.11.28")) }
         end
       end
 
       context "with no update possible due to a version conflict" do
-        let(:gemfile_fixture_name) { "version_conflict_with_listed_subdep" }
-        let(:lockfile_fixture_name) do
-          "version_conflict_with_listed_subdep.lock"
-        end
         let(:dependency_name) { "rspec-mocks" }
         let(:requirement_string) { ">= 0" }
 
+        let(:dependency_files) { project_dependency_files("bundler1/version_conflict_with_listed_subdep") }
         its([:version]) { is_expected.to eq(Gem::Version.new("3.6.0")) }
       end
 
       context "with a legacy Ruby which disallows the latest version" do
-        let(:gemfile_fixture_name) { "legacy_ruby" }
-        let(:lockfile_fixture_name) { "legacy_ruby.lock" }
         let(:dependency_name) { "public_suffix" }
         let(:requirement_string) { ">= 0" }
 
         # The latest version of public_suffix is 2.0.5, but requires Ruby 2.0.0
         # or greater.
+        let(:dependency_files) { project_dependency_files("bundler1/legacy_ruby") }
         its([:version]) { is_expected.to eq(Gem::Version.new("1.4.6")) }
 
         context "when Bundler's compact index is down" do
+          let(:dependency_files) { project_dependency_files("bundler1/legacy_ruby") }
           let(:versions_url) do
             "https://rubygems.org/api/v1/versions/public_suffix.json"
           end
@@ -259,47 +218,45 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
               ).gsub(/"ruby_version": .*,/, '"ruby_version": null,')
             end
 
+            let(:dependency_files) { project_dependency_files("bundler1/legacy_ruby") }
             its([:version]) { is_expected.to eq(Gem::Version.new("3.0.2")) }
           end
         end
       end
 
       context "with JRuby" do
-        let(:gemfile_fixture_name) { "jruby" }
-        let(:lockfile_fixture_name) { "jruby.lock" }
         let(:dependency_name) { "json" }
         let(:requirement_string) { ">= 0" }
 
+        let(:dependency_files) { project_dependency_files("bundler1/jruby") }
         its([:version]) { is_expected.to be >= Gem::Version.new("1.4.6") }
       end
 
       context "when a gem has been yanked" do
-        let(:gemfile_fixture_name) { "minor_version_specified" }
-        let(:lockfile_fixture_name) { "yanked_gem.lock" }
         let(:requirement_string) { "~> 1.4" }
 
         context "and it's that gem that we're attempting to bump" do
+          let(:dependency_files) { project_dependency_files("bundler1/minor_version_specified_yanked_gem") }
           its([:version]) { is_expected.to eq(Gem::Version.new("1.18.0")) }
         end
 
         context "and it's another gem" do
           let(:dependency_name) { "statesman" }
           let(:requirement_string) { "~> 1.2" }
+          let(:dependency_files) { project_dependency_files("bundler1/minor_version_specified_yanked_gem") }
           its([:version]) { is_expected.to eq(Gem::Version.new("1.3.1")) }
         end
       end
 
       context "when unlocking a git dependency would cause errors" do
         let(:current_version) { "1.4.0" }
-        let(:gemfile_fixture_name) { "git_source_circular" }
-        let(:lockfile_fixture_name) { "git_source_circular.lock" }
 
+        let(:dependency_files) { project_dependency_files("bundler1/git_source_circular") }
         its([:version]) { is_expected.to eq(Gem::Version.new("2.1.0")) }
       end
 
       context "with a ruby exec command that fails" do
-        let(:gemfile_fixture_name) { "exec_error" }
-        let(:dependency_files) { [gemfile] }
+        let(:dependency_files) { project_dependency_files("bundler1/exec_error_no_lockfile") }
 
         it "raises a DependencyFileNotEvaluatable error" do
           expect { subject }.
@@ -309,7 +266,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
     end
 
     context "when the Gem can't be found" do
-      let(:gemfile_fixture_name) { "unavailable_gem" }
+      let(:dependency_files) { project_dependency_files("bundler1/unavailable_gem_gemfile") }
       let(:requirement_string) { "~> 1.4" }
 
       it "raises a DependencyFileNotResolvable error" do
@@ -319,24 +276,22 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
     end
 
     context "given an unreadable Gemfile" do
-      let(:gemfile_fixture_name) { "includes_requires" }
+      let(:dependency_files) { project_dependency_files("bundler1/includes_requires_gemfile") }
 
       it "raises a useful error" do
         expect { subject }.
           to raise_error(Dependabot::DependencyFileNotEvaluatable) do |error|
-            # Test that the temporary path isn't included in the error message
-            expect(error.message).to_not include("dependabot_20")
-          end
+          # Test that the temporary path isn't included in the error message
+          expect(error.message).to_not include("dependabot_20")
+        end
       end
     end
 
     context "given a path source" do
-      let(:gemfile_fixture_name) { "path_source" }
-      let(:lockfile_fixture_name) { "path_source.lock" }
       let(:requirement_string) { "~> 1.4.0" }
 
       context "without a downloaded gemspec" do
-        let(:dependency_files) { [gemfile, lockfile] }
+        let(:dependency_files) { project_dependency_files("bundler1/path_source") }
 
         it "raises a PathDependenciesNotReachable error" do
           expect { subject }.
@@ -347,8 +302,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
     context "given a git source" do
       context "where updating would cause a circular dependency" do
-        let(:gemfile_fixture_name) { "git_source_circular" }
-        let(:lockfile_fixture_name) { "git_source_circular.lock" }
+        let(:dependency_files) { project_dependency_files("bundler1/git_source_circular") }
 
         let(:dependency_name) { "rubygems-circular-dependency" }
         let(:current_version) { "3c85f0bd8d6977b4dfda6a12acf93a282c4f5bf1" }
@@ -356,7 +310,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
           {
             type: "git",
             url: "https://github.com/dependabot-fixtures/"\
-                 "rubygems-circular-dependency",
+            "rubygems-circular-dependency",
             branch: "master",
             ref: "master"
           }
@@ -367,9 +321,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
     end
 
     context "with a gemspec and a Gemfile" do
-      let(:dependency_files) { [gemfile, gemspec] }
-      let(:gemfile_fixture_name) { "imports_gemspec" }
-      let(:gemspec_fixture_name) { "small_example" }
+      let(:dependency_files) { project_dependency_files("bundler1/imports_gemspec_small_example_no_lockfile") }
       let(:unlock_requirement) { true }
       let(:current_version) { nil }
       let(:requirements) do
@@ -392,6 +344,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
       end
 
       context "with an upper bound that is lower than the current req" do
+        let(:dependency_files) { project_dependency_files("bundler1/imports_gemspec_small_example_no_lockfile") }
         let(:latest_allowable_version) { "1.0.0" }
         let(:ignored_versions) { ["> 1.0.0"] }
 
@@ -419,7 +372,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
       # end
 
       context "when an old required ruby is specified in the gemspec" do
-        let(:gemspec_fixture_name) { "old_required_ruby" }
+        let(:dependency_files) { project_dependency_files("bundler1/imports_gemspec_old_required_ruby_no_lockfile") }
         let(:dependency_name) { "statesman" }
         let(:latest_allowable_version) { "7.2.0" }
 
@@ -429,6 +382,9 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
         end
 
         context "that isn't satisfied by the dependencies" do
+          let(:dependency_files) do
+            project_dependency_files("bundler1/imports_gemspec_version_clash_old_required_ruby_no_lockfile")
+          end
           let(:gemfile_fixture_name) { "imports_gemspec_version_clash" }
           let(:current_version) { "3.0.1" }
 

--- a/bundler/spec/fixtures/projects/bundler1/blocked_by_subdep/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/blocked_by_subdep/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "dummy-pkg-a"
+gem "dummy-pkg-b"

--- a/bundler/spec/fixtures/projects/bundler1/blocked_by_subdep/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/blocked_by_subdep/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    dummy-pkg-a (1.0.1)
+    dummy-pkg-b (1.0.0)
+      dummy-pkg-a (< 2.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  dummy-pkg-a (= 1.0.1)
+  dummy-pkg-b (= 1.0.0)
+
+BUNDLED WITH
+   1.17.3

--- a/bundler/spec/fixtures/projects/bundler1/bundler_specified/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/bundler_specified/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "bundler", "~> 1.15.0"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/bundler_specified/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/bundler_specified/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.15.0)
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.15.4

--- a/bundler/spec/fixtures/projects/bundler1/bundler_specified_in_source_bundler_specified/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/bundler_specified_in_source_bundler_specified/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org" do
+  gem "bundler", "~> 1.15.0"
+
+  gem "business", "~> 1.4.0"
+  gem "statesman", "~> 1.2.0"
+end

--- a/bundler/spec/fixtures/projects/bundler1/bundler_specified_in_source_bundler_specified/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/bundler_specified_in_source_bundler_specified/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.15.0)
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.15.4

--- a/bundler/spec/fixtures/projects/bundler1/default_gem_specified/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/default_gem_specified/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "openssl", "~> 2.1.2"
+
+gem "business", "~> 1.4"
+gem "statesman", "~> 1.2"

--- a/bundler/spec/fixtures/projects/bundler1/default_gem_specified/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/default_gem_specified/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.18.0)
+    openssl (2.1.2)
+    statesman (1.3.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4)
+  openssl (~> 2.1.2)
+  statesman (~> 1.2)
+
+BUNDLED WITH
+   1.17.3

--- a/bundler/spec/fixtures/projects/bundler1/exec_error_no_lockfile/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/exec_error_no_lockfile/Gemfile
@@ -1,0 +1,6 @@
+exec "curl https://example.com"
+
+source "https://rubygems.org"
+
+gem "business", "~> 1.0.0"
+gem "uk_phone_numbers", "~> 0.1.0"

--- a/bundler/spec/fixtures/projects/bundler1/gemfile/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/gemfile/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/gemfile/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/gemfile/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/bundler/spec/fixtures/projects/bundler1/git_source_circular/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/git_source_circular/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "rubygems-circular-dependency", git: "https://github.com/dependabot-fixtures/rubygems-circular-dependency"
+gem "business"

--- a/bundler/spec/fixtures/projects/bundler1/git_source_circular/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/git_source_circular/Gemfile.lock
@@ -1,0 +1,20 @@
+GIT
+  remote: https://github.com/dependabot-fixtures/rubygems-circular-dependency
+  revision: 3c85f0bd8d6977b4dfda6a12acf93a282c4f5bf1
+  specs:
+    rubygems-circular-dependency (0.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business
+  rubygems-circular-dependency!
+
+BUNDLED WITH
+   1.17.3

--- a/bundler/spec/fixtures/projects/bundler1/imports_gemspec_old_required_ruby_no_lockfile/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/imports_gemspec_old_required_ruby_no_lockfile/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/imports_gemspec_old_required_ruby_no_lockfile/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/imports_gemspec_old_required_ruby_no_lockfile/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 1.9.3"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler1/imports_gemspec_small_example_no_lockfile/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/imports_gemspec_small_example_no_lockfile/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/imports_gemspec_small_example_no_lockfile/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/imports_gemspec_small_example_no_lockfile/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler1/imports_gemspec_version_clash_old_required_ruby_no_lockfile/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/imports_gemspec_version_clash_old_required_ruby_no_lockfile/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 3.0.0"

--- a/bundler/spec/fixtures/projects/bundler1/imports_gemspec_version_clash_old_required_ruby_no_lockfile/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/imports_gemspec_version_clash_old_required_ruby_no_lockfile/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 1.9.3"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler1/includes_requires_gemfile/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/includes_requires_gemfile/Gemfile
@@ -1,0 +1,5 @@
+source 'http://rubygems.org'
+
+%w[cli dependency].each do |path|
+  require File.expand_path("../lib/backup/#{path}", __FILE__)
+end

--- a/bundler/spec/fixtures/projects/bundler1/includes_requires_gemfile/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/includes_requires_gemfile/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/bundler/spec/fixtures/projects/bundler1/jruby/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/jruby/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source 'https://rubygems.org'
+
+gem "json"

--- a/bundler/spec/fixtures/projects/bundler1/jruby/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/jruby/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    json (1.4.3-java)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  json
+
+BUNDLED WITH
+   1.15.1

--- a/bundler/spec/fixtures/projects/bundler1/legacy_ruby/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/legacy_ruby/Gemfile
@@ -1,0 +1,4 @@
+ruby "1.9.3"
+source "https://rubygems.org"
+
+gem "public_suffix"

--- a/bundler/spec/fixtures/projects/bundler1/legacy_ruby/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/legacy_ruby/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    public_suffix (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  public_suffix
+
+RUBY VERSION
+   ruby 1.9.3p551
+
+BUNDLED WITH
+   1.15.1

--- a/bundler/spec/fixtures/projects/bundler1/minor_version_specified_gemfile/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/minor_version_specified_gemfile/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4"
+gem "statesman", "~> 1.2"

--- a/bundler/spec/fixtures/projects/bundler1/minor_version_specified_gemfile/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/minor_version_specified_gemfile/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/bundler/spec/fixtures/projects/bundler1/minor_version_specified_yanked_gem/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/minor_version_specified_yanked_gem/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4"
+gem "statesman", "~> 1.2"

--- a/bundler/spec/fixtures/projects/bundler1/minor_version_specified_yanked_gem/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/minor_version_specified_yanked_gem/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.1)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/bundler/spec/fixtures/projects/bundler1/path_source/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/path_source/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"
+gem "example", ">= 0.9.0", path: "plugins/example"
+gem "prius", git: "https://github.com/gocardless/prius"

--- a/bundler/spec/fixtures/projects/bundler1/path_source/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/path_source/Gemfile.lock
@@ -1,0 +1,30 @@
+GIT
+  remote: https://github.com/gocardless/prius
+  revision: cff701b3bfb182afc99a85657d7c9f3d6c1ccce2
+  specs:
+    prius (1.0.0)
+
+PATH
+  remote: plugins/example
+  specs:
+    example (0.9.3)
+      i18n (>= 0.3.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    i18n (0.8.4)
+    statesman (1.2.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  example (>= 0.9.0)!
+  prius!
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.15.1

--- a/bundler/spec/fixtures/projects/bundler1/subdependency/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/subdependency/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "ibandit", "~> 0.7.0"

--- a/bundler/spec/fixtures/projects/bundler1/subdependency/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/subdependency/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    i18n (0.7.0.beta1)
+    ibandit (0.7.0)
+      i18n (~> 0.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ibandit (~> 0.7.0)
+
+BUNDLED WITH
+   1.16.1

--- a/bundler/spec/fixtures/projects/bundler1/unavailable_gem_gemfile/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/unavailable_gem_gemfile/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4"
+gem "statesman", "~> 1.2"
+gem "unresolvable_gem_name"

--- a/bundler/spec/fixtures/projects/bundler1/unavailable_gem_gemfile/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/unavailable_gem_gemfile/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/bundler/spec/fixtures/projects/bundler1/version_conflict_no_req_change/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/version_conflict_no_req_change/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "ibandit", "~> 0.1"
+gem "i18n", "~> 0.6"

--- a/bundler/spec/fixtures/projects/bundler1/version_conflict_no_req_change/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/version_conflict_no_req_change/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    i18n (0.6.11)
+    ibandit (0.1.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  i18n (~> 0.6)
+  ibandit (~> 0.1)
+
+BUNDLED WITH
+   1.14.6

--- a/bundler/spec/fixtures/projects/bundler1/version_conflict_no_req_change_gems_rb/gems.locked
+++ b/bundler/spec/fixtures/projects/bundler1/version_conflict_no_req_change_gems_rb/gems.locked
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    i18n (0.6.11)
+    ibandit (0.1.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  i18n (~> 0.6)
+  ibandit (~> 0.1)
+
+BUNDLED WITH
+   1.14.6

--- a/bundler/spec/fixtures/projects/bundler1/version_conflict_no_req_change_gems_rb/gems.rb
+++ b/bundler/spec/fixtures/projects/bundler1/version_conflict_no_req_change_gems_rb/gems.rb
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "ibandit", "~> 0.1"
+gem "i18n", "~> 0.6"

--- a/bundler/spec/fixtures/projects/bundler1/version_conflict_with_listed_subdep/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/version_conflict_with_listed_subdep/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "rspec-mocks"
+gem "rspec-support"

--- a/bundler/spec/fixtures/projects/bundler1/version_conflict_with_listed_subdep/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/version_conflict_with_listed_subdep/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rspec-mocks
+  rspec-support
+
+BUNDLED WITH
+   1.16.3


### PR DESCRIPTION
This was mostly an automated pass with some manual cleanup.

The project names are slightly gnarly, and I think we'll want to name
them ourselves eventually, but I figured that keeping them as is until
we've converted all specs will make it easier to do a single rename pass
once we're done.