### PR TITLE
v0.138.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.138.6, 26 March 2021
+
+- chore: export LOCAL_GITHUB_ACCESS_TOKEN to docker dev container
+- fix: Raise resolvability error when pseudo version does not match version control
+- test: Add a helper method to load bundler fixtures by version
+- test: Explicitly raise if attempting to load a missing project fixture
+- test: Project fixtures for UpdateChecker spec
+
 ## v0.138.5, 26 March 2021
 
 - Maven/Gradle: Treat dev and pr as pre-releases for gradle/maven

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.138.5"
+  VERSION = "0.138.6"
 end


### PR DESCRIPTION
## v0.138.6, 26 March 2021

- chore: export LOCAL_GITHUB_ACCESS_TOKEN to docker dev container
- fix: Raise resolvability error when pseudo version does not match version control
- test: Add a helper method to load bundler fixtures by version
- test: Explicitly raise if attempting to load a missing project fixture
- test: Project fixtures for UpdateChecker spec

https://github.com/dependabot/dependabot-core/compare/v0.138.5...v0.138.6-release-notes