### PR TITLE
Convert the spec for Bundler::FileParser::GemfileDeclarationFinder to use project based fixtures. 

### DIFF
--- a/bundler/spec/dependabot/bundler/file_parser/gemfile_declaration_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser/gemfile_declaration_finder_spec.rb
@@ -21,10 +21,7 @@ RSpec.describe Dependabot::Bundler::FileParser::GemfileDeclarationFinder do
   let(:dependency_name) { "business" }
   let(:dependency_requirement_sting) { "~> 1" }
 
-  let(:gemfile) do
-    Dependabot::DependencyFile.new(content: gemfile_body, name: "Gemfile")
-  end
-  let(:gemfile_body) { fixture("ruby", "gemfiles", "Gemfile") }
+  let(:gemfile) { bundler_project_dependency_file("gemfile", filename: "Gemfile") }
 
   describe "#gemfile_includes_dependency?" do
     subject(:gemfile_includes_dependency) do
@@ -37,7 +34,9 @@ RSpec.describe Dependabot::Bundler::FileParser::GemfileDeclarationFinder do
     end
 
     context "when the file is just comments" do
-      let(:gemfile_body) { "#Lol this is just a comment" }
+      let(:gemfile) do
+        Dependabot::DependencyFile.new(content: "#Lol this is just a comment", name: "Gemfile")
+      end
       it { is_expected.to eq(false) }
     end
 
@@ -46,16 +45,14 @@ RSpec.describe Dependabot::Bundler::FileParser::GemfileDeclarationFinder do
       it { is_expected.to eq(true) }
 
       context "but it's in a source block" do
-        let(:gemfile_body) { fixture("ruby", "gemfiles", "sidekiq_pro") }
+        let(:gemfile) { bundler_project_dependency_file("sidekiq_pro", filename: "Gemfile") }
         let(:dependency_name) { "sidekiq-pro" }
 
         it { is_expected.to eq(true) }
       end
 
       context "but it's in a group block" do
-        let(:gemfile_body) do
-          fixture("ruby", "gemfiles", "development_dependencies")
-        end
+        let(:gemfile) { bundler_project_dependency_file("development_dependencies", filename: "Gemfile") }
         let(:dependency_name) { "business" }
 
         it { is_expected.to eq(true) }
@@ -72,7 +69,10 @@ RSpec.describe Dependabot::Bundler::FileParser::GemfileDeclarationFinder do
     end
 
     context "when the file is just comments" do
-      let(:gemfile_body) { "#Lol this is just a comment" }
+      let(:gemfile) do
+        Dependabot::DependencyFile.new(content: "#Lol this is just a comment", name: "Gemfile")
+      end
+
       it { is_expected.to be_nil }
     end
 
@@ -82,9 +82,7 @@ RSpec.describe Dependabot::Bundler::FileParser::GemfileDeclarationFinder do
       it { is_expected.to eq("~> 1.4.0") }
 
       context "but doesn't specify a requirement" do
-        let(:gemfile_body) do
-          fixture("ruby", "gemfiles", "version_not_specified")
-        end
+        let(:gemfile) { bundler_project_dependency_file("version_not_specified", filename: "Gemfile") }
         let(:dependency_requirement_sting) { nil }
 
         # NOTE: It would be equally valid to return `nil` here
@@ -102,9 +100,7 @@ RSpec.describe Dependabot::Bundler::FileParser::GemfileDeclarationFinder do
       end
 
       context "but it's using a version that would be transformed" do
-        let(:gemfile_body) do
-          fixture("ruby", "gemfiles", "prerelease_with_dash")
-        end
+        let(:gemfile) { bundler_project_dependency_file("prerelease_with_dash_gemfile", filename: "Gemfile") }
         let(:dependency_name) { "business" }
         let(:dependency_requirement_sting) { "~> 1.4.0.pre.rc1" }
 
@@ -117,7 +113,7 @@ RSpec.describe Dependabot::Bundler::FileParser::GemfileDeclarationFinder do
       end
 
       context "but it's using a function version" do
-        let(:gemfile_body) { fixture("ruby", "gemfiles", "function_version") }
+        let(:gemfile) { bundler_project_dependency_file("function_version_gemfile", filename: "Gemfile") }
         let(:dependency_name) { "business" }
         let(:dependency_requirement_sting) { "~> 1.0.0" }
 

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -19,6 +19,14 @@ def bundler_project_dependency_files(project)
   project_dependency_files(File.join("bundler1", project))
 end
 
+def bundler_project_dependency_file(project, filename:)
+  dependency_file = bundler_project_dependency_files(project).find{ |file| file.name == filename }
+
+  raise "Dependency File '#{filename} does not exist for project '#{project}'" unless dependency_file
+
+  dependency_file
+end
+
 RSpec.configure do |config|
   config.around do |example|
     if bundler_2_available? && example.metadata[:bundler_v1_only]


### PR DESCRIPTION
Follows on from https://github.com/dependabot/dependabot-core/pull/3373

This prepares the way for bundler version detection by ensuring we can readily produce builds against lockfiles with the correct BUNDLED WITH values based on test parameters.

### Notes

This test loads single files out of our fixture set. Rather than leave this as an exception to the rule, I decided to add a helper method to load a single file out of a project folder so we can eventually delete the old fixture folders and avoid having a mix of strategies.

It would also block testing a matrix of bunder 1 and bundler 2 properly unless we load these files via `bundler_project_dependency_files`