### PR TITLE
Pull Requests: Sanitize team mentions

### DIFF
--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -36,11 +36,6 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
         end
       end
 
-      context "that includes a slash" do
-        let(:text) { "Great work on @greysteil/repo!" }
-        it { is_expected.to eq("<p>Great work on @greysteil/repo!</p>\n") }
-      end
-
       context "that is in brackets" do
         let(:text) { "The team (by @greysteil) etc." }
 
@@ -198,6 +193,36 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
               "<code>@\u200Bfeelepxyz</code></a></p>\n"
             )
           end
+        end
+      end
+
+      context "team mentions" do
+        let(:text) { "Thanks @dependabot/reviewers" }
+
+        it "sanitizes the team mention" do
+          expect(sanitize_links_and_mentions).to eq(
+            "<p>Thanks <code>@\u200Bdependabot/reviewers</code></p>\n"
+          )
+        end
+      end
+
+      context "multiple team mentions" do
+        let(:text) { "Thanks @dependabot/reviewers @dependabot/developers" }
+
+        it "sanitizes the team mentions" do
+          expect(sanitize_links_and_mentions).to eq(
+            "<p>Thanks <code>@\u200Bdependabot/reviewers</code> <code>@\u200Bdependabot/developers</code></p>\n"
+          )
+        end
+      end
+
+      context "team mention and non-mention line" do
+        let(:text) { "Thanks @dependabot/reviewers\n\nAnd more regular text" }
+
+        it "sanitizes the team mention" do
+          expect(sanitize_links_and_mentions).to eq(
+            "<p>Thanks <code>@\u200Bdependabot/reviewers</code></p>\n<p>And more regular text</p>\n"
+          )
         end
       end
     end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1196,7 +1196,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 "<p>Mad props to <a href=\"https://github.com/greysteil\">"\
                 "<code>@\u200Bgreysteil</code></a> and <a href=\"https://github.com/hmarr\">"\
                 "<code>@\u200Bhmarr</code></a> for the "\
-                "@angular/scope work - see <a href=\"https://github.com/"\
+                "<code>@\u200Bangular/scope</code> work - see <a href=\"https://github.com/"\
                 "gocardless/business/blob/HEAD/CHANGELOG.md\">changelog</a>."\
                 "</p>\n"\
                 "</blockquote>\n"\


### PR DESCRIPTION
When we pull in changelogs and commits etc we sanitize user mentions
(`@jurre`), by wrapping them in a codeblock and inserting a zero-width
space between the `@` and the username, and wrapping that in a link to
the profile, to prevent users from getting notifications from Dependabot PRs.

Something that we didn't cover before yet were team-mentions, e.q:
@dependabot/reviewers. These are slightly tricky in the sense that there
are ecosystems (npm for example) that have package names that follow the
same pattern. There is no way to distinguish between a package name and
a team mention, so we treat them the same and sanitize them but do not
attempt to link, as this is expected to lead to a lot of false
positives.

Fixes https://github.com/dependabot/dependabot-core/issues/3378