### PR TITLE
NpmRcBuilder accept lowercase escaped slash

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -169,7 +169,7 @@ module Dependabot
             end
 
           scopes = affected_urls.map do |url|
-            url.split(/\%40|@/)[1]&.split(%r{\%2F|/})&.first
+            url.split(/\%40|@/)[1]&.split(%r{\%2[fF]|/})&.first
           end
 
           # Registry used for unscoped packages

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npmrc_builder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npmrc_builder_spec.rb
@@ -581,6 +581,23 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
                 to eq("@dependabot:registry=https://npm.fury.io/dependabot/")
             end
           end
+
+          context "that match a scoped package with lowercase escaped slash" do
+            let(:dependency_files) { project_dependency_files("npm6/private_source_lower") }
+            let(:credentials) do
+              [{
+                "type" => "git_source",
+                "host" => "github.com"
+              }, {
+                "type" => "npm_registry",
+                "registry" => "npm.fury.io/dependabot"
+              }]
+            end
+            it "adds auth details, and scopes them correctly" do
+              expect(npmrc_content).
+                to eq("@dependabot:registry=https://npm.fury.io/dependabot/")
+            end
+          end
         end
       end
 

--- a/npm_and_yarn/spec/fixtures/projects/npm6/private_source_lower/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/private_source_lower/package-lock.json
@@ -1,0 +1,104 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+      "chalk": {
+        "version": "2.3.0",
+        "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.3.0.tgz",
+        "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+        "requires": {
+          "ansi-styles": "3.2.0",
+          "escape-string-regexp": "1.0.5",
+          "supports-color": "4.4.0"
+        }
+      },
+      "encoding": {
+          "version": "0.1.12",
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+          "requires": {
+              "iconv-lite": "0.4.19"
+          }
+      },
+      "es6-promise": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+      },
+      "@dependabot/etag": {
+          "version": "1.8.1",
+          "resolved": "https://npm.fury.io/dependabot/~/d/%40dependabot%2fetag/%40dependabot%2fetag-1.8.1",
+          "integrity": "sha1-/HizFb1hVT38sBYgsMHMF2qMbC8="
+      },
+      "@dependabot/pack-core": {
+          "version": "2.0.14",
+          "resolved": "https://artifactory01.mydomain.com/artifactory/api/npm/my-repo/@dependabot/pack-core/-/pack-core-2.0.14.tgz",
+          "integrity": "sha1-/HizFb1hVT38sBYgsMHMF2qMbC8="
+      },
+      "@dependabot/pack-core-2": {
+          "version": "2.0.14",
+          "resolved": "https://dl.bintray.com//dependabot/npm-private/@dependabot/pack-core-2/-/@dependabot/pack-core-2-2.0.14.tgz",
+          "integrity": "sha1-/HizFb1hVT38sBYgsMHMF2qMbC8="
+      },
+      "@dependabot/pack-core-3": {
+          "version": "2.0.14",
+          "resolved": "https://npm.pkg.github.com/download/@dependabot/pack-core-3/2.0.14/55a2db17e0946313e6d150d2d63d5e9539458e4fcaf3fe928c320a7dd1b7f90b",
+          "integrity": "sha1-/HizFb1hVT38sBYgsMHMF2qMbC8="
+      },
+      "@dependabot/pack-core-4": {
+          "version": "2.0.14",
+          "resolved": "https://gitlab.mydomain.com/api/v4/projects/229/packages/npm/@dependabot/pack-core-4/-/@dependabot/pack-core-4-2.0.14.tgz",
+          "integrity": "sha1-/HizFb1hVT38sBYgsMHMF2qMbC8="
+      },
+      "fetch-factory": {
+          "version": "0.0.1",
+          "resolved": "https://artifactory01.mydomain.com/artifactory/api/npm/my-repo/fetch-factory/-/fetch-factory-0.0.1.tgz",
+          "integrity": "sha1-4AdgWb2zHjFHx1s7jAQTO6jH4HE=",
+          "requires": {
+              "es6-promise": "3.3.1",
+              "isomorphic-fetch": "2.2.1",
+              "lodash": "3.10.1"
+          }
+      },
+      "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      },
+      "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      },
+      "isomorphic-fetch": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+          "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+          "requires": {
+              "node-fetch": "1.7.3",
+              "whatwg-fetch": "2.0.3"
+          }
+      },
+      "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+      },
+      "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+              "encoding": "0.1.12",
+              "is-stream": "1.1.0"
+          }
+      },
+      "whatwg-fetch": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+          "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm6/private_source_lower/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/private_source_lower/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+      "type": "git",
+      "url": "git+https://github.com/waltfy/PROTO_TEST.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+      "url": "https://github.com/waltfy/PROTO_TEST/issues"
+  },
+  "homepage": "https://github.com/waltfy/PROTO_TEST#readme",
+  "dependencies": {
+    "fetch-factory": "^0.0.1",
+    "chalk": "^2.0.0"
+  },
+  "devDependencies": {
+    "@dependabot/etag": "^1.0.0",
+    "@dependabot/pack-core": "^2.0.1",
+    "@dependabot/pack-core-2": "^2.0.1",
+    "@dependabot/pack-core-3": "^2.0.1",
+    "@dependabot/pack-core-4": "^2.0.1"
+  }
+}


### PR DESCRIPTION
This PR modifies the pattern used by `NpmRcBuilder` to accept `/` characters escaped as lowercase hex. They're the same thing, e.g. `decodeURIComponent('%2F') === decodeURIComponent('%2f')`.

There's a full project harness introduced to exercise this case, which may be overkill:
```
$ diff npm_and_yarn/spec/fixtures/projects/npm6/private_source{,_lower}
diff npm_and_yarn/spec/fixtures/projects/npm6/private_source/package-lock.json npm_and_yarn/spec/fixtures/projects/npm6/private_source_lower/package-lock.json
32c32
<           "resolved": "https://npm.fury.io/dependabot/~/d/%40dependabot%2Fetag/%40dependabot%2Fetag-1.8.1",
---
>           "resolved": "https://npm.fury.io/dependabot/~/d/%40dependabot%2fetag/%40dependabot%2fetag-1.8.1",
```

# Related
- Identified https://github.com/dependabot/dependabot-core/issues/3305#issuecomment-804126276
- Closes https://github.com/dependabot/dependabot-core/issues/3305