### PR TITLE
Bundler req replacer not equal

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb
@@ -167,6 +167,8 @@ module Dependabot
             req_string.include?(" ")
           end
 
+          EQUALITY_OPERATOR = /(?<![<>!])=/.freeze
+
           def use_equality_operator?(requirement_nodes)
             return true if requirement_nodes.none?
 
@@ -178,7 +180,7 @@ module Dependabot
                 requirement_nodes.first.children.first.loc.expression.source
               end
 
-            req_string.match?(/(?<![<>!])=/)
+            req_string.match?(EQUALITY_OPERATOR)
           end
 
           def new_requirement_string(quote_characters:,
@@ -203,7 +205,7 @@ module Dependabot
             # Gem::Requirement serializes exact matches as a string starting
             # with `=`. We may need to remove that equality operator if it
             # wasn't used originally.
-            tmp_req = tmp_req.gsub(/(?<![<>!])=/, "") unless use_equality_operator
+            tmp_req = tmp_req.gsub(EQUALITY_OPERATOR, "") unless use_equality_operator
 
             tmp_req.strip
           end

--- a/bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb
@@ -178,7 +178,7 @@ module Dependabot
                 requirement_nodes.first.children.first.loc.expression.source
               end
 
-            req_string.match?(/(?<![<>])=/)
+            req_string.match?(/(?<![<>!])=/)
           end
 
           def new_requirement_string(quote_characters:,
@@ -203,7 +203,7 @@ module Dependabot
             # Gem::Requirement serializes exact matches as a string starting
             # with `=`. We may need to remove that equality operator if it
             # wasn't used originally.
-            tmp_req = tmp_req.gsub(/(?<![<>])=/, "") unless use_equality_operator
+            tmp_req = tmp_req.gsub(/(?<![<>!])=/, "") unless use_equality_operator
 
             tmp_req.strip
           end

--- a/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
@@ -188,7 +188,7 @@ module Dependabot
               req
             end
           when "<", "<=" then [update_greatest_version(req, latest_version)]
-          when "~>" then convert_twidle_to_range(req, latest_version)
+          when "~>" then convert_twiddle_to_range(req, latest_version)
           when "!=" then []
           when ">", ">=" then raise UnfixableRequirement
           else raise "Unexpected operation for requirement: #{op}"
@@ -214,7 +214,7 @@ module Dependabot
           end
         end
 
-        def convert_twidle_to_range(requirement, version_to_be_permitted)
+        def convert_twiddle_to_range(requirement, version_to_be_permitted)
           version = requirement.requirements.first.last
           version = version.release if version.prerelease?
 

--- a/bundler/spec/dependabot/bundler/file_updater/requirement_replacer_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/requirement_replacer_spec.rb
@@ -256,6 +256,16 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RequirementReplacer do
         end
       end
 
+      context "with inequality matchers" do
+        let(:previous_requirement) { ">= 2.0.0, != 2.0.3, != 2.0.4" }
+        let(:updated_requirement) { "~> 2.0.1, != 2.0.3, != 2.0.4" }
+        let(:content) do
+          %(s.add_runtime_dependency("business", "~> 2.0.1", "!= 2.0.3", "!= 2.0.4"))
+        end
+
+        it { is_expected.to eq(content) }
+      end
+
       context "when declared with `add_development_dependency`" do
         let(:dependency_name) { "rspec" }
         it { is_expected.to include(%(ent_dependency "rspec", "~> 1.5.0"\n)) }


### PR DESCRIPTION
This adjusts the `Dependabot::Bundler::FileUpdater::RequirementReplacer` to adequately ignore `!=` operators within requirements.
Previously the implementation would produce invalid requirements (e.g. for the included test case: `~> 2.0.1, ! 2.0.3, ! 2.0.4`).

This also addresses a nit in the  `Dependabot::Bundler::FileUpdater::RequirementUpdater`: settling on `twiddle` instead of a mix of `twidle`/`twiddle`.