### PR TITLE
v0.137.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.137.0, 15 March 2021
+
+- Bump npm from 7.5.4 to 7.6.1
+- Python: Add python versions 3.9.2, 3.8.8, 3.7.10 and 3.6.13
+- Bundler: Run v1 native helpers with bundler v1
+- Bump composer/composer from 2.0.10 to 2.0.11 in /composer/helpers/v2
+- Bump eslint-config-prettier from 8.0.0 to 8.1.0 in /npm_and_yarn/helpers
+- Bump phpstan/phpstan from 0.12.78 to 0.12.81 in /composer/helpers/v2
+- Bump phpstan/phpstan from 0.12.78 to 0.12.81 in /composer/helpers/v1
+
 ## v0.136.0, 8 March 2021
 
 - Bundler: Run Bundler v1 native helpers with an explicit version setting the

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.136.0"
+  VERSION = "0.137.0"
 end


### PR DESCRIPTION
## v0.137.0, 15 March 2021

- Bump npm from 7.5.4 to 7.6.1
- Python: Add python versions 3.9.2, 3.8.8, 3.7.10 and 3.6.13
- Bundler: Run v1 native helpers with bundler v1
- Bump composer/composer from 2.0.10 to 2.0.11 in /composer/helpers/v2
- Bump eslint-config-prettier from 8.0.0 to 8.1.0 in /npm_and_yarn/helpers
- Bump phpstan/phpstan from 0.12.78 to 0.12.81 in /composer/helpers/v2
- Bump phpstan/phpstan from 0.12.78 to 0.12.81 in /composer/helpers/v1
