### PR TITLE
Adding update PR elements in azure PR updater

### DIFF
--- a/common/lib/dependabot/pull_request_updater/azure.rb
+++ b/common/lib/dependabot/pull_request_updater/azure.rb
@@ -27,6 +27,21 @@ module Dependabot
         update_source_branch
       end
 
+      def update_pr_elements(elements = {})
+        return unless elements
+
+        azure_client_for_source.update_pull_request(
+          pull_request_id: pull_request_number,
+          status: elements[:status],
+          pr_name: elements[:pr_name],
+          description: elements[:description],
+          completion_options: elements[:completion_options],
+          merge_options: elements[:merge_options],
+          auto_complete_setby_user_id: elements[:auto_complete_setby_user_id],
+          target_branch: elements[:target_branch]
+        )
+      end
+
       private
 
       def azure_client_for_source

--- a/common/spec/dependabot/pull_request_updater/azure_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/azure_spec.rb
@@ -166,4 +166,39 @@ RSpec.describe Dependabot::PullRequestUpdater::Azure do
         )
     end
   end
+
+  describe "#update_pr_elements" do
+    let(:update_pull_request_url) { repo_url + "/pullrequests/" + pull_request_number.to_s + "?api-version=5.0" }
+
+    context "returns nil" do
+      it "when elements hash is empty" do
+        expect(updater.update_pr_elements).to be_nil
+      end
+
+      it "when elements hash does not contain expected parameters for update" do
+        elements = { test_parameter: "test" }
+
+        expect(updater.update_pr_elements(elements)).to be_nil
+      end
+    end
+
+    it "updates the given pr elements" do
+      elements = { pr_name: "Test PR", auto_complete_setby_user_id: "id" }
+
+      stub_request(:patch, update_pull_request_url).
+        to_return(status: 200)
+
+      updater.update_pr_elements(elements)
+
+      expect(WebMock).
+        to(
+          have_requested(:patch, update_pull_request_url).
+              with(body:
+                {
+                  title: elements[:pr_name],
+                  autoCompleteSetBy: { id: elements[:auto_complete_setby_user_id] }
+                })
+        )
+    end
+  end
 end


### PR DESCRIPTION
This change allows to update PR elements such as `title`, `description`, `status`, set autocomplete on an existing PR,etc. for any PR in `azure devops`. 
@feelepxyz @jurre Can you guys review this PR and verify in this change makes sense to keep in dependabot-core?