### PR TITLE
Go mod: Handle multi-line error messages

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -269,22 +269,20 @@ module Dependabot
           write_go_mod(body)
         end
 
-        # rubocop:disable Metrics/AbcSize
-        # rubocop:disable Metrics/PerceivedComplexity
         def handle_subprocess_error(stderr)
           stderr = stderr.gsub(Dir.getwd, "")
 
           # Package version doesn't match the module major version
           error_regex = RESOLVABILITY_ERROR_REGEXES.find { |r| stderr =~ r }
           if error_regex
-            lines = stderr.lines.drop_while { |l| error_regex !~ l }
-            raise Dependabot::DependencyFileNotResolvable, lines.join
+            error_message = filter_error_message(message: stderr, regex: error_regex)
+            raise Dependabot::DependencyFileNotResolvable, error_message
           end
 
           repo_error_regex = REPO_RESOLVABILITY_ERROR_REGEXES.find { |r| stderr =~ r }
           if repo_error_regex
-            lines = stderr.lines.drop_while { |l| repo_error_regex !~ l }
-            ResolvabilityErrors.handle(lines.join, credentials: credentials)
+            error_message = filter_error_message(message: stderr, regex: repo_error_regex)
+            ResolvabilityErrors.handle(error_message, credentials: credentials)
           end
 
           path_regex = MODULE_PATH_MISMATCH_REGEXES.find { |r| stderr =~ r }
@@ -296,16 +294,22 @@ module Dependabot
 
           out_of_disk_regex = OUT_OF_DISK_REGEXES.find { |r| stderr =~ r }
           if out_of_disk_regex
-            lines = stderr.lines.select { |l| out_of_disk_regex =~ l }
-            raise Dependabot::OutOfDisk.new, lines.join
+            error_message = filter_error_message(message: stderr, regex: out_of_disk_regex)
+            raise Dependabot::OutOfDisk.new, error_message
           end
 
           # We don't know what happened so we raise a generic error
           msg = stderr.lines.last(10).join.strip
           raise Dependabot::DependabotError, msg
         end
-        # rubocop:enable Metrics/PerceivedComplexity
-        # rubocop:enable Metrics/AbcSize
+
+        def filter_error_message(message:, regex:)
+          lines = message.lines.select { |l| regex =~ l }
+          return lines.join if lines.any?
+
+          # In case the regex is multi-line, match the whole string
+          message.match(regex).to_s
+        end
 
         def go_mod_path
           return "go.mod" if directory == "/"

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -465,6 +465,39 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
         end
       end
     end
+
+    context "for an unknown revision version" do
+      let(:project_name) { "unknown_revision_version" }
+      let(:dependency_name) do
+        "github.com/deislabs/oras"
+      end
+      let(:dependency_version) { "v0.10.0" }
+      let(:dependency_previous_version) { "v0.9.0" }
+      let(:requirements) do
+        [{
+          file: "go.mod",
+          requirement: dependency_version,
+          groups: [],
+          source: {
+            type: "default",
+            source: "github.com/deislabs/oras"
+          }
+        }]
+      end
+      let(:previous_requirements) { [] }
+
+      it "raises the correct error" do
+        error_class = Dependabot::DependencyFileNotResolvable
+        expect { updater.updated_go_sum_content }.
+          to raise_error(error_class) do |error|
+          expect(error.message).to include(
+            "go: github.com/deislabs/oras@v0.10.0 requires\n"\
+            "	github.com/docker/distribution@v0.0.0-00010101000000-000000000000: "\
+            "invalid version: unknown revision"
+          )
+        end
+      end
+    end
   end
 
   describe "#updated_go_sum_content" do

--- a/go_modules/spec/fixtures/projects/unknown_revision_version/go.mod
+++ b/go_modules/spec/fixtures/projects/unknown_revision_version/go.mod
@@ -1,0 +1,7 @@
+module github.com/dependabot/vgotest
+
+go 1.16
+
+require (
+  github.com/deislabs/oras v0.9.0
+)

--- a/go_modules/spec/fixtures/projects/unknown_revision_version/main.go
+++ b/go_modules/spec/fixtures/projects/unknown_revision_version/main.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	_ "github.com/deislabs/oras"
+)
+
+func main() {
+}


### PR DESCRIPTION
Changes the go mod updater error handling to fall back to matching the
whole string if no lines where matched against the regex.

Some errors where surfacing with an empty error message as we initially
match on the whole string but filter per line.