### PR TITLE
Add dependency to dependabot-maven from dependabot-gradle

### DIFF
--- a/gradle/dependabot-gradle.gemspec
+++ b/gradle/dependabot-gradle.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = common_gemspec.required_ruby_version
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
+  spec.add_dependency "dependabot-maven", Dependabot::VERSION
 
   common_gemspec.development_dependencies.each do |dep|
     spec.add_development_dependency dep.name, dep.requirement.to_s


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/3403 we added a dependency on `dependabot-maven` from the `dependabot-gradle` gem.
To ensure that the `dependabot-maven` gem is installed when we install the `dependabot-gradle` gem we need to declare `dependabot-maven` as a runtime dependency.
