### PR TITLE
chore: mount bundler/helpers in docker dev container

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -160,6 +160,7 @@ docker run --rm -ti \
   -v "$(pwd)/bundler/Gemfile:$CODE_DIR/bundler/Gemfile" \
   -v "$(pwd)/bundler/dependabot-bundler.gemspec:$CODE_DIR/bundler/dependabot-bundler.gemspec" \
   -v "$(pwd)/bundler/lib:$CODE_DIR/bundler/lib" \
+  -v "$(pwd)/bundler/helpers:$CODE_DIR/bundler/helpers" \
   -v "$(pwd)/bundler/spec:$CODE_DIR/bundler/spec" \
   -v "$(pwd)/bundler/helpers:/opt/bundler" \
   -v "$(pwd)/bundler/helpers:/opt/bundler/helpers" \


### PR DESCRIPTION
# Why is this needed?

When mounting the development environment via `./bin/docker-dev-shell`
the `bundler/helpers` folder is not mounted to the `$CODE_DIR` so
the line `native_spec_helper` that attempts to load one of the files
in that directory will fail.

# How was this fixed?

I add a volume mount point to include the `bundler/helpers` directory
in the `$CODE_DIR`.

Before:

```bash
[dependabot-core-dev] ~/dependabot-core $ cd bundler && bundle exec rspec

An error occurred while loading ./spec/native_helpers/functions/conflicting_dependency_resolver_spec.rb.
Hint: Install the `did_you_mean` gem in order to provide suggestions for similarly named files.
Failure/Error: require "definition_ruby_version_patch"

LoadError:
  cannot load such file -- definition_ruby_version_patch
# ./spec/native_spec_helper.rb:9:in `require'
# ./spec/native_spec_helper.rb:9:in `<top (required)>'
# ./spec/native_helpers/functions/conflicting_dependency_resolver_spec.rb:3:in `require'
# ./spec/native_helpers/functions/conflicting_dependency_resolver_spec.rb:3:in `<top (required)>'

An error occurred while loading ./spec/native_helpers/functions/dependency_source_spec.rb.
Hint: Install the `did_you_mean` gem in order to provide suggestions for similarly named files.
Failure/Error: require "definition_ruby_version_patch"

LoadError:
  cannot load such file -- definition_ruby_version_patch
# ./spec/native_spec_helper.rb:9:in `require'
# ./spec/native_spec_helper.rb:9:in `<top (required)>'
# ./spec/native_helpers/functions/dependency_source_spec.rb:3:in `require'
# ./spec/native_helpers/functions/dependency_source_spec.rb:3:in `<top (required)>'

An error occurred while loading ./spec/native_helpers/functions/file_parser_spec.rb.
Hint: Install the `did_you_mean` gem in order to provide suggestions for similarly named files.
Failure/Error: require "definition_ruby_version_patch"

LoadError:
  cannot load such file -- definition_ruby_version_patch
# ./spec/native_spec_helper.rb:9:in `require'
# ./spec/native_spec_helper.rb:9:in `<top (required)>'
# ./spec/native_helpers/functions/file_parser_spec.rb:3:in `require'
# ./spec/native_helpers/functions/file_parser_spec.rb:3:in `<top (required)>'

An error occurred while loading ./spec/native_helpers/functions/version_resolver_spec.rb.
Hint: Install the `did_you_mean` gem in order to provide suggestions for similarly named files.
Failure/Error: require "definition_ruby_version_patch"

LoadError:
  cannot load such file -- definition_ruby_version_patch
# ./spec/native_spec_helper.rb:9:in `require'
# ./spec/native_spec_helper.rb:9:in `<top (required)>'
# ./spec/native_helpers/functions/version_resolver_spec.rb:3:in `require'
# ./spec/native_helpers/functions/version_resolver_spec.rb:3:in `<top (required)>'


Finished in 0.00005 seconds (files took 1.16 seconds to load)
0 examples, 0 failures, 4 errors occurred outside of examples

Coverage report generated for RSpec to /home/dependabot/dependabot-core/bundler/coverage. 735 / 2216 LOC (33.17%) covered.
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
```

After:

```bash
[dependabot-core-dev] ~/dependabot-core/bundler $ bundle exec rspec

Randomized with seed 23468
......................................................................
```
