### PR TITLE
Instrument bundler version

### DIFF
--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -23,6 +23,7 @@ module Dependabot
         dependency_set += gemspec_dependencies
         dependency_set += lockfile_dependencies
         check_external_code(dependency_set.dependencies)
+        instrument_package_manager_version
         dependency_set.dependencies
       end
 
@@ -40,6 +41,17 @@ module Dependabot
         dependencies.any? do |dep|
           dep.requirements.any? { |req| req.fetch(:source)&.fetch(:type) == "git" }
         end
+      end
+
+      def instrument_package_manager_version
+        version = Helpers.detected_bundler_version(lockfile)
+        Dependabot.instrument(
+          Notifications::FILE_PARSER_PACKAGE_MANAGER_VERSION_PARSED,
+          ecosystem: "bundler",
+          package_managers: {
+            "bundler" => version
+          }
+        )
       end
 
       def gemfile_dependencies

--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -11,6 +11,13 @@ module Dependabot
       def self.bundler_version(_lockfile)
         V1
       end
+
+      def self.detected_bundler_version(lockfile)
+        return "unknown" unless lockfile
+        return V2 if lockfile.content.match?(/BUNDLED WITH\s+2/m)
+
+        V1
+      end
     end
   end
 end

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -724,5 +724,18 @@ RSpec.describe Dependabot::Bundler::FileParser do
         end
       end
     end
+
+    it "instruments the package manager version" do
+      events = []
+      Dependabot.subscribe(Dependabot::Notifications::FILE_PARSER_PACKAGE_MANAGER_VERSION_PARSED) do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      parser.parse
+
+      expect(events.last.payload).to eq(
+        { ecosystem: "bundler", package_managers: { "bundler" => "1" } }
+      )
+    end
   end
 end

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
   spec.required_rubygems_version = ">= 2.7.3"
 
+  spec.add_dependency "activesupport", ">= 6.0.0"
   spec.add_dependency "aws-sdk-codecommit", "~> 1.28"
   spec.add_dependency "aws-sdk-ecr", "~> 1.5"
   spec.add_dependency "bundler", ">= 1.16", "< 3.0.0"

--- a/common/lib/dependabot/file_parsers/base.rb
+++ b/common/lib/dependabot/file_parsers/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "dependabot/notifications"
+
 module Dependabot
   module FileParsers
     class Base

--- a/common/lib/dependabot/notifications.rb
+++ b/common/lib/dependabot/notifications.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "active_support/notifications"
+
+module Dependabot
+  module Notifications
+    FILE_PARSER_PACKAGE_MANAGER_VERSION_PARSED = "dependabot.file_parser.package_manager_version_parsed"
+  end
+
+  def self.instrument(name, payload = {})
+    ActiveSupport::Notifications.instrument(name, payload)
+  end
+
+  def self.subscribe(pattern = nil, callback = nil, &block)
+    ActiveSupport::Notifications.subscribe(pattern, callback, &block)
+  end
+end


### PR DESCRIPTION
Instrument the version of bundler that a package has specified.

This way we can collect metrics about usage of these gems.

This PR implements just a single ecosystem, but we've tried to take into account changes that might be required for other ecosystems. For python, for example, it is possible to have multiple package managers configured, so we instrument a hash of package manager => version.

Planning to have the consumer side of this set up and reporting actual data before adding more ecosystems to the mix.