### PR TITLE
CI: Only bundle install for ecosystem under test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,6 @@ jobs:
         if: matrix.suite.name == 'python'
         run: |
           docker run --rm "$CORE_CI_IMAGE" bash -c "pyenv exec flake8 python/helpers/. --count --exclude=./.*,./python/spec/fixtures --show-source --statistics"
-      - name: Run Ruby Rubocop linting
-        run: |
-          docker run --rm "$CORE_CI_IMAGE" bash -c "cd /home/dependabot/dependabot-core/${{ matrix.suite.path }} && bundle exec rubocop ."
       - name: Run js linting and tests
         if: matrix.suite.name == 'npm_and_yarn'
         run: |
@@ -123,4 +120,4 @@ jobs:
       - name: Run ${{ matrix.suite.name }} tests with rspec
         run: |
           docker run --env "CI=true" --env "DEPENDABOT_TEST_ACCESS_TOKEN=$DEPENDABOT_TEST_ACCESS_TOKEN" --env "SUITE_NAME=${{ matrix.suite.name }}" --rm "$CORE_CI_IMAGE" bash -c \
-            "cd /home/dependabot/dependabot-core/${{ matrix.suite.path }} && bundle exec rspec spec"
+            "cd /home/dependabot/dependabot-core/${{ matrix.suite.path }} && ./script/ci-test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           docker run --rm "$CORE_CI_IMAGE" bash -c \
             "cd /home/dependabot/dependabot-core/bundler/helpers/v2 && BUNDLER_VERSION=2 bundle install && BUNDLER_VERSION=2 bundle exec rspec spec"
-      - name: Run ${{ matrix.suite.name }} tests with rspec
+      - name: Run ${{ matrix.suite.name }} tests
         run: |
           docker run --env "CI=true" --env "DEPENDABOT_TEST_ACCESS_TOKEN=$DEPENDABOT_TEST_ACCESS_TOKEN" --env "SUITE_NAME=${{ matrix.suite.name }}" --rm "$CORE_CI_IMAGE" bash -c \
             "cd /home/dependabot/dependabot-core/${{ matrix.suite.path }} && ./script/ci-test"

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -48,25 +48,6 @@ COPY python/Gemfile python/dependabot-python.gemspec ${CODE_DIR}/python/
 COPY terraform/Gemfile terraform/dependabot-terraform.gemspec ${CODE_DIR}/terraform/
 COPY omnibus/Gemfile omnibus/dependabot-omnibus.gemspec ${CODE_DIR}/omnibus/
 
-RUN cd common && bundle install
-RUN cd bundler && bundle install
-RUN cd cargo && bundle install
-RUN cd composer && bundle install
-RUN cd dep && bundle install
-RUN cd docker && bundle install
-RUN cd elm && bundle install
-RUN cd git_submodules && bundle install
-RUN cd github_actions && bundle install
-RUN cd go_modules && bundle install
-RUN cd gradle && bundle install
-RUN cd hex && bundle install
-RUN cd maven && bundle install
-RUN cd npm_and_yarn && bundle install
-RUN cd nuget && bundle install
-RUN cd python && bundle install
-RUN cd terraform && bundle install
-RUN cd omnibus && bundle install
-
 COPY common/ ${CODE_DIR}/common/
 COPY bundler/ ${CODE_DIR}/bundler/
 COPY cargo/ ${CODE_DIR}/cargo/

--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/cargo/script/ci-test
+++ b/cargo/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/common/script/ci-test
+++ b/common/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/composer/script/ci-test
+++ b/composer/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/dep/script/ci-test
+++ b/dep/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/docker/script/ci-test
+++ b/docker/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/elm/script/ci-test
+++ b/elm/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/git_submodules/script/ci-test
+++ b/git_submodules/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/github_actions/script/ci-test
+++ b/github_actions/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/go_modules/script/ci-test
+++ b/go_modules/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/gradle/script/ci-test
+++ b/gradle/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/hex/script/ci-test
+++ b/hex/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/maven/script/ci-test
+++ b/maven/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/npm_and_yarn/script/ci-test
+++ b/npm_and_yarn/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/nuget/script/ci-test
+++ b/nuget/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/omnibus/script/ci-test
+++ b/omnibus/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/python/script/ci-test
+++ b/python/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec

--- a/terraform/script/ci-test
+++ b/terraform/script/ci-test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bundle install
+bundle exec rubocop .
+bundle exec rspec spec


### PR DESCRIPTION
Currently in the CI container we bundle install for _every_ package,
this ends up taking 4 to 5 minutes on every build for every ecosystem.

Since the tests are split up per ecosystem, we only need to install the
gems for the package that is being tested in this matrix step.

This also introduces a `script/ci-test` per ecosystem, it currently runs
both rubocop and rspec for all ecosystems, but the expectation is that
these scripts might diverge per ecosystem.

Running both rspec and rubocop in the same script is done to prevent us
from having to `bundle install` for each of those steps.

We could take this approach a step further and split out a CI container
per ecosystem, and that would let us run rubocop and rspec as separate
steps, but I don't think this is currently worth it.

This should shave about 5 minutes of every matrix build.