### PR TITLE
If SUITE_NAME is not specified, default to bundler2

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -11,13 +11,12 @@ end
 require "#{common_dir}/spec/spec_helper.rb"
 
 module PackageManagerHelper
-  # TODO: Make bundler 2 the default if no `SUITE_NAME` is set
   def self.use_bundler_1?
-    !use_bundler_2?
+    ENV["SUITE_NAME"] == "bundler1"
   end
 
   def self.use_bundler_2?
-    ENV["SUITE_NAME"] == "bundler2"
+    !use_bundler_1?
   end
 
   def self.bundler_version


### PR DESCRIPTION
This branch inverts our current default testing behaviour to use bundler2 by default since it is the latest release.

This mostly impacts developer workflows where it is anticipated they won't set the SUITE_NAME flag unless specifically testing a bunder 1-specific change.

This will have no affect on CI but just sets the expectation that in future, the builder1 CI build is a regression test and all new work will focus the latest release.

