### PR TITLE
Update dev and ci Dockerfile to match updater

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,12 +1,29 @@
 FROM dependabot/dependabot-core
-ARG CODE_DIR=/home/dependabot/dependabot-core
+
+USER root
+
+ARG USERNAME=dependabot
+ARG DEPENDABOT_HOME=/home/${USERNAME}
+ARG CODE_DIR=${DEPENDABOT_HOME}/dependabot-core
+
+# Install project dependencies as an unprivileged user
+RUN useradd -m ${USERNAME} && mkdir ${CODE_DIR}
+RUN chown -R ${USERNAME}:${USERNAME} \
+  ${CODE_DIR} \
+  /usr/local/.pyenv \
+  /opt/go/gopath \
+  /opt/rust/ \
+  /opt/bundler/
+
 WORKDIR ${CODE_DIR}
 
-ENV BUNDLE_PATH="/home/dependabot/.bundle" \
-  BUNDLE_BIN=".bundle/binstubs" \
-  PATH=".bundle/binstubs:$PATH:/home/dependabot/.bundle/bin"
+USER ${USERNAME}
 
-COPY .rubocop.yml /home/dependabot/dependabot-core/
+ENV BUNDLE_PATH="${CODE_DIR}/.bundle" \
+  BUNDLE_BIN=".bundle/bin"
+ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
+
+COPY .rubocop.yml ${CODE_DIR}/
 
 RUN mkdir -p \
   ${CODE_DIR}/bundler \
@@ -67,23 +84,25 @@ RUN cd python && bundle install
 RUN cd terraform && bundle install
 RUN cd omnibus && bundle install
 
-COPY common/ ${CODE_DIR}/common/
-COPY bundler/ ${CODE_DIR}/bundler/
-COPY cargo/ ${CODE_DIR}/cargo/
-COPY composer/ ${CODE_DIR}/composer/
-COPY dep/ ${CODE_DIR}/dep/
-COPY docker/ ${CODE_DIR}/docker/
-COPY elm/ ${CODE_DIR}/elm/
-COPY git_submodules/ ${CODE_DIR}/git_submodules/
-COPY github_actions/ ${CODE_DIR}/github_actions/
-COPY go_modules/ ${CODE_DIR}/go_modules/
-COPY gradle/ ${CODE_DIR}/gradle/
-COPY hex/ ${CODE_DIR}/hex/
-COPY maven/ ${CODE_DIR}/maven/
-COPY npm_and_yarn/ ${CODE_DIR}/npm_and_yarn/
-COPY nuget/ ${CODE_DIR}/nuget/
-COPY python/ ${CODE_DIR}/python/
-COPY terraform/ ${CODE_DIR}/terraform/
-COPY omnibus/ ${CODE_DIR}/omnibus/
+# Set the owner to be dependabot instead of defaulting to `root` allowing test
+# helpers to writing to the spec folder
+COPY --chown=${USERNAME}:${USERNAME} common/ ${CODE_DIR}/common/
+COPY --chown=${USERNAME}:${USERNAME} bundler/ ${CODE_DIR}/bundler/
+COPY --chown=${USERNAME}:${USERNAME} cargo/ ${CODE_DIR}/cargo/
+COPY --chown=${USERNAME}:${USERNAME} composer/ ${CODE_DIR}/composer/
+COPY --chown=${USERNAME}:${USERNAME} dep/ ${CODE_DIR}/dep/
+COPY --chown=${USERNAME}:${USERNAME} docker/ ${CODE_DIR}/docker/
+COPY --chown=${USERNAME}:${USERNAME} elm/ ${CODE_DIR}/elm/
+COPY --chown=${USERNAME}:${USERNAME} git_submodules/ ${CODE_DIR}/git_submodules/
+COPY --chown=${USERNAME}:${USERNAME} github_actions/ ${CODE_DIR}/github_actions/
+COPY --chown=${USERNAME}:${USERNAME} go_modules/ ${CODE_DIR}/go_modules/
+COPY --chown=${USERNAME}:${USERNAME} gradle/ ${CODE_DIR}/gradle/
+COPY --chown=${USERNAME}:${USERNAME} hex/ ${CODE_DIR}/hex/
+COPY --chown=${USERNAME}:${USERNAME} maven/ ${CODE_DIR}/maven/
+COPY --chown=${USERNAME}:${USERNAME} npm_and_yarn/ ${CODE_DIR}/npm_and_yarn/
+COPY --chown=${USERNAME}:${USERNAME} nuget/ ${CODE_DIR}/nuget/
+COPY --chown=${USERNAME}:${USERNAME} python/ ${CODE_DIR}/python/
+COPY --chown=${USERNAME}:${USERNAME} terraform/ ${CODE_DIR}/terraform/
+COPY --chown=${USERNAME}:${USERNAME} omnibus/ ${CODE_DIR}/omnibus/
 
 RUN git config --global user.name dependabot-ci && git config --global user.email no-reply@github.com

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -15,17 +15,19 @@ RUN apt-get update && apt-get install -y vim strace ltrace gdb
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 ARG USERNAME=dependabot
+ARG DEPENDABOT_HOME=/home/${USERNAME}
 
 RUN groupadd -o --gid "${USER_GID}" "${USERNAME}" && \
   useradd --uid "${USER_UID}" --gid "${USER_GID}" -m "${USERNAME}"
 RUN chown -R "${USERNAME}":"${USERNAME}" \
   /usr/local/.pyenv \
   /opt/go/gopath \
-  /opt/rust/
+  /opt/rust/ \
+  /opt/bundler/
 USER $USERNAME
 RUN git config --global user.name dependabot-ci && git config --global user.email no-reply@github.com
 
-ARG CODE_DIR=/home/$USERNAME/dependabot-core
+ARG CODE_DIR=${DEPENDABOT_HOME}/dependabot-core
 
 RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/main/vimrc-vanilla.vim && \
   echo 'export PS1="[dependabot-core-dev] \w \[$(tput setaf 4)\]$ \[$(tput sgr 0)\]"' >> ~/.bashrc
@@ -33,8 +35,8 @@ RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/main/vimrc-vanilla
 RUN mkdir -p ${CODE_DIR}/common/lib/dependabot
 WORKDIR ${CODE_DIR}
 
-ENV BUNDLE_PATH="/home/$USERNAME/.bundle" \
-  BUNDLE_BIN=".bundle/binstubs"
+ENV BUNDLE_PATH="${CODE_DIR}/.bundle" \
+  BUNDLE_BIN=".bundle/bin"
 ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
 
 COPY common/Gemfile common/dependabot-common.gemspec ${CODE_DIR}/common/


### PR DESCRIPTION
Updating the dev and ci Dockerfile to match the user permissions set by the updater image.

This reproduces the error seen production when updating a vendored bundler project.

The [failing bundler specs](https://github.com/dependabot/dependabot-core/runs/2122196759) are expected and fixed here https://github.com/dependabot/dependabot-core/pull/3280