### PR TITLE
Clean up feature flag protecting use of Bundler v2

### DIFF
--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -313,7 +313,7 @@ module Dependabot
       end
 
       def bundler_version
-        @bundler_version ||= Helpers.bundler_version(lockfile, options: options)
+        @bundler_version ||= Helpers.bundler_version(lockfile)
       end
     end
   end

--- a/bundler/lib/dependabot/bundler/file_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater.rb
@@ -163,7 +163,7 @@ module Dependabot
       end
 
       def bundler_version
-        @bundler_version ||= Helpers.bundler_version(lockfile, options: options)
+        @bundler_version ||= Helpers.bundler_version(lockfile)
       end
     end
   end

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -305,7 +305,7 @@ module Dependabot
         end
 
         def bundler_version
-          @bundler_version ||= Helpers.bundler_version(lockfile, options: options)
+          @bundler_version ||= Helpers.bundler_version(lockfile)
         end
       end
     end

--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -15,7 +15,6 @@ module Dependabot
 
       BUNDLER_MAJOR_VERSION_REGEX = /BUNDLED WITH\s+(?<version>\d+)\./m.freeze
 
-      # NOTE: options is a manditory argument to ensure we pass it from all calling classes
       def self.bundler_version(lockfile)
         return DEFAULT unless lockfile
 

--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -16,7 +16,7 @@ module Dependabot
       BUNDLER_MAJOR_VERSION_REGEX = /BUNDLED WITH\s+(?<version>\d+)\./m.freeze
 
       # NOTE: options is a manditory argument to ensure we pass it from all calling classes
-      def self.bundler_version(lockfile, _options:)
+      def self.bundler_version(lockfile)
         return DEFAULT unless lockfile
 
         if (matches = lockfile.content.match(BUNDLER_MAJOR_VERSION_REGEX))

--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -16,9 +16,7 @@ module Dependabot
       BUNDLER_MAJOR_VERSION_REGEX = /BUNDLED WITH\s+(?<version>\d+)\./m.freeze
 
       # NOTE: options is a manditory argument to ensure we pass it from all calling classes
-      def self.bundler_version(lockfile, options:)
-        # TODO: Remove once bundler 2 is fully supported
-        return V1 unless options[:bundler_2_available]
+      def self.bundler_version(lockfile, _options:)
         return DEFAULT unless lockfile
 
         if (matches = lockfile.content.match(BUNDLER_MAJOR_VERSION_REGEX))

--- a/bundler/lib/dependabot/bundler/update_checker/conflicting_dependency_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/conflicting_dependency_resolver.rb
@@ -50,7 +50,7 @@ module Dependabot
         private
 
         def bundler_version
-          @bundler_version ||= Helpers.bundler_version(lockfile, options: options)
+          @bundler_version ||= Helpers.bundler_version(lockfile)
         end
       end
     end

--- a/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
@@ -152,7 +152,7 @@ module Dependabot
         end
 
         def bundler_version
-          @bundler_version ||= Helpers.bundler_version(lockfile, options: options)
+          @bundler_version ||= Helpers.bundler_version(lockfile)
         end
       end
     end

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
@@ -147,7 +147,7 @@ module Dependabot
           end
 
           def bundler_version
-            @bundler_version ||= Helpers.bundler_version(lockfile, options: options)
+            @bundler_version ||= Helpers.bundler_version(lockfile)
           end
         end
       end

--- a/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
@@ -225,7 +225,7 @@ module Dependabot
         end
 
         def bundler_version
-          @bundler_version ||= Helpers.bundler_version(lockfile, options: options)
+          @bundler_version ||= Helpers.bundler_version(lockfile)
         end
       end
     end

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
     described_class.new(
       dependency_files: dependency_files,
       source: source,
-      reject_external_code: reject_external_code,
-      options: { bundler_2_available: PackageManagerHelper.use_bundler_2? }
+      reject_external_code: reject_external_code
     )
   end
   let(:source) do

--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -20,10 +20,7 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
         "type" => "git_source",
         "host" => "github.com"
       }],
-      repo_contents_path: repo_contents_path,
-      options: {
-        bundler_2_available: PackageManagerHelper.use_bundler_2?
-      }
+      repo_contents_path: repo_contents_path
     )
   end
   let(:dependencies) { [dependency] }

--- a/bundler/spec/dependabot/bundler/helper_spec.rb
+++ b/bundler/spec/dependabot/bundler/helper_spec.rb
@@ -42,57 +42,27 @@ RSpec.describe Dependabot::Bundler::Helpers do
 
   describe "#bundler_version" do
     def described_method(lockfile)
-      described_class.bundler_version(lockfile, options: options)
+      described_class.bundler_version(lockfile)
     end
 
-    context "when bundler 2 is not available" do
-      let(:options) { {} }
-
-      it "is 1 if there is no lockfile" do
-        expect(described_method(no_lockfile)).to eql("1")
-      end
-
-      it "is 1 if there is no bundled with string" do
-        expect(described_method(lockfile_bundled_with_missing)).to eql("1")
-      end
-
-      it "is 1 if it was bundled with a v1.x version" do
-        expect(described_method(lockfile_bundled_with_v1)).to eql("1")
-      end
-
-      it "is 1 if it was bundled with a v2.x version" do
-        expect(described_method(lockfile_bundled_with_v2)).to eql("1")
-      end
-
-      it "is 1 if it was bundled with a future version" do
-        expect(described_method(lockfile_bundled_with_future_version)).to eql("1")
-      end
+    it "is 2 if there is no lockfile" do
+      expect(described_method(no_lockfile)).to eql("2")
     end
 
-    context "when bundler 2 is available" do
-      let(:options) do
-        { bundler_2_available: true }
-      end
+    it "is 1 if there is no bundled with string" do
+      expect(described_method(lockfile_bundled_with_missing)).to eql("1")
+    end
 
-      it "is 2 if there is no lockfile" do
-        expect(described_method(no_lockfile)).to eql("2")
-      end
+    it "is 1 if it was bundled with a v1.x version" do
+      expect(described_method(lockfile_bundled_with_v1)).to eql("1")
+    end
 
-      it "is 1 if there is no bundled with string" do
-        expect(described_method(lockfile_bundled_with_missing)).to eql("1")
-      end
+    it "is 2 if it was bundled with a v2.x version" do
+      expect(described_method(lockfile_bundled_with_v2)).to eql("2")
+    end
 
-      it "is 1 if it was bundled with a v1.x version" do
-        expect(described_method(lockfile_bundled_with_v1)).to eql("1")
-      end
-
-      it "is 2 if it was bundled with a v2.x version" do
-        expect(described_method(lockfile_bundled_with_v2)).to eql("2")
-      end
-
-      it "is 2 if it was bundled with a future version" do
-        expect(described_method(lockfile_bundled_with_future_version)).to eql("2")
-      end
+    it "is 2 if it was bundled with a future version" do
+      expect(described_method(lockfile_bundled_with_future_version)).to eql("2")
     end
   end
 

--- a/bundler/spec/dependabot/bundler/update_checker/conflicting_dependency_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/conflicting_dependency_resolver_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe(Dependabot::Bundler::UpdateChecker::ConflictingDependencyResolver
         "username" => "x-access-token",
         "password" => "token"
       }],
-      options: { bundler_2_available: PackageManagerHelper.use_bundler_2? }
+      options: {}
     )
   end
   let(:dependency_files) do

--- a/bundler/spec/dependabot/bundler/update_checker/force_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/force_updater_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::ForceUpdater do
         "username" => "x-access-token",
         "password" => "token"
       }],
-      options: { bundler_2_available: PackageManagerHelper.use_bundler_2? }
+      options: {}
     )
   end
   let(:dependency_files) { bundler_project_dependency_files("gemfile") }

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -20,9 +20,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
         "username" => "x-access-token",
         "password" => "token"
       }],
-      options: {
-        bundler_2_available: PackageManagerHelper.use_bundler_2?
-      }
+      options: {}
     )
   end
   let(:dependency_files) { bundler_project_dependency_files("gemfile") }

--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -445,18 +445,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
             to eq(Gem::Version.new("2.0.1"))
         end
 
-        context "that isn't satisfied by the dependencies", :bundler_v1_only do
-          let(:dependency_files) do
-            bundler_project_dependency_files("imports_gemspec_version_clash_old_required_ruby_no_lockfile")
-          end
-          let(:current_version) { "3.0.1" }
-
-          it "ignores the minimum ruby version in the gemspec" do
-            expect(resolver.latest_resolvable_version_details[:version]).
-              to eq(Gem::Version.new("7.2.0"))
-          end
-        end
-
         context "that isn't satisfied by the dependencies", :bundler_v2_only do
           let(:dependency_files) do
             bundler_project_dependency_files("imports_gemspec_version_clash_old_required_ruby_no_lockfile")

--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
       }],
       unlock_requirement: unlock_requirement,
       latest_allowable_version: latest_allowable_version,
-      options: { bundler_2_available: PackageManagerHelper.use_bundler_2? }
+      options: {}
     )
   end
   let(:ignored_versions) { [] }

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -16,10 +16,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       dependency_files: dependency_files,
       credentials: credentials,
       ignored_versions: ignored_versions,
-      security_advisories: security_advisories,
-      options: {
-        bundler_2_available: PackageManagerHelper.use_bundler_2?
-      }
+      security_advisories: security_advisories
     )
   end
   let(:credentials) do

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -1367,15 +1367,6 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
             to_return(status: 401)
         end
 
-        it "raises a helpful error", :bundler_v1_only do
-          expect { checker.latest_resolvable_version }.
-            to raise_error do |error|
-              expect(error).to be_a(Dependabot::GitDependenciesNotReachable)
-              expect(error.dependency_urls).
-                to eq(["git://github.com/fundingcircle/prius.git"])
-            end
-        end
-
         it "raises a helpful error", :bundler_v2_only do
           expect { checker.latest_resolvable_version }.
             to raise_error do |error|


### PR DESCRIPTION
Update dependabot-bundler to support V2 by default