### PR TITLE
Fix flaky bundler spec by pinning business gem

### DIFF
--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -323,6 +323,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
     context "with a gemspec and a Gemfile" do
       let(:dependency_files) { project_dependency_files("bundler1/imports_gemspec_small_example_no_lockfile") }
       let(:unlock_requirement) { true }
+      let(:latest_allowable_version) { "2.1.0" }
       let(:current_version) { nil }
       let(:requirements) do
         [{

--- a/bundler/spec/fixtures/projects/bundler1/git_source_circular/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/git_source_circular/Gemfile
@@ -2,4 +2,4 @@
 source "https://rubygems.org"
 
 gem "rubygems-circular-dependency", git: "https://github.com/dependabot-fixtures/rubygems-circular-dependency"
-gem "business"
+gem "business", "< 2.2.0"


### PR DESCRIPTION
Pin the `business` gem version to 2.1.0 to keep specs from flaking when
new versions are released.

Fixes these test failures:
https://github.com/dependabot/dependabot-core/runs/2034039927