### PR TITLE
cargo: support build annotations

### DIFF
--- a/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
@@ -94,7 +94,7 @@ module Dependabot
         end
 
         def update_version_string(req_string)
-          new_target_parts = target_version.to_s.sub(/\+.*/, '').split(".")
+          new_target_parts = target_version.to_s.sub(/\+.*/, "").split(".")
           req_string.sub(VERSION_REGEX) do |old_version|
             # For pre-release versions, just use the full version string
             next target_version.to_s if old_version.match?(/\d-/)

--- a/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
@@ -94,13 +94,13 @@ module Dependabot
         end
 
         def update_version_string(req_string)
+          new_target_parts = target_version.to_s.sub(/\+.*/, '').split(".")
           req_string.sub(VERSION_REGEX) do |old_version|
             # For pre-release versions, just use the full version string
             next target_version.to_s if old_version.match?(/\d-/)
 
             old_parts = old_version.split(".")
-            new_parts = target_version.to_s.split(".").
-                        first(old_parts.count)
+            new_parts = new_target_parts.first(old_parts.count)
             new_parts.map.with_index do |part, i|
               old_parts[i] == "*" ? "*" : part
             end.join(".")

--- a/cargo/lib/dependabot/cargo/version.rb
+++ b/cargo/lib/dependabot/cargo/version.rb
@@ -29,6 +29,12 @@ module Dependabot
       def inspect # :nodoc:
         "#<#{self.class} #{@version_string}>"
       end
+
+      def self.correct?(version)
+        return false if version.nil?
+
+        version.to_s.match?(ANCHORED_VERSION_PATTERN)
+      end
     end
   end
 end

--- a/cargo/lib/dependabot/cargo/version.rb
+++ b/cargo/lib/dependabot/cargo/version.rb
@@ -10,7 +10,7 @@ require "rubygems_version_patch"
 module Dependabot
   module Cargo
     class Version < Gem::Version
-      VERSION_PATTERN = '[0-9]+[0-9a-zA-Z]*(?>\.[0-9a-zA-Z]+)*' \
+      VERSION_PATTERN = '[0-9]+(?>\.[0-9a-zA-Z]+)*' \
                         '(-[0-9A-Za-z-]+(\.[0-9a-zA-Z-]+)*)?' \
                         '(\+[0-9a-zA-Z]+(\.[0-9a-zA-Z]+)*)?'
       ANCHORED_VERSION_PATTERN = /\A\s*(#{VERSION_PATTERN})?\s*\z/.freeze

--- a/cargo/spec/dependabot/cargo/update_checker/requirements_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/requirements_updater_spec.rb
@@ -211,6 +211,12 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::RequirementsUpdater do
             )
           end
         end
+
+        context "and the target version has a build annotation" do
+          let(:req_string) { "1.2.3" }
+          let(:target_version) { "1.5.0+build.1" }
+          its([:requirement]) { is_expected.to eq("1.5.0") }
+        end
       end
     end
 

--- a/cargo/spec/dependabot/cargo/version_spec.rb
+++ b/cargo/spec/dependabot/cargo/version_spec.rb
@@ -60,4 +60,24 @@ RSpec.describe Dependabot::Cargo::Version do
       it { is_expected.to eq(true) }
     end
   end
+
+  describe "#correct?" do
+    subject { described_class.correct?(version_string) }
+
+    valid = %w(1.0.0 1.0.0.pre1 1.0.0-pre1 1.0.0-pre1+something)
+    valid.each do |version|
+      context "with version #{version}" do
+        let(:version_string) { version }
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    invalid = %w(☃ questionmark?)
+    invalid.each do |version|
+      context "with version #{version}" do
+        let(:version_string) { version }
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR amends the cargo updater to handle target versions with a build annotation, such as `1.5.0+build.1`.

First: there are several calls to `Cargo::Version#correct?` that probably expect to be validated against the regexp in `Cargo::Version`, but are actually evaluated against `Gem::Version`. The biggest implication of this bug is that the `RequirementsUpdater` will silently ignore the upgrade - so `Cargo.lock` will be updated but `Cargo.toml` will be unaffected:
* https://github.com/dependabot/dependabot-core/blob/2e5dd943912f005208ea1b43a5e4ad164029d96e/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb#L31
* https://github.com/dependabot/dependabot-core/blob/2e5dd943912f005208ea1b43a5e4ad164029d96e/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb#L42

Next up, the `RequirementsUpdater` would include the build annotation in the `Cargo.toml` update. This is accepted, but noise that users may not be expecting:
```
warning: /src/Cargo.toml: version requirement `0.7.0+std` for dependency `zstd` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
```

Finally, another place was relying on `Gem::Version#correct?` to reject Git commits as invalid versions. To address that I changed the `Cargo::Version::VERSION_PATTERN` to reject alphanumeric major versions.

Changing the `VERSION_PATTERN` is the biggest risk.
