### PR TITLE
v0.140.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.140.0, 7 April 2021
+
+- Bundler: Detecting and using the correct major Bundler version is now enabled by default
+- Python: Add versions 3.8.9, 3.9.3 and 3.9.4
+- Bump friendsofphp/php-cs-fixer in /composer/helpers/v1
+- Bump friendsofphp/php-cs-fixer in /composer/helpers/v2
+
 ## v0.139.2, 6 April 2021
 
 - Cargo: fix error when upgrading to a version with a build annotation (e.g. `0.7.0+zstd.1.4.9`)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.139.2"
+  VERSION = "0.140.0"
 end


### PR DESCRIPTION
## v0.140.0, 7 April 2021

- Bundler: Detecting and using the correct major Bundler version is now enabled by default
- Python: Add versions 3.8.9, 3.9.3 and 3.9.4
- Bump friendsofphp/php-cs-fixer in /composer/helpers/v1
- Bump friendsofphp/php-cs-fixer in /composer/helpers/v2
