### PR TITLE
Avoid subtle runtime failures by raising if a native helper is invoked with the wrong bundler version

### DIFF
--- a/bundler/helpers/v1/run.rb
+++ b/bundler/helpers/v1/run.rb
@@ -11,11 +11,25 @@ require "git_source_patch"
 
 require "functions"
 
+MAX_BUNDLER_VERSION="2.0.0"
+
+def validate_bundler_version!
+  return true if correct_bundler_version?
+
+  raise StandardError, "Called with Bundler '#{Bundler::VERSION}', expected < '#{MAX_BUNDLER_VERSION}'"
+end
+
+def correct_bundler_version?
+  Gem::Version.new(Bundler::VERSION) < Gem::Version.new(MAX_BUNDLER_VERSION)
+end
+
 def output(obj)
   print JSON.dump(obj)
 end
 
 begin
+  validate_bundler_version!
+
   request = JSON.parse($stdin.read)
 
   function = request["function"]

--- a/bundler/helpers/v2/run.rb
+++ b/bundler/helpers/v2/run.rb
@@ -11,11 +11,25 @@ require "git_source_patch"
 
 require "functions"
 
+MIN_BUNDLER_VERSION = "2.0.0"
+
+def validate_bundler_version!
+  return true if correct_bundler_version?
+
+  raise StandardError, "Called with Bundler '#{Bundler::VERSION}', expected >= '#{MIN_BUNDLER_VERSION}'"
+end
+
+def correct_bundler_version?
+  Gem::Version.new(Bundler::VERSION) >= Gem::Version.new(MIN_BUNDLER_VERSION)
+end
+
 def output(obj)
   print JSON.dump(obj)
 end
 
 begin
+  validate_bundler_version!
+
   request = JSON.parse($stdin.read)
 
   function = request["function"]


### PR DESCRIPTION
I've ran into a few subtle bugs running tests where my environment wasn't set up properly and my native helpers were actually failing over to an unexpected bundler version.

Since a native helper running with the wrong bundler version is likely to fail in subtle ways that might be hard to diagnose, let's force a clear failure if/when it happens.