### PR TITLE
v0.139.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.139.1, 30 March 2021
+
+- Pull Requests: Fix github redirect for www.github.com links
+- Pull Requests: Sanitize team mentions
+- Bundler 2 [Beta]: Add test for bundler dependency
+
 ## v0.139.0, 30 March 2021
 
 - Bundler [Beta]: Detect and run Bundler V1 or V2 based on Gemfile.lock

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.139.0"
+  VERSION = "0.139.1"
 end


### PR DESCRIPTION
## v0.139.1, 30 March 2021

- Pull Requests: Fix github redirect for www.github.com links
- Pull Requests: Sanitize team mentions
- Bundler 2 [Beta]: Add test for bundler dependency