### PR TITLE
Bump npm from 7.5.4 to 7.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN npm install elm@0.18.0 \
 
 # NOTE: This is a hack to get around the fact that elm 18 fails to install with
 # npm 7, we should look into deprecating elm 18
-RUN npm install -g npm@v7.5.4
+RUN npm install -g npm@v7.6.0
 
 
 ### PHP


### PR DESCRIPTION
v7.6.0 (2021-02-25): https://github.com/npm/cli/releases/tag/v7.6.0

FEATURES
983d218f7 #2750 feat(explain): mark when dependency is bundled (@kumavis)

DEPENDENCIES
b9fa7e32a chore(package-lock): resetdeps and eslint@7.20.0 (@wraithgar)
28d036ae9 arborist@2.2.5
fix: hidden lockfiles were not respected on Node v10.0-10.12

DOCUMENTATION
ba1adef42 #2760 chore(docs): capitalize all Instaces of "package" (@MrBrain295)
8bfa05fa1 #2775 chore(docs): add navigation configuration (@ethomson)
238e474a4 #2778 chore(docs):update unpublish cooldown (@christoflemke)