### PR TITLE
Raise resolvability errors when incompatible pseudo version is detected

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -27,6 +27,9 @@ module Dependabot
           /cannot find module providing package/.freeze,
           # Package in module was likely renamed or removed
           /module .* found \(.*\), but does not contain package/m.freeze,
+          # Package pseudo-version does not match the version-control metadata
+          # https://golang.google.cn/doc/go1.13#version-validation
+          /go: .*: invalid pseudo-version/m.freeze,
           # Package does not exist, has been pulled or cannot be reached due to
           # auth problems with either git or the go proxy
           /go: .*: unknown revision/m.freeze

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -458,7 +458,10 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
         error_class = Dependabot::DependencyFileNotResolvable
         expect { updater.updated_go_sum_content }.
           to raise_error(error_class) do |error|
-            expect(error.message).to include("go: github.com/openshift/api@v3.9.1-0.20190424152011-77b8897ec79a+incompatible: invalid pseudo-version:")
+          expect(error.message).to include(
+            "go: github.com/openshift/api@v3.9.1-0.20190424152011-77b8897ec79a+incompatible: " \
+            "invalid pseudo-version:"
+          )
         end
       end
     end

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -433,6 +433,35 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
         end
       end
     end
+
+    context "for a invalid pseudo version" do
+      let(:project_name) { "invalid_pseudo_version" }
+      let(:dependency_name) do
+        "rsc.io/quote"
+      end
+      let(:dependency_version) { "v1.5.2" }
+      let(:dependency_previous_version) { "v1.4.0" }
+      let(:requirements) do
+        [{
+          file: "go.mod",
+          requirement: dependency_version,
+          groups: [],
+          source: {
+            type: "default",
+            source: "rsc.io/quote"
+          }
+        }]
+      end
+      let(:previous_requirements) { [] }
+
+      it "raises the correct error" do
+        error_class = Dependabot::DependencyFileNotResolvable
+        expect { updater.updated_go_sum_content }.
+          to raise_error(error_class) do |error|
+            expect(error.message).to include("go: github.com/openshift/api@v3.9.1-0.20190424152011-77b8897ec79a+incompatible: invalid pseudo-version:")
+        end
+      end
+    end
   end
 
   describe "#updated_go_sum_content" do

--- a/go_modules/spec/fixtures/projects/invalid_pseudo_version/go.mod
+++ b/go_modules/spec/fixtures/projects/invalid_pseudo_version/go.mod
@@ -1,0 +1,8 @@
+module github.com/dependabot/vgotest
+
+go 1.13
+
+require (
+  rsc.io/quote v1.4.0
+  github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible
+)

--- a/go_modules/spec/fixtures/projects/invalid_pseudo_version/main.go
+++ b/go_modules/spec/fixtures/projects/invalid_pseudo_version/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+  _ "github.com/openshift/api"
+  _ "rsc.io/quote"
+)
+
+func main() {
+}


### PR DESCRIPTION
# Why is this needed?

This helps to raise awareness when a specific resolvability error occurs.
This allows code owners to take corrective action on their go module projects.

## What does this do?

It raises an error and discloses the nature of the incompatible pseudo version
detected in a `go.mod` file.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
