### PR TITLE
fix: detect No Space errors

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -157,6 +157,8 @@ module Dependabot
       backup_git_config_path = stash_global_git_config
       configure_git_to_use_https_with_credentials(credentials)
       yield
+    rescue Errno::ENOSPC => e
+      raise Dependabot::OutOfDisk, e.message
     ensure
       reset_global_git_config(backup_git_config_path)
     end

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -447,5 +447,15 @@ RSpec.describe Dependabot::SharedHelpers do
         expect(configured_git_credentials).to eq("https://x-access-token:fake-token@private.com\n")
       end
     end
+
+    context "when the host has run out of disk space" do
+      before do
+        allow(File).to receive(:open).
+          with(described_class::GIT_CONFIG_GLOBAL_PATH, anything).
+          and_raise(Errno::ENOSPC)
+      end
+
+      specify { expect { configured_git_config }.to raise_error(Dependabot::OutOfDisk) }
+    end
   end
 end


### PR DESCRIPTION
# Why is this needed?

To detect out of disk errors and fail gracefully.

## What does this do?

It rescues `Errno::ENOSPC` and converts it to a `Dependabot::OutofDisk` error.

Example:

From job id `109063142`.

```plaintext
ERROR <job_109063142> Error processing github.com/sirupsen/logrus (Errno::ENOSPC)
ERROR <job_109063142> No space left on device @ fptr_finalize_flush - /home/dependabot/.gitconfig
ERROR <job_109063142> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-common-0.140.2/lib/dependabot/shared_helpers.rb:171:in `close'
ERROR <job_109063142> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-common-0.140.2/lib/dependabot/shared_helpers.rb:171:in `open'
ERROR <job_109063142> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-common-0.140.2/lib/dependabot/shared_helpers.rb:171:in `configure_git_to_use_https_with_credentials'
ERROR <job_109063142> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-common-0.140.2/lib/dependabot/shared_helpers.rb:158:in `with_git_configured'
ERROR <job_109063142> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-go_modules-0.140.2/lib/dependabot/go_modules/update_checker.rb:60:in `block in find_latest_resolvable_version'
ERROR <job_109063142> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-common-0.140.2/lib/dependabot/shared_helpers.rb:45:in `block (2 levels) in in_a_temporary_directory'
ERROR <job_109063142> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-common-0.140.2/lib/dependabot/shared_helpers.rb:45:in `chdir'
ERROR <job_109063142> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-common-0.140.2/lib/dependabot/shared_helpers.rb:45:in `block in in_a_temporary_directory'
ERROR <job_109063142> /usr/lib/ruby/2.6.0/tmpdir.rb:93:in `mktmpdir'
ERROR <job_109063142> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-common-0.140.2/lib/dependabot/shared_helpers.rb:42:in `in_a_temporary_directory'
ERROR <job_109063142> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-go_modules-0.140.2/lib/dependabot/go_modules/update_checker.rb:59:in `find_latest_resolvable_version'
ERROR <job_109063142> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-go_modules-0.140.2/lib/dependabot/go_modules/update_checker.rb:35:in `latest_resolvable_version'
ERROR <job_109063142> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-go_modules-0.140.2/lib/dependabot/go_modules/update_checker.rb:42:in `latest_version'
ERROR <job_109063142> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:436:in `log_checking_for_update'
ERROR <job_109063142> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:175:in `check_and_create_pull_request'
ERROR <job_109063142> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:68:in `check_and_create_pr_with_error_handling'
ERROR <job_109063142> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:53:in `block in run'
ERROR <job_109063142> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:53:in `each'
ERROR <job_109063142> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:53:in `run'
ERROR <job_109063142> /home/dependabot/dependabot-updater/lib/dependabot/update_files_job.rb:17:in `perform_job'
ERROR <job_109063142> /home/dependabot/dependabot-updater/lib/dependabot/base_job.rb:28:in `run'
ERROR <job_109063142> bin/update_files.rb:21:in `<main>'
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
