### PR TITLE
docker: consider each requirement when updating dependencies

### DIFF
--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -70,6 +70,21 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to be_falsey }
     end
 
+    context "given an outdated requirement" do
+      let(:version) { "17.10" }
+
+      before do
+        dependency.requirements << {
+          requirement: nil,
+          groups: [],
+          file: "Dockerfile.other",
+          source: { tag: "17.04" }
+        }
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
     context "given a purely numeric version" do
       let(:version) { "1234567890" }
       it { is_expected.to be_truthy }

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -686,5 +686,37 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
           )
       end
     end
+
+    context "when specified with tags with different prefixes in separate files" do
+      let(:version) { "trusty-20170728" }
+      let(:source) { { tag: "trusty-20170728" } }
+
+      before do
+        dependency.requirements << {
+          requirement: nil,
+          groups: [],
+          file: "Dockerfile.other",
+          source: { tag: "xenial-20170802" }
+        }
+      end
+
+      it "updates the tags" do
+        expect(checker.updated_requirements).
+          to eq(
+            [{
+              requirement: nil,
+              groups: [],
+              file: "Dockerfile",
+              source: { tag: "trusty-20170817" }
+            },
+             {
+               requirement: nil,
+               groups: [],
+               file: "Dockerfile.other",
+               source: { tag: "xenial-20170915" }
+             }]
+          )
+      end
+    end
   end
 end


### PR DESCRIPTION
This change works toward resolving #3173 with an alternate approach to https://github.com/dependabot/dependabot-core/pull/3251. It maintains grouping of updates so that we can update `php:8.0.1-apache` and `php:8.0.1-cli` in a single PR instead of two as suggested in https://github.com/dependabot/dependabot-core/pull/3251#pullrequestreview-612037713.

Prior to this change if there were multiple tags with different prefixes/suffixes we'd only resolve the latest version for one of them and would end up updating all of the tags to a common version:
```
=== php (8.0.1-apache)
 => checking for updates 1/1
 => latest available version is 8.0.3-apache
 => latest allowed version is 8.0.3-apache
 => requirements to unlock: own
 => requirements update strategy: 
 => updating php from 8.0.1-apache to 8.0.3-apache

    ± Dockerfile
    ~~~
    1c1
    < FROM php:8.0.1-apache
    ---
    > FROM php:8.0.3-apache
    ~~~

    ± Dockerfile.cli
    ~~~
    1c1
    < FROM php:8.0.1-cli
    ---
    > FROM php:8.0.3-apache
    ~~~
```

This change resolves the latest version for each tag we can correctly preserve the prefix/suffix in the update:
```
=== php (8.0.1-apache)
 => checking for updates 1/1
 => latest available version is 8.0.3-apache
 => latest allowed version is 8.0.3-apache
 => requirements to unlock: own
 => requirements update strategy: 
 => updating php from 8.0.1-apache to 8.0.3-apache

    ± Dockerfile
    ~~~
    1c1
    < FROM php:8.0.1-apache
    ---
    > FROM php:8.0.3-apache
    ~~~

    ± Dockerfile.cli
    ~~~
    1c1
    < FROM php:8.0.1-cli
    ---
    > FROM php:8.0.3-cli
    ~~~
```

One caveat is this only works if the tags are in different files. If a Dockerfile includes two tags with different prefixes/suffixes then we still end up replacing both of them with a single tag. Fixing that requires splitting out to multiple dependencies and updating the file updater to handle multiple dependencies. I started going down that road (https://github.com/dependabot/dependabot-core/commit/b5b80df63869bd54186dfd5afd027b8f49f2889d) but that's going to be a bigger chunk of work and I think it would be better to release this initial fix first.
