### PR TITLE
[ci skip] Explain pre-installed pythons in Dockerfile.ci

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -6,6 +6,9 @@ ENV BUNDLE_PATH="/home/dependabot/.bundle" \
   BUNDLE_BIN=".bundle/binstubs" \
   PATH=".bundle/binstubs:$PATH:/home/dependabot/.bundle/bin"
 
+# We pre-install these versions of python as they're known to be used in the
+# test suite. These used to be installed in-line, and pre-installing them helps
+# with the performance of the python test suite.
 RUN pyenv install -s 3.6.13
 RUN pyenv install -s 3.7.1
 RUN pyenv install -s 3.7.10


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/3431 we introduced
some pre-installed versions of Python in an effort to speed up our test.

@brrygrdn rightfully pointed out it'd be good to add a note as to why
this is here. This is said note.