### PR TITLE
Sanitize mentions for merge requests in Gitlab

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -245,7 +245,7 @@ module Dependabot
         end
 
         def sanitize_links_and_mentions(text, unsafe: false)
-          return text unless source.provider == "github"
+          return text unless source.provider == "github" || source.provider == "gitlab"
 
           LinkAndMentionSanitizer.
             new(github_redirection_service: github_redirection_service).

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -976,8 +976,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             Dependabot::Source.new(provider: "gitlab", repo: "gocardless/bump")
           end
 
-          it "does not sanitize github links" do
-            expect(pr_message).not_to include(github_redirection_service)
+          it "sanitizes github links" do
+            expect(pr_message).to include(github_redirection_service)
           end
         end
 


### PR DESCRIPTION
I have encountered an issue that quite often handles in gitlab will be the same as on github. This creates an issue where PR descriptions in various projects can send notifications to people mentioned in release notes.

I'm not entirely sure if same issue could exist on bitbucket as well and maybe this check should be removed all together. For now it seemed safer to explicitly just add gitlab to conditional.