### PR TITLE
CI: Rely on cache-from instead of pulling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,6 @@ jobs:
           else
             echo "No Docker credentials, skipping login"
           fi
-      - name: Pull Docker base images & warm Docker cache
-        run: |
-          docker pull "$BASE_IMAGE"
-          docker pull "$CORE_IMAGE:branch--$BRANCH_REF" ||
-            docker pull "$CORE_IMAGE:latest" || true
-          docker pull "$CORE_CI_IMAGE:branch--$BRANCH_REF" ||
-            docker pull "$CORE_CI_IMAGE:latest" || true
       - name: Build dependabot-core image
         run: |
           DOCKER_BUILDKIT=1 docker build \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,10 +17,6 @@ jobs:
         run: |
           echo "BASE_IMAGE=ubuntu:18.04" >> $GITHUB_ENV
           echo "CORE_IMAGE=dependabot/dependabot-core" >> $GITHUB_ENV
-      - name: Pull Docker base image & warm Docker cache
-        run: |
-          docker pull "$BASE_IMAGE"
-          docker pull "$CORE_IMAGE:latest"
       - name: Build dependabot-core image
         env:
           DOCKER_BUILDKIT: 1


### PR DESCRIPTION
When building images with the buildkit inline cache and using
`--cache-from` when building docker should be smart enough to only pull
the layers it needs so we don't need to do a full docker pull up front.