### PR TITLE
docker: valid Accept header

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -29,7 +29,7 @@ module DockerRegistry2
         headers["Accept"] = %w(
           application/vnd.docker.distribution.manifest.v2+json
           application/vnd.docker.distribution.manifest.list.v2+json
-          application/json"
+          application/json
         ).join(",")
       end
       headers["Content-Type"] = "application/vnd.docker.distribution.manifest.v2+json" unless payload.nil?


### PR DESCRIPTION
Remove an errant `"` included in a string array constant used to derive the `Accept` headers for querying docker registries. Oh Ruby.

```
irb(main):001:0] %w(
irb(main):002:0]           application/vnd.docker.distribution.manifest.v2+json
irb(main):003:0]           application/vnd.docker.distribution.manifest.list.v2+json
irb(main):004:0]           application/json"
irb(main):005:0]         ).join(",")
=> "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/json\""
```

Many registries don't mind, but this manifests as a `400` response from Artifactory Pro:
```
[dependabot-core-dev] ~/dependabot-core $ curl -H'Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/json"' https://2b0c7819212f.ngrok.io:443/v2/test-docker/alpine/tags/list
{
  "errors" : [ {
    "status" : 400,
    "message" : "Bad Request"
  } ]
}[dependabot-core-dev] ~/dependabot-core $ curl -H'Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/json' https://2b0c7819212f.ngrok.io:443/v2/test-docker/alpine/tags/list
{
  "name" : "alpine",
  "tags" : [ "3.11.0", "3.12.0" ]
}[dependabot-core-dev] ~/dependabot-core $
```

# Related
- Introduced https://github.com/dependabot/dependabot-core/pull/3119