### PR TITLE
v0.140.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.140.2, 8 April 2021
+
+- Go mod: Handle repo not found errors projects https://github.com/dependabot/dependabot-core/pull/3456
+
 ## v0.140.1, 8 April 2021
 
 - Python: Disabled poetry experimental new installer @honnix

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.140.1"
+  VERSION = "0.140.2"
 end


### PR DESCRIPTION
## v0.140.2, 8 April 2021

- Go mod: Handle repo not found errors projects https://github.com/dependabot/dependabot-core/pull/3456

https://github.com/dependabot/dependabot-core/compare/v0.140.1...09e9cb5
