### PR TITLE
Fix bundler2 CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,5 @@ jobs:
             "cd /home/dependabot/dependabot-core/bundler/helpers/v2 && BUNDLER_VERSION=2 bundle install && BUNDLER_VERSION=2 bundle exec rspec spec"
       - name: Run ${{ matrix.suite.name }} tests with rspec
         run: |
-          echo "SUITE_NAME=${{ matrix.suite.name }}" >> $GITHUB_ENV
-          docker run --env "CI=true" --env "DEPENDABOT_TEST_ACCESS_TOKEN=$DEPENDABOT_TEST_ACCESS_TOKEN" --env "SUITE_NAME=$SUITE_NAME" --rm "$CORE_CI_IMAGE" bash -c \
+          docker run --env "CI=true" --env "DEPENDABOT_TEST_ACCESS_TOKEN=$DEPENDABOT_TEST_ACCESS_TOKEN" --env "SUITE_NAME=${{ matrix.suite.name }}" --rm "$CORE_CI_IMAGE" bash -c \
             "cd /home/dependabot/dependabot-core/${{ matrix.suite.path }} && bundle exec rspec spec"

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -11,6 +11,7 @@ fi
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/lib" \
+  "$helpers_dir/monkey_patches" \
   "$helpers_dir/run.rb" \
   "$helpers_dir/Gemfile" \
   "$install_dir"


### PR DESCRIPTION
I pushed some breaking changes to the bundler2 implementation in a [WIP branch](https://github.com/dependabot/dependabot-core/pull/3350) in https://github.com/dependabot/dependabot-core/pull/3350/commits/fd3d377c95e3597c42174e1ffe33660cf8b1fa7b but all checks passed unexpectedly.

It seems CI isn't actually setting the `SUITE_NAME` properly at present, so I've cherry picked a fix from my WIP to fix that asap.