### PR TITLE
v0.141.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.141.0, 12 April 2021
+
+- Dockerfile: create a `dependabot` user and drop privileges
+  This is a potentially BREAKING change for consumers of the `dependabot/dependabot-core` docker image.
+- Maven/Gradle: Add option to use Gitlab access token for authentication against maven repositories @gringostar
+- common: raise Dependabot::OutOfDisk on more out of space errors
+- Bump eslint from 7.23.0 to 7.24.0
+
 ## v0.140.3, 9 April 2021
 
 - fix(Go mod): detect when remote end hangs up

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.140.3"
+  VERSION = "0.141.0"
 end


### PR DESCRIPTION
Release of [these commits](https://github.com/dependabot/dependabot-core/compare/v0.140.3...v0.141.0-release-notes)

As noted in the changelog, this is a potentially breaking change for consumers of the `dependabot/dependabot-core` docker image. You could work around it with `USER root` at the top of the consuming `Dockerfile`, but we encourage updating images to follow least privilege.

* https://github.com/dependabot/dependabot-core/pull/3472
* https://github.com/dependabot/dependabot-core/pull/3473
* https://github.com/dependabot/dependabot-core/pull/3470
* https://github.com/dependabot/dependabot-core/pull/3398

