### PR TITLE
v0.138.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
+## v0.138.2, 23 March 2021
+
+- npm: support private registries using lowercase URI components (e.g. `%40dependabot%2fdependabot-core`)
+- Bundler: [Prerelease] Add a file parser for Bundler 2
+- Nuget: add support for disablePackageSources in NuGet.Config (@AshleighAdams)
+- Bump phpstan/phpstan from 0.12.81 to 0.12.82
+- Bump friendsofphp/php-cs-fixer to 2.18.4
+- CI: reduce disk space
+
 ## v0.138.1, 17 March 2021
 
-- Bundler: Add instrumentation to capture the bundler verison being used
+- Bundler: Add instrumentation to capture the bundler version being used
 - Bundler: [Prerelease] Add a stubbed out native helper for Bundler 2
 - Bundler: [Prerelease] Allow the v2 native helper to be invoked via an options argument
 

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.138.1"
+  VERSION = "0.138.2"
 end


### PR DESCRIPTION
Release notes for a patch release.

Release [these commits](https://github.com/dependabot/dependabot-core/compare/v0.138.1...v0.138.2-release-notes).

Which means these PRs:
* https://github.com/dependabot/dependabot-core/pull/3279 (later reverted)
* https://github.com/dependabot/dependabot-core/pull/3296
* https://github.com/dependabot/dependabot-core/pull/3315
* https://github.com/dependabot/dependabot-core/pull/3304 - composer dependency bump
* https://github.com/dependabot/dependabot-core/pull/3303 - composer dependency bump
* https://github.com/dependabot/dependabot-core/pull/3313 - composer dependency bump
* https://github.com/dependabot/dependabot-core/pull/3314 - composer dependency bump
* https://github.com/dependabot/dependabot-core/pull/3317 - CI improvements
* https://github.com/dependabot/dependabot-core/pull/3320 (aforementioned revert)
* https://github.com/dependabot/dependabot-core/pull/3318
