### PR TITLE
CI: Pre-install python versions used in tests

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -6,6 +6,10 @@ ENV BUNDLE_PATH="/home/dependabot/.bundle" \
   BUNDLE_BIN=".bundle/binstubs" \
   PATH=".bundle/binstubs:$PATH:/home/dependabot/.bundle/bin"
 
+RUN pyenv install -s 3.6.13
+RUN pyenv install -s 3.7.1
+RUN pyenv install -s 3.7.10
+
 COPY .rubocop.yml /home/dependabot/dependabot-core/
 
 RUN mkdir -p \


### PR DESCRIPTION
I hacked together a little script to figure out which python versions
we're actually installing in our test suite, turns out it's not that
many:

https://github.com/dependabot/dependabot-core/pull/3425/commits/9f7251b423dccd474077da9227c3dbfb14f3535f

But this leads to almost 10 minutes of time spent _every python run_.

This change runs the install steps in the CI Dockerfile so they can be
cached.

It does nothing to prevent newer versions from python being added in new
tests, but it's a fairly safe way to shave 10 minutes of the build.