### PR TITLE
Use --http1.1 when fetching go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ RUN add-apt-repository ppa:ondrej/php \
 # Install Go and dep
 ARG GOLANG_VERSION=1.15.7
 ARG GOLANG_CHECKSUM=0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3
-RUN curl -o go.tar.gz https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz \
+RUN curl --http1.1 -o go.tar.gz https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz \
   && echo "$GOLANG_CHECKSUM go.tar.gz" | sha256sum -c - \
   && tar -xzf go.tar.gz -C /opt \
   && mkdir /opt/go/gopath \


### PR DESCRIPTION
Attempting to docker build failure seen on CI by forcing http1.1:
https://github.com/dependabot/dependabot-core/pull/3219/checks?check_run_id=2057169372

Specifically this error: `curl: (16) Error in the HTTP2 framing layer`

Ref: https://github.com/CircleCI-Public/circleci-cli/issues/382#issuecomment-688989139