### PR TITLE
Bundler: fix deprecated --without flag in build

### DIFF
--- a/bundler/helpers/v1/build
+++ b/bundler/helpers/v1/build
@@ -21,4 +21,5 @@ cd "$install_dir"
 
 # NOTE: Sets `BUNDLED WITH` to match the installed v1 version in Gemfile.lock
 # forcing native helpers to run with the same version
-BUNDLER_VERSION=1 bundle install --without test
+BUNDLER_VERSION=1 bundle config set --local without "test"
+BUNDLER_VERSION=1 bundle install

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -20,4 +20,5 @@ cd "$install_dir"
 # NOTE: Sets `BUNDLED WITH` to match the installed v1 version in Gemfile.lock
 # forcing specs and native helpers to run with the same version
 BUNDLER_VERSION=2 bundle config set --local path ".bundle"
-BUNDLER_VERSION=2 bundle install --without test
+BUNDLER_VERSION=2 bundle config set --local without "test"
+BUNDLER_VERSION=2 bundle install


### PR DESCRIPTION
Fixes this warning in the build output:

```
[DEPRECATED] The `--without` flag is deprecated because it relies on
being remembered across bundler invocations, which bundler will no
longer do in future versions. Instead please use `bundle config set
--local without 'test'`, and stop using this flag
```