### PR TITLE
v0.134.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.134.1, 2 March 2021
+
+- Run Bundler v1 native helpers with an explicit version setting the stage for
+  Bundler v2 support
+
 ## v0.134.0, 1 March 2021
 
 - Introduce `Dependabot::PullRequestCreator::Message` as an alternative to `Dependabot::PullRequestCreator::MessageBuilder`

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.134.0"
+  VERSION = "0.134.1"
 end


### PR DESCRIPTION
## v0.134.1, 2 March 2021

- Run Bundler v1 native helpers with an explicit version setting the stage for
  Bundler v2 support