### PR TITLE
Install bundler 2.2.11 and update gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,12 +54,13 @@ RUN apt-get update \
 
 # Install Ruby 2.6.6, update RubyGems, and install Bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
-RUN apt-get install -y software-properties-common \
+RUN apt-get update && apt-get install -y software-properties-common \
   && apt-add-repository ppa:brightbox/ruby-ng \
   && apt-get update \
   && apt-get install -y ruby2.6 ruby2.6-dev \
-  && gem update --system 3.0.3 \
-  && gem install bundler -v 1.17.3 --no-document
+  && gem update --system 3.2.14 \
+  && gem install bundler -v 1.17.3 --no-document \
+  && gem install bundler -v 2.2.11 --no-document
 
 
 ### PYTHON


### PR DESCRIPTION
Install bundler 2 and update gem from 3.0.3 to 3.2.14

Bundler 2 is only used to install core's gems when building the image, bundler 1 is still used for all updates.

Once we ship this we can enable bundler v2 support here https://github.com/dependabot/dependabot-core/blob/main/bundler/lib/dependabot/bundler/helpers.rb#L10