### PR TITLE
v0.139.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.139.0, 30 March 2021
+
+- Bundler [Beta]: Detect and run Bundler V1 or V2 based on Gemfile.lock
+  - Requires `{ options: { bundler_2_available: true }}` to be passed for this release
+- Dockerfile: promote software-properties-common
+
 ## v0.138.7, 30 March 2021
 
 - Go mod: Handle multi-line error messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.139.0, 30 March 2021
 
 - Bundler [Beta]: Detect and run Bundler V1 or V2 based on Gemfile.lock
-  - Requires `{ options: { bundler_2_available: true }}` to be passed for this release
+  - Requires `options: { bundler_2_available: true }` to be passed to Bundler classes for this release
 - Dockerfile: promote software-properties-common
 
 ## v0.138.7, 30 March 2021

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.138.7"
+  VERSION = "0.139.0"
 end


### PR DESCRIPTION
## v0.139.0, 30 March 2021

- Bundler [Beta]: Detect and run Bundler V1 or V2 based on Gemfile.lock
  - Requires `{ options: { bundler_2_available: true }}` to be passed for this release
- Dockerfile: promote software-properties-common
