### PR TITLE
v0.138.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.138.0, 16 March 2021
+
+- Go: Bump golang to v1.16.2
+
 ## v0.137.2, 16 March 2021
 
 - Bundler: Fix permission error when vendoring gems

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.137.2"
+  VERSION = "0.138.0"
 end


### PR DESCRIPTION
## v0.138.0, 16 March 2021

- Go: Bump golang to v1.16.2