### PR TITLE
Add support for updating Maven extensions.xml files

### DIFF
--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -37,11 +37,11 @@ module Dependabot
         return @extensions if defined?(@extensions)
         return @extensions if defined?(@extensions)
 
-          begin
-            fetch_file_if_present(".mvn/extensions.xml")
-          rescue Dependabot::DependencyFileNotFound
-            nil
-          end
+        begin
+          fetch_file_if_present(".mvn/extensions.xml")
+        rescue Dependabot::DependencyFileNotFound
+          nil
+        end
       end
 
       def child_poms

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -34,7 +34,15 @@ module Dependabot
       end
 
       def extensions
-        @extensions ||= fetch_file_if_present(".mvn/extensions.xml")
+        return @extensions if defined?(@extensions)
+        
+        @extensions =
+          begin
+            fetch_file_if_present(".mvn/extensions.xml")
+          rescue Dependabot::DependencyFileNotFound
+            nil
+          end
+
       end
 
       def child_poms

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -34,10 +34,7 @@ module Dependabot
       end
 
       def extensions
-        @extensions ||= fetch_file_from_host(".mvn/extensions.xml")
-      rescue Dependabot::DependencyFileNotFound
-        # extensions.xml is optional
-        nil
+        @extensions ||= fetch_file_if_present(".mvn/extensions.xml")
       end
 
       def child_poms

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -35,7 +35,6 @@ module Dependabot
 
       def extensions
         return @extensions if defined?(@extensions)
-        
         @extensions =
           begin
             fetch_file_if_present(".mvn/extensions.xml")

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -42,7 +42,6 @@ module Dependabot
           rescue Dependabot::DependencyFileNotFound
             nil
           end
-
       end
 
       def child_poms

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -25,7 +25,7 @@ module Dependabot
         fetched_files << pom
         fetched_files += child_poms
         fetched_files += relative_path_parents(fetched_files)
-        fetched_files << extensions unless extensions.nil?
+        fetched_files << extensions if extensions
         fetched_files.uniq
       end
 

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -25,9 +25,7 @@ module Dependabot
         fetched_files << pom
         fetched_files += child_poms
         fetched_files += relative_path_parents(fetched_files)
-        unless extensions.nil?
-          fetched_files << extensions
-        end
+        fetched_files << extensions unless extensions.nil?
         fetched_files.uniq
       end
 

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -25,11 +25,21 @@ module Dependabot
         fetched_files << pom
         fetched_files += child_poms
         fetched_files += relative_path_parents(fetched_files)
+        unless extensions.nil?
+          fetched_files << extensions
+        end
         fetched_files.uniq
       end
 
       def pom
         @pom ||= fetch_file_from_host("pom.xml")
+      end
+
+      def extensions
+        @extensions ||= fetch_file_from_host(".mvn/extensions.xml")
+      rescue Dependabot::DependencyFileNotFound
+        # extensions.xml is optional
+        nil
       end
 
       def child_poms

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -35,7 +35,8 @@ module Dependabot
 
       def extensions
         return @extensions if defined?(@extensions)
-        @extensions =
+        return @extensions if defined?(@extensions)
+
           begin
             fetch_file_if_present(".mvn/extensions.xml")
           rescue Dependabot::DependencyFileNotFound

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -43,7 +43,7 @@ module Dependabot
       private
 
       def check_required_files
-        raise "No pom.xml!" unless get_original_file("pom.xml") || get_original_file("extensions.xml")
+        raise "No pom.xml!" unless get_original_file("pom.xml")
       end
 
       def update_files_for_dependency(original_files:, dependency:)

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -13,7 +13,7 @@ module Dependabot
       def self.updated_files_regex
         [
           /^pom\.xml$/, %r{/pom\.xml$},
-          /^extensions.\.xml$/, %r{/extensions\.xml$},
+          /^extensions.\.xml$/, %r{/extensions\.xml$}
         ]
       end
 

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -11,24 +11,27 @@ module Dependabot
       require_relative "file_updater/property_value_updater"
 
       def self.updated_files_regex
-        [/^pom\.xml$/, %r{/pom\.xml$}]
+        [
+          /^pom\.xml$/, %r{/pom\.xml$},
+          /^extensions.\.xml$/, %r{/extensions\.xml$},
+        ]
       end
 
       def updated_dependency_files
         updated_files = dependency_files.dup
 
         # Loop through each of the changed requirements, applying changes to
-        # all pomfiles for that change. Note that the logic is different here
-        # to other languages because Java has property inheritance across
-        # files
+        # all pom and extensions files for that change. Note that the logic
+        # is different here to other package managers because Maven has property
+        # inheritance across files
         dependencies.each do |dependency|
-          updated_files = update_pomfiles_for_dependency(
-            pomfiles: updated_files,
+          updated_files = update_files_for_dependency(
+            original_files: updated_files,
             dependency: dependency
           )
         end
 
-        updated_files.select! { |f| f.name.end_with?("pom.xml") }
+        updated_files.select! { |f| f.name.end_with?("pom.xml") || f.name.end_with?("extensions.xml") }
         updated_files.reject! { |f| original_pomfiles.include?(f) }
 
         raise "No files changed!" if updated_files.none?
@@ -40,18 +43,18 @@ module Dependabot
       private
 
       def check_required_files
-        raise "No pom.xml!" unless get_original_file("pom.xml")
+        raise "No pom.xml!" unless get_original_file("pom.xml") || get_original_file("extensions.xml")
       end
 
-      def update_pomfiles_for_dependency(pomfiles:, dependency:)
-        files = pomfiles.dup
+      def update_files_for_dependency(original_files:, dependency:)
+        files = original_files.dup
 
         # The UpdateChecker ensures the order of requirements is preserved
         # when updating, so we can zip them together in new/old pairs.
         reqs = dependency.requirements.zip(dependency.previous_requirements).
                reject { |new_req, old_req| new_req == old_req }
 
-        # Loop through each changed requirement and update the pomfiles
+        # Loop through each changed requirement and update the files
         reqs.each do |new_req, old_req|
           raise "Bad req match" unless new_req[:file] == old_req[:file]
           next if new_req[:requirement] == old_req[:requirement]
@@ -62,9 +65,9 @@ module Dependabot
             files[files.index(pom)] =
               remove_property_suffix_in_pom(dependency, pom, old_req)
           else
-            pom = files.find { |f| f.name == new_req.fetch(:file) }
-            files[files.index(pom)] =
-              update_version_in_pom(dependency, pom, old_req, new_req)
+            file = files.find { |f| f.name == new_req.fetch(:file) }
+            files[files.index(file)] =
+              update_version_in_file(dependency, file, old_req, new_req)
           end
         end
 
@@ -82,25 +85,25 @@ module Dependabot
           )
       end
 
-      def update_version_in_pom(dependency, pom, previous_req, requirement)
-        updated_content = pom.content
+      def update_version_in_file(dependency, file, previous_req, requirement)
+        updated_content = file.content
 
-        original_pom_declarations(dependency, previous_req).each do |old_dec|
+        original_file_declarations(dependency, previous_req).each do |old_dec|
           updated_content = updated_content.gsub(
             old_dec,
-            updated_pom_declaration(old_dec, previous_req, requirement)
+            updated_file_declaration(old_dec, previous_req, requirement)
           )
         end
 
-        raise "Expected content to change!" if updated_content == pom.content
+        raise "Expected content to change!" if updated_content == file.content
 
-        updated_file(file: pom, content: updated_content)
+        updated_file(file: file, content: updated_content)
       end
 
       def remove_property_suffix_in_pom(dep, pom, req)
         updated_content = pom.content
 
-        original_pom_declarations(dep, req).each do |old_declaration|
+        original_file_declarations(dep, req).each do |old_declaration|
           updated_content = updated_content.gsub(old_declaration) do |old_dec|
             version_string =
               old_dec.match(%r{(?<=\<version\>).*(?=\</version\>)})
@@ -116,7 +119,7 @@ module Dependabot
         updated_file(file: pom, content: updated_content)
       end
 
-      def original_pom_declarations(dependency, requirement)
+      def original_file_declarations(dependency, requirement)
         declaration_finder(dependency, requirement).declaration_strings
       end
 
@@ -132,7 +135,7 @@ module Dependabot
           )
       end
 
-      def updated_pom_declaration(old_declaration, previous_req, requirement)
+      def updated_file_declaration(old_declaration, previous_req, requirement)
         original_req_string = previous_req.fetch(:requirement)
 
         old_declaration.gsub(

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -32,7 +32,7 @@ module Dependabot
         end
 
         updated_files.select! { |f| f.name.end_with?("pom.xml") || f.name.end_with?("extensions.xml") }
-        updated_files.reject! { |f| original_pomfiles.include?(f) }
+        updated_files.reject! { |f| dependency_files.include?(f) }
 
         raise "No files changed!" if updated_files.none?
         raise "Updated a supporting POM!" if updated_files.any? { |f| f.name.end_with?("pom_parent.xml") }

--- a/maven/spec/dependabot/maven/file_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/file_fetcher_spec.rb
@@ -42,10 +42,38 @@ RSpec.describe Dependabot::Maven::FileFetcher do
         )
     end
 
-    it "fetches the pom" do
-      expect(file_fetcher_instance.files.count).to eq(1)
-      expect(file_fetcher_instance.files.map(&:name)).
-        to match_array(%w(pom.xml))
+    context "without extensions.xml" do
+      before do
+        stub_request(:get, File.join(url, ".mvn/extensions.xml?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 404
+          )
+      end
+
+      it "only fetches the pom.xml" do
+        expect(file_fetcher_instance.files.count).to eq(1)
+        expect(file_fetcher_instance.files.map(&:name)).
+          to match_array(%w(pom.xml))
+      end
+    end
+
+    context "with extensions.xml" do
+      before do
+        stub_request(:get, File.join(url, ".mvn/extensions.xml?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "contents_java_extensions_xml.json"),
+            headers: { "content-type" => "application/json" }
+          )
+      end
+
+      it "fetches the pom.xml and extensions.xml" do
+        expect(file_fetcher_instance.files.count).to eq(2)
+        expect(file_fetcher_instance.files.map(&:name)).
+          to match_array(%w(pom.xml .mvn/extensions.xml))
+      end
     end
   end
 
@@ -81,6 +109,12 @@ RSpec.describe Dependabot::Maven::FileFetcher do
           status: 200,
           body: fixture("github", "contents_java_basic_pom.json"),
           headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, ".mvn/extensions.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 404
         )
     end
 
@@ -127,6 +161,11 @@ RSpec.describe Dependabot::Maven::FileFetcher do
             body: fixture("github", "contents_java_basic_pom.json"),
             headers: { "content-type" => "application/json" }
           )
+        stub_request(:get, File.join(url, ".mvn/extensions.xml?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 404
+          )
       end
 
       it "doesn't fetch the submodule pom (which we couldn't update)" do
@@ -152,6 +191,12 @@ RSpec.describe Dependabot::Maven::FileFetcher do
           to_return(
             status: 404,
             headers: { "content-type" => "application/json" }
+          )
+
+        stub_request(:get, File.join(url, ".mvn/extensions.xml?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 404
           )
       end
 
@@ -196,6 +241,12 @@ RSpec.describe Dependabot::Maven::FileFetcher do
             body: fixture("github", "contents_java_basic_pom.json"),
             headers: { "content-type" => "application/json" }
           )
+
+        stub_request(:get, File.join(url, ".mvn/extensions.xml?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 404
+          )
       end
 
       it "fetches the poms" do
@@ -210,6 +261,13 @@ RSpec.describe Dependabot::Maven::FileFetcher do
       end
 
       context "when asked to fetch only a subdirectory" do
+        before do
+          stub_request(:get, File.join(url, "util/util/.mvn/extensions.xml?ref=sha")).
+            with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 404
+            )
+        end
         let(:directory) { "/util/util" }
 
         it "fetches the relevant poms" do

--- a/maven/spec/dependabot/maven/file_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/file_fetcher_spec.rb
@@ -29,7 +29,15 @@ RSpec.describe Dependabot::Maven::FileFetcher do
     }]
   end
 
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
+  before do
+    allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+    stub_request(:get, File.join(url, ".mvn?ref=sha")).
+      with(headers: { "Authorization" => "token token" }).
+      to_return(
+        status: 404
+      )
+  end
 
   context "with a basic pom" do
     before do
@@ -60,6 +68,13 @@ RSpec.describe Dependabot::Maven::FileFetcher do
 
     context "with extensions.xml" do
       before do
+        stub_request(:get, File.join(url, ".mvn?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "contents_mvn_directory.json"),
+            headers: { "content-type" => "application/json" }
+          )
         stub_request(:get, File.join(url, ".mvn/extensions.xml?ref=sha")).
           with(headers: { "Authorization" => "token token" }).
           to_return(
@@ -262,6 +277,11 @@ RSpec.describe Dependabot::Maven::FileFetcher do
 
       context "when asked to fetch only a subdirectory" do
         before do
+          stub_request(:get, File.join(url, "util/util/.mvn?ref=sha")).
+            with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 404
+            )
           stub_request(:get, File.join(url, "util/util/.mvn/extensions.xml?ref=sha")).
             with(headers: { "Authorization" => "token token" }).
             to_return(

--- a/maven/spec/dependabot/maven/file_parser_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser_spec.rb
@@ -87,6 +87,33 @@ RSpec.describe Dependabot::Maven::FileParser do
       end
     end
 
+    context "with extensions.xml" do
+      let(:files) { [extensions, pom] }
+      let(:extensions) do
+        Dependabot::DependencyFile.new(name: ".mvn/extensions.xml", content: extensions_body)
+      end
+      let(:extensions_body) { fixture("extensions", "extensions.xml") }
+
+      describe "the sole dependency" do
+        subject(:dependency) { dependencies[3] }
+
+        it "has the right details" do 
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("io.takari.polyglot:polyglot-yaml")
+          expect(dependency.version).to eq("0.4.6")
+          expect(dependency.requirements).to eq(
+            [{
+              requirement: "0.4.6",
+              file: ".mvn/extensions.xml",
+              groups: [],
+              source: nil,
+              metadata: { packaging_type: "jar" }
+            }]
+          )
+        end
+      end
+    end
+
     context "with rogue whitespace" do
       let(:pom_body) { fixture("poms", "whitespace.xml") }
 

--- a/maven/spec/dependabot/maven/file_parser_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Dependabot::Maven::FileParser do
       describe "the sole dependency" do
         subject(:dependency) { dependencies[3] }
 
-        it "has the right details" do 
+        it "has the right details" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("io.takari.polyglot:polyglot-yaml")
           expect(dependency.version).to eq("0.4.6")

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -602,7 +602,7 @@ RSpec.describe Dependabot::Maven::FileUpdater do
     end
 
     context "the updated extensions.xml file" do
-      let(:dependency_files) { [extensions] }
+      let(:dependency_files) { [pom, extensions] }
       let(:extensions) do
         Dependabot::DependencyFile.new(
           name: "extensions.xml",

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -601,6 +601,43 @@ RSpec.describe Dependabot::Maven::FileUpdater do
       end
     end
 
+    context "the updated extensions.xml file" do
+      let(:dependency_files) { [extensions] }
+      let(:extensions) do
+        Dependabot::DependencyFile.new(
+          name: "extensions.xml",
+          content: fixture("extensions", "extensions.xml")
+        )
+      end
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "io.takari.polyglot:polyglot-yaml",
+          version: "0.4.7",
+          requirements: [{
+            file: "extensions.xml",
+            requirement: "0.4.7",
+            groups: [],
+            source: nil,
+            metadata: { packaging_type: "jar" }
+          }],
+          previous_requirements: [{
+            file: "extensions.xml",
+            requirement: "0.4.6",
+            groups: [],
+            source: nil,
+            metadata: { packaging_type: "jar" }
+          }],
+          package_manager: "maven"
+        )
+      end
+
+      subject(:updated_extensions_file) do
+        updated_files.find { |f| f.name == "extensions.xml" }
+      end
+
+      its(:content) { is_expected.to include("<version>0.4.7</version>") }
+    end
+
     context "with a multimodule pom" do
       let(:dependency_files) do
         [

--- a/maven/spec/fixtures/extensions/extensions.xml
+++ b/maven/spec/fixtures/extensions/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>io.takari.polyglot</groupId>
+    <artifactId>polyglot-yaml</artifactId>
+    <version>0.4.6</version>
+  </extension>
+</extensions>

--- a/maven/spec/fixtures/github/contents_java_extensions_xml.json
+++ b/maven/spec/fixtures/github/contents_java_extensions_xml.json
@@ -1,0 +1,18 @@
+{
+  "name": "extensions.xml",
+  "path": "extensions.xml",
+  "sha": "3bc1640c9cc83c05b7a5c38909076f25998fd780",
+  "size": 5682,
+  "url": "https://api.github.com/repos/evenh/versionmonitor/contents/.mvn/extensions.xml?ref=master",
+  "html_url": "https://github.com/evenh/versionmonitor/blob/master/.mvn/extensions.xml",
+  "git_url": "https://api.github.com/repos/evenh/versionmonitor/git/blobs/3bc1640c9cc83c05b7a5c38909076f25998fd780",
+  "download_url": "https://raw.githubusercontent.com/evenh/versionmonitor/master/.mvn/extensions.xml",
+  "type": "file",
+  "content": "PHByb2plY3QgeG1sbnM9Imh0dHA6Ly9tYXZlbi5hcGFjaGUub3JnL1BPTS80\nLjAuMCIKICAgICAgICAgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8y\nMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIKICAgICAgICAgeHNpOnNjaGVtYUxv\nY2F0aW9uPSJodHRwOi8vbWF2ZW4uYXBhY2hlLm9yZy9QT00vNC4wLjAgaHR0\ncDovL21hdmVuLmFwYWNoZS5vcmcvbWF2ZW4tdjRfMF8wLnhzZCI+CiAgPG1v\nZGVsVmVyc2lvbj40LjAuMDwvbW9kZWxWZXJzaW9uPgoKICA8Z3JvdXBJZD5j\nb20uZGVwZW5kYWJvdDwvZ3JvdXBJZD4KICA8YXJ0aWZhY3RJZD5iYXNpYy1w\nb208L2FydGlmYWN0SWQ+CiAgPHZlcnNpb24+MC4wLjEtUkVMRUFTRTwvdmVy\nc2lvbj4KICA8bmFtZT5EZXBlbmRhYm90IEJhc2ljIFBPTTwvbmFtZT4KCiAg\nPHBhY2thZ2luZz5wb208L3BhY2thZ2luZz4KCiAgPGRlcGVuZGVuY2llcz4K\nICAgIDxkZXBlbmRlbmN5PgogICAgICA8Z3JvdXBJZD5jb20uZ29vZ2xlLmd1\nYXZhPC9ncm91cElkPgogICAgICA8YXJ0aWZhY3RJZD5ndWF2YTwvYXJ0aWZh\nY3RJZD4KICAgICAgPHZlcnNpb24+MjMuMy1qcmU8L3ZlcnNpb24+CiAgICA8\nL2RlcGVuZGVuY3k+CgogICAgPGRlcGVuZGVuY3k+CiAgICAgIDxncm91cElk\nPm9yZy5hcGFjaGUuaHR0cGNvbXBvbmVudHM8L2dyb3VwSWQ+CiAgICAgIDxh\ncnRpZmFjdElkPmh0dHBjbGllbnQ8L2FydGlmYWN0SWQ+CiAgICAgIDx2ZXJz\naW9uPjQuNS4zPC92ZXJzaW9uPgogICAgPC9kZXBlbmRlbmN5PgogIDwvZGVw\nZW5kZW5jaWVzPgo8L3Byb2plY3Q+Cg==\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/evenh/versionmonitor/contents/.mvn/extensions.xml?ref=master",
+    "git": "https://api.github.com/repos/evenh/versionmonitor/git/blobs/3bc1640c9cc83c05b7a5c38909076f25998fd780",
+    "html": "https://github.com/evenh/versionmonitor/blob/master/.mvn/extensions.xml"
+  }
+}

--- a/maven/spec/fixtures/github/contents_mvn_directory.json
+++ b/maven/spec/fixtures/github/contents_mvn_directory.json
@@ -1,0 +1,18 @@
+[
+  {
+      "name": "extensions.xml",
+      "path": "extensions.xml",
+      "sha": "7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+      "size": 917,
+      "url": "https://api.github.com/repos/gocardless/business/contents/extensions.xml?ref=master",
+      "html_url": "https://github.com/gocardless/business/blob/master/extensions.xml",
+      "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+      "download_url": "https://raw.githubusercontent.com/gocardless/business/master/extensions.xml",
+      "type": "file",
+      "_links": {
+          "self": "https://api.github.com/repos/gocardless/business/contents/extensions.xml?ref=master",
+          "git": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+          "html": "https://github.com/gocardless/business/blob/master/extensions.xml"
+      }
+  }
+]

--- a/maven/spec/fixtures/vcr_cassettes/Dependabot_Maven_FileFetcher/with_a_multimodule_pom/with_a_nested_multimodule_pom/when_asked_to_fetch_only_a_subdirectory/fetches_the_relevant_poms.yml
+++ b/maven/spec/fixtures/vcr_cassettes/Dependabot_Maven_FileFetcher/with_a_multimodule_pom/with_a_nested_multimodule_pom/when_asked_to_fetch_only_a_subdirectory/fetches_the_relevant_poms.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/gocardless/bump/contents/util/util/.mvn?ref=sha
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      user-agent:
+      - Octokit Ruby Gem 4.21.0
+      accept:
+      - application/vnd.github.v3+json
+      content-type:
+      - application/json
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      server:
+      - GitHub.com
+      date:
+      - Tue, 29 Jun 2021 11:51:46 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '80'
+      x-github-media-type:
+      - github.v3; format=json
+      x-ratelimit-limit:
+      - '60'
+      x-ratelimit-remaining:
+      - '59'
+      x-ratelimit-reset:
+      - '1624971106'
+      x-ratelimit-used:
+      - '1'
+      x-ratelimit-resource:
+      - core
+      access-control-expose-headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      access-control-allow-origin:
+      - "*"
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      x-frame-options:
+      - deny
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - '0'
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      content-security-policy:
+      - default-src 'none'
+      vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      x-github-request-id:
+      - D141:7BEC:C7F7A:CC746:60DB0952
+    body:
+      encoding: UTF-8
+      string: '{"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}'
+  recorded_at: Tue, 29 Jun 2021 11:51:47 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
These files contain dependency coordinates for Maven extensions that
want to receive the Maven afterSessionStart event. The file is always
located in the .mvn folder in the project root and is optional.

See also
  - https://maven.apache.org/guides/mini/guide-using-extensions.html
  - https://maven.apache.org/examples/maven-3-lifecycle-extensions.html