### PR TITLE
Convert the spec for Bundler::UpdateChecker to use project based fixtures.

### DIFF
--- a/bundler/helpers/v1/spec/native_spec_helper.rb
+++ b/bundler/helpers/v1/spec/native_spec_helper.rb
@@ -27,6 +27,9 @@ LOCKFILE_ENDING = /(?<ending>\s*(?:RUBY VERSION|BUNDLED WITH).*)/m.freeze
 
 def project_dependency_files(project)
   project_path = File.expand_path(File.join("../../spec/fixtures/projects/bundler1", project))
+
+  raise "Fixture does not exist for project: '#{project}'" unless Dir.exist?(project_path)
+
   Dir.chdir(project_path) do
     # NOTE: Include dotfiles (e.g. .npmrc)
     files = Dir.glob("**/*", File::FNM_DOTMATCH)

--- a/bundler/helpers/v2/spec/native_spec_helper.rb
+++ b/bundler/helpers/v2/spec/native_spec_helper.rb
@@ -26,7 +26,11 @@ end
 LOCKFILE_ENDING = /(?<ending>\s*(?:RUBY VERSION|BUNDLED WITH).*)/m.freeze
 
 def project_dependency_files(project)
+  # TODO: Retrieve files from bundler2 folder once it is fully up to date
   project_path = File.expand_path(File.join("../../spec/fixtures/projects/bundler1", project))
+
+  raise "Fixture does not exist for project: '#{project}'" unless Dir.exist?(project_path)
+
   Dir.chdir(project_path) do
     # NOTE: Include dotfiles (e.g. .npmrc)
     files = Dir.glob("**/*", File::FNM_DOTMATCH)

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       "password" => "token"
     }]
   end
-  let(:dependency_files) { [gemfile, lockfile] }
+  let(:dependency_files) { bundler_project_dependency_files("gemfile") }
+
   let(:github_token) { "token" }
   let(:directory) { "/" }
   let(:ignored_versions) { [] }
@@ -50,29 +51,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     [{ file: "Gemfile", requirement: "~> 1.4.0", groups: [], source: nil }]
   end
 
-  let(:gemfile) do
-    Dependabot::DependencyFile.new(
-      content: fixture("ruby", "gemfiles", gemfile_fixture_name),
-      name: "Gemfile",
-      directory: directory
-    )
-  end
-  let(:lockfile) do
-    Dependabot::DependencyFile.new(
-      content: fixture("ruby", "lockfiles", lockfile_fixture_name),
-      name: "Gemfile.lock",
-      directory: directory
-    )
-  end
-  let(:gemspec) do
-    Dependabot::DependencyFile.new(
-      content: fixture("ruby", "gemspecs", gemspec_fixture_name),
-      name: "example.gemspec"
-    )
-  end
-  let(:gemfile_fixture_name) { "Gemfile" }
-  let(:lockfile_fixture_name) { "Gemfile.lock" }
-  let(:gemspec_fixture_name) { "example" }
   let(:rubygems_url) { "https://rubygems.org/api/v1/" }
 
   describe "#latest_version" do
@@ -88,8 +66,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       it { is_expected.to eq(Gem::Version.new("1.5.0")) }
 
       context "that only appears in the lockfile" do
-        let(:gemfile_fixture_name) { "subdependency" }
-        let(:lockfile_fixture_name) { "subdependency.lock" }
+        let(:dependency_files) { bundler_project_dependency_files("subdependency") }
+
         let(:requirements) { [] }
         let(:dependency_name) { "i18n" }
         let(:current_version) { "0.7.0.beta1" }
@@ -113,36 +91,14 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "with a Gemfile that includes a file with require_relative" do
-        let(:dependency_files) { [gemfile, lockfile, required_file] }
-        let(:gemfile_fixture_name) { "includes_require_relative" }
-        let(:lockfile_fixture_name) { "Gemfile.lock" }
-        let(:required_file) do
-          Dependabot::DependencyFile.new(
-            name: "../some_other_file.rb",
-            content: "SOME_CONSTANT = 5",
-            directory: directory
-          )
-        end
+        let(:dependency_files) { bundler_project_dependency_files("includes_require_relative_gemfile") }
         let(:directory) { "app/" }
 
         it { is_expected.to eq(Gem::Version.new("1.5.0")) }
       end
 
       context "with a gem.rb and gems.locked setup" do
-        let(:gemfile) do
-          Dependabot::DependencyFile.new(
-            content: fixture("ruby", "gemfiles", gemfile_fixture_name),
-            name: "gems.rb",
-            directory: directory
-          )
-        end
-        let(:lockfile) do
-          Dependabot::DependencyFile.new(
-            content: fixture("ruby", "lockfiles", lockfile_fixture_name),
-            name: "gems.locked",
-            directory: directory
-          )
-        end
+        let(:dependency_files) { bundler_project_dependency_files("gems_rb") }
 
         let(:requirements) do
           [{
@@ -181,8 +137,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "with a private rubygems source" do
-      let(:lockfile_fixture_name) { "specified_source.lock" }
-      let(:gemfile_fixture_name) { "specified_source" }
+      let(:dependency_files) { bundler_project_dependency_files("specified_source") }
+
       let(:requirements) do
         [{
           file: "Gemfile",
@@ -224,8 +180,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "given a git source" do
-      let(:lockfile_fixture_name) { "git_source_no_ref.lock" }
-      let(:gemfile_fixture_name) { "git_source_no_ref" }
+      let(:dependency_files) { bundler_project_dependency_files("git_source_no_ref") }
 
       before do
         rubygems_response = fixture("ruby", "rubygems_response_versions.json")
@@ -284,8 +239,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         context "when the gem's tag is pinned" do
-          let(:lockfile_fixture_name) { "git_source.lock" }
-          let(:gemfile_fixture_name) { "git_source" }
+          let(:dependency_files) { bundler_project_dependency_files("git_source") }
 
           let(:requirements) do
             [{
@@ -384,8 +338,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "given a path source" do
-      let(:gemfile_fixture_name) { "path_source" }
-      let(:lockfile_fixture_name) { "path_source.lock" }
+      let(:dependency_files) { bundler_project_dependency_files("path_source") }
 
       before do
         rubygems_response = fixture("ruby", "rubygems_response_versions.json")
@@ -394,9 +347,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "with a downloaded gemspec" do
-        let(:gemspec_fixture_name) { "example" }
-        let(:dependency_files) { [gemfile, lockfile, gemspec] }
-
         context "that is the gem we're checking" do
           let(:dependency_name) { "example" }
           let(:current_version) { "0.9.3" }
@@ -473,10 +423,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "when the force updater raises" do
-        let(:gemfile_fixture_name) { "subdep_blocked_by_subdep" }
-        let(:lockfile_fixture_name) do
-          "subdep_blocked_by_subdep.lock"
-        end
+        let(:dependency_files) { bundler_project_dependency_files("subdep_blocked_by_subdep") }
         let(:target_version) { "2.0.0" }
         let(:dependency_name) { "dummy-pkg-a" }
         let(:requirements) do
@@ -492,8 +439,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "when the force updater succeeds" do
-        let(:gemfile_fixture_name) { "version_conflict" }
-        let(:lockfile_fixture_name) { "version_conflict.lock" }
+        let(:dependency_files) { bundler_project_dependency_files("version_conflict") }
         let(:target_version) { "3.6.0" }
         let(:dependency_name) { "rspec-mocks" }
         let(:requirements) do
@@ -517,8 +463,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "when the force updater succeeds" do
-        let(:gemfile_fixture_name) { "version_conflict" }
-        let(:lockfile_fixture_name) { "version_conflict.lock" }
+        let(:dependency_files) { bundler_project_dependency_files("version_conflict") }
         let(:target_version) { "3.6.0" }
         let(:dependency_name) { "rspec-mocks" }
         let(:requirements) do
@@ -562,20 +507,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         context "with a gem.rb and gems.locked setup" do
-          let(:gemfile) do
-            Dependabot::DependencyFile.new(
-              content: fixture("ruby", "gemfiles", gemfile_fixture_name),
-              name: "gems.rb",
-              directory: directory
-            )
-          end
-          let(:lockfile) do
-            Dependabot::DependencyFile.new(
-              content: fixture("ruby", "lockfiles", lockfile_fixture_name),
-              name: "gems.locked",
-              directory: directory
-            )
-          end
+          let(:dependency_files) { bundler_project_dependency_files("version_conflict_gems_rb") }
 
           let(:requirements) do
             [{
@@ -627,8 +559,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
     subject { checker.conflicting_dependencies }
 
-    let(:gemfile_fixture_name) { "subdep_blocked_by_subdep" }
-    let(:lockfile_fixture_name) { "subdep_blocked_by_subdep.lock" }
+    let(:dependency_files) { bundler_project_dependency_files("subdep_blocked_by_subdep") }
     let(:target_version) { "2.0.0" }
     let(:dependency_name) { "dummy-pkg-a" }
     let(:requirements) do
@@ -677,8 +608,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
     context "given a gem from rubygems" do
       context "that only appears in the lockfile" do
-        let(:gemfile_fixture_name) { "subdependency" }
-        let(:lockfile_fixture_name) { "subdependency.lock" }
+        let(:dependency_files) { bundler_project_dependency_files("subdependency") }
         let(:requirements) { [] }
         let(:dependency_name) { "i18n" }
         let(:current_version) { "0.7.0.beta1" }
@@ -687,8 +617,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "with no version specified" do
-        let(:gemfile_fixture_name) { "version_not_specified" }
-        let(:lockfile_fixture_name) { "version_not_specified.lock" }
+        let(:dependency_files) { bundler_project_dependency_files("version_not_specified") }
         let(:requirements) do
           [{ file: "Gemfile", requirement: ">= 0", groups: [], source: nil }]
         end
@@ -702,8 +631,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "with a greater than or equal to matcher" do
-        let(:gemfile_fixture_name) { "gte_matcher" }
-        let(:lockfile_fixture_name) { "gte_matcher.lock" }
+        let(:dependency_files) { bundler_project_dependency_files("gte_matcher") }
         let(:requirements) do
           [{
             file: "Gemfile",
@@ -717,7 +645,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "with multiple requirements" do
-        let(:gemfile_fixture_name) { "version_between_bounds" }
+        let(:dependency_files) { bundler_project_dependency_files("version_between_bounds_gemfile") }
         let(:requirements) do
           [{
             file: "Gemfile",
@@ -731,24 +659,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "with a gem.rb and gems.locked setup" do
-        let(:gemfile) do
-          Dependabot::DependencyFile.new(
-            content: fixture("ruby", "gemfiles", gemfile_fixture_name),
-            name: "gems.rb",
-            directory: directory
-          )
-        end
-        let(:lockfile) do
-          Dependabot::DependencyFile.new(
-            content: fixture("ruby", "lockfiles", lockfile_fixture_name),
-            name: "gems.locked",
-            directory: directory
-          )
-        end
-
         context "that only appears in the lockfile" do
-          let(:gemfile_fixture_name) { "subdependency" }
-          let(:lockfile_fixture_name) { "subdependency.lock" }
+          let(:dependency_files) { bundler_project_dependency_files("subdependency_gems_rb") }
           let(:requirements) { [] }
           let(:dependency_name) { "i18n" }
           let(:current_version) { "0.7.0.beta1" }
@@ -757,7 +669,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         context "with a range requirement" do
-          let(:gemfile_fixture_name) { "version_between_bounds" }
+          let(:dependency_files) { bundler_project_dependency_files("version_between_bounds_gems_rb") }
           let(:requirements) do
             [{
               file: "gems.rb",
@@ -773,19 +685,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "given a gem with a path source" do
-      let(:gemfile_fixture_name) { "path_source" }
-      let(:lockfile_fixture_name) { "path_source.lock" }
-
       context "with a downloaded gemspec" do
-        let(:dependency_files) { [gemfile, lockfile, gemspec] }
-        let(:gemspec) do
-          Dependabot::DependencyFile.new(
-            content: fixture("ruby", "gemspecs", gemspec_fixture_name),
-            name: "plugins/example/example.gemspec",
-            support_file: true
-          )
-        end
-        let(:gemspec_fixture_name) { "no_overlap" }
+        let(:dependency_files) { bundler_project_dependency_files("path_source_no_overlap") }
 
         it { is_expected.to eq(Gem::Version.new("1.13.0")) }
 
@@ -795,7 +696,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         context "that requires other files" do
-          let(:gemspec_fixture_name) { "no_overlap_with_require" }
+          let(:dependency_files) { bundler_project_dependency_files("path_source_no_overlap_with_require") }
+
           it { is_expected.to eq(Gem::Version.new("1.13.0")) }
         end
 
@@ -806,16 +708,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         context "that has a .specification" do
-          let(:dependency_files) { [gemfile, lockfile, specification] }
-          let(:gemfile_fixture_name) { "path_source_statesman" }
-          let(:lockfile_fixture_name) { "path_source_statesman.lock" }
-          let(:specification) do
-            Dependabot::DependencyFile.new(
-              content: fixture("ruby", "specifications", "statesman"),
-              name: "vendor/gems/statesman-4.1.1/.specification",
-              support_file: true
-            )
-          end
+          let(:dependency_files) { bundler_project_dependency_files("path_source_statesman") }
 
           it { is_expected.to eq(Gem::Version.new("1.13.0")) }
         end
@@ -823,8 +716,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "given a gem with a git source" do
-      let(:lockfile_fixture_name) { "git_source_no_ref.lock" }
-      let(:gemfile_fixture_name) { "git_source_no_ref" }
+      let(:dependency_files) { bundler_project_dependency_files("git_source_no_ref") }
 
       context "that is the gem we're checking" do
         let(:dependency_name) { "business" }
@@ -867,10 +759,11 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           end
 
           context "and the Gemfile doesn't specify a git source" do
+            let(:dependency_files) { bundler_project_dependency_files("git_source_mismatched") }
+
             # If the dependency has a git version in the Gemfile.lock but not in
             # the Gemfile (i.e., because they're out-of-sync) we leave that
             # problem to the user.
-            let(:gemfile_fixture_name) { "Gemfile" }
             it { is_expected.to be_nil }
           end
         end
@@ -886,9 +779,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         context "when the dependency has never been released" do
-          let(:lockfile_fixture_name) { "git_source.lock" }
-          let(:gemfile_fixture_name) { "git_source" }
-          let(:dependency_name) { "prius" }
+          let(:dependency_files) { bundler_project_dependency_files("git_source") }
           let(:current_version) { "cff701b3bfb182afc99a85657d7c9f3d6c1ccce2" }
           let(:requirements) do
             [{
@@ -928,10 +819,9 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         context "when the gem's tag is pinned" do
+          let(:dependency_files) { bundler_project_dependency_files("git_source") }
           let(:dependency_name) { "business" }
           let(:current_version) { "a1b78a929dac93a52f08db4f2847d76d6cfe39bd" }
-          let(:lockfile_fixture_name) { "git_source.lock" }
-          let(:gemfile_fixture_name) { "git_source" }
 
           let(:requirements) do
             [{
@@ -1010,8 +900,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
             end
 
             context "but this dependency has never been released" do
-              let(:lockfile_fixture_name) { "git_source_unreleased.lock" }
-              let(:gemfile_fixture_name) { "git_source_unreleased" }
+              let(:dependency_files) { bundler_project_dependency_files("git_source_unreleased") }
               let(:dependency_name) { "dummy-git-dependency" }
               let(:current_version) do
                 "20151f9b67c8a04461fa0ee28385b6187b86587b"
@@ -1066,10 +955,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
             end
 
             context "when updating the gem results in a conflict" do
-              let(:gemfile_fixture_name) { "git_source_with_tag_conflict" }
-              let(:lockfile_fixture_name) do
-                "git_source_with_tag_conflict.lock"
-              end
+              let(:dependency_files) { bundler_project_dependency_files("git_source_with_tag_conflict") }
 
               before do
                 allow_any_instance_of(Dependabot::GitCommitChecker).
@@ -1113,8 +999,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         context "when the gem has a version specified, too" do
-          let(:gemfile_fixture_name) { "git_source_with_version" }
-          let(:lockfile_fixture_name) { "git_source_with_version.lock" }
+          let(:dependency_files) { bundler_project_dependency_files("git_source_with_version_gemfile") }
+
           let(:requirements) do
             [{
               file: "Gemfile",
@@ -1162,8 +1048,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         context "when the gem has a bad branch" do
-          let(:gemfile_fixture_name) { "bad_branch" }
-          let(:lockfile_fixture_name) { "bad_branch.lock" }
+          let(:dependency_files) { bundler_project_dependency_files("bad_branch") }
           around { |example| capture_stderr { example.run } }
 
           let(:dependency_name) { "prius" }
@@ -1215,8 +1100,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         context "when updating the gem results in a conflict" do
-          let(:gemfile_fixture_name) { "git_source_with_conflict" }
-          let(:lockfile_fixture_name) { "git_source_with_conflict.lock" }
+          let(:dependency_files) { bundler_project_dependency_files("git_source_with_conflict") }
           around { |example| capture_stderr { example.run } }
 
           before do
@@ -1263,16 +1147,14 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "that is not the gem we're checking" do
-        let(:lockfile_fixture_name) { "git_source.lock" }
-        let(:gemfile_fixture_name) { "git_source" }
+        let(:dependency_files) { bundler_project_dependency_files("git_source") }
         let(:dependency_name) { "statesman" }
         let(:current_version) { "1.2" }
 
         it { is_expected.to eq(Gem::Version.new("3.4.1")) }
 
         context "that is private" do
-          let(:gemfile_fixture_name) { "private_git_source" }
-          let(:lockfile_fixture_name) { "private_git_source.lock" }
+          let(:dependency_files) { bundler_project_dependency_files("private_git_source") }
           let(:token) do
             Base64.encode64("x-access-token:#{github_token}").delete("\n")
           end
@@ -1306,8 +1188,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         context "that has a bad reference" do
-          let(:gemfile_fixture_name) { "bad_ref" }
-          let(:lockfile_fixture_name) { "bad_ref.lock" }
+          let(:dependency_files) { bundler_project_dependency_files("bad_ref") }
           around { |example| capture_stderr { example.run } }
 
           before do
@@ -1333,8 +1214,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         context "that has a bad branch" do
-          let(:gemfile_fixture_name) { "bad_branch" }
-          let(:lockfile_fixture_name) { "bad_branch.lock" }
+          let(:dependency_files) { bundler_project_dependency_files("bad_branch") }
 
           it { is_expected.to eq(Gem::Version.new("3.4.1")) }
         end
@@ -1342,7 +1222,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "given a Gemfile that specifies a Ruby version" do
-      let(:gemfile_fixture_name) { "explicit_ruby" }
+      let(:dependency_files) { bundler_project_dependency_files("explicit_ruby") }
       let(:dependency_name) { "statesman" }
       let(:requirements) do
         [{ file: "Gemfile", requirement: "~> 1.2.0", groups: [], source: nil }]
@@ -1351,16 +1231,14 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       it { is_expected.to eq(Gem::Version.new("3.4.1")) }
 
       context "that is old" do
-        let(:gemfile_fixture_name) { "explicit_ruby_old" }
+        let(:dependency_files) { bundler_project_dependency_files("explicit_ruby_old") }
 
         it { is_expected.to eq(Gem::Version.new("2.0.1")) }
       end
     end
 
     context "with a gemspec and a Gemfile" do
-      let(:dependency_files) { [gemfile, gemspec] }
-      let(:gemfile_fixture_name) { "imports_gemspec" }
-      let(:gemspec_fixture_name) { "small_example" }
+      let(:dependency_files) { bundler_project_dependency_files("imports_gemspec_small_example_no_lockfile") }
       let(:requirements) do
         [{
           file: "Gemfile",
@@ -1381,13 +1259,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "when the gemspec has a path" do
-        let(:gemfile_fixture_name) { "imports_gemspec_from_path" }
-        let(:gemspec) do
-          Dependabot::DependencyFile.new(
-            content: fixture("ruby", "gemspecs", gemspec_fixture_name),
-            name: "subdir/example.gemspec"
-          )
-        end
+        let(:dependency_files) { bundler_project_dependency_files("imports_gemspec_from_path") }
         let(:requirements) do
           [{
             file: "Gemfile",
@@ -1409,7 +1281,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "when an old required ruby is specified in the gemspec" do
-        let(:gemspec_fixture_name) { "old_required_ruby" }
+        let(:dependency_files) { bundler_project_dependency_files("imports_gemspec_old_required_ruby_no_lockfile") }
         let(:dependency_name) { "statesman" }
 
         it "takes the minimum ruby version into account" do
@@ -1419,7 +1291,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "when the Gemfile doesn't import the gemspec" do
-        let(:gemfile_fixture_name) { "only_statesman" }
+        let(:dependency_files) { bundler_project_dependency_files("gemspec_not_imported_no_lockfile") }
 
         it "falls back to latest_version" do
           expect(checker.latest_resolvable_version).
@@ -1429,8 +1301,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "with only a gemspec" do
-      let(:dependency_files) { [gemspec] }
-      let(:gemspec_fixture_name) { "small_example" }
+      let(:dependency_files) { bundler_project_dependency_files("gemspec_small_example_no_lockfile") }
 
       it "falls back to latest_version" do
         dummy_version_resolver =
@@ -1447,8 +1318,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "with only a Gemfile" do
-      let(:dependency_files) { [gemfile] }
-      let(:gemfile_fixture_name) { "Gemfile" }
+      let(:dependency_files) { bundler_project_dependency_files("no_lockfile") }
 
       it "doesn't just fall back to latest_version" do
         expect(checker.latest_resolvable_version).
@@ -1456,7 +1326,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "given a gem with a private git source" do
-        let(:gemfile_fixture_name) { "private_git_source" }
+        let(:dependency_files) { bundler_project_dependency_files("private_git_source_no_lockfile") }
         let(:token) do
           Base64.encode64("x-access-token:#{github_token}").delete("\n")
         end
@@ -1482,7 +1352,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "given a gem with a private github source" do
-        let(:gemfile_fixture_name) { "private_github_source" }
+        let(:dependency_files) { bundler_project_dependency_files("private_github_source_no_lockfile") }
         let(:token) do
           Base64.encode64("x-access-token:#{github_token}").delete("\n")
         end
@@ -1517,7 +1387,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "when the git request raises a timeout" do
-        let(:gemfile_fixture_name) { "private_git_source" }
+        let(:dependency_files) { bundler_project_dependency_files("private_git_source_no_lockfile") }
         let(:token) do
           Base64.encode64("x-access-token:#{github_token}").delete("\n")
         end
@@ -1577,8 +1447,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       it { is_expected.to eq(Gem::Version.new("1.4.0")) }
 
       context "with a version conflict at the latest version" do
-        let(:gemfile_fixture_name) { "version_conflict_no_req_change" }
-        let(:lockfile_fixture_name) { "version_conflict_no_req_change.lock" }
+        let(:dependency_files) { bundler_project_dependency_files("version_conflict_no_req_change") }
         let(:dependency_name) { "ibandit" }
         let(:current_version) { "0.1.0" }
         let(:requirements) do
@@ -1592,8 +1461,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "with a sub-dependency" do
-      let(:gemfile_fixture_name) { "subdependency" }
-      let(:lockfile_fixture_name) { "subdependency.lock" }
+      let(:dependency_files) { bundler_project_dependency_files("subdependency") }
       let(:requirements) { [] }
       let(:dependency_name) { "i18n" }
       let(:current_version) { "0.7.0.beta1" }
@@ -1616,7 +1484,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "with a Gemfile and a Gemfile.lock" do
-      let(:dependency_files) { [gemfile, lockfile] }
+      let(:dependency_files) { bundler_project_dependency_files("gemfile") }
       let(:dependency_name) { "business" }
       let(:current_version) { "1.4.0" }
 
@@ -1670,8 +1538,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "with a sub-dependency" do
-        let(:gemfile_fixture_name) { "subdependency" }
-        let(:lockfile_fixture_name) { "subdependency.lock" }
+        let(:dependency_files) { bundler_project_dependency_files("subdependency") }
         let(:requirements) { [] }
         let(:dependency_name) { "i18n" }
         let(:current_version) { "0.7.0.beta1" }
@@ -1680,20 +1547,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "with a gems.rb and gems.locked" do
-        let(:gemfile) do
-          Dependabot::DependencyFile.new(
-            content: fixture("ruby", "gemfiles", gemfile_fixture_name),
-            name: "gems.rb",
-            directory: directory
-          )
-        end
-        let(:lockfile) do
-          Dependabot::DependencyFile.new(
-            content: fixture("ruby", "lockfiles", lockfile_fixture_name),
-            name: "gems.locked",
-            directory: directory
-          )
-        end
+        let(:dependency_files) { bundler_project_dependency_files("gems_rb") }
 
         let(:requirements) do
           [{
@@ -1721,9 +1575,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       context "for a gem with a git source" do
-        let(:gemfile_fixture_name) { "git_source_with_version" }
-        let(:lockfile_fixture_name) { "git_source_with_version.lock" }
-
+        let(:dependency_files) { bundler_project_dependency_files("git_source_with_version_gemfile") }
         let(:dependency_name) { "dependabot-test-ruby-package" }
         let(:current_version) { "81073f9462f228c6894e3e384d0718def310d99f" }
         let(:requirements) do
@@ -1779,8 +1631,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         end
 
         context "that is pinned" do
-          let(:gemfile_fixture_name) { "git_source" }
-          let(:lockfile_fixture_name) { "git_source.lock" }
+          let(:dependency_files) { bundler_project_dependency_files("git_source") }
 
           let(:dependency_name) { "business" }
           let(:current_version) { "a1b78a929dac93a52f08db4f2847d76d6cfe39bd" }
@@ -1901,10 +1752,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "with a Gemfile, a Gemfile.lock and a gemspec" do
-      let(:dependency_files) { [gemfile, gemspec, lockfile] }
-      let(:gemfile_fixture_name) { "imports_gemspec" }
-      let(:lockfile_fixture_name) { "imports_gemspec.lock" }
-      let(:gemspec_fixture_name) { "small_example" }
+      let(:dependency_files) { bundler_project_dependency_files("imports_gemspec") }
       let(:dependency_name) { "business" }
       let(:current_version) { "1.4.0" }
 
@@ -1939,9 +1787,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "with a Gemfile and a gemspec" do
-      let(:dependency_files) { [gemfile, gemspec] }
-      let(:gemfile_fixture_name) { "imports_gemspec" }
-      let(:gemspec_fixture_name) { "small_example" }
+      let(:dependency_files) { bundler_project_dependency_files("imports_gemspec_small_example_no_lockfile") }
       let(:dependency_name) { "business" }
       let(:current_version) { nil }
 
@@ -1976,7 +1822,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "with a Gemfile only" do
-      let(:dependency_files) { [gemfile] }
+      let(:dependency_files) { bundler_project_dependency_files("no_lockfile") }
       let(:dependency_name) { "business" }
       let(:current_version) { nil }
       let(:requirements) do
@@ -2004,8 +1850,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "with a gemspec only" do
-      let(:dependency_files) { [gemspec] }
-      let(:gemspec_fixture_name) { "small_example" }
+      let(:dependency_files) { bundler_project_dependency_files("gemspec_no_lockfile") }
       let(:dependency_name) { "business" }
       let(:current_version) { nil }
       let(:requirements) do
@@ -2037,8 +1882,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     subject { checker.requirements_unlocked_or_can_be? }
 
     context "with a Gemfile dependency that is already unlocked" do
-      let(:gemfile_fixture_name) { "version_not_specified" }
-      let(:lockfile_fixture_name) { "version_not_specified.lock" }
+      let(:dependency_files) { bundler_project_dependency_files("version_not_specified") }
       let(:requirements) do
         [{ file: "Gemfile", requirement: ">= 0", groups: [], source: nil }]
       end
@@ -2047,8 +1891,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "with a sub-dependency" do
-      let(:gemfile_fixture_name) { "subdependency" }
-      let(:lockfile_fixture_name) { "subdependency.lock" }
+      let(:dependency_files) { bundler_project_dependency_files("subdependency") }
       let(:requirements) { [] }
       let(:dependency_name) { "i18n" }
       let(:current_version) { "0.7.0.beta1" }
@@ -2057,8 +1900,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "with a Gemfile dependency that can be unlocked" do
-      let(:gemfile_fixture_name) { "Gemfile" }
-      let(:lockfile_fixture_name) { "Gemfile.lock" }
+      let(:dependency_files) { bundler_project_dependency_files("gemfile") }
       let(:requirements) do
         [{ file: "Gemfile", requirement: req, groups: [], source: nil }]
       end
@@ -2067,7 +1909,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       it { is_expected.to eq(true) }
 
       context "with multiple requirements" do
-        let(:gemfile_fixture_name) { "version_between_bounds" }
+        let(:dependency_files) { bundler_project_dependency_files("version_between_bounds_gemfile") }
         let(:req) { "> 1.0.0, < 1.5.0" }
 
         it { is_expected.to eq(true) }
@@ -2076,8 +1918,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
 
     # For now we always let git dependencies through
     context "with a Gemfile dependency that is a git dependency" do
-      let(:gemfile_fixture_name) { "git_source_no_ref" }
-      let(:lockfile_fixture_name) { "git_source_no_ref.lock" }
+      let(:dependency_files) { bundler_project_dependency_files("git_source_no_ref") }
       let(:requirements) do
         [{
           file: "Gemfile",
@@ -2096,7 +1937,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
 
     context "with a Gemfile with a function version" do
-      let(:gemfile_fixture_name) { "function_version" }
+      let(:dependency_files) { bundler_project_dependency_files("function_version_gemfile") }
       let(:requirements) do
         [{ file: "Gemfile", requirement: "1.0.0", groups: [], source: nil }]
       end

--- a/bundler/spec/fixtures/projects/bundler1/bad_branch/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/bad_branch/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"
+gem "prius", git: "https://github.com/gocardless/prius", branch: "bad"

--- a/bundler/spec/fixtures/projects/bundler1/bad_branch/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/bad_branch/Gemfile.lock
@@ -1,0 +1,23 @@
+GIT
+  remote: https://github.com/gocardless/prius
+  revision: cff701b3bfb182afc99a85657d7c9f3d6c1ccce2
+  branch: bad
+  specs:
+    prius (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  prius!
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.14.6

--- a/bundler/spec/fixtures/projects/bundler1/bad_ref/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/bad_ref/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "prius", git: "https://github.com/gocardless/prius"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/bad_ref/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/bad_ref/Gemfile.lock
@@ -1,0 +1,22 @@
+GIT
+  remote: https://github.com/gocardless/prius
+  revision: cff701b3bfb182afc99a85657d7c9f3d6c1ccce1
+  specs:
+    prius (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  prius!
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.17.3

--- a/bundler/spec/fixtures/projects/bundler1/explicit_ruby/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/explicit_ruby/Gemfile
@@ -1,0 +1,5 @@
+ruby "2.2.0"
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/explicit_ruby/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/explicit_ruby/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/bundler/spec/fixtures/projects/bundler1/explicit_ruby_old/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/explicit_ruby_old/Gemfile
@@ -1,0 +1,5 @@
+ruby "1.9.3"
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/explicit_ruby_old/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/explicit_ruby_old/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/bundler/spec/fixtures/projects/bundler1/gemspec_not_imported_no_lockfile/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/gemspec_not_imported_no_lockfile/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/gemspec_not_imported_no_lockfile/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/gemspec_not_imported_no_lockfile/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler1/gemspec_small_example_no_lockfile/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/gemspec_small_example_no_lockfile/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler1/git_source_mismatched/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/git_source_mismatched/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "business", "~> 1.6.0"
+gem "statesman", "~> 1.2.0"
+gem "prius", git: "https://github.com/gocardless/prius"
+gem "que", git: "git@github.com:chanks/que", tag: "v0.11.6"
+gem "uk_phone_numbers", git: "http://github.com/gocardless/uk_phone_numbers"

--- a/bundler/spec/fixtures/projects/bundler1/git_source_mismatched/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/git_source_mismatched/Gemfile.lock
@@ -1,0 +1,43 @@
+GIT
+  remote: git@github.com:gocardless/business
+  revision: a1b78a929dac93a52f08db4f2847d76d6cfe39bd
+  ref: a1b78a9
+  specs:
+    business (1.6.0)
+
+GIT
+  remote: git@github.com:chanks/que
+  revision: 997d1a6ee76a1f254fd72ce16acbc8d347fcaee3
+  tag: v0.11.6
+  specs:
+    que (0.11.6)
+
+GIT
+  remote: http://github.com/gocardless/uk_phone_numbers
+  revision: 1530024bd6a68d36ac18e04836ce110e0d433c36
+  specs:
+    uk_phone_numbers (0.1.1)
+
+GIT
+  remote: https://github.com/gocardless/prius
+  revision: cff701b3bfb182afc99a85657d7c9f3d6c1ccce2
+  specs:
+    prius (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    statesman (1.2.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.6.0)!
+  prius!
+  que!
+  statesman (~> 1.2.0)
+  uk_phone_numbers!
+
+BUNDLED WITH
+   1.16.0.pre.2

--- a/bundler/spec/fixtures/projects/bundler1/git_source_no_ref/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/git_source_no_ref/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "business", "~> 1.6.0", git: "git@github.com:gocardless/business"

--- a/bundler/spec/fixtures/projects/bundler1/git_source_no_ref/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/git_source_no_ref/Gemfile.lock
@@ -1,0 +1,18 @@
+GIT
+  remote: git@github.com:gocardless/business
+  revision: a1b78a929dac93a52f08db4f2847d76d6cfe39bd
+  specs:
+    business (1.6.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.6.0)!
+
+BUNDLED WITH
+   1.16.0.pre.2

--- a/bundler/spec/fixtures/projects/bundler1/git_source_unreleased/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/git_source_unreleased/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "dummy-git-dependency",
+    git: "git@github.com:dependabot-fixtures/ruby-dummy-git-dependency",
+    ref: "v1.0.0"

--- a/bundler/spec/fixtures/projects/bundler1/git_source_unreleased/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/git_source_unreleased/Gemfile.lock
@@ -1,0 +1,19 @@
+GIT
+  remote: git@github.com:dependabot-fixtures/ruby-dummy-git-dependency
+  revision: 20151f9b67c8a04461fa0ee28385b6187b86587b
+  ref: v1.0.0
+  specs:
+    dummy-git-dependency (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  dummy-git-dependency!
+
+BUNDLED WITH
+   1.17.3

--- a/bundler/spec/fixtures/projects/bundler1/git_source_with_conflict/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/git_source_with_conflict/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "rest-client", "~> 1.8"
+gem "onfido", git: "https://github.com/hvssle/onfido"

--- a/bundler/spec/fixtures/projects/bundler1/git_source_with_conflict/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/git_source_with_conflict/Gemfile.lock
@@ -1,0 +1,34 @@
+GIT
+  remote: https://github.com/hvssle/onfido
+  revision: 7b36eac82a7e42049052a58af0a7943fe0363714
+  ref: v0.4.0
+  specs:
+    onfido (0.4.0)
+      rest-client (~> 1.8.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    mime-types (2.99.3)
+    netrc (0.11.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  onfido!
+  rest-client (~> 1.8)
+
+BUNDLED WITH
+   1.16.0.pre.3

--- a/bundler/spec/fixtures/projects/bundler1/git_source_with_tag_conflict/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/git_source_with_tag_conflict/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "rest-client", "~> 1.8"
+gem "onfido", git: "https://github.com/hvssle/onfido", ref: "v0.4.0"

--- a/bundler/spec/fixtures/projects/bundler1/git_source_with_tag_conflict/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/git_source_with_tag_conflict/Gemfile.lock
@@ -1,0 +1,34 @@
+GIT
+  remote: https://github.com/hvssle/onfido
+  revision: 7b36eac82a7e42049052a58af0a7943fe0363714
+  ref: v0.4.0
+  specs:
+    onfido (0.4.0)
+      rest-client (~> 1.8.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    mime-types (2.99.3)
+    netrc (0.11.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  onfido!
+  rest-client (~> 1.8)
+
+BUNDLED WITH
+   1.16.0.pre.3

--- a/bundler/spec/fixtures/projects/bundler1/gte_matcher/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/gte_matcher/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "business", ">= 1.4.0"
+gem "statesman", ">= 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/gte_matcher/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/gte_matcher/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (>= 1.4.0)
+  statesman (>= 1.2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/bundler/spec/fixtures/projects/bundler1/no_lockfile/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/no_lockfile/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/path_source_no_overlap/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/path_source_no_overlap/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"
+gem "example", ">= 0.9.0", path: "plugins/example"
+gem "prius", git: "https://github.com/gocardless/prius"

--- a/bundler/spec/fixtures/projects/bundler1/path_source_no_overlap/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/path_source_no_overlap/Gemfile.lock
@@ -1,0 +1,30 @@
+GIT
+  remote: https://github.com/gocardless/prius
+  revision: cff701b3bfb182afc99a85657d7c9f3d6c1ccce2
+  specs:
+    prius (1.0.0)
+
+PATH
+  remote: plugins/example
+  specs:
+    example (0.9.3)
+      i18n (>= 0.3.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    i18n (0.8.4)
+    statesman (1.2.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  example (>= 0.9.0)!
+  prius!
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.15.1

--- a/bundler/spec/fixtures/projects/bundler1/path_source_no_overlap/plugins/example/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/path_source_no_overlap/plugins/example/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'json', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler1/path_source_no_overlap_with_require/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/path_source_no_overlap_with_require/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"
+gem "example", ">= 0.9.0", path: "plugins/example"
+gem "prius", git: "https://github.com/gocardless/prius"

--- a/bundler/spec/fixtures/projects/bundler1/path_source_no_overlap_with_require/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/path_source_no_overlap_with_require/Gemfile.lock
@@ -1,0 +1,30 @@
+GIT
+  remote: https://github.com/gocardless/prius
+  revision: cff701b3bfb182afc99a85657d7c9f3d6c1ccce2
+  specs:
+    prius (1.0.0)
+
+PATH
+  remote: plugins/example
+  specs:
+    example (0.9.3)
+      i18n (>= 0.3.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    i18n (0.8.4)
+    statesman (1.2.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  example (>= 0.9.0)!
+  prius!
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.15.1

--- a/bundler/spec/fixtures/projects/bundler1/path_source_no_overlap_with_require/plugins/example/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/path_source_no_overlap_with_require/plugins/example/example.gemspec
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'example/version'
+
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = Example::VERSION
+  spec.summary      = "Automated dependency management #{Example::VERSION}"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+  spec.date         = Example::DATE
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'json', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler1/path_source_statesman/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/path_source_statesman/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "4.1.1", path: "vendor/gems/statesman-4.1.1"

--- a/bundler/spec/fixtures/projects/bundler1/path_source_statesman/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/path_source_statesman/Gemfile.lock
@@ -1,0 +1,19 @@
+PATH
+  remote: vendor/gems/statesman-4.1.1
+  specs:
+    statesman (4.1.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (= 4.1.1)!
+
+BUNDLED WITH
+   1.17.3

--- a/bundler/spec/fixtures/projects/bundler1/path_source_statesman/vendor/gems/statesman-4.1.1/.specification
+++ b/bundler/spec/fixtures/projects/bundler1/path_source_statesman/vendor/gems/statesman-4.1.1/.specification
@@ -1,0 +1,246 @@
+--- !ruby/object:Gem::Specification
+name: statesman
+version: !ruby/object:Gem::Version
+  version: 4.1.1
+platform: ruby
+authors:
+- GoCardless
+autorequire:
+bindir: bin
+cert_chain: []
+date: 2019-07-06 00:00:00.000000000 Z
+dependencies:
+- !ruby/object:Gem::Dependency
+  name: ammeter
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '1.1'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '1.1'
+- !ruby/object:Gem::Dependency
+  name: bundler
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '1.3'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '1.3'
+- !ruby/object:Gem::Dependency
+  name: gc_ruboconfig
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 2.3.9
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 2.3.9
+- !ruby/object:Gem::Dependency
+  name: mysql2
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '0.4'
+    - - "<"
+      - !ruby/object:Gem::Version
+        version: '0.6'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '0.4'
+    - - "<"
+      - !ruby/object:Gem::Version
+        version: '0.6'
+- !ruby/object:Gem::Dependency
+  name: pg
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '0.18'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '0.18'
+- !ruby/object:Gem::Dependency
+  name: pry
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '0'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '0'
+- !ruby/object:Gem::Dependency
+  name: rails
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '3.2'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '3.2'
+- !ruby/object:Gem::Dependency
+  name: rake
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 12.3.0
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 12.3.0
+- !ruby/object:Gem::Dependency
+  name: rspec
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '3.1'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '3.1'
+- !ruby/object:Gem::Dependency
+  name: rspec-its
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '1.1'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '1.1'
+- !ruby/object:Gem::Dependency
+  name: rspec-rails
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '3.1'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '3.1'
+- !ruby/object:Gem::Dependency
+  name: rspec_junit_formatter
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 0.4.0
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 0.4.0
+- !ruby/object:Gem::Dependency
+  name: sqlite3
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 1.3.6
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 1.3.6
+- !ruby/object:Gem::Dependency
+  name: timecop
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 0.9.1
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: 0.9.1
+description: A statesman-like state machine library
+email:
+- developers@gocardless.com
+executables: []
+extensions: []
+extra_rdoc_files: []
+files: []
+homepage: https://github.com/gocardless/statesman
+licenses:
+- MIT
+metadata: {}
+post_install_message:
+rdoc_options: []
+require_paths:
+- lib
+required_ruby_version: !ruby/object:Gem::Requirement
+  requirements:
+  - - ">="
+    - !ruby/object:Gem::Version
+      version: '2.2'
+required_rubygems_version: !ruby/object:Gem::Requirement
+  requirements:
+  - - ">="
+    - !ruby/object:Gem::Version
+      version: '0'
+requirements: []
+rubygems_version: 3.0.3
+signing_key:
+specification_version: 4
+summary: A statesman-like state machine library
+test_files: []
+

--- a/bundler/spec/fixtures/projects/bundler1/private_git_source/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/private_git_source/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "prius", git: "git@github.com:fundingcircle/prius"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/private_git_source/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/private_git_source/Gemfile.lock
@@ -1,0 +1,22 @@
+GIT
+  remote: git@github.com:fundingcircle/prius
+  revision: cff701b3bfb182afc99a85657d7c9f3d6c1ccce2
+  specs:
+    prius (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  prius!
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.17.3

--- a/bundler/spec/fixtures/projects/bundler1/private_git_source_no_lockfile/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/private_git_source_no_lockfile/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"
+gem "prius", git: "git@github.com:fundingcircle/prius"

--- a/bundler/spec/fixtures/projects/bundler1/private_github_source_no_lockfile/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/private_github_source_no_lockfile/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"
+gem "prius", github: "fundingcircle/prius"

--- a/bundler/spec/fixtures/projects/bundler1/subdependency_gems_rb/gems.locked
+++ b/bundler/spec/fixtures/projects/bundler1/subdependency_gems_rb/gems.locked
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    i18n (0.7.0.beta1)
+    ibandit (0.7.0)
+      i18n (~> 0.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ibandit (~> 0.7.0)
+
+BUNDLED WITH
+   1.16.1

--- a/bundler/spec/fixtures/projects/bundler1/subdependency_gems_rb/gems.rb
+++ b/bundler/spec/fixtures/projects/bundler1/subdependency_gems_rb/gems.rb
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "ibandit", "~> 0.7.0"

--- a/bundler/spec/fixtures/projects/bundler1/version_between_bounds_gems_rb/gems.locked
+++ b/bundler/spec/fixtures/projects/bundler1/version_between_bounds_gems_rb/gems.locked
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/bundler/spec/fixtures/projects/bundler1/version_between_bounds_gems_rb/gems.rb
+++ b/bundler/spec/fixtures/projects/bundler1/version_between_bounds_gems_rb/gems.rb
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "business", "> 1.0.0", "< 1.5.0"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/version_conflict_gems_rb/gems.locked
+++ b/bundler/spec/fixtures/projects/bundler1/version_conflict_gems_rb/gems.locked
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  diff-lcs (= 1.2.0)
+  rspec-mocks (= 3.5.0)
+  rspec-support (= 3.5.0)
+
+BUNDLED WITH
+   1.17.3

--- a/bundler/spec/fixtures/projects/bundler1/version_conflict_gems_rb/gems.rb
+++ b/bundler/spec/fixtures/projects/bundler1/version_conflict_gems_rb/gems.rb
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "rspec-mocks", "3.5.0"
+gem "rspec-support", "3.5.0"
+
+gem "diff-lcs", "1.2.0"

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -14,6 +14,11 @@ def bundler_2_available?
   ENV["SUITE_NAME"] == "bundler2"
 end
 
+# Load project files prepended with the bundler version, which is currently only ever bundler1
+def bundler_project_dependency_files(project)
+  project_dependency_files(File.join("bundler1", project))
+end
+
 RSpec.configure do |config|
   config.around do |example|
     if bundler_2_available? && example.metadata[:bundler_v1_only]

--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -93,6 +93,9 @@ end
 
 def project_dependency_files(project)
   project_path = File.expand_path(File.join("spec/fixtures/projects", project))
+
+  raise "Fixture does not exist for project: '#{project}'" unless Dir.exist?(project_path)
+
   Dir.chdir(project_path) do
     # NOTE: Include dotfiles (e.g. .npmrc)
     files = Dir.glob("**/*", File::FNM_DOTMATCH)


### PR DESCRIPTION
This PR extracts from https://github.com/dependabot/dependabot-core/pull/3350

It prepares the way for bundler version detection by ensuring we can readily produce builds against lockfiles with the correct `BUNDLED WITH` values based on test parameters.

### Methodology

In order to verify the change over, I used a helper shim to force any tests that called `fixture` to load gemfiles to raise, e.g.

```
# bundler/spec/spec_helper.rb
alias non_project_fixture fixture

def fixture(*name)
  if name.any? { |folder| %w(gemfiles gemspecs lockfiles).include? folder }
    raise "Non-Project Fixture Loaded: '#{File.join(name)}'."
  end

  non_project_fixture(*name)
end
```

A large number of the `bundler1` fixtures already existed, so it was just a case of generating any missing files, checking their naming lined up and then finally grepping the file for `_fixture_name` to ensure no test cases were quietly failing over to the top-level dependency files.