### PR TITLE
CI: Remove step freeing up disk space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Free up disk space
-        run: |
-          sudo apt autoremove --purge && sudo apt -y clean
-          docker system prune -af --volumes
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          df -h
       - name: Prepare environment variables
         run: |
           echo "BRANCH_REF=$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')" >> $GITHUB_ENV


### PR DESCRIPTION
This was only added because of the changes here
https://github.com/dependabot/dependabot-core/pull/3279 which where
reverted here https://github.com/dependabot/dependabot-core/pull/3320

This step sometimes takes over a minute.