### PR TITLE
v0.140.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.140.3, 9 April 2021
+
+- fix(Go mod): detect when remote end hangs up
+
 ## v0.140.2, 8 April 2021
 
 - Go mod: Handle repo not found errors projects https://github.com/dependabot/dependabot-core/pull/3456

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.140.2"
+  VERSION = "0.140.3"
 end


### PR DESCRIPTION
## v0.140.3, 9 April 2021

- fix(Go mod): detect when remote end hangs up

https://github.com/dependabot/dependabot-core/compare/v0.140.2...dc12c50
