### PR TITLE
Improve maintainability of labeler class using polymorphism

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -12,6 +12,7 @@ module Dependabot
     require "dependabot/pull_request_creator/message_builder"
     require "dependabot/pull_request_creator/branch_namer"
     require "dependabot/pull_request_creator/labeler"
+    require "dependabot/pull_request_creator/labelers/factory"
 
     class RepoNotFound < StandardError; end
 
@@ -225,7 +226,7 @@ module Dependabot
 
     def labeler
       @labeler ||=
-        Labeler.new(
+        Dependabot::PullRequestCreator::Labelers::Factory.for_source(
           source: source,
           custom_labels: custom_labels,
           credentials: credentials,

--- a/common/lib/dependabot/pull_request_creator/labelers/azure.rb
+++ b/common/lib/dependabot/pull_request_creator/labelers/azure.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "dependabot/pull_request_creator/labeler"
+
+module Dependabot
+  class PullRequestCreator
+    module Labelers
+      class Azure < Labeler
+        @package_manager_labels = {}
+
+        # Azure does not have centralised labels
+        def labels
+          @labels ||= [
+            DEFAULT_DEPENDENCIES_LABEL,
+            DEFAULT_SECURITY_LABEL,
+            language_name
+          ]
+        end
+
+        def create_dependencies_label
+          labels
+        end
+
+        def create_security_label
+          labels
+        end
+
+        def create_language_label
+          labels
+        end
+      end
+    end
+  end
+end

--- a/common/lib/dependabot/pull_request_creator/labelers/factory.rb
+++ b/common/lib/dependabot/pull_request_creator/labelers/factory.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Dependabot
+  class PullRequestCreator
+    module Labelers
+      class Factory
+        class << self
+          def for_source(source:, custom_labels:, credentials:, includes_security_fixes:, dependencies:,
+                         label_language:, automerge_candidate:)
+            labeler_params = {
+              custom_labels: custom_labels,
+              includes_security_fixes: includes_security_fixes,
+              dependencies: dependencies,
+              label_language: label_language,
+              automerge_candidate: automerge_candidate
+            }
+
+            case source.provider
+            when "github" then github_labeler(source, credentials, labeler_params)
+            when "gitlab" then gitlab_labeler(source, credentials, labeler_params)
+            when "azure" then azure_labeler(source, labeler_params)
+            when "bitbucket" then base_labeler(source, labeler_params)
+            when "codecommit" then base_labeler(source, labeler_params)
+            else raise "Unsupported provider '#{source.provider}'."
+            end
+          end
+
+          private
+
+          def github_labeler(source, credentials, labeler_params)
+            require "dependabot/pull_request_creator/labelers/github"
+            require "dependabot/clients/github_with_retries"
+            client = Dependabot::Clients::GithubWithRetries.for_source(
+              source: source,
+              credentials: credentials
+            )
+            Dependabot::PullRequestCreator::Labelers::Github.new(
+              source: source,
+              client: client,
+              **labeler_params
+            )
+          end
+
+          def gitlab_labeler(source, credentials, labeler_params)
+            require "dependabot/pull_request_creator/labelers/gitlab"
+            require "dependabot/clients/gitlab_with_retries"
+            client = Dependabot::Clients::GitlabWithRetries.for_source(
+              source: source,
+              credentials: credentials
+            )
+            Dependabot::PullRequestCreator::Labelers::Gitlab.new(
+              source: source,
+              client: client,
+              **labeler_params
+            )
+          end
+
+          def azure_labeler(source, labeler_params)
+            require "dependabot/pull_request_creator/labelers/azure"
+            Dependabot::PullRequestCreator::Labelers::Azure.new(
+              source: source,
+              **labeler_params
+            )
+          end
+
+          def base_labeler(source, labeler_params)
+            require "dependabot/pull_request_creator/labeler"
+            Dependabot::PullRequestCreator.Labeler.new(
+              source: source,
+              **labeler_params
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/common/lib/dependabot/pull_request_creator/labelers/github.rb
+++ b/common/lib/dependabot/pull_request_creator/labelers/github.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "octokit"
+require "dependabot/pull_request_creator/labeler"
+
+module Dependabot
+  class PullRequestCreator
+    module Labelers
+      class Github < Labeler
+        @package_manager_labels = {}
+
+        def initialize(source:, custom_labels:, dependencies:,
+                       includes_security_fixes:, label_language:,
+                       automerge_candidate:, client:)
+          super(
+            source: source,
+            custom_labels: custom_labels,
+            includes_security_fixes: includes_security_fixes,
+            dependencies: dependencies,
+            label_language: label_language,
+            automerge_candidate: automerge_candidate
+          )
+          @client = client
+        end
+
+        def labels
+          @labels ||= fetch_labels
+        end
+
+        def label_pull_request(pull_request_number)
+          create_default_labels_if_required
+
+          return if labels_for_pr.none?
+
+          @client.add_labels_to_an_issue(
+            source.repo,
+            pull_request_number,
+            labels_for_pr
+          )
+        rescue Octokit::UnprocessableEntity, Octokit::NotFound
+          retry_count ||= 0
+          retry_count += 1
+          raise if retry_count > 10
+
+          sleep(rand(1..1.99))
+          retry
+        end
+
+        def create_dependencies_label
+          create_label(
+            DEFAULT_DEPENDENCIES_LABEL,
+            "0366d6",
+            "Pull requests that update a dependency file"
+          )
+        end
+
+        def create_security_label
+          create_label(
+            DEFAULT_SECURITY_LABEL,
+            "ee0701",
+            "Pull requests that address a security vulnerability"
+          )
+        end
+
+        def create_language_label
+          create_label(
+            language_name,
+            colour,
+            "Pull requests that update #{language_name.capitalize} code"
+          )
+        end
+
+        private
+
+        def fetch_labels
+          labels ||= @client.labels(source.repo, per_page: 100).map(&:name)
+
+          next_link = @client.last_response.rels[:next]
+
+          while next_link
+            next_page = next_link.get
+            labels += next_page.data.map(&:name)
+            next_link = next_page.rels[:next]
+          end
+
+          labels
+        end
+
+        def create_label(label, colour, description)
+          @client.add_label(
+            source.repo,
+            label,
+            colour,
+            description: description,
+            accept: "application/vnd.github.symmetra-preview+json"
+          )
+          @labels = [*@labels, label].uniq
+        rescue Octokit::UnprocessableEntity => e
+          raise unless e.errors.first.fetch(:code) == "already_exists"
+
+          @labels = [*@labels, label].uniq
+        end
+      end
+    end
+  end
+end

--- a/common/lib/dependabot/pull_request_creator/labelers/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/labelers/gitlab.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "dependabot/pull_request_creator/labeler"
+
+module Dependabot
+  class PullRequestCreator
+    module Labelers
+      class Gitlab < Labeler
+        @package_manager_labels = {}
+
+        def initialize(source:, custom_labels:, dependencies:,
+                       includes_security_fixes:, label_language:,
+                       automerge_candidate:, client:)
+          super(
+            source: source,
+            custom_labels: custom_labels,
+            includes_security_fixes: includes_security_fixes,
+            dependencies: dependencies,
+            label_language: label_language,
+            automerge_candidate: automerge_candidate
+          )
+          @client = client
+        end
+
+        def labels
+          @labels ||= fetch_labels
+        end
+
+        def create_dependencies_label
+          create_label(
+            DEFAULT_DEPENDENCIES_LABEL,
+            "0366d6",
+            "Pull requests that update a dependency file"
+          )
+        end
+
+        def create_security_label
+          create_label(
+            DEFAULT_SECURITY_LABEL,
+            "ee0701",
+            "Pull requests that address a security vulnerability"
+          )
+        end
+
+        def create_language_label
+          create_label(
+            language_name,
+            colour,
+            "Pull requests that update #{language_name.capitalize} code"
+          )
+        end
+
+        private
+
+        def fetch_labels
+          @client.labels(source.repo, per_page: 100).auto_paginate.map(&:name)
+        end
+
+        def create_label(label, colour, description)
+          @client.create_label(
+            source.repo,
+            label,
+            '#' + colour,
+            description: description
+          )
+          @labels = [*@labels, label].uniq
+        end
+      end
+    end
+  end
+end

--- a/common/spec/dependabot/pull_request_creator/azure_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/azure_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require "dependabot/dependency"
 require "dependabot/dependency_file"
 require "dependabot/pull_request_creator/azure"
+require "dependabot/pull_request_creator/labelers/azure"
 
 RSpec.describe Dependabot::PullRequestCreator::Azure do
   subject(:creator) do
@@ -44,9 +45,8 @@ RSpec.describe Dependabot::PullRequestCreator::Azure do
   let(:assignee) { nil }
   let(:milestone) { nil }
   let(:labeler) do
-    Dependabot::PullRequestCreator::Labeler.new(
+    Dependabot::PullRequestCreator::Labelers::Azure.new(
       source: source,
-      credentials: credentials,
       custom_labels: custom_labels,
       includes_security_fixes: false,
       dependencies: [dependency],

--- a/common/spec/dependabot/pull_request_creator/github_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/github_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require "dependabot/dependency"
 require "dependabot/dependency_file"
 require "dependabot/pull_request_creator/github"
+require "dependabot/pull_request_creator/labelers/github"
 
 RSpec.describe Dependabot::PullRequestCreator::Github do
   subject(:creator) do
@@ -51,15 +52,21 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
   let(:assignees) { nil }
   let(:milestone) { nil }
   let(:require_up_to_date_base) { false }
-  let(:labeler) do
-    Dependabot::PullRequestCreator::Labeler.new(
+  let(:client) do
+    Dependabot::Clients::GithubWithRetries.for_source(
       source: source,
-      credentials: credentials,
+      credentials: credentials
+    )
+  end
+  let(:labeler) do
+    Dependabot::PullRequestCreator::Labelers::Github.new(
+      source: source,
       custom_labels: custom_labels,
       includes_security_fixes: false,
       dependencies: [dependency],
       label_language: false,
-      automerge_candidate: false
+      automerge_candidate: false,
+      client: client
     )
   end
   let(:custom_labels) { nil }

--- a/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require "dependabot/dependency"
 require "dependabot/dependency_file"
 require "dependabot/pull_request_creator/gitlab"
+require "dependabot/pull_request_creator/labelers/gitlab"
 
 RSpec.describe Dependabot::PullRequestCreator::Gitlab do
   subject(:creator) do
@@ -45,15 +46,21 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
   let(:approvers) { nil }
   let(:assignees) { nil }
   let(:milestone) { nil }
-  let(:labeler) do
-    Dependabot::PullRequestCreator::Labeler.new(
+  let(:client) do
+    Dependabot::Clients::GitlabWithRetries.for_source(
       source: source,
-      credentials: credentials,
+      credentials: credentials
+    )
+  end
+  let(:labeler) do
+    Dependabot::PullRequestCreator::Labelers::Gitlab.new(
+      source: source,
       custom_labels: custom_labels,
       includes_security_fixes: false,
       dependencies: [dependency],
       label_language: false,
-      automerge_candidate: false
+      automerge_candidate: false,
+      client: client
     )
   end
   let(:custom_labels) { nil }

--- a/common/spec/dependabot/pull_request_creator/labeler_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/labeler_spec.rb
@@ -5,10 +5,11 @@ require "dependabot/dependency"
 require "dependabot/dependency_file"
 require "dependabot/source"
 require "dependabot/pull_request_creator/labeler"
+require "dependabot/pull_request_creator/labelers/factory"
 
-RSpec.describe Dependabot::PullRequestCreator::Labeler do
+RSpec.describe Dependabot::PullRequestCreator::Labelers::Factory do
   subject(:labeler) do
-    described_class.new(
+    described_class.for_source(
       source: source,
       credentials: credentials,
       custom_labels: custom_labels,
@@ -58,7 +59,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
   let(:repo_api_url) { "https://api.github.com/repos/#{source.repo}" }
 
   describe ".package_manager_labels" do
-    subject { described_class.package_manager_labels }
+    subject { labeler.package_manager_labels }
 
     it { is_expected.to eq("dummy" => { colour: "ce2d2d", name: "ruby" }) }
   end

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe Dependabot::PullRequestCreator do
             author_details: author_details,
             signature_key: signature_key,
             custom_headers: nil,
-            labeler: instance_of(described_class::Labeler),
+            labeler: instance_of(described_class::Labelers::Github),
             reviewers: reviewers,
             assignees: assignees,
             milestone: milestone,
@@ -212,7 +212,7 @@ RSpec.describe Dependabot::PullRequestCreator do
       let(:source) { Dependabot::Source.new(provider: "gitlab", repo: "gc/bp") }
       let(:dummy_creator) { instance_double(described_class::Gitlab) }
 
-      it "delegates to PullRequestCreator::Github with correct params" do
+      it "delegates to PullRequestCreator::Gitlab with correct params" do
         expect(described_class::Gitlab).
           to receive(:new).
           with(
@@ -225,7 +225,7 @@ RSpec.describe Dependabot::PullRequestCreator do
             pr_description: "PR msg",
             pr_name: "PR name",
             author_details: author_details,
-            labeler: instance_of(described_class::Labeler),
+            labeler: instance_of(described_class::Labelers::Gitlab),
             approvers: reviewers,
             assignees: nil,
             milestone: milestone
@@ -253,7 +253,7 @@ RSpec.describe Dependabot::PullRequestCreator do
             pr_description: "PR msg",
             pr_name: "PR name",
             author_details: author_details,
-            labeler: instance_of(described_class::Labeler),
+            labeler: instance_of(described_class::Labelers::Azure),
             work_item: 123
           ).and_return(dummy_creator)
         expect(dummy_creator).to receive(:create)
@@ -311,7 +311,7 @@ RSpec.describe Dependabot::PullRequestCreator do
             author_details: author_details,
             signature_key: signature_key,
             custom_headers: nil,
-            labeler: instance_of(described_class::Labeler),
+            labeler: instance_of(described_class::Labelers::Github),
             reviewers: reviewers,
             assignees: assignees,
             milestone: milestone,


### PR DESCRIPTION
The more frequent code smells in the dependabot core code base are shotgun surgery and duplication. There is a lot of duplicate provider clients initialisation. I have tried to reduce this duplication since 2018 but it was very difficult to find a simple thread to pull without taking all the codebase in. I think this PR is a good example of what could be done to reduce the complexity and the duplication. 
After an evening tinkering with the common/pull_request_creator/labeler class, I think this polymorphism proposal is a good way to tackle the duplication from multiple providers. I hope this PR to be a base and to be able to find my way trough all the provider duplication.