### PR TITLE
Dockerfile: promote software-properties-common

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
     unzip \
     locales \
     openssh-client \
+    software-properties-common \
     make \
     libpq-dev \
     libssl-dev \
@@ -54,8 +55,7 @@ RUN apt-get update \
 
 # Install Ruby 2.6.6, update RubyGems, and install Bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
-RUN apt-get update && apt-get install -y software-properties-common \
-  && apt-add-repository ppa:brightbox/ruby-ng \
+RUN apt-add-repository ppa:brightbox/ruby-ng \
   && apt-get update \
   && apt-get install -y ruby2.6 ruby2.6-dev \
   && gem update --system 3.2.14 \


### PR DESCRIPTION
This moves `software-properties-common`  to earlier in the `Dockerfile`.

This package provides the `apt-add-repository` used by setup PPAs used by several ecosystems: `ruby`, `php`. Since the package is part of baseline ubuntu, we can install it in the first layer to avoid a duplicate `apt-get update`.

I opted to place it before `make`, so the preceding "things after `make` are for python" comment was still valid.