### PR TITLE
Treat dev and pr as pre-releases for gradle/maven

### DIFF
--- a/gradle/lib/dependabot/gradle/version.rb
+++ b/gradle/lib/dependabot/gradle/version.rb
@@ -21,7 +21,7 @@ module Dependabot
         "b" => 2, "beta"      => 2,
         "m" => 3, "milestone" => 3,
         "rc" => 4, "cr" => 4, "pr" => 4,
-        "snapshot" => 5,
+        "snapshot" => 5, "dev" => 5,
         "ga" => 6, "" => 6, "final" => 6,
         "sp" => 7
       }.freeze

--- a/gradle/spec/dependabot/gradle/version_spec.rb
+++ b/gradle/spec/dependabot/gradle/version_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Dependabot::Gradle::Version do
       it { is_expected.to eq(true) }
     end
 
-    context "with an dev token" do
+    context "with a dev token" do
       let(:version_string) { "1.2.1-dev-65" }
       it { is_expected.to eq(true) }
     end

--- a/gradle/spec/dependabot/gradle/version_spec.rb
+++ b/gradle/spec/dependabot/gradle/version_spec.rb
@@ -92,6 +92,11 @@ RSpec.describe Dependabot::Gradle::Version do
       let(:version_string) { "1.2.1-1.3.40-eap13-67" }
       it { is_expected.to eq(true) }
     end
+
+    context "with an dev token" do
+      let(:version_string) { "1.2.1-dev-65" }
+      it { is_expected.to eq(true) }
+    end
   end
 
   describe "#<=>" do

--- a/maven/lib/dependabot/maven/version.rb
+++ b/maven/lib/dependabot/maven/version.rb
@@ -21,8 +21,8 @@ module Dependabot
         "a" => 1, "alpha"     => 1,
         "b" => 2, "beta"      => 2,
         "m" => 3, "milestone" => 3,
-        "rc" => 4, "cr" => 4,
-        "snapshot" => 5,
+        "rc" => 4, "cr" => 4, "pr" => 4,
+        "snapshot" => 5, "dev" => 5,
         "ga" => 6, "" => 6, "final" => 6,
         "sp" => 7
       }.freeze

--- a/maven/spec/dependabot/maven/version_spec.rb
+++ b/maven/spec/dependabot/maven/version_spec.rb
@@ -92,6 +92,16 @@ RSpec.describe Dependabot::Maven::Version do
       let(:version_string) { "1.0.0.sp7" }
       it { is_expected.to eq(false) }
     end
+
+    context "with a pre-release" do
+      let(:version_string) { "2.10.0.pr3" }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with an dev token" do
+      let(:version_string) { "1.2.1-dev-65" }
+      it { is_expected.to eq(true) }
+    end
   end
 
   describe "#<=>" do

--- a/maven/spec/dependabot/maven/version_spec.rb
+++ b/maven/spec/dependabot/maven/version_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Dependabot::Maven::Version do
       it { is_expected.to eq(true) }
     end
 
-    context "with an dev token" do
+    context "with a dev token" do
       let(:version_string) { "1.2.1-dev-65" }
       it { is_expected.to eq(true) }
     end


### PR DESCRIPTION
Add `dev` as a pre-release token for gradle and maven.

Also added `pr` as a pre-release token to maven to align with gradle.

Reported here https://github.com/dependabot/dependabot-core/issues/3255