### PR TITLE
v0.139.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.139.2, 6 April 2021
+
+- Cargo: fix error when upgrading to a version with a build annotation (e.g. `0.7.0+zstd.1.4.9`)
+- Maven: fix error when comparing string and integer versions
+- Generate alternatives for every git source (thanks @jerbob92)
+- CI: performance improvements
+- Bump phpstan/phpstan from 0.12.82 to 0.12.83 in /composer/helpers/v2
+- Bump phpstan/phpstan from 0.12.82 to 0.12.83 in /composer/helpers/v1
+- Bump composer/composer from 2.0.11 to 2.0.12 in /composer/helpers/v2
+- Bump composer/composer from 1.10.20 to 1.10.21 in /composer/helpers/v1
+- Bump @npmcli/arborist from 2.2.9 to 2.3.0 in /npm_and_yarn/helpers
+
 ## v0.139.1, 30 March 2021
 
 - Pull Requests: Fix github redirect for www.github.com links

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.139.1"
+  VERSION = "0.139.2"
 end


### PR DESCRIPTION
Patch release containing [these commits](https://github.com/dependabot/dependabot-core/compare/v0.139.1...v0.139.2-release-notes)

These PRS:
* https://github.com/dependabot/dependabot-core/pull/3415
* https://github.com/dependabot/dependabot-core/pull/3401
* https://github.com/dependabot/dependabot-core/pull/3413
* https://github.com/dependabot/dependabot-core/pull/3417
* https://github.com/dependabot/dependabot-core/pull/3424
* https://github.com/dependabot/dependabot-core/pull/3426
* https://github.com/dependabot/dependabot-core/pull/3427
* https://github.com/dependabot/dependabot-core/pull/3430
* https://github.com/dependabot/dependabot-core/pull/3431
* https://github.com/dependabot/dependabot-core/pull/3433
* https://github.com/dependabot/dependabot-core/pull/3442
* https://github.com/dependabot/dependabot-core/pull/3441
* https://github.com/dependabot/dependabot-core/pull/3436
* https://github.com/dependabot/dependabot-core/pull/3435
* https://github.com/dependabot/dependabot-core/pull/3434
* https://github.com/dependabot/dependabot-core/pull/3428
* https://github.com/dependabot/dependabot-core/pull/3274
* https://github.com/dependabot/dependabot-core/pull/3446
* https://github.com/dependabot/dependabot-core/pull/3445