### PR TITLE
Bundler 2 [pre-release]: Detect bundler version to use when bundler 2 is available

### DIFF
--- a/bundler/helpers/v2/run.rb
+++ b/bundler/helpers/v2/run.rb
@@ -11,7 +11,7 @@ require "git_source_patch"
 
 require "functions"
 
-MIN_BUNDLER_VERSION = "2.0.0"
+MIN_BUNDLER_VERSION = "2.1.0"
 
 def validate_bundler_version!
   return true if correct_bundler_version?

--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -5,23 +5,36 @@ module Dependabot
     module Helpers
       V1 = "1"
       V2 = "2"
+      # If we are updating a project with no Gemfile.lock, we default to the
+      # newest version we support
+      DEFAULT = V2
+      # If we are updating a project with a Gemfile.lock that does not specify
+      # the version it was bundled with, with failover to V1 on the assumption
+      # it was created with an old version that didn't add this information
+      FAILOVER = V1
+
+      BUNDLER_MAJOR_VERSION_REGEX = /BUNDLED WITH\s+(?<version>\d+)\./m
 
       # NOTE: options is a manditory argument to ensure we pass it from all calling classes
-      def self.bundler_version(_lockfile, options:)
-        # For now, force V2 if bundler_2_available
-        return V2 if options[:bundler_2_available]
+      def self.bundler_version(lockfile, options:)
+        # TODO: Remove once bundler 2 is fully supported
+        return V1 unless options[:bundler_2_available]
+        return DEFAULT unless lockfile
 
-        # TODO: Add support for bundler v2 based on lockfile
-        # return V2 if lockfile.content.match?(/BUNDLED WITH\s+2/m)
-
-        V1
+        if matches = lockfile.content.match(BUNDLER_MAJOR_VERSION_REGEX)
+          matches[:version].to_i >= 2 ? V2 : V1
+        else
+          FAILOVER
+        end
       end
 
       def self.detected_bundler_version(lockfile)
         return "unknown" unless lockfile
-        return V2 if lockfile.content.match?(/BUNDLED WITH\s+2/m)
-
-        V1
+        if matches = lockfile.content.match(BUNDLER_MAJOR_VERSION_REGEX)
+          matches[:version]
+        else
+          FAILOVER
+        end
       end
     end
   end

--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -13,7 +13,7 @@ module Dependabot
       # it was created with an old version that didn't add this information
       FAILOVER = V1
 
-      BUNDLER_MAJOR_VERSION_REGEX = /BUNDLED WITH\s+(?<version>\d+)\./m
+      BUNDLER_MAJOR_VERSION_REGEX = /BUNDLED WITH\s+(?<version>\d+)\./m.freeze
 
       # NOTE: options is a manditory argument to ensure we pass it from all calling classes
       def self.bundler_version(lockfile, options:)
@@ -21,7 +21,7 @@ module Dependabot
         return V1 unless options[:bundler_2_available]
         return DEFAULT unless lockfile
 
-        if matches = lockfile.content.match(BUNDLER_MAJOR_VERSION_REGEX)
+        if (matches = lockfile.content.match(BUNDLER_MAJOR_VERSION_REGEX))
           matches[:version].to_i >= 2 ? V2 : V1
         else
           FAILOVER
@@ -30,7 +30,8 @@ module Dependabot
 
       def self.detected_bundler_version(lockfile)
         return "unknown" unless lockfile
-        if matches = lockfile.content.match(BUNDLER_MAJOR_VERSION_REGEX)
+
+        if (matches = lockfile.content.match(BUNDLER_MAJOR_VERSION_REGEX))
           matches[:version]
         else
           FAILOVER

--- a/bundler/spec/dependabot/bundler/helper_spec.rb
+++ b/bundler/spec/dependabot/bundler/helper_spec.rb
@@ -78,12 +78,12 @@ RSpec.describe Dependabot::Bundler::Helpers do
         expect(described_method(no_lockfile)).to eql("2")
       end
 
-      it "is 2 if there is no bundled with string" do
-        expect(described_method(lockfile_bundled_with_missing)).to eql("2")
+      it "is 1 if there is no bundled with string" do
+        expect(described_method(lockfile_bundled_with_missing)).to eql("1")
       end
 
-      it "is 2 if it was bundled with a v1.x version" do
-        expect(described_method(lockfile_bundled_with_1)).to eql("2")
+      it "is 1 if it was bundled with a v1.x version" do
+        expect(described_method(lockfile_bundled_with_1)).to eql("1")
       end
 
       it "is 2 if it was bundled with a v2.x version" do
@@ -117,9 +117,8 @@ RSpec.describe Dependabot::Bundler::Helpers do
       expect(described_method(lockfile_bundled_with_2)).to eql("2")
     end
 
-    # This is semantically surprising, but documents existing behaviour.
     it "is 1 if it was bundled with a future version" do
-      expect(described_method(lockfile_bundled_with_future_version)).to eql("1")
+      expect(described_method(lockfile_bundled_with_future_version)).to eql("3")
     end
   end
 end

--- a/bundler/spec/dependabot/bundler/helper_spec.rb
+++ b/bundler/spec/dependabot/bundler/helper_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Dependabot::Bundler::Helpers do
     LOCKFILE
   end
 
-  let(:lockfile_bundled_with_1) do
+  let(:lockfile_bundled_with_v1) do
     Dependabot::DependencyFile.new(name: "Gemfile.lock", content: <<~LOCKFILE)
       Mock Gemfile.lock Content Goes Here
 
@@ -22,7 +22,7 @@ RSpec.describe Dependabot::Bundler::Helpers do
     LOCKFILE
   end
 
-  let(:lockfile_bundled_with_2) do
+  let(:lockfile_bundled_with_v2) do
     Dependabot::DependencyFile.new(name: "Gemfile.lock", content: <<~LOCKFILE)
       Mock Gemfile.lock Content Goes Here
 
@@ -46,7 +46,7 @@ RSpec.describe Dependabot::Bundler::Helpers do
     end
 
     context "when bundler 2 is not available" do
-      let(:options) { Hash.new }
+      let(:options) { {} }
 
       it "is 1 if there is no lockfile" do
         expect(described_method(no_lockfile)).to eql("1")
@@ -57,11 +57,11 @@ RSpec.describe Dependabot::Bundler::Helpers do
       end
 
       it "is 1 if it was bundled with a v1.x version" do
-        expect(described_method(lockfile_bundled_with_1)).to eql("1")
+        expect(described_method(lockfile_bundled_with_v1)).to eql("1")
       end
 
       it "is 1 if it was bundled with a v2.x version" do
-        expect(described_method(lockfile_bundled_with_2)).to eql("1")
+        expect(described_method(lockfile_bundled_with_v2)).to eql("1")
       end
 
       it "is 1 if it was bundled with a future version" do
@@ -83,11 +83,11 @@ RSpec.describe Dependabot::Bundler::Helpers do
       end
 
       it "is 1 if it was bundled with a v1.x version" do
-        expect(described_method(lockfile_bundled_with_1)).to eql("1")
+        expect(described_method(lockfile_bundled_with_v1)).to eql("1")
       end
 
       it "is 2 if it was bundled with a v2.x version" do
-        expect(described_method(lockfile_bundled_with_2)).to eql("2")
+        expect(described_method(lockfile_bundled_with_v2)).to eql("2")
       end
 
       it "is 2 if it was bundled with a future version" do
@@ -110,11 +110,11 @@ RSpec.describe Dependabot::Bundler::Helpers do
     end
 
     it "is 1 if it was bundled with a v1.x version" do
-      expect(described_method(lockfile_bundled_with_1)).to eql("1")
+      expect(described_method(lockfile_bundled_with_v1)).to eql("1")
     end
 
     it "is 2 if it was bundled with a v2.x version" do
-      expect(described_method(lockfile_bundled_with_2)).to eql("2")
+      expect(described_method(lockfile_bundled_with_v2)).to eql("2")
     end
 
     it "is 1 if it was bundled with a future version" do

--- a/bundler/spec/dependabot/bundler/helper_spec.rb
+++ b/bundler/spec/dependabot/bundler/helper_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "dependabot/bundler/helpers"
+
+RSpec.describe Dependabot::Bundler::Helpers do
+  let(:no_lockfile) { nil }
+
+  let(:lockfile_bundled_with_missing) do
+    Dependabot::DependencyFile.new(name: "Gemfile.lock", content: <<~LOCKFILE)
+      Mock Gemfile.lock Content Goes Here
+    LOCKFILE
+  end
+
+  let(:lockfile_bundled_with_1) do
+    Dependabot::DependencyFile.new(name: "Gemfile.lock", content: <<~LOCKFILE)
+      Mock Gemfile.lock Content Goes Here
+
+      BUNDLED WITH
+        1.17.3
+    LOCKFILE
+  end
+
+  let(:lockfile_bundled_with_2) do
+    Dependabot::DependencyFile.new(name: "Gemfile.lock", content: <<~LOCKFILE)
+      Mock Gemfile.lock Content Goes Here
+
+      BUNDLED WITH
+        2.2.11
+    LOCKFILE
+  end
+
+  let(:lockfile_bundled_with_future_version) do
+    Dependabot::DependencyFile.new(name: "Gemfile.lock", content: <<~LOCKFILE)
+      Mock Gemfile.lock Content Goes Here
+
+      BUNDLED WITH
+        3.9.99
+    LOCKFILE
+  end
+
+  describe "#bundler_version" do
+    def described_method(lockfile)
+      described_class.bundler_version(lockfile, options: options)
+    end
+
+    context "when bundler 2 is not available" do
+      let(:options) { Hash.new }
+
+      it "is 1 if there is no lockfile" do
+        expect(described_method(no_lockfile)).to eql("1")
+      end
+
+      it "is 1 if there is no bundled with string" do
+        expect(described_method(lockfile_bundled_with_missing)).to eql("1")
+      end
+
+      it "is 1 if it was bundled with a v1.x version" do
+        expect(described_method(lockfile_bundled_with_1)).to eql("1")
+      end
+
+      it "is 1 if it was bundled with a v2.x version" do
+        expect(described_method(lockfile_bundled_with_2)).to eql("1")
+      end
+
+      it "is 1 if it was bundled with a future version" do
+        expect(described_method(lockfile_bundled_with_future_version)).to eql("1")
+      end
+    end
+
+    context "when bundler 2 is available" do
+      let(:options) do
+        { bundler_2_available: true }
+      end
+
+      it "is 2 if there is no lockfile" do
+        expect(described_method(no_lockfile)).to eql("2")
+      end
+
+      it "is 2 if there is no bundled with string" do
+        expect(described_method(lockfile_bundled_with_missing)).to eql("2")
+      end
+
+      it "is 2 if it was bundled with a v1.x version" do
+        expect(described_method(lockfile_bundled_with_1)).to eql("2")
+      end
+
+      it "is 2 if it was bundled with a v2.x version" do
+        expect(described_method(lockfile_bundled_with_2)).to eql("2")
+      end
+
+      it "is 2 if it was bundled with a future version" do
+        expect(described_method(lockfile_bundled_with_future_version)).to eql("2")
+      end
+    end
+  end
+
+  describe "#detected_bundler_version" do
+    def described_method(lockfile)
+      described_class.detected_bundler_version(lockfile)
+    end
+
+    it "is unknown if there is no lockfile" do
+      expect(described_method(no_lockfile)).to eql("unknown")
+    end
+
+    it "is 1 if there is no bundled with string" do
+      expect(described_method(lockfile_bundled_with_missing)).to eql("1")
+    end
+
+    it "is 1 if it was bundled with a v1.x version" do
+      expect(described_method(lockfile_bundled_with_1)).to eql("1")
+    end
+
+    it "is 2 if it was bundled with a v2.x version" do
+      expect(described_method(lockfile_bundled_with_2)).to eql("2")
+    end
+
+    # This is semantically surprising, but documents existing behaviour.
+    it "is 1 if it was bundled with a future version" do
+      expect(described_method(lockfile_bundled_with_future_version)).to eql("1")
+    end
+  end
+end


### PR DESCRIPTION
Depends on https://github.com/dependabot/dependabot-core/pull/3406

This modifies the `bundler_2_available` option so it no longer forces use of the bundler 2 native helpers but rather decides based on the lockfile if present.

The primary change is to expand and test the `Dependabot::Bundler::Helper` to clearly specify scenarios such as defaulting to the newest when no Lockfile is present and failing over to v1 if a file is present but appears to pre-date the `BUNDLED_WITH` notation.

This also clarifies how Dependabot will behave if a new/malformed Gemfile.lock version were to appear.