### PR TITLE
Update npm from 7.6.1 to 7.7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ RUN npm install elm@0.18.0 \
 
 # NOTE: This is a hack to get around the fact that elm 18 fails to install with
 # npm 7, we should look into deprecating elm 18
-RUN npm install -g npm@v7.6.1
+RUN npm install -g npm@v7.7.4
 
 
 ### PHP


### PR DESCRIPTION

## v7.7.4 (2021-03-24)
BUG FIXES
200bee74b #2951 fix(config): accept explicit production=false (@wraithgar)
7b45e9df6 #2950 warn if using workspaces config options in npm config (@ruyadorno)

## v7.7.3 (2021-03-24)
BUG FIXES
c76f04ac2 #2925 fix(set-script): add completion (@yash-singh1)
0379eab69 #2929 fix(install): ignore auditLevel (@wraithgar)
98efadeb4 #2923 fix(audit-level): add info audit level (@wraithgar)
e8d2adcf4 #2945 config should not error when workspaces are configured (@nlf)
aba2bc623 #2944 fix(progress): re-add progress bar to reify (@wraithgar)
877b4ed29 #2946 fix(flatOptions): re-add _auth (@wraithgar)

## v7.7.2 (2021-03-24)
BUG FIXES
a4df2b98d #2942 Restore --dev flag, unify --omit flatteners (@isaacs)
DEPENDENCIES
2cbfaac0e hosted-git-info@4.0.2
#83 Do not parse urls for gitlab (@nlf)

## v7.7.0 (2021-03-23)
FEATURES
33c4189f9 #2864 add npm run-script workspaces support (@ruyadorno)
e1b3b318f #2886 add npm exec workspaces support (@ruyadorno)
41facf643 #2859 expanded "Did you mean?" suggestions for missing cmds and scripts (@wraithgar)

BUG FIXES
8cce4282f #2865 npm publish: handle case where multiple config list is present (@kenrick95)
6598bfe86 mark deprecated configs (@isaacs)
8a38afe77 #2881 docs(package-json): document default main behavior (@klausbayrhammer)
93a061d73 #2917 add action items to npm run error output (@wraithgar)

DOCUMENTATION
ad65bd910 #2860 fix link in configuring-npm (@varmakarthik12)
b419bfb02 #2876 fix test-coverage command in contributing guide (@chowkapow)

DEPENDENCIES
7b5606b93 @npmcli/arborist@2.2.9
#254 Honor explicit prefix when saving dependencies (@jameschensmith)
#255 Never save to bundleDependencies when saving a peer or peerOptional dependency. (@isaacs)
f76e7c21f pacote@11.3.1
increases tarball compression level
4928512bc semver@7.3.5
fix handling prereleases/ANY ranges in subset
1924eb457 libnpmversion@1.0.12
fix removing undescored-prefixed package.json properties in npm version
916623056 @npmcli/run-script@1.8.4
fix expanding windows-style environment variables
a8d0751e4 npm-pick-manifest@6.1.1
fix running packages with a single executable binary with npm exec
af7eaac50 hosted-git-info@4.0.1
f52c51db1 @npmcli/config@2.0.0

## v7.7.0 (2021-03-23)
FEATURES
33c4189f9 #2864 add npm run-script workspaces support (@ruyadorno)
e1b3b318f #2886 add npm exec workspaces support (@ruyadorno)
41facf643 #2859 expanded "Did you mean?" suggestions for missing cmds and scripts (@wraithgar)

BUG FIXES
8cce4282f #2865 npm publish: handle case where multiple config list is present (@kenrick95)
6598bfe86 mark deprecated configs (@isaacs)
8a38afe77 #2881 docs(package-json): document default main behavior (@klausbayrhammer)
93a061d73 #2917 add action items to npm run error output (@wraithgar)

DOCUMENTATION
ad65bd910 #2860 fix link in configuring-npm (@varmakarthik12)
b419bfb02 #2876 fix test-coverage command in contributing guide (@chowkapow)

DEPENDENCIES
7b5606b93 @npmcli/arborist@2.2.9
- #254 Honor explicit prefix when saving dependencies (@jameschensmith)
- #255 Never save to bundleDependencies when saving a peer or peerOptional dependency. (@isaacs)
f76e7c21f pacote@11.3.1
increases tarball compression level
4928512bc semver@7.3.5
fix handling prereleases/ANY ranges in subset
1924eb457 libnpmversion@1.0.12
fix removing undescored-prefixed package.json properties in npm version
916623056 @npmcli/run-script@1.8.4
fix expanding windows-style environment variables
a8d0751e4 npm-pick-manifest@6.1.1
fix running packages with a single executable binary with npm exec
af7eaac50 hosted-git-info@4.0.1
f52c51db1 @npmcli/config@2.0.0

## v7.6.3 (2021-03-11)
DOCUMENTATION
8c44e999b #2855 Correct "npm COMMAND help" to "npm help COMMAND" (@dwardu)

DEPENDENCIES
57ed390d6 @npmcli/arborist@2.2.8
Respect link deps when calculating peerDep sets

## v7.6.2 (2021-03-09)
BUG FIXES
e0a3a5218 #2831 Fix cb() never called in search with --json option (@fraqe)
85a8694dd #2795 fix(npm.output): make output go through npm.output (@wraithgar)
9fe0df5b5 #2821 fix(usage): clean up usage declarations (@wraithgar)

DEPENDENCIES
7f470b5c2 @npmcli/arborist@2.2.7
fix(install): Do not revert a file: dep to version on bare name re-install
e9b7fc275 libnpmdiff@2.0.4
fix(diff): Gracefully handle packages with prepare script
c7314aa62 byte-size@7.0.1
864f48d43 pacote@11.3.0