### PR TITLE
Repurpose custom_headers for github client

### DIFF
--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -353,7 +353,7 @@ module Dependabot
           branch_name,
           pr_name,
           pr_description,
-          headers: custom_headers || {}
+          options: custom_headers || {}
         )
       rescue Octokit::UnprocessableEntity => e
         return handle_pr_creation_error(e) if e.message.include? "Error summary"


### PR DESCRIPTION
According to https://github.com/octokit/octokit.rb/blob/d56af021d21d9a8f623e0b41cac073c272864ec2/lib/octokit/client/pull_requests.rb#L52, github API expects `options` as general purpose JSON body extension, passing down `headers` won't make any impact. This PR repurposes `custom_headers` to pass additional JSON body fields.