### PR TITLE
v0.138.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.138.5, 26 March 2021
+
+- Update maven/spec/dependabot/maven/version_spec.rb
+- Update gradle/spec/dependabot/gradle/version_spec.rb
+- Maven/Gradle: Treat dev and pr as pre-releases for gradle/maven
+- Bundler v2 [pre-release]: Add and test jfrog source helper
+- Cargo: Update Rust to 1.51.0
+- Bump npm from 6.14.11 to 6.14.12 in /npm_and_yarn/helpers
+- Internal: bump-version: re-tag the release notes ref
+- Azure: adding azure pr updater reference in pr updater common class
+
 ## v0.138.4, 25 March 2021
 
 - Docker: fix invalid Accept header when checking for updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## v0.138.5, 26 March 2021
 
-- Update maven/spec/dependabot/maven/version_spec.rb
-- Update gradle/spec/dependabot/gradle/version_spec.rb
 - Maven/Gradle: Treat dev and pr as pre-releases for gradle/maven
 - Bundler v2 [pre-release]: Add and test jfrog source helper
 - Cargo: Update Rust to 1.51.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Maven/Gradle: Treat dev and pr as pre-releases for gradle/maven
 - Bundler v2 [pre-release]: Add and test jfrog source helper
-- Cargo: Update Rust to 1.51.0
+- Cargo: Update Rust to 1.51.0 (thanks @CryZe)
 - Bump npm from 6.14.11 to 6.14.12 in /npm_and_yarn/helpers
 - Internal: bump-version: re-tag the release notes ref
 - Azure: adding azure pr updater reference in pr updater common class

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.138.4"
+  VERSION = "0.138.5"
 end


### PR DESCRIPTION
- Update maven/spec/dependabot/maven/version_spec.rb
- Update gradle/spec/dependabot/gradle/version_spec.rb
- Maven/Gradle: Treat dev and pr as pre-releases for gradle/maven
- Bundler v2 [pre-release]: Add and test jfrog source helper
- Cargo: Update Rust to 1.51.0
- Bump npm from 6.14.11 to 6.14.12 in /npm_and_yarn/helpers
- Internal: bump-version: re-tag the release notes ref
- Azure: adding azure pr updater reference in pr updater common class