### PR TITLE
Bundler v2 [pre-release]: Add and test jfrog source helper

### DIFF
--- a/bundler/helpers/v2/lib/functions.rb
+++ b/bundler/helpers/v2/lib/functions.rb
@@ -105,7 +105,13 @@ module Functions
   end
 
   def self.jfrog_source(dir:, gemfile_name:, credentials:, using_bundler2:)
-    raise NotImplementedError, "Bundler 2 adapter does not yet implement #{__method__}"
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials, using_bundler2: using_bundler2)
+
+    Bundler::Definition.build(gemfile_name, nil, {}).
+      send(:sources).
+      rubygems_remotes.
+      find { |uri| uri.host.include?("jfrog") }&.
+      host
   end
 
   def self.git_specs(dir:, gemfile_name:, credentials:, using_bundler2:)

--- a/bundler/helpers/v2/spec/functions_spec.rb
+++ b/bundler/helpers/v2/spec/functions_spec.rb
@@ -1,21 +1,24 @@
 # frozen_string_literal: true
 
 require "native_spec_helper"
+require "shared_contexts"
 
 RSpec.describe Functions do
-  # Verify v1 method signatures are exist, but raise as NYI
-  {
-    jfrog_source: %i(dir gemfile_name credentials using_bundler2)
-  }.each do |function, kwargs|
-    describe "::#{function}" do
-      let(:args) do
-        kwargs.inject({}) do |args, keyword|
-          args.merge({ keyword => anything })
-        end
-      end
+  include_context "in a temporary bundler directory"
 
-      it "raises a NYI" do
-        expect { Functions.send(function, **args) }.to raise_error(Functions::NotImplementedError)
+  describe "#jfrog_source" do
+    let(:project_name) { "jfrog_source" }
+
+    it "returns the jfrog source" do
+      in_tmp_folder do
+        jfrog_source = Functions.jfrog_source(
+          dir: tmp_path,
+          gemfile_name: "Gemfile",
+          credentials: {},
+          using_bundler2: true
+        )
+
+        expect(jfrog_source).to eq("test.jfrog.io")
       end
     end
   end

--- a/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
@@ -187,7 +187,9 @@ module Dependabot
         end
 
         def jfrog_source
-          in_a_native_bundler_context(error_handling: false) do |dir|
+          return @jfrog_source unless defined?(@jfrog_source)
+
+          @jfrog_source = in_a_native_bundler_context(error_handling: false) do |dir|
             NativeHelpers.run_bundler_subprocess(
               bundler_version: bundler_version,
               function: "jfrog_source",

--- a/bundler/spec/fixtures/projects/bundler1/jfrog_source/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/jfrog_source/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+
+source "https://test.jfrog.io/test/api/gems" do
+  gem "statesman", "~> 1.2.0"
+end


### PR DESCRIPTION
Adds a basic test for the jfrog_source method. I tried to test this from
the core codebase where it's used as well, but due to the current setup
it's currently very hard to do that without connecting to an actual
jfrog server. Since we had no coverage for this before, I'm calling it
an improvement.