### PR TITLE
Maven: fix error when comparing string and integer versions

### DIFF
--- a/maven/lib/dependabot/maven/version.rb
+++ b/maven/lib/dependabot/maven/version.rb
@@ -175,8 +175,11 @@ module Dependabot
 
         return 1 if NAMED_QUALIFIERS_HIERARCHY[other_token]
 
-        token = token.to_i if token.match?(/^\d+$/)
-        other_token = other_token.to_i if other_token.match?(/^\d+$/)
+        if token.match?(/\A\d+\z/) && other_token.match?(/\A\d+\z/)
+          token = token.to_i
+          other_token = other_token.to_i
+        end
+
         token <=> other_token
       end
     end

--- a/maven/spec/dependabot/maven/version_spec.rb
+++ b/maven/spec/dependabot/maven/version_spec.rb
@@ -307,6 +307,12 @@ RSpec.describe Dependabot::Maven::Version do
           let(:other_version) { described_class.new("1-alpha-1") }
           it { is_expected.to eq(0) }
         end
+
+        context "comparing string versions with integer ones" do
+          let(:version) { described_class.new("181") }
+          let(:other_version) { described_class.new("dev") }
+          it { is_expected.to eq(1) }
+        end
       end
     end
   end


### PR DESCRIPTION
When comparing a string version with one that can be coerced to an
integer, we would call `<=>` on two different types, resulting in `nil`
values that would raise errors further up the call stack.

This introduces a change to only coerce these values to ints if we can
do this on both, and perform a string comparison otherwise.

Fixes: https://github.com/dependabot/dependabot-core/issues/2992