### PR TITLE
bundler: Fix flaky specs by checking major version unlock only

### DIFF
--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -252,7 +252,10 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
         let(:current_version) { "1.4.0" }
 
         let(:dependency_files) { project_dependency_files("bundler1/git_source_circular") }
-        its([:version]) { is_expected.to eq(Gem::Version.new("2.2.0")) }
+
+        it "unlocks the version" do
+          expect(resolver.latest_resolvable_version_details[:version].canonical_segments.first).to eq(2)
+        end
       end
 
       context "with a ruby exec command that fails" do
@@ -339,8 +342,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
       end
 
       it "unlocks the latest version" do
-        expect(resolver.latest_resolvable_version_details[:version]).
-          to eq(Gem::Version.new("2.2.0"))
+        expect(resolver.latest_resolvable_version_details[:version].canonical_segments.first).to eq(2)
       end
 
       context "with an upper bound that is lower than the current req" do


### PR DESCRIPTION
These tests run bundler to check the latest version, but any time this
is updated the test would start to fail
(https://github.com/dependabot/dependabot-core/pull/3235). This change
makes sure that we only check that the version was unlocked by checking
the major version only. If a v3 is ever released this will fail again,
but at least it buys us a bit more time.