### PR TITLE
v0.137.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.137.2, 16 March 2021
+
+- Bundler: Fix permission error when vendoring gems
+- Bump friendsofphp/php-cs-fixer in /composer/helpers/v1
+- Bump friendsofphp/php-cs-fixer in /composer/helpers/v2
+
 ## v0.137.1, 15 March 2021
 
 - Bundler: Install dependabot-core's gems using Bundler v2 (unused for updates)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.137.1"
+  VERSION = "0.137.2"
 end


### PR DESCRIPTION
## v0.137.2, 16 March 2021

- Bundler: Fix permission error when vendoring gems
- Bump friendsofphp/php-cs-fixer in /composer/helpers/v1
- Bump friendsofphp/php-cs-fixer in /composer/helpers/v2