### PR TITLE
CI: Use GitHub Container Registry for CI images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,10 @@ jobs:
           echo "BRANCH_REF=$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')" >> $GITHUB_ENV
           echo "BASE_IMAGE=ubuntu:18.04" >> $GITHUB_ENV
           echo "CORE_IMAGE=dependabot/dependabot-core" >> $GITHUB_ENV
-          echo "CORE_CI_IMAGE=dependabot/dependabot-core-ci" >> $GITHUB_ENV
+          echo "CORE_CI_IMAGE=ghcr.io/${{ github.repository_owner }}/dependabot/dependabot-core-ci" >> $GITHUB_ENV
       - name: Log in to Docker registry
         run: |
-          if [ -n "${{ secrets.DOCKER_USERNAME }}" ] && [ -n "${{ secrets.DOCKER_PASSWORD }}" ]; then
-            echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-            echo "DOCKER_LOGGED_IN=true" >> $GITHUB_ENV
-          else
-            echo "No Docker credentials, skipping login"
-          fi
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Set test env credentials
         run: |
           echo "DEPENDABOT_TEST_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
@@ -80,7 +75,6 @@ jobs:
             --cache-from "$CORE_IMAGE:latest" \
             .
       - name: Push dependabot-core image to Docker registry
-        if: env.DOCKER_LOGGED_IN == 'true'
         run: |
           docker push "$CORE_CI_IMAGE:core--$BRANCH_REF"
       - name: Build dependabot-core-ci image
@@ -94,7 +88,6 @@ jobs:
             --cache-from "$CORE_CI_IMAGE:ci--$BRANCH_REF" \
             .
       - name: Push dependabot-core-ci image to Docker registry
-        if: env.DOCKER_LOGGED_IN == 'true'
         run: |
           docker push "$CORE_CI_IMAGE:latest"
           docker push "$CORE_CI_IMAGE:ci--$BRANCH_REF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
           echo "BRANCH_REF=$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')" >> $GITHUB_ENV
           echo "BASE_IMAGE=ubuntu:18.04" >> $GITHUB_ENV
           echo "CORE_IMAGE=dependabot/dependabot-core" >> $GITHUB_ENV
-          echo "CORE_CI_IMAGE=ghcr.io/${{ github.repository_owner }}/dependabot/dependabot-core-ci" >> $GITHUB_ENV
+          echo "CORE_CI_IMAGE=ghcr.io/${{ github.repository_owner }}/dependabot-core/dependabot-core-ci" >> $GITHUB_ENV
       - name: Log in to Docker registry
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Set test env credentials
         run: |
           echo "DEPENDABOT_TEST_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           echo "CORE_CI_IMAGE=ghcr.io/${{ github.repository_owner }}/dependabot-core/dependabot-core-ci" >> $GITHUB_ENV
       - name: Log in to Docker registry
         run: |
-          if [ -n "${{ secrets.GHCR_PAT }}" ] ]; then
+          if [[ -z "${{ secrets.GHCR_PAT }}" ]]; then
             echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             echo "DOCKER_LOGGED_IN=true" >> $GITHUB_ENV
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,12 @@ jobs:
           echo "CORE_CI_IMAGE=ghcr.io/${{ github.repository_owner }}/dependabot-core/dependabot-core-ci" >> $GITHUB_ENV
       - name: Log in to Docker registry
         run: |
-          echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          if [ -n "${{ secrets.GHCR_PAT }}" ] ]; then
+            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            echo "DOCKER_LOGGED_IN=true" >> $GITHUB_ENV
+          else
+            echo "No Docker credentials, skipping login"
+          fi
       - name: Set test env credentials
         run: |
           echo "DEPENDABOT_TEST_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
@@ -75,6 +80,7 @@ jobs:
             --cache-from "$CORE_IMAGE:latest" \
             .
       - name: Push dependabot-core image to Docker registry
+        if: env.DOCKER_LOGGED_IN == 'true'
         run: |
           docker push "$CORE_CI_IMAGE:core--$BRANCH_REF"
       - name: Build dependabot-core-ci image
@@ -88,6 +94,7 @@ jobs:
             --cache-from "$CORE_CI_IMAGE:ci--$BRANCH_REF" \
             .
       - name: Push dependabot-core-ci image to Docker registry
+        if: env.DOCKER_LOGGED_IN == 'true'
         run: |
           docker push "$CORE_CI_IMAGE:latest"
           docker push "$CORE_CI_IMAGE:ci--$BRANCH_REF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,10 @@ jobs:
       - name: Log in to Docker registry
         run: |
           if [[ -z "${{ secrets.GHCR_PAT }}" ]]; then
+            echo "No Docker credentials, skipping login"
+          else
             echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             echo "DOCKER_LOGGED_IN=true" >> $GITHUB_ENV
-          else
-            echo "No Docker credentials, skipping login"
           fi
       - name: Set test env credentials
         run: |


### PR DESCRIPTION
Attempting to use ghrc.io for CI images. This will probably not work on
forks.