### PR TITLE
Fix bundler helpers/v1 folder not being writeable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -194,7 +194,7 @@ ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt" \
 RUN bash /opt/terraform/helpers/build /opt/terraform && \
   bash /opt/python/helpers/build /opt/python && \
   bash /opt/dep/helpers/build /opt/dep && \
-  bash /opt/bundler/helpers/v1/build /opt/bundler/v1 && \
+  mkdir -p /opt/bundler/v1 && bash /opt/bundler/helpers/v1/build /opt/bundler/v1 && \
   bash /opt/go_modules/helpers/build /opt/go_modules && \
   bash /opt/npm_and_yarn/helpers/build /opt/npm_and_yarn && \
   bash /opt/hex/helpers/build /opt/hex && \

--- a/bundler/helpers/v1/build
+++ b/bundler/helpers/v1/build
@@ -8,10 +8,6 @@ if [ -z "$install_dir" ]; then
   exit 1
 fi
 
-if [ ! -d "$install_dir" ]; then
-  mkdir -p "$install_dir"
-fi
-
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/lib" \

--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -10,19 +10,24 @@ module Dependabot
           command: helper_path(bundler_version: bundler_version),
           function: function,
           args: args,
+          unsetenv_others: true,
           env: {
             # Bundler will pick the matching installed major version
             "BUNDLER_VERSION" => bundler_version,
-            # Force bundler to use the helper Gemfile that has been bundled with
-            # v1, otherwise it will point to core's bundler/Gemfile which will
-            # be bundled with v2 once it's installed
-            "BUNDLE_GEMFILE" => File.join(versioned_helper_path(bundler_version: bundler_version), "Gemfile"),
-            # Unset ruby env set by running dependabot-core with bundle exec,
-            # forcing bundler to reset them from helpers/v1
-            "RUBYLIB" => nil,
-            "RUBYOPT" => nil,
-            "GEM_PATH" => nil,
-            "GEM_HOME" => nil
+            # Required to find the ruby bin
+            "PATH" => ENV["PATH"],
+            # # Requried to create tmp directories in a writeable folder
+            "HOME" => ENV["HOME"],
+            # Required to git clone to a writeable folder
+            "GEM_HOME" => ENV["GEM_HOME"],
+            # Required by git fetch
+            "SSH_AUTH_SOCK" => ENV["SSH_AUTH_SOCK"],
+            # Env set by the runner
+            "SSL_CERT_FILE" => ENV["SSL_CERT_FILE"],
+            "http_proxy" => ENV["http_proxy"],
+            "HTTP_PROXY" => ENV["HTTP_PROXY"],
+            "https_proxy" => ENV["https_proxy"],
+            "HTTPS_PROXY" => ENV["HTTPS_PROXY"]
           }
         )
       end
@@ -33,7 +38,7 @@ module Dependabot
       end
 
       def self.helper_path(bundler_version:)
-        "bundle exec ruby #{File.join(versioned_helper_path(bundler_version: bundler_version), 'run.rb')}"
+        "ruby #{File.join(versioned_helper_path(bundler_version: bundler_version), 'run.rb')}"
       end
 
       def self.native_helpers_root

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -71,7 +71,8 @@ module Dependabot
     # rubocop:disable Metrics/MethodLength
     def self.run_helper_subprocess(command:, function:, args:, env: nil,
                                    stderr_to_stdout: false,
-                                   allow_unsafe_shell_command: false)
+                                   allow_unsafe_shell_command: false,
+                                   unsetenv_others: false)
       start = Time.now
       stdin_data = JSON.dump(function: function, args: args)
       cmd = allow_unsafe_shell_command ? command : escape_command(command)
@@ -86,7 +87,7 @@ module Dependabot
       end
 
       env_cmd = [env, cmd].compact
-      stdout, stderr, process = Open3.capture3(*env_cmd, stdin_data: stdin_data)
+      stdout, stderr, process = Open3.capture3(*env_cmd, stdin_data: stdin_data, unsetenv_others: unsetenv_others)
       time_taken = Time.now - start
 
       if ENV["DEBUG_HELPERS"] == "true"


### PR DESCRIPTION
When creating the folder inside the bash script it gets created with as
read-only so bundler can't install anything into the `v1/.bundle`
folder when running `bundle install`.

Spotted this when running the updaters tests.