### PR TITLE
Attempt to fix npm install timing out ci builds

### DIFF
--- a/npm_and_yarn/helpers/build
+++ b/npm_and_yarn/helpers/build
@@ -20,4 +20,4 @@ cp -r \
   "$install_dir"
 
 cd "$install_dir"
-npm ci --no-audit --fetch-timeout=600000
+npm ci --no-audit --fetch-timeout=600000 --fetch-retries=5

--- a/npm_and_yarn/helpers/build
+++ b/npm_and_yarn/helpers/build
@@ -20,4 +20,4 @@ cp -r \
   "$install_dir"
 
 cd "$install_dir"
-npm ci
+npm ci --no-audit --fetch-timeout=600000


### PR DESCRIPTION
Looks like npm installing the npm_and_yarn helpers is timing out a fair
bit on ci:
https://github.com/dependabot/dependabot-core/pull/3329/checks?check_run_id=2183869598

Seeing errors like:

```
npm ERR! code ERR_SOCKET_TIMEOUT
npm ERR! errno ERR_SOCKET_TIMEOUT
npm ERR! request to https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz failed, reason: Socket timeout
```

I also disabled `npm audit` when isntalling which we never look at from
the build output.