### PR TITLE
Update Rust to 1.51.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -170,11 +170,11 @@ RUN wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
 
 ### RUST
 
-# Install Rust 1.47.0
+# Install Rust 1.51.0
 ENV RUSTUP_HOME=/opt/rust \
   PATH="${PATH}:/opt/rust/bin"
 RUN export CARGO_HOME=/opt/rust ; curl https://sh.rustup.rs -sSf | sh -s -- -y
-RUN export CARGO_HOME=/opt/rust ; rustup toolchain install 1.47.0 && rustup default 1.47.0
+RUN export CARGO_HOME=/opt/rust ; rustup toolchain install 1.51.0 && rustup default 1.51.0
 
 
 ### NEW NATIVE HELPERS

--- a/cargo/spec/dependabot/cargo/file_parser_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_parser_spec.rb
@@ -773,6 +773,12 @@ RSpec.describe Dependabot::Cargo::FileParser do
         end
       end
 
+      context "with resolver version 2" do
+        let(:manifest_fixture_name) { "resolver2" }
+        let(:lockfile_fixture_name) { "no_dependencies" }
+        it { is_expected.to eq([]) }
+      end
+
       context "with no dependencies" do
         let(:manifest_fixture_name) { "no_dependencies" }
         let(:lockfile_fixture_name) { "no_dependencies" }

--- a/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
             # Test that the temporary path isn't included in the error message
             expect(error.message).to_not include("dependabot_20")
             expect(error.message).
-              to include("feature `namespaced-features` is required")
+              to include("feature `metabuild` is required")
           end
       end
     end

--- a/cargo/spec/fixtures/manifests/disabled_feature
+++ b/cargo/spec/fixtures/manifests/disabled_feature
@@ -2,7 +2,7 @@
 name = "dependabot" # the name of the package
 version = "0.1.0"    # the current version, obeying semver
 authors = ["support@dependabot.com"]
-namespaced-features = true
+metabuild = ["foo", "bar"]
 
 [dependencies]
 time = "0.1.12"

--- a/cargo/spec/fixtures/manifests/resolver2
+++ b/cargo/spec/fixtures/manifests/resolver2
@@ -1,11 +1,5 @@
-cargo-features = ["metabuild"]
-
 [package]
 name = "dependabot" # the name of the package
 version = "0.1.0"    # the current version, obeying semver
 authors = ["support@dependabot.com"]
-metabuild = ["foo", "bar"]
-
-[dependencies]
-time = "0.1.12"
-regex = "0.1.41"
+resolver = "2"


### PR DESCRIPTION
With Rust 1.51.0 cargo now supports resolver = "2", which dependabot currently fails to parse.

https://github.com/LiveSplit/livesplit-core/issues/417

```
error: failed to parse manifest at `/home/dependabot/dependabot-updater/dependabot_tmp_dir/Cargo.toml`

Caused by:
  feature `resolver` is required

  this Cargo does not support nightly features, but if you
  switch to nightly channel you can add
  `cargo-features = ["resolver"]` to enable this feature
  ````