### PR TITLE
Fixes #3236 - Adding Maven Central fallback for gradle

### DIFF
--- a/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
@@ -36,9 +36,7 @@ module Dependabot
           repository_urls += own_buildfile_repository_urls
           repository_urls = repository_urls.uniq
 
-          return repository_urls unless repository_urls.empty?
-
-          [CENTRAL_REPO_URL]
+          return (repository_urls + [CENTRAL_REPO_URL]).uniq
         end
 
         private

--- a/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
@@ -36,7 +36,7 @@ module Dependabot
           repository_urls += own_buildfile_repository_urls
           repository_urls = repository_urls.uniq
 
-          return (repository_urls + [CENTRAL_REPO_URL]).uniq
+          (repository_urls + [CENTRAL_REPO_URL]).uniq
         end
 
         private

--- a/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
@@ -39,16 +39,47 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
             https://jcenter.bintray.com
             https://dl.bintray.com/magnusja/maven
             https://maven.google.com
+            https://repo.maven.apache.org/maven2
           )
         )
       end
+
+    context "when there is only maven central defined" do
+      let(:buildfile_fixture_name) { "maven_central_only.gradle" }
+
+      it "it is not duplicated" do
+        expect(repository_urls).to match_array(
+          %w(
+            https://repo.maven.apache.org/maven2
+          )
+        )
+      end
+    end
+
+    context "when there are private only repository declarations" do
+      let(:buildfile_fixture_name) { "private_only_repos_build.gradle" }
+
+      it "includes private repo as well as maven central as a fallback" do
+        expect(repository_urls).to match_array(
+          %w(
+            https://nexus.noyoucanthaveaccess.net/repository/maven
+            https://repo.maven.apache.org/maven2
+          )
+        )
+      end
+    end
 
       context "some of which are for subprojects" do
         let(:buildfile_fixture_name) { "subproject_repos.gradle" }
 
         it "doesn't include the subproject declarations" do
           expect(repository_urls).
-            to match_array(%w(https://jcenter.bintray.com))
+            to match_array(
+              %w(
+                https://jcenter.bintray.com
+                https://repo.maven.apache.org/maven2
+              )
+            )
         end
 
         context "and this is a subproject" do
@@ -67,6 +98,7 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
                 https://jcenter.bintray.com
                 https://dl.bintray.com/magnusja/maven
                 https://maven.google.com
+                https://repo.maven.apache.org/maven2
               )
             )
           end
@@ -81,6 +113,7 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
             %w(
               https://jcenter.bintray.com
               https://maven.google.com
+              https://repo.maven.apache.org/maven2
             )
           )
         end
@@ -98,6 +131,7 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
               https://kotlin.bintray.com/kotlinx
               https://kotlin.bintray.com/ktor
               https://kotlin.bintray.com/kotlin-dev/
+              https://repo.maven.apache.org/maven2
             )
           )
         end
@@ -111,6 +145,7 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
             %w(
               https://jcenter.bintray.com
               https://hub.spigotmc.org/nexus/content/repositories/snapshots
+              https://repo.maven.apache.org/maven2
             )
           )
         end
@@ -126,6 +161,7 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
               https://dl.bintray.com/magnusja/maven
               https://kotlin.bintray.com/kotlinx
               https://maven.google.com
+              https://repo.maven.apache.org/maven2
             )
           )
         end

--- a/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
@@ -44,30 +44,30 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
         )
       end
 
-    context "when there is only maven central defined" do
-      let(:buildfile_fixture_name) { "maven_central_only.gradle" }
+      context "when there is only maven central defined" do
+        let(:buildfile_fixture_name) { "maven_central_only.gradle" }
 
-      it "it is not duplicated" do
-        expect(repository_urls).to match_array(
-          %w(
-            https://repo.maven.apache.org/maven2
+        it "it is not duplicated" do
+          expect(repository_urls).to match_array(
+            %w(
+              https://repo.maven.apache.org/maven2
+            )
           )
-        )
+        end
       end
-    end
 
-    context "when there are private only repository declarations" do
-      let(:buildfile_fixture_name) { "private_only_repos_build.gradle" }
+      context "when there are private only repository declarations" do
+        let(:buildfile_fixture_name) { "private_only_repos_build.gradle" }
 
-      it "includes private repo as well as maven central as a fallback" do
-        expect(repository_urls).to match_array(
-          %w(
-            https://nexus.noyoucanthaveaccess.net/repository/maven
-            https://repo.maven.apache.org/maven2
+        it "includes private repo as well as maven central as a fallback" do
+          expect(repository_urls).to match_array(
+            %w(
+              https://nexus.noyoucanthaveaccess.net/repository/maven
+              https://repo.maven.apache.org/maven2
+            )
           )
-        )
+        end
       end
-    end
 
       context "some of which are for subprojects" do
         let(:buildfile_fixture_name) { "subproject_repos.gradle" }

--- a/gradle/spec/fixtures/buildfiles/maven_central_only.gradle
+++ b/gradle/spec/fixtures/buildfiles/maven_central_only.gradle
@@ -1,0 +1,19 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.1.2'
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        maven { url 'https://repo.maven.apache.org/maven2' }
+    }
+}

--- a/gradle/spec/fixtures/buildfiles/private_only_repos_build.gradle
+++ b/gradle/spec/fixtures/buildfiles/private_only_repos_build.gradle
@@ -1,0 +1,19 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    repositories {
+        maven { url 'https://nexus.noyoucanthaveaccess.net/repository/maven/' }
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.1.2'
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        maven { url 'https://nexus.noyoucanthaveaccess.net/repository/maven/' }
+    }
+}


### PR DESCRIPTION
Fixes #3236

By following what Maven ecosystem is doing by always adding Maven Central repo to the list.