### PR TITLE
v0.134.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.134.0, 1 March 2021
+
+- Introduce `Dependabot::PullRequestCreator::Message` as an alternative to `Dependabot::PullRequestCreator::MessageBuilder`
+- Test: convert Bundler specs to projects
+- Test: fix npm6 fixture
+- Bump composer/composer from 2.0.9 to 2.0.10 in /composer/helpers/v2
+- Bump @npmcli/arborist from 2.2.3 to 2.2.4 in /npm_and_yarn/helpers
+- Bump eslint-config-prettier from 7.2.0 to 8.0.0 in /npm_and_yarn/helpers
+- Bump phpstan/phpstan from 0.12.77 to 0.12.78 in /composer/helpers/v2
+- Bump phpstan/phpstan from 0.12.77 to 0.12.78 in /composer/helpers/v1
+- Bump cython from 0.29.21 to 0.29.22 in /python/helpers
+
 ## v0.133.6, 22 February 2021
 
 - npm: Use CLI for peer dep conflicts, and default to it without lockfile

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.133.6"
+  VERSION = "0.134.0"
 end


### PR DESCRIPTION
Release [these commits](https://github.com/dependabot/dependabot-core/compare/v0.133.6...v0.134.0-release-notes)

These PRs:
* https://github.com/dependabot/dependabot-core/pull/3180
* https://github.com/dependabot/dependabot-core/pull/3185
* https://github.com/dependabot/dependabot-core/pull/3187
* https://github.com/dependabot/dependabot-core/pull/3175
* https://github.com/dependabot/dependabot-core/pull/3176
* https://github.com/dependabot/dependabot-core/pull/3177
* https://github.com/dependabot/dependabot-core/pull/3178
* https://github.com/dependabot/dependabot-core/pull/3183
* https://github.com/dependabot/dependabot-core/commit/351cf5fd1fbd8b68b977dca637a289178fb9ec0d no review