### PR TITLE
v0.137.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.137.1, 15 March 2021
+
+- Bundler: Install dependabot-core's gems using Bundler v2 (unused for updates)
+
 ## v0.137.0, 15 March 2021
 
 - Bump npm from 7.5.4 to 7.6.1

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.137.0"
+  VERSION = "0.137.1"
 end


### PR DESCRIPTION
## v0.137.1, 15 March 2021

- Bundler: Install dependabot-core's gems using Bundler v2 (unused for updates)
