### PR TITLE
Use project fixtures for GemspecFinder spec

### DIFF
--- a/bundler/spec/dependabot/bundler/file_fetcher/gemspec_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_fetcher/gemspec_finder_spec.rb
@@ -8,22 +8,16 @@ require "dependabot/bundler/file_fetcher/gemspec_finder"
 RSpec.describe Dependabot::Bundler::FileFetcher::GemspecFinder do
   let(:finder) { described_class.new(gemfile: gemfile) }
 
-  let(:gemfile) do
-    Dependabot::DependencyFile.new(content: gemfile_body, name: gemfile_name)
-  end
-  let(:gemfile_name) { "Gemfile" }
-  let(:gemfile_body) { fixture("ruby", "gemfiles", "Gemfile") }
-
   describe "#gemspec_directories" do
     subject(:gemspec_directories) { finder.gemspec_directories }
 
     context "when the file does not include any gemspecs" do
-      let(:gemfile_body) { fixture("ruby", "gemfiles", "Gemfile") }
+      let(:gemfile) { bundler_project_dependency_file("gemfile", filename: "Gemfile") }
       it { is_expected.to eq([]) }
     end
 
     context "with invalid Ruby in the Gemfile" do
-      let(:gemfile_body) { fixture("ruby", "gemfiles", "invalid_ruby") }
+      let(:gemfile) { bundler_project_dependency_file("invalid_ruby", filename: "Gemfile") }
 
       it "raises a helpful error" do
         expect { finder.gemspec_directories }.to raise_error do |error|
@@ -34,18 +28,19 @@ RSpec.describe Dependabot::Bundler::FileFetcher::GemspecFinder do
     end
 
     context "when the file does include a gemspec reference" do
-      let(:gemfile_body) { fixture("ruby", "gemfiles", "imports_gemspec") }
+      let(:gemfile) { bundler_project_dependency_file("imports_gemspec", filename: "Gemfile") }
       it { is_expected.to eq([Pathname.new(".")]) }
 
       context "that has a path specified" do
-        let(:gemfile_body) do
-          fixture("ruby", "gemfiles", "imports_gemspec_from_path")
-        end
+        let(:gemfile) { bundler_project_dependency_file("imports_gemspec_from_path", filename: "Gemfile") }
 
         it { is_expected.to eq([Pathname.new("subdir")]) }
 
         context "when this Gemfile is already in a nested directory" do
-          let(:gemfile_name) { "nested/Gemfile" }
+          let(:gemfile) do
+            bundler_project_dependency_file("imports_gemspec_from_nested_path", filename: "nested/Gemfile")
+          end
+
           it { is_expected.to eq([Pathname.new("nested/subdir")]) }
         end
       end

--- a/bundler/spec/fixtures/projects/bundler1/imports_gemspec_from_nested_path/nested/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/imports_gemspec_from_nested_path/nested/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gemspec path: 'subdir'
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/imports_gemspec_from_nested_path/nested/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/imports_gemspec_from_nested_path/nested/Gemfile.lock
@@ -1,0 +1,22 @@
+PATH
+  remote: subdir
+  specs:
+    example (0.9.3)
+      business (~> 1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  example!
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.15.3

--- a/bundler/spec/fixtures/projects/bundler1/imports_gemspec_from_nested_path/nested/subdir/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/imports_gemspec_from_nested_path/nested/subdir/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end


### PR DESCRIPTION
Breaks out from https://github.com/dependabot/dependabot-core/pull/3350
Follows on from https://github.com/dependabot/dependabot-core/pull/3381