### PR TITLE
Adding missing azure PR updater reference in Dependabot::PullRequestUpdater

### DIFF
--- a/common/lib/dependabot/pull_request_updater.rb
+++ b/common/lib/dependabot/pull_request_updater.rb
@@ -2,6 +2,7 @@
 
 require "dependabot/pull_request_updater/github"
 require "dependabot/pull_request_updater/gitlab"
+require "dependabot/pull_request_updater/azure"
 
 module Dependabot
   class PullRequestUpdater


### PR DESCRIPTION
`Dependabot::PullRequestUpdater` class was missing the require statement for the azure client implementation for the PR updater which in turn raises a `missing module` error when trying to run pull request updater for azure client
@feelepxyz @jurre FYI