### PR TITLE
bundler: retain `!=` conditions when upgrading

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb
@@ -167,6 +167,8 @@ module Dependabot
             req_string.include?(" ")
           end
 
+          EQUALITY_OPERATOR = /(?<![<>!])=/.freeze
+
           def use_equality_operator?(requirement_nodes)
             return true if requirement_nodes.none?
 
@@ -178,7 +180,7 @@ module Dependabot
                 requirement_nodes.first.children.first.loc.expression.source
               end
 
-            req_string.match?(/(?<![<>!])=/)
+            req_string.match?(EQUALITY_OPERATOR)
           end
 
           def new_requirement_string(quote_characters:,
@@ -203,7 +205,7 @@ module Dependabot
             # Gem::Requirement serializes exact matches as a string starting
             # with `=`. We may need to remove that equality operator if it
             # wasn't used originally.
-            tmp_req = tmp_req.gsub(/(?<![<>!])=/, "") unless use_equality_operator
+            tmp_req = tmp_req.gsub(EQUALITY_OPERATOR, "") unless use_equality_operator
 
             tmp_req.strip
           end

--- a/bundler/spec/dependabot/bundler/update_checker/requirements_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/requirements_updater_spec.rb
@@ -335,6 +335,14 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::RequirementsUpdater do
               end
             end
           end
+
+          context "when latest version is denied" do
+            let(:latest_version) { "2.0.4" }
+            let(:latest_resolvable_version) { "2.0.3" }
+            let(:gemspec_requirement_string) { ">= 2.0.0, != 2.0.4" }
+
+            its([:requirement]) { is_expected.to eq(">= 2.0.0, != 2.0.4") }
+          end
         end
 
         context "when a beta version was used in the old requirement" do

--- a/bundler/spec/dependabot/bundler/update_checker/requirements_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/requirements_updater_spec.rb
@@ -324,14 +324,14 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::RequirementsUpdater do
 
           context "and one is a != requirement" do
             context "that is binding" do
-              let(:gemspec_requirement_string) { "~> 1.4, != 1.8.0" }
+              let(:gemspec_requirement_string) { "~> 1.4, != #{latest_version}" }
               its([:requirement]) { is_expected.to eq("~> 1.4") }
             end
 
             context "that is not binding" do
-              let(:gemspec_requirement_string) { "~> 1.4.0, != 1.5.0" }
+              let(:gemspec_requirement_string) { "~> 1.4, != #{latest_resolvable_version}" }
               its([:requirement]) do
-                is_expected.to eq(">= 1.4, != 1.5.0, < 1.9")
+                is_expected.to eq("~> 1.4, != #{latest_resolvable_version}")
               end
             end
           end
@@ -400,6 +400,20 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::RequirementsUpdater do
           context "when there are multiple requirements" do
             let(:gemspec_requirement_string) { "> 1.0.0, <= 1.4.0" }
             its([:requirement]) { is_expected.to eq("> 1.0.0, <= 1.9.0") }
+
+            context "and one is a != requirement" do
+              context "that is binding" do
+                let(:gemspec_requirement_string) { "~> 1.4, != #{latest_resolvable_version}" }
+                its([:requirement]) { is_expected.to eq("~> 1.4") }
+              end
+
+              context "that is not binding" do
+                let(:gemspec_requirement_string) { "~> 1.4, != #{latest_version}" }
+                its([:requirement]) do
+                  is_expected.to eq("~> 1.4, != #{latest_version}")
+                end
+              end
+            end
           end
 
           context "when a beta version was used in the old requirement" do


### PR DESCRIPTION
This PR introduces some tests that codify the current behaviour of the `Dependabot::Bundler::UpdateChecker::RequirementsUpdater`, and introduces a failing test case for what smelled like a bug.

Consider the following scenario:
* `foo` depends on `bar`
* `bar` depends on `netaddr >= 2.0.0, != 2.0.4`
* `foo` depends on `netaddr >= 2.0.0, != 2.0.4`
* `foo` realizes `netaddr = 2.0.1` in its `Gemfile.lock`.

The implications of this, when `foo` is updating `netaddr`:
* the latest version is `2.0.4`
* the latest resolvable version is `2.0.3`
* therefore, we expect dependabot to update to `netaddr = 2.0.1` to `netaddr = 2.0.3`

Because of the way [ranges are widened/bumped](https://github.com/dependabot/dependabot-core/blob/11e5cbe07bc54a13148e61669ac44336e0369a64/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb#L192), Dependabot ends up replacing the requirement in `foo` with `netaddr >= 2.0.0`. I instead expect it to retain both conditions, `netaddr >= 2.0.0, != 2.0.4`.

My assumption is that `!=` requirements should be retained if they don't interfere with the target version of the update.

This is complicated by the `RequirementsUpdater` having two potential target versions: `latest_version` and `latest_resolvable_version`. I got lost sorting through the contexts in which one was preferred to the other, and trying to grok why both were needed (versus having the decision about the target version being made once external to the `RequirementsUpdater`).
