### PR TITLE
Bundler: Fix permission error when vendoring gems

### DIFF
--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -17,7 +17,9 @@ module Dependabot
               # Bundler will pick the matching installed major version
               "BUNDLER_VERSION" => bundler_version,
               "BUNDLE_GEMFILE" => File.join(versioned_helper_path(bundler_version: bundler_version), "Gemfile"),
-              "BUNDLE_PATH" => File.join(versioned_helper_path(bundler_version: bundler_version), ".bundle")
+              "BUNDLE_PATH" => File.join(versioned_helper_path(bundler_version: bundler_version), ".bundle"),
+              # Prevent the GEM_HOME from being set to a folder owned by root
+              "GEM_HOME" => File.join(versioned_helper_path(bundler_version: bundler_version), ".bundle")
             }
           )
         end


### PR DESCRIPTION
This fixes a permissions error when vendoring gems, when `GEM_HOME` was
unset it defaulted to `/var/lib` which isn't writeable.

Attempting to fix the discrepancy between ci and updater here:
https://github.com/dependabot/dependabot-core/pull/3279