### PR TITLE
v0.140.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.140.1, 8 April 2021
+
+- Python: Disabled poetry experimental new installer @honnix
+- GitLab: Implement delete/create action in client @jerbob92
+
 ## v0.140.0, 7 April 2021
 
 - Bundler: Detecting and using the correct major Bundler version is now enabled by default

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.140.0"
+  VERSION = "0.140.1"
 end


### PR DESCRIPTION
## v0.140.1, 8 April 2021

- Python: Disabled poetry experimental new installer @honnix
- GitLab: Implement delete/create action in client @jerbob92