### PR TITLE
Attempt to fix builds running out of disk space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Free up disk space
+        run: |
+          sudo apt autoremove --purge && sudo apt -y clean
+          docker system prune -af --volumes
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          df -h
       - name: Prepare environment variables
         run: |
           echo "BRANCH_REF=$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')" >> $GITHUB_ENV


### PR DESCRIPTION
Looks like most builds on main are now running out of disk space when
`chown`ing: https://github.com/dependabot/dependabot-core/runs/2168114315

This is a quick fix to try and get builds green. We should look into
removing the need to chown files.