### PR TITLE
Make code coverage optional via an envvar

### DIFF
--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -10,21 +10,23 @@ require "simplecov-console"
 require "dependabot/dependency_file"
 require_relative "dummy_package_manager/dummy"
 
-SimpleCov::Formatter::Console.output_style = "block"
-SimpleCov.formatter = if ENV["CI"]
-                        SimpleCov::Formatter::Console
-                      else
-                        SimpleCov::Formatter::HTMLFormatter
-                      end
+if ENV["COVERAGE"]
+  SimpleCov::Formatter::Console.output_style = "block"
+  SimpleCov.formatter = if ENV["CI"]
+                          SimpleCov::Formatter::Console
+                        else
+                          SimpleCov::Formatter::HTMLFormatter
+                        end
 
-SimpleCov.start do
-  add_filter "/spec/"
+  SimpleCov.start do
+    add_filter "/spec/"
 
-  enable_coverage :branch
-  minimum_coverage line: 80, branch: 70
-  # TODO: Enable minimum coverage per file once outliers have been increased
-  # minimum_coverage_by_file 80
-  refuse_coverage_drop
+    enable_coverage :branch
+    minimum_coverage line: 80, branch: 70
+    # TODO: Enable minimum coverage per file once outliers have been increased
+    # minimum_coverage_by_file 80
+    refuse_coverage_drop
+  end
 end
 
 RSpec.configure do |config|

--- a/go_modules/spec/spec_helper.rb
+++ b/go_modules/spec/spec_helper.rb
@@ -10,5 +10,7 @@ end
 
 require "#{common_dir}/spec/spec_helper.rb"
 
-# TODO: Bring branch coverage up
-SimpleCov.minimum_coverage line: 80, branch: 65
+if ENV["COVERAGE"]
+  # TODO: Bring branch coverage up
+  SimpleCov.minimum_coverage line: 80, branch: 65
+end

--- a/nuget/spec/spec_helper.rb
+++ b/nuget/spec/spec_helper.rb
@@ -10,5 +10,7 @@ end
 
 require "#{common_dir}/spec/spec_helper.rb"
 
-# TODO: Bring branch coverage up
-SimpleCov.minimum_coverage line: 80, branch: 65
+if ENV["COVERAGE"]
+  # TODO: Bring branch coverage up
+  SimpleCov.minimum_coverage line: 80, branch: 65
+end

--- a/terraform/spec/spec_helper.rb
+++ b/terraform/spec/spec_helper.rb
@@ -10,5 +10,7 @@ end
 
 require "#{common_dir}/spec/spec_helper.rb"
 
-# TODO: Bring branch coverage up
-SimpleCov.minimum_coverage line: 80, branch: 55
+if ENV["COVERAGE"]
+  # TODO: Bring branch coverage up
+  SimpleCov.minimum_coverage line: 80, branch: 55
+end


### PR DESCRIPTION
Calculating code coverage reports isn't free and our CI builds are quite long running as-is.

Let's turn this off for now to save some time as we are not actively pushing coverage right now - individual developers can still generate these reports via:

`COVERAGE=true bundle exec rspec spec`

We can review the status of coverage reporting after making some optimisation passes on builds.