### PR TITLE
dry-run: redirection-service

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -700,6 +700,7 @@ dependencies.each do |dep|
       files: updated_files,
       credentials: $options[:credentials],
       source: $source,
+      github_redirection_service: Dependabot::PullRequestCreator::DEFAULT_GITHUB_REDIRECTION_SERVICE,
     ).message
     puts "Pull Request Title: #{msg.pr_name}"
     puts "--description--\n#{msg.pr_message}\n--/description--"


### PR DESCRIPTION
Modifies the dry-run script so that when the `--pull-request` argument is passed, the GitHub pull request message is rendered to stdout.

This is a regression from #3301 , that only affected an infrequent path for development.