### PR TITLE
CI: Simplify workflow by moving suite specific tests into test script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,25 +98,6 @@ jobs:
         run: |
           docker push "$CORE_CI_IMAGE:latest"
           docker push "$CORE_CI_IMAGE:ci--$BRANCH_REF"
-      - name: Run Python flake8 linting
-        if: matrix.suite.name == 'python'
-        run: |
-          docker run --rm "$CORE_CI_IMAGE" bash -c "pyenv exec flake8 python/helpers/. --count --exclude=./.*,./python/spec/fixtures --show-source --statistics"
-      - name: Run js linting and tests
-        if: matrix.suite.name == 'npm_and_yarn'
-        run: |
-          docker run --rm "$CORE_CI_IMAGE" bash -c "cd /opt/npm_and_yarn && npm run lint"
-          docker run --rm "$CORE_CI_IMAGE" bash -c "cd /opt/npm_and_yarn && npm test"
-      - name: Run bundler v1 native helper specs
-        if: matrix.suite.name == 'bundler1'
-        run: |
-          docker run --rm "$CORE_CI_IMAGE" bash -c \
-            "cd /home/dependabot/dependabot-core/bundler/helpers/v1 && BUNDLER_VERSION=1 bundle install && BUNDLER_VERSION=1 bundle exec rspec spec"
-      - name: Run bundler v2 native helper specs
-        if: matrix.suite.name == 'bundler2'
-        run: |
-          docker run --rm "$CORE_CI_IMAGE" bash -c \
-            "cd /home/dependabot/dependabot-core/bundler/helpers/v2 && BUNDLER_VERSION=2 bundle install && BUNDLER_VERSION=2 bundle exec rspec spec"
       - name: Run ${{ matrix.suite.name }} tests
         run: |
           docker run --env "CI=true" --env "DEPENDABOT_TEST_ACCESS_TOKEN=$DEPENDABOT_TEST_ACCESS_TOKEN" --env "SUITE_NAME=${{ matrix.suite.name }}" --rm "$CORE_CI_IMAGE" bash -c \

--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -5,13 +5,13 @@ bundle exec rubocop .
 bundle exec rspec spec
 
 [ "$SUITE_NAME" == "bundler1" ] &&\
-  cd /home/dependabot/dependabot-core/bundler/helpers/v1 && \
+  cd helpers/v1 && \
   BUNDLER_VERSION=1 bundle install && \
   BUNDLER_VERSION=1 bundle exec rspec spec &&\
   cd -
 
 [ "$SUITE_NAME" == "bundler2" ] &&\
-  cd /home/dependabot/dependabot-core/bundler/helpers/v2 && \
+  cd helpers/v2 && \
   BUNDLER_VERSION=2 bundle install && \
   BUNDLER_VERSION=2 bundle exec rspec spec &&\
   cd -

--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -3,3 +3,15 @@
 bundle install
 bundle exec rubocop .
 bundle exec rspec spec
+
+[ "$SUITE_NAME" == "bundler1" ] &&\
+  cd /home/dependabot/dependabot-core/bundler/helpers/v1 && \
+  BUNDLER_VERSION=1 bundle install && \
+  BUNDLER_VERSION=1 bundle exec rspec spec &&\
+  cd -
+
+[ "$SUITE_NAME" == "bundler2" ] &&\
+  cd /home/dependabot/dependabot-core/bundler/helpers/v2 && \
+  BUNDLER_VERSION=2 bundle install && \
+  BUNDLER_VERSION=2 bundle exec rspec spec &&\
+  cd -

--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -4,14 +4,16 @@ bundle install
 bundle exec rubocop .
 bundle exec rspec spec
 
-[ "$SUITE_NAME" == "bundler1" ] &&\
+if [ "$SUITE_NAME" == "bundler1" ]; then
   cd helpers/v1 && \
   BUNDLER_VERSION=1 bundle install && \
   BUNDLER_VERSION=1 bundle exec rspec spec &&\
   cd -
+fi
 
-[ "$SUITE_NAME" == "bundler2" ] &&\
+if [ "$SUITE_NAME" == "bundler2" ]; then
   cd helpers/v2 && \
   BUNDLER_VERSION=2 bundle install && \
   BUNDLER_VERSION=2 bundle exec rspec spec &&\
   cd -
+fi

--- a/npm_and_yarn/script/ci-test
+++ b/npm_and_yarn/script/ci-test
@@ -3,3 +3,6 @@
 bundle install
 bundle exec rubocop .
 bundle exec rspec spec
+
+cd /opt/npm_and_yarn && npm run lint && cd -
+cd /opt/npm_and_yarn && npm test && cd -

--- a/python/script/ci-test
+++ b/python/script/ci-test
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 bundle install
+pyenv exec flake8 helpers/. --count --exclude=./.*,./python/spec/fixtures --show-source --statistics
 bundle exec rubocop .
 bundle exec rspec spec


### PR DESCRIPTION
We were setting up a bunch of conditional tests/linting in the workflow
file, but now that we have test scripts I think it's cleaner to run
those inline in the `script/ci-test` script