### PR TITLE
v0.138.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.138.7, 30 March 2021
+
+- Go mod: Handle multi-line error messages
+- Bump golang.org/x/mod from 0.4.1 to 0.4.2 in /go_modules/helpers
+- Update rubocop requirement from ~> 1.11.0 to ~> 1.12.0 in /common
+- Bump flake8 from 3.8.4 to 3.9.0 in /python/helpers
+- Bump eslint from 7.22.0 to 7.23.0 in /npm_and_yarn/helpers
+- Bundler [Prerelease]: Bump bundler to 2.2.15
+- Bundler: Use project fixtures
+- Docs: change ci url @flaxel
+
 ## v0.138.6, 26 March 2021
 
 - chore: export LOCAL_GITHUB_ACCESS_TOKEN to docker dev container

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.138.6"
+  VERSION = "0.138.7"
 end


### PR DESCRIPTION
## v0.138.7, 30 March 2021

- Go mod: Handle multi-line error messages
- Bump golang.org/x/mod from 0.4.1 to 0.4.2 in /go_modules/helpers
- Update rubocop requirement from ~> 1.11.0 to ~> 1.12.0 in /common
- Bump flake8 from 3.8.4 to 3.9.0 in /python/helpers
- Bump eslint from 7.22.0 to 7.23.0 in /npm_and_yarn/helpers
- Bundler [Prerelease]: Bump bundler to 2.2.15
- Bundler: Use project fixtures
- Docs: change ci url @flaxel