### PR TITLE
Link sanitizer: Strip www from github.com

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -87,7 +87,7 @@ module Dependabot
 
         def replace_github_host(text)
           text.gsub(
-            "github.com", github_redirection_service || "github.com"
+            /(www\.)?github.com/, github_redirection_service || "github.com"
           )
         end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -4,8 +4,7 @@ require "spec_helper"
 require "dependabot/pull_request_creator/message_builder/"\
         "link_and_mention_sanitizer"
 
-namespace = Dependabot::PullRequestCreator::MessageBuilder
-RSpec.describe namespace::LinkAndMentionSanitizer do
+RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSanitizer do
   subject(:sanitizer) do
     described_class.new(github_redirection_service: github_redirection_service)
   end
@@ -224,6 +223,17 @@ RSpec.describe namespace::LinkAndMentionSanitizer do
 
     context "with a GitHub link" do
       let(:text) { "Check out https://github.com/my/repo/issues/5" }
+
+      it do
+        is_expected.to eq(
+          "<p>Check out <a href=\"https://github-redirect.com/my/repo/"\
+          "issues/5\">my/repo#5</a></p>\n"
+        )
+      end
+    end
+
+    context "with a GitHub link including www" do
+      let(:text) { "Check out https://www.github.com/my/repo/issues/5" }
 
       it do
         is_expected.to eq(


### PR DESCRIPTION
Strip `www.` from `github.com` links when replacing them with the github
redirect service as this currently doesn't support the `www` subdomain.

Fixes links in PRs updating `y18n` as these have been hardcoded in the
changelog with `www.github.com`:
https://github.com/react-atomic/reshow/pull/57