### PR TITLE
export LOCAL_GITHUB_ACCESS_TOKEN to docker dev container

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -170,6 +170,7 @@ docker run --rm -ti \
   -v "$(pwd)/omnibus/spec:$CODE_DIR/omnibus/spec" \
   -v "$(pwd)/tmp:/$CODE_DIR/tmp" \
   --name "$CONTAINER_NAME" \
+  --env "LOCAL_GITHUB_ACCESS_TOKEN=$LOCAL_GITHUB_ACCESS_TOKEN" \
   "${DOCKER_OPTS[@]}" \
   --cap-add=SYS_PTRACE \
   "$IMAGE_NAME" "${CONTAINER_ARGS[@]}"


### PR DESCRIPTION
This exports the `LOCAL_GITHUB_ACCESS_TOKEN` from the host machine to the
development container. So that it is easier to export the token into
the shell environment without needing to copy and paste it into the docker
container environment.
