### PR TITLE
Set bitbucket labeler to nil

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -175,7 +175,7 @@ module Dependabot
         pr_description: message_builder.pr_message,
         pr_name: message_builder.pr_name,
         author_details: author_details,
-        labeler: labeler,
+        labeler: nil,
         work_item: provider_metadata&.fetch(:work_item, nil)
       )
     end


### PR DESCRIPTION
As bitbucket does not support the labeler, @iinuwa tried to fix it in https://github.com/dependabot/dependabot-core/commit/52db87ebd750452d500e713bc85b745bc84f4352 by setting the default labeler in the constructor to nil. However from my testing this does not fix it, as we're still injecting the default labeler here.