### PR TITLE
fix(go mod): capture module mismatch error

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -38,6 +38,7 @@ module Dependabot
         ].freeze
 
         MODULE_PATH_MISMATCH_REGEXES = [
+          /go get: \S+ updating to\n\s+\S+\sparsing\sgo.mod:\n\s+module declares its path as: \S+\n\s+but was required as: \S+/,
           /go: ([^@\s]+)(?:@[^\s]+)?: .* has non-.* module path "(.*)" at/,
           /go: ([^@\s]+)(?:@[^\s]+)?: .* unexpected module path "(.*)"/,
           /go: ([^@\s]+)(?:@[^\s]+)?: .* declares its path as: ([\S]*)/m

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -91,6 +91,27 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
       expect(updated_files.find { |f| f.name == "go.sum" }).to_not be_nil
     end
 
+    context "with an invalid module path" do
+      let(:stderr) do
+        <<~STDERR
+          go get: github.com/etcd-io/bbolt@none updating to
+          	github.com/etcd-io/bbolt@v1.3.5: parsing go.mod:
+          	module declares its path as: go.etcd.io/bbolt
+          	        but was required as: github.com/etcd-io/bbolt
+        STDERR
+      end
+
+      before do
+        exit_status = double(success?: false)
+        allow(Open3).to receive(:capture3).and_call_original
+        allow(Open3).to receive(:capture3).with(anything, "go get -d").and_return(["", stderr, exit_status])
+      end
+
+      it "raises a helpful error" do
+        expect { updated_files }.to raise_error(Dependabot::GoModulePathMismatch)
+      end
+    end
+
     context "with an indirect dependency from an unreachable repo" do
       let(:project_name) { "repo_not_found" }
       let(:dependency_name) { "github.com/go-openapi/spec" }


### PR DESCRIPTION
# Why is this needed?

To detect module mismatch errors when resolving dependencies with `go mod`.

E.g. Job id: 109392653

```bash
Error processing github.com/aws/amazon-ecs-agent (Dependabot::DependabotError)
go: downloading github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
go: downloading github.com/awslabs/go-config-generator-for-fluentd-and-fluentbit v0.0.0-20210308162251-8959c62cb8f9
go: downloading github.com/containernetworking/plugins v0.9.1
go: downloading github.com/etcd-io/bbolt v1.3.5
go: downloading github.com/vishvananda/netlink v1.1.0
go get: github.com/etcd-io/bbolt@none updating to
	github.com/etcd-io/bbolt@v1.3.5: parsing go.mod:
	module declares its path as: go.etcd.io/bbolt
	        but was required as: github.com/etcd-io/bbolt
```

## What does this do?

This change adds a regex to detect this error so that a `GoModulePathMismatch` error can be raised.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)