### PR TITLE
Handle both ruby and package manager specific version requirements from ignore conditions

### DIFF
--- a/bundler/lib/dependabot/bundler/requirement.rb
+++ b/bundler/lib/dependabot/bundler/requirement.rb
@@ -16,7 +16,7 @@ module Dependabot
       # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
-          req_string.split(",")
+          req_string.split(",").map(&:strip)
         end
 
         super(requirements)

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -70,7 +70,7 @@ module Dependabot
 
         def filter_ignored_versions(versions_array)
           filtered = versions_array.
-                     reject { |v| ignore_reqs.any? { |r| r.satisfied_by?(v) } }
+                     reject { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }
           raise AllVersionsIgnored if @raise_on_ignored && filtered.empty? && versions_array.any?
 
           filtered
@@ -110,8 +110,8 @@ module Dependabot
           )
         end
 
-        def ignore_reqs
-          ignored_versions.map { |req| Gem::Requirement.new(req.split(",")) }
+        def ignore_requirements
+          ignored_versions.flat_map { |req| requirement_class.requirements_array(req) }
         end
 
         def gemfile

--- a/cargo/lib/dependabot/cargo/requirement.rb
+++ b/cargo/lib/dependabot/cargo/requirement.rb
@@ -42,7 +42,7 @@ module Dependabot
 
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
-          req_string.split(",").map do |r|
+          req_string.split(",").map(&:strip).map do |r|
             convert_rust_constraint_to_ruby_constraint(r.strip)
           end
         end

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -55,7 +55,7 @@ module Dependabot
 
         def filter_ignored_versions(versions_array)
           filtered = versions_array.
-                     reject { |v| ignore_reqs.any? { |r| r.satisfied_by?(v) } }
+                     reject { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }
           raise Dependabot::AllVersionsIgnored if @raise_on_ignored && filtered.empty? && versions_array.any?
 
           filtered
@@ -108,8 +108,8 @@ module Dependabot
           end
         end
 
-        def ignore_reqs
-          ignored_versions.map { |req| requirement_class.new(req.split(",")) }
+        def ignore_requirements
+          ignored_versions.flat_map { |req| requirement_class.requirements_array(req) }
         end
 
         def version_class

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -92,7 +92,7 @@ module Dependabot
         local_tags.
         select { |t| version_tag?(t.name) && matches_existing_prefix?(t.name) }
       filtered = tags.
-                 reject { |t| tag_included_in_ignore_reqs?(t) }
+                 reject { |t| tag_included_in_ignore_requirements?(t) }
       raise Dependabot::AllVersionsIgnored if @raise_on_ignored && tags.any? && filtered.empty?
 
       tag = filtered.
@@ -317,8 +317,8 @@ module Dependabot
       listing_repo_git_metadata_fetcher.upload_pack
     end
 
-    def ignore_reqs
-      ignored_versions.map { |req| requirement_class.new(req.split(",")) }
+    def ignore_requirements
+      ignored_versions.flat_map { |req| requirement_class.requirements_array(req) }
     end
 
     def wants_prerelease?
@@ -330,9 +330,9 @@ module Dependabot
       version_class.new(version).prerelease?
     end
 
-    def tag_included_in_ignore_reqs?(tag)
+    def tag_included_in_ignore_requirements?(tag)
       version = tag.name.match(VERSION_REGEX).named_captures.fetch("version")
-      ignore_reqs.any? { |r| r.satisfied_by?(version_class.new(version)) }
+      ignore_requirements.any? { |r| r.satisfied_by?(version_class.new(version)) }
     end
 
     def tag_is_prerelease?(tag)

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -38,7 +38,7 @@ module Dependabot
 
       def can_update?(requirements_to_unlock:)
         # Can't update if all versions are being ignored
-        return false if ignore_reqs.include?(requirement_class.new(">= 0"))
+        return false if ignore_requirements.include?(requirement_class.new(">= 0"))
 
         if dependency.version
           version_can_update?(requirements_to_unlock: requirements_to_unlock)
@@ -139,6 +139,10 @@ module Dependabot
 
         version = version_class.new(dependency.version)
         security_advisories.any? { |a| a.vulnerable?(version) }
+      end
+
+      def ignore_requirements
+        ignored_versions.flat_map { |req| requirement_class.requirements_array(req) }
       end
 
       private
@@ -295,10 +299,6 @@ module Dependabot
         return false if changed_requirements.none?
 
         changed_requirements.none? { |r| r[:requirement] == :unfixable }
-      end
-
-      def ignore_reqs
-        ignored_versions.map { |req| requirement_class.new(req.split(",")) }
       end
     end
   end

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -925,6 +925,11 @@ RSpec.describe Dependabot::GitCommitChecker do
           its([:tag]) { is_expected.to eq("v1.11.1") }
         end
 
+        context "multiple ignore conditions" do
+          let(:ignored_versions) { [">= 1.11.2, < 1.12.0"] }
+          its([:tag]) { is_expected.to eq("v1.13.0") }
+        end
+
         context "all versions ignored" do
           let(:ignored_versions) { [">= 0"] }
           it "returns nil" do

--- a/common/spec/dependabot/update_checkers/base_spec.rb
+++ b/common/spec/dependabot/update_checkers/base_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
     described_class.new(
       dependency: dependency,
       dependency_files: [],
+      ignored_versions: ignored_versions,
       credentials: [{
         "type" => "git_source",
         "host" => "github.com",
@@ -26,6 +27,7 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
       package_manager: "dummy"
     )
   end
+  let(:ignored_versions) { [] }
   let(:latest_version) { Gem::Version.new("1.0.0") }
   let(:original_requirements) do
     [{ file: "Gemfile", requirement: ">= 0", groups: [], source: nil }]
@@ -598,6 +600,18 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
         ]
       end
       it { is_expected.to eq(false) }
+    end
+  end
+
+  describe "#ignore_requirements" do
+    subject(:ignore_requirements) { updater_instance.ignore_requirements }
+
+    it { is_expected.to eq([]) }
+
+    context "with ignored versions" do
+      let(:ignored_versions) { ["~> 1.0, < 2"] }
+
+      it { is_expected.to eq([updater_instance.requirement_class.new("~> 1.0", "< 2")]) }
     end
   end
 end

--- a/common/spec/dummy_package_manager/requirement.rb
+++ b/common/spec/dummy_package_manager/requirement.rb
@@ -7,6 +7,16 @@ module DummyPackageManager
     def self.requirements_array(requirement_string)
       [new(requirement_string)]
     end
+
+    # Patches Gem::Requirement to make it accept requirement strings like
+    # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
+    def initialize(*requirements)
+      requirements = requirements.flatten.flat_map do |req_string|
+        req_string.split(",").map(&:strip)
+      end
+
+      super(requirements)
+    end
   end
 end
 

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -60,7 +60,7 @@ module Dependabot
         def filter_ignored_versions(versions_array)
           filtered =
             versions_array.
-            reject { |v| ignore_reqs.any? { |r| r.satisfied_by?(v) } }
+            reject { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }
 
           raise AllVersionsIgnored if @raise_on_ignored && filtered.empty? && versions_array.any?
 
@@ -178,7 +178,7 @@ module Dependabot
           dependency_files.find { |f| f.name == "auth.json" }
         end
 
-        def ignore_reqs
+        def ignore_requirements
           ignored_versions.map { |req| requirement_class.new(req.split(",")) }
         end
 

--- a/dep/lib/dependabot/dep/requirement.rb
+++ b/dep/lib/dependabot/dep/requirement.rb
@@ -49,7 +49,7 @@ module Dependabot
 
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
-          req_string.split(",").map do |r|
+          req_string.split(",").map(&:strip).map do |r|
             convert_go_constraint_to_ruby_constraint(r.strip)
           end
         end

--- a/docker/lib/dependabot/docker/requirement.rb
+++ b/docker/lib/dependabot/docker/requirement.rb
@@ -17,7 +17,7 @@ module Dependabot
       # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
-          req_string.split(",")
+          req_string.split(",").map(&:strip)
         end
 
         super(requirements)

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -358,17 +358,11 @@ module Dependabot
           candidate_tags.
           reject do |tag|
             version = version_class.new(numeric_version_from(tag))
-            ignore_reqs.any? { |r| r.satisfied_by?(version) }
+            ignore_requirements.any? { |r| r.satisfied_by?(version) }
           end
         raise AllVersionsIgnored if @raise_on_ignored && filtered.empty? && candidate_tags.any?
 
         filtered
-      end
-
-      def ignore_reqs
-        # NOTE: we use Gem::Requirement here because ignore conditions will
-        # be passed as Ruby ranges
-        ignored_versions.map { |req| Gem::Requirement.new(req.split(",")) }
       end
     end
   end

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -190,6 +190,11 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("17.04") }
     end
 
+    context "when ignoring multiple versions" do
+      let(:ignored_versions) { [">= 17.10, < 17.2"] }
+      it { is_expected.to eq("17.10") }
+    end
+
     context "when all versions are being ignored" do
       let(:ignored_versions) { [">= 0"] }
       it { is_expected.to eq("17.04") }

--- a/elm/lib/dependabot/elm/requirement.rb
+++ b/elm/lib/dependabot/elm/requirement.rb
@@ -22,7 +22,7 @@ module Dependabot
         requirements = requirements.flatten.flat_map do |req_string|
           raise BadRequirementError, "Nil requirement not supported in Elm" if req_string.nil?
 
-          req_string.split(",").map do |r|
+          req_string.split(",").map(&:strip).map do |r|
             convert_elm_constraint_to_ruby_constraint(r)
           end
         end

--- a/elm/lib/dependabot/elm/update_checker.rb
+++ b/elm/lib/dependabot/elm/update_checker.rb
@@ -80,7 +80,7 @@ module Dependabot
 
       def candidate_versions
         filtered = all_versions.
-                   reject { |v| ignore_reqs.any? { |r| r.satisfied_by?(v) } }
+                   reject { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }
 
         raise AllVersionsIgnored if @raise_on_ignored && filtered.empty? && all_versions.any?
 
@@ -117,12 +117,6 @@ module Dependabot
           map { |r| r.fetch(:requirement) }.
           map { |r| requirement_class.new(r) }.
           all? { |r| r.satisfied_by?(latest_version) }
-      end
-
-      def ignore_reqs
-        # NOTE: we use Gem::Requirement here because ignore conditions will
-        # be passed as Ruby ranges
-        ignored_versions.map { |req| Gem::Requirement.new(req.split(",")) }
       end
     end
   end

--- a/elm/spec/dependabot/elm/update_checker_spec.rb
+++ b/elm/spec/dependabot/elm/update_checker_spec.rb
@@ -155,6 +155,11 @@ RSpec.describe Dependabot::Elm::UpdateChecker do
       it { is_expected.to eq(Dependabot::Elm::Version.new("4.0.5")) }
     end
 
+    context "when ignoring several versions" do
+      let(:ignored_versions) { [">= 5.0.0, < 5.1.0"] }
+      it { is_expected.to eq(Dependabot::Elm::Version.new("5.1.1")) }
+    end
+
     context "when all versions are being ignored" do
       let(:ignored_versions) { [">= 0"] }
       it "returns nil" do

--- a/git_submodules/lib/dependabot/git_submodules/requirement.rb
+++ b/git_submodules/lib/dependabot/git_submodules/requirement.rb
@@ -16,7 +16,7 @@ module Dependabot
       # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
-          req_string.split(",")
+          req_string.split(",").map(&:strip)
         end
 
         super(requirements)

--- a/github_actions/lib/dependabot/github_actions/requirement.rb
+++ b/github_actions/lib/dependabot/github_actions/requirement.rb
@@ -18,7 +18,7 @@ module Dependabot
       # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
-          req_string.split(",")
+          req_string.split(",").map(&:strip)
         end
 
         super(requirements)

--- a/go_modules/lib/dependabot/go_modules/requirement.rb
+++ b/go_modules/lib/dependabot/go_modules/requirement.rb
@@ -49,7 +49,7 @@ module Dependabot
 
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
-          req_string.split(",").map do |r|
+          req_string.split(",").map(&:strip).map do |r|
             convert_go_constraint_to_ruby_constraint(r.strip)
           end
         end

--- a/gradle/lib/dependabot/gradle/requirement.rb
+++ b/gradle/lib/dependabot/gradle/requirement.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dependabot/utils"
+require "dependabot/maven/requirement"
 require "dependabot/gradle/version"
 
 module Dependabot
@@ -32,7 +33,14 @@ module Dependabot
 
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
-          convert_java_constraint_to_ruby_constraint(req_string)
+          # NOTE: Support ruby-style version requirements that are created from
+          # PR ignore conditions
+          version_reqs = req_string.split(",").map(&:strip)
+          if version_reqs.all? { |s| Gem::Requirement::PATTERN.match?(s) }
+            version_reqs
+          else
+            convert_java_constraint_to_ruby_constraint(req_string)
+          end
         end
 
         super(requirements)
@@ -46,7 +54,9 @@ module Dependabot
       private
 
       def self.split_java_requirement(req_string)
-        req_string.split(/(?<=\]|\)),/).flat_map do |str|
+        return [req_string] unless req_string.match?(Maven::Requirement::OR_SYNTAX)
+
+        req_string.split(Maven::Requirement::OR_SYNTAX).flat_map do |str|
           next str if str.start_with?("(", "[")
 
           exacts, *rest = str.split(/,(?=\[|\()/)

--- a/gradle/spec/dependabot/gradle/requirement_spec.rb
+++ b/gradle/spec/dependabot/gradle/requirement_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe Dependabot::Gradle::Requirement do
       let(:requirement_string) { "[1.0.0]" }
       it { is_expected.to eq(Gem::Requirement.new("= 1.0.0")) }
     end
+
+    context "with a comma-separated ruby style version requirement" do
+      let(:requirement_string) { "~> 4.2.5, >= 4.2.5.1" }
+      it { is_expected.to eq(described_class.new("~> 4.2.5", ">= 4.2.5.1")) }
+    end
   end
 
   describe ".requirements_array" do
@@ -95,6 +100,11 @@ RSpec.describe Dependabot::Gradle::Requirement do
           ]
         )
       end
+    end
+
+    context "with a comma-separated ruby style version requirement" do
+      let(:requirement_string) { "~> 4.2.5, >= 4.2.5.1" }
+      it { is_expected.to eq([described_class.new("~> 4.2.5", ">= 4.2.5.1")]) }
     end
   end
 

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -121,6 +121,12 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
       its([:version]) { is_expected.to eq(version_class.new("22.0")) }
     end
 
+    context "when the user has asked to ignore several major versions" do
+      let(:ignored_versions) { ["[23.0,24),[22.0,23)"] }
+      let(:dependency_version) { "17.0" }
+      its([:version]) { is_expected.to eq(version_class.new("21.0")) }
+    end
+
     context "when a version range is specified using Ruby syntax" do
       let(:ignored_versions) { [">= 23.0, < 24"] }
       let(:dependency_version) { "17.0" }

--- a/hex/lib/dependabot/hex/requirement.rb
+++ b/hex/lib/dependabot/hex/requirement.rb
@@ -26,6 +26,16 @@ module Dependabot
         end
       end
 
+      # Patches Gem::Requirement to make it accept requirement strings like
+      # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
+      def initialize(*requirements)
+        requirements = requirements.flatten.flat_map do |req_string|
+          req_string.split(",").map(&:strip)
+        end
+
+        super(requirements)
+      end
+
       # Override the parser to create Hex::Versions
       def self.parse(obj)
         return ["=", Hex::Version.new(obj.to_s)] if obj.is_a?(Gem::Version)

--- a/hex/lib/dependabot/hex/update_checker.rb
+++ b/hex/lib/dependabot/hex/update_checker.rb
@@ -218,7 +218,7 @@ module Dependabot
             versions.reject!(&:prerelease?) unless wants_prerelease?
 
             filtered = versions.reject do |v|
-              ignore_reqs.any? { |r| r.satisfied_by?(v) }
+              ignore_requirements.any? { |r| r.satisfied_by?(v) }
             end
 
             raise AllVersionsIgnored if @raise_on_ignored && filtered.empty? && versions.any?

--- a/hex/spec/dependabot/hex/requirement_spec.rb
+++ b/hex/spec/dependabot/hex/requirement_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe Dependabot::Hex::Requirement do
   describe ".new" do
     subject { described_class.new(requirement_string) }
 
+    context "with a comma-separated string" do
+      let(:requirement_string) { "~> 4.2.5, >= 4.2.5.1" }
+      it { is_expected.to eq(described_class.new("~> 4.2.5", ">= 4.2.5.1")) }
+    end
+
     context "with an == specifier" do
       let(:requirement_string) { "== 1.0.0" }
       it { is_expected.to be_satisfied_by(Gem::Version.new("1.0.0")) }

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -14,8 +14,6 @@ module Dependabot
       class VersionFinder
         TYPE_SUFFICES = %w(jre android java).freeze
 
-        MAVEN_RANGE_REGEX = /[\(\[].*,.*[\)\]]/.freeze
-
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, security_advisories:,
                        raise_on_ignored: false)
@@ -95,21 +93,15 @@ module Dependabot
           filtered = possible_versions
 
           ignored_versions.each do |req|
-            ignore_req = Maven::Requirement.new(parse_requirement_string(req))
+            ignore_requirements = Maven::Requirement.requirements_array(req)
             filtered =
               filtered.
-              reject { |v| ignore_req.satisfied_by?(v.fetch(:version)) }
+              reject { |v| ignore_requirements.any? { |r| r.satisfied_by?(v.fetch(:version)) } }
           end
 
           raise AllVersionsIgnored if @raise_on_ignored && filtered.empty? && possible_versions.any?
 
           filtered
-        end
-
-        def parse_requirement_string(string)
-          return string if string.match?(MAVEN_RANGE_REGEX)
-
-          string.split(",").map(&:strip)
         end
 
         def filter_vulnerable_versions(possible_versions)

--- a/maven/spec/dependabot/maven/requirement_spec.rb
+++ b/maven/spec/dependabot/maven/requirement_spec.rb
@@ -80,6 +80,11 @@ RSpec.describe Dependabot::Maven::Requirement do
       let(:requirement_string) { "[1.0.0]" }
       it { is_expected.to eq(Gem::Requirement.new("= 1.0.0")) }
     end
+
+    context "with a comma-separated ruby style version requirement" do
+      let(:requirement_string) { "~> 4.2.5, >= 4.2.5.1" }
+      it { is_expected.to eq(described_class.new("~> 4.2.5", ">= 4.2.5.1")) }
+    end
   end
 
   describe ".requirements_array" do
@@ -105,6 +110,11 @@ RSpec.describe Dependabot::Maven::Requirement do
           ]
         )
       end
+    end
+
+    context "with a comma-separated ruby style version requirement" do
+      let(:requirement_string) { "~> 4.2.5, >= 4.2.5.1" }
+      it { is_expected.to eq([described_class.new("~> 4.2.5", ">= 4.2.5.1")]) }
     end
   end
 

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -188,6 +188,19 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       its([:version]) { is_expected.to eq(version_class.new("22.0")) }
     end
 
+    context "when the user has asked to ignore several major versions" do
+      let(:ignored_versions) { ["[23.0,24),[22.0,23)"] }
+      let(:dependency_version) { "17.0" }
+      let(:maven_central_version_files_url) do
+        "https://repo.maven.apache.org/maven2/"\
+        "com/google/guava/guava/21.0/guava-21.0.jar"
+      end
+      let(:maven_central_version_files) do
+        fixture("maven_central_version_files", "guava-22.0.html")
+      end
+      its([:version]) { is_expected.to eq(version_class.new("21.0")) }
+    end
+
     context "when a version range is specified using Ruby syntax" do
       let(:ignored_versions) { [">= 23.0, < 24"] }
       let(:dependency_version) { "17.0" }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/requirement.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/requirement.rb
@@ -45,9 +45,9 @@ module Dependabot
       end
 
       def initialize(*requirements)
-        requirements = requirements.flatten.flat_map do |req_string|
-          convert_js_constraint_to_ruby_constraint(req_string)
-        end
+        requirements = requirements.flatten.
+                       flat_map { |req_string| req_string.split(",").map(&:strip) }.
+                       flat_map { |req_string| convert_js_constraint_to_ruby_constraint(req_string) }
 
         super(requirements)
       end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -106,7 +106,7 @@ module Dependabot
 
         def filter_ignored_versions(versions_array)
           filtered = versions_array.reject do |v, _|
-            ignore_reqs.any? { |r| r.satisfied_by?(v) }
+            ignore_requirements.any? { |r| r.satisfied_by?(v) }
           end
 
           raise AllVersionsIgnored if @raise_on_ignored && filtered.empty? && versions_array.any?
@@ -201,7 +201,7 @@ module Dependabot
           return false if related_to_current_pre?(ver) ^ ver.prerelease?
           return false if current_version_greater_than?(ver)
           return false if current_requirement_greater_than?(ver)
-          return false if ignore_reqs.any? { |r| r.satisfied_by?(ver) }
+          return false if ignore_requirements.any? { |r| r.satisfied_by?(ver) }
           return false if yanked?(ver)
 
           true
@@ -388,8 +388,8 @@ module Dependabot
           )
         end
 
-        def ignore_reqs
-          ignored_versions.map { |req| requirement_class.new(req.split(",")) }
+        def ignore_requirements
+          ignored_versions.flat_map { |req| requirement_class.requirements_array(req) }
         end
 
         def version_class

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/requirement_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/requirement_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe Dependabot::NpmAndYarn::Requirement do
   describe ".new" do
     it { is_expected.to be_a(described_class) }
 
+    context "with a comma-separated string" do
+      let(:requirement_string) { "^ 4.2.5, >= 4.2.5.1" }
+      it { is_expected.to eq(described_class.new([">= 4.2.5", "< 5.0.0.a", ">= 4.2.5.1"])) }
+    end
+
     context "with an exact version specified" do
       let(:requirement_string) { "1.0.0" }
       it { is_expected.to eq(described_class.new("1.0.0")) }

--- a/python/lib/dependabot/python/requirement.rb
+++ b/python/lib/dependabot/python/requirement.rb
@@ -50,7 +50,7 @@ module Dependabot
         requirements = requirements.flatten.flat_map do |req_string|
           next if req_string.nil?
 
-          req_string.split(",").map do |r|
+          req_string.split(",").map(&:strip).map do |r|
             convert_python_constraint_to_ruby_constraint(r)
           end
         end

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -100,7 +100,7 @@ module Dependabot
 
         def filter_ignored_versions(versions_array)
           filtered = versions_array.
-                     reject { |v| ignore_reqs.any? { |r| r.satisfied_by?(v) } }
+                     reject { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }
           raise Dependabot::AllVersionsIgnored if @raise_on_ignored && filtered.empty? && versions_array.any?
 
           filtered
@@ -226,8 +226,8 @@ module Dependabot
           )
         end
 
-        def ignore_reqs
-          ignored_versions.map { |req| requirement_class.new(req.split(",")) }
+        def ignore_requirements
+          ignored_versions.flat_map { |req| requirement_class.requirements_array(req) }
         end
 
         def normalised_name

--- a/terraform/lib/dependabot/terraform/requirement.rb
+++ b/terraform/lib/dependabot/terraform/requirement.rb
@@ -26,6 +26,16 @@ module Dependabot
       def self.requirements_array(requirement_string)
         [new(requirement_string)]
       end
+
+      # Patches Gem::Requirement to make it accept requirement strings like
+      # "~> 4.2.5, >= 4.2.5.1" without first needing to split them.
+      def initialize(*requirements)
+        requirements = requirements.flatten.flat_map do |req_string|
+          req_string.split(",").map(&:strip)
+        end
+
+        super(requirements)
+      end
     end
   end
 end

--- a/terraform/lib/dependabot/terraform/update_checker.rb
+++ b/terraform/lib/dependabot/terraform/update_checker.rb
@@ -67,7 +67,7 @@ module Dependabot
 
         versions = all_registry_versions
         versions.reject!(&:prerelease?) unless wants_prerelease?
-        versions.reject! { |v| ignore_reqs.any? { |r| r.satisfied_by?(v) } }
+        versions.reject! { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }
 
         @latest_version_for_registry_dependency = versions.max
       end

--- a/terraform/spec/dependabot/terraform/requirement_spec.rb
+++ b/terraform/spec/dependabot/terraform/requirement_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/terraform/requirement"
+
+RSpec.describe Dependabot::Terraform::Requirement do
+  subject(:requirement) { described_class.new(requirement_string) }
+  let(:requirement_string) { ">=1.0.0" }
+
+  describe ".new" do
+    it { is_expected.to be_a(described_class) }
+
+    context "with a comma-separated string" do
+      let(:requirement_string) { "~> 4.2.5, >= 4.2.5.1" }
+      it { is_expected.to eq(described_class.new("~> 4.2.5", ">= 4.2.5.1")) }
+    end
+  end
+end

--- a/terraform/spec/dependabot/terraform/update_checker_spec.rb
+++ b/terraform/spec/dependabot/terraform/update_checker_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Dependabot::Terraform::UpdateChecker do
     described_class.new(
       dependency: dependency,
       dependency_files: [],
-      credentials: credentials
+      credentials: credentials,
+      ignored_versions: ignored_versions
     )
   end
   let(:credentials) do
@@ -24,6 +25,7 @@ RSpec.describe Dependabot::Terraform::UpdateChecker do
       "password" => "token"
     }]
   end
+  let(:ignored_versions) { [] }
 
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -98,6 +100,11 @@ RSpec.describe Dependabot::Terraform::UpdateChecker do
       end
 
       it { is_expected.to eq(Gem::Version.new("0.3.8")) }
+
+      context "when the user is ignoring the latest version" do
+        let(:ignored_versions) { [">= 0.3.8, < 0.4.0"] }
+        it { is_expected.to eq(Gem::Version.new("0.3.7")) }
+      end
 
       context "for a custom registry" do
         let(:source) do


### PR DESCRIPTION
This is an attempt to handle both ruby and package manager specific version requirements from ignore conditions in the package manager specific requirement class.

We currently create ruby style ignore requirement when commenting on dependabot PRs with `£dependabot ignore this major version` for example. We also [say to use the package manager specific requirement syntax](https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore) when adding `ignore`s to the config file.

We also support specifying comma-separated ignore conditions as a single string, `> 1.2.3, <= 2.0.0` and split these when parsing the ignore conditions. This works for most ecosystems except for gradle/maven that have special range syntax, we used to handle this specifically when parsing ignore conditions: https://github.com/dependabot/dependabot-core/pull/3368/files#diff-3107de50e63836063ddedc0b51b50e47d1dba7d517f060e051b1b4d9494dd2abL131-L135

All requirement classes now support splitting comma-separated strings, whereas only some did this in the past and those who didn't would raise from `Gem::Requirement`.

Using the `requirements_array` method also means we'll properly deal with languages that support `OR` syntax, e.q. https://github.com/dependabot/dependabot-core/blob/main/maven/lib/dependabot/maven/requirement.rb#L28