### PR TITLE
v0.135.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.135.0, 4 March 2021
+
+- Gracefully handle cargo version conflicts #3213
+- Pull request updater for azure client #3153 (@milind009)
+
 ## v0.134.2, 3 March 2021
 
 - Revert: Run Bundler v1 native helpers with an explicit version

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.134.2"
+  VERSION = "0.135.0"
 end


### PR DESCRIPTION
## v0.135.0, 4 March 2021

- Gracefully handle cargo version conflicts #3213
- Pull request updater for azure client #3153 (@milind009)

https://github.com/dependabot/dependabot-core/compare/v0.134.2...v0.135.0-release-notes