### PR TITLE
fix(Go mod): detect when remote end hangs up

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -21,6 +21,7 @@ module Dependabot
         ].freeze
 
         REPO_RESOLVABILITY_ERROR_REGEXES = [
+          /fatal: The remote end hung up unexpectedly/,
           /repository '.+' not found/,
           # (Private) module could not be fetched
           /go: .*: git fetch .*: exit status 128/.freeze,


### PR DESCRIPTION
# Why is this needed?

To handle job failures due to network issues causing errors like `fatal: The remote end hung up unexpectedly`.

Example jobs:

* 109068953
* 109064542
* 109050277
* 109043842
* 109043677

E.g.

```plaintext
Error processing k8s.io/cri-api (Dependabot::DependabotError)
go: github.com/containers/podman/v3@v3.1.0 requires
gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in <snip> exit status 128:
fatal: The remote end hung up unexpectedly
```

```plaintext
Error processing k8s.io/cli-runtime (Dependabot::DependabotError)
go: github.com/spf13/viper@v1.7.1 requires
	github.com/grpc-ecosystem/grpc-gateway@v1.9.0 requires
	gopkg.in/yaml.v2@v2.0.0-20170812160011-eb3733d160e7: invalid version: git fetch --unshallow -f origin in <snip> exit status 128:
	fatal: The remote end hung up unexpectedly
```

```plaintext
Error processing github.com/aws/aws-sdk-go (Dependabot::DependabotError)
go: github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.4 requires
	github.com/hashicorp/terraform-exec@v0.13.0 requires
	github.com/go-git/go-git/v5@v5.1.0 requires
	gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in <snip> exit status 128:
	fatal: The remote end hung up unexpectedly
```

```plaintext
Error processing github.com/google/uuid (Dependabot::DependabotError)
go: github.com/manifoldco/promptui@v0.8.0 requires
	gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in <snip> exit status 128:
	fatal: The remote end hung up unexpectedly
```

```plaintext
Error processing github.com/ethereum/go-ethereum (Dependabot::DependabotError)
go: github.com/ethereum/go-ethereum@v1.10.2 requires
	gopkg.in/olebedev/go-duktape.v3@v3.0.0-20200619000410-60c24ae608a6: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in <snip> exit status 128:
	fatal: The remote end hung up unexpectedly
```


## What does this do?

This change detects the error and raises a `Dependabot::DependencyFileNotResolvable` error so that the appropriate error message can be rendered in a build console.

Fixes # https://github.com/github/dependabot-updates/issues/1280

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
