### PR TITLE
Add support for disablePackageSources in NuGet.Config

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -166,6 +166,20 @@ module Dependabot
               }
             end
 
+          disabled_sources =
+            doc.css("configuration > disabledPackageSources > add").map do |node|
+              value = node.attribute("value")&.value&.strip&.downcase ||
+                node.at_xpath("./value")&.content&.strip&.downcase
+              if value == "true"
+                node.attribute("key")&.value&.strip ||
+                  node.at_xpath("./key")&.content&.strip
+              end
+          end
+
+          sources.reject! do |s|
+            disabled_sources.include?(s[:key])
+          end
+
           unless doc.css("configuration > packageSources > clear").any?
             sources << { url: DEFAULT_REPOSITORY_URL, key: nil }
           end

--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -151,6 +151,7 @@ module Dependabot
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/PerceivedComplexity
         # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/MethodLength
         def repos_from_config_file(config_file)
           doc = Nokogiri::XML(config_file.content)
           doc.remove_namespaces!
@@ -169,12 +170,12 @@ module Dependabot
           disabled_sources =
             doc.css("configuration > disabledPackageSources > add").map do |node|
               value = node.attribute("value")&.value&.strip&.downcase ||
-                node.at_xpath("./value")&.content&.strip&.downcase
+                      node.at_xpath("./value")&.content&.strip&.downcase
               if value == "true"
                 node.attribute("key")&.value&.strip ||
                   node.at_xpath("./key")&.content&.strip
               end
-          end
+            end
 
           sources.reject! do |s|
             disabled_sources.include?(s[:key])
@@ -196,6 +197,7 @@ module Dependabot
 
           sources
         end
+        # rubocop:enable Metrics/MethodLength
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/PerceivedComplexity
         # rubocop:enable Metrics/CyclomaticComplexity

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -253,6 +253,27 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RepositoryFinder do
             )
           end
         end
+
+        context "that has disabled package sources" do
+          let(:config_file_fixture_name) { "disabled_sources.config" }
+
+          it "only includes the enabled package sources" do
+            expect(dependency_urls).to match_array(
+              [{
+                repository_url: "https://www.myget.org/F/exceptionless/api/v3/"\
+                                "index.json",
+                versions_url: "https://www.myget.org/F/exceptionless/api/v3/"\
+                                "flatcontainer/microsoft.extensions."\
+                                "dependencymodel/index.json",
+                search_url: "https://www.myget.org/F/exceptionless/api/v3/"\
+                                "query?q=microsoft.extensions.dependencymodel"\
+                                "&prerelease=true",
+                auth_header: { "Authorization" => "Basic bXk6cGFzc3cwcmQ=" },
+                repository_type: "v3"
+              }]
+            )
+          end
+        end
       end
 
       context "that has a numeric key" do

--- a/nuget/spec/fixtures/configs/disabled_sources.config
+++ b/nuget/spec/fixtures/configs/disabled_sources.config
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <config>
+        <!--
+            Used to specify the default location to expand packages.
+            See: nuget.exe help install
+            See: nuget.exe help update
+
+            In this example, %PACKAGEHOME% is an environment variable. On Mac/Linux,
+            use $PACKAGE_HOME/External as the value.
+        -->
+        <add key="repositoryPath" value="%PACKAGEHOME%\External" />
+
+        <!--
+            Used to specify default source for the push command.
+            See: nuget.exe help push
+        -->
+
+        <add key="defaultPushSource" value="https://MyRepo/ES/api/v2/package" />
+
+        <!-- Proxy settings -->
+        <add key="http_proxy" value="host" />
+        <add key="http_proxy.user" value="username" />
+        <add key="http_proxy.password" value="encrypted_password" />
+    </config>
+
+    <packageRestore>
+        <!-- Allow NuGet to download missing packages -->
+        <add key="enabled" value="True" />
+
+        <!-- Automatically check for missing packages during build in Visual Studio -->
+        <add key="automatic" value="True" />
+    </packageRestore>
+
+    <!--
+        Used to specify the default Sources for list, install and update.
+        See: nuget.exe help list
+        See: nuget.exe help install
+        See: nuget.exe help update
+    -->
+    <packageSources>
+        <clear />
+        <add key="MyRepo - ES" value="https://www.myget.org/F/exceptionless/api/v3/index.json" />
+        <add key="Local repo" value="lib" />
+        <add key="Some disabled source" value="https://disabled.example/api/v3/index.json" />
+    </packageSources>
+
+    <!-- Used to store credentials -->
+    <packageSourceCredentials>
+        <MyRepo_x0020_-_x0020_ES>
+            <add key="Username" value="my" />
+            <add key="ClearTextPassword" value="passw0rd" />
+        </Test_x0020_Source>
+    </packageSourceCredentials>
+
+    <!-- Used to disable package sources  -->
+    <disabledPackageSources>
+        <add key="Some disabled source" value="true" />
+        <add key="missing source" value="true" />
+        <add key="MyRepo - ES" value="false" />
+    </disabledPackageSources>
+
+    <!--
+        Used to specify default API key associated with sources.
+        See: nuget.exe help setApiKey
+        See: nuget.exe help push
+        See: nuget.exe help mirror
+    -->
+    <apikeys>
+        <add key="https://MyRepo/ES/api/v2/package" value="encrypted_api_key" />
+    </apikeys>
+</configuration>


### PR DESCRIPTION
This prevents disabled package sources, such as those used for doing deploys to private package registries, from being used.

Will read, and disable, any repositories specified in `disabledPackageSources` in `NuGet.Config`, for example, the following `github` package source will not be used:

```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <packageSources>
    <add key="github" value="https://nuget.pkg.github.com/AshleighAdams/index.json" />
  </packageSources>
  <disabledPackageSources>
    <add key="github" value="true" />
  </disabledPackageSources>
</configuration>
```

https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file#disabledpackagesources

~~Though I haven't tested, I strongly suspect that without this change, if a disabled source has a newer dependency version, that the PR dependabot creates would fail to build.~~

Edit: Confirmed, does trigger the bug, see https://github.com/AshleighAdams/dependabot-bug-poc/pull/1

Fix #3295