### PR TITLE
npm/yarn: Always use registry source when available

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -252,10 +252,9 @@ module Dependabot
 
         return unless resolved_url
         return unless resolved_url.start_with?("http")
-        return if CENTRAL_REGISTRIES.any? { |u| resolved_url.start_with?(u) }
         return if resolved_url.match?(/(?<!pkg\.)github/)
 
-        private_registry_source_for(resolved_url, name)
+        registry_source_for(resolved_url, name)
       end
 
       def requirement_for(requirement)
@@ -287,7 +286,7 @@ module Dependabot
         }
       end
 
-      def private_registry_source_for(resolved_url, name)
+      def registry_source_for(resolved_url, name)
         url =
           if resolved_url.include?("/~/")
             # Gemfury format
@@ -305,7 +304,7 @@ module Dependabot
           else resolved_url.split("/")[0..2].join("/")
           end
 
-        { type: "private_registry", url: url }
+        { type: "registry", url: url }
       end
 
       def url_for_relevant_cred(resolved_url)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -39,7 +39,7 @@ module Dependabot
 
         case source_type
         when "git" then find_source_from_git_url
-        when "private_registry" then find_source_from_registry
+        when "registry" then find_source_from_registry
         else raise "Unexpected source type: #{source_type}"
         end
       end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
@@ -62,8 +62,8 @@ module Dependabot
 
         def registry_url
           protocol =
-            if private_registry_source_url
-              private_registry_source_url.split("://").first
+            if registry_source_url
+              registry_source_url.split("://").first
             else
               "https"
             end
@@ -92,10 +92,10 @@ module Dependabot
         end
 
         def locked_registry
-          return unless private_registry_source_url
+          return unless registry_source_url
 
           lockfile_registry =
-            private_registry_source_url.
+            registry_source_url.
             gsub("https://", "").
             gsub("http://", "")
           detailed_registry =
@@ -210,7 +210,7 @@ module Dependabot
           dependency.name.gsub("/", "%2F")
         end
 
-        def private_registry_source_url
+        def registry_source_url
           sources = dependency.requirements.
                     map { |r| r.fetch(:source) }.uniq.compact
 
@@ -218,8 +218,8 @@ module Dependabot
           # it's unclear how we should proceed
           raise "Multiple sources! #{sources.join(', ')}" if sources.map { |s| [s[:type], s[:url]] }.uniq.count > 1
 
-          # Otherwise we just take the URL of the first private registry
-          sources.find { |s| s[:type] == "private_registry" }&.fetch(:url)
+          # Otherwise we just take the URL of the first registry
+          sources.find { |s| s[:type] == "registry" }&.fetch(:url)
         end
       end
     end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "^0.0.1",
                   file: "package.json",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.npmjs.org" }
                 }]
               )
             end
@@ -84,7 +84,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "*",
                   file: "package.json",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.npmjs.org" }
                 }]
               )
             end
@@ -127,7 +127,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "^1.1.4",
                   file: "package.json",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.npmjs.org" }
                 }]
               )
             end
@@ -149,7 +149,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "^1.0.0",
                   file: "package.json",
                   groups: ["devDependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.npmjs.org" }
                 }]
               )
             end
@@ -203,7 +203,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   file: "package.json",
                   groups: ["dependencies"],
                   source: {
-                    type: "private_registry",
+                    type: "registry",
                     url: "http://registry.npm.taobao.org"
                   }
                 }]
@@ -224,7 +224,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   file: "package.json",
                   groups: ["devDependencies"],
                   source: {
-                    type: "private_registry",
+                    type: "registry",
                     url: "https://npm.fury.io/dependabot"
                   }
                 }]
@@ -245,7 +245,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   file: "package.json",
                   groups: ["devDependencies"],
                   source: {
-                    type: "private_registry",
+                    type: "registry",
                     url: "https://npm.pkg.github.com"
                   }
                 }]
@@ -266,7 +266,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   file: "package.json",
                   groups: ["devDependencies"],
                   source: {
-                    type: "private_registry",
+                    type: "registry",
                     url: "https://gitlab.mydomain.com/api/v4/"\
                          "packages/npm"
                   }
@@ -288,7 +288,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   file: "package.json",
                   groups: ["devDependencies"],
                   source: {
-                    type: "private_registry",
+                    type: "registry",
                     url: "https://artifactory01.mydomain.com/artifactory/api/"\
                          "npm/my-repo"
                   }
@@ -310,7 +310,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   file: "package.json",
                   groups: ["dependencies"],
                   source: {
-                    type: "private_registry",
+                    type: "registry",
                     url: "https://artifactory01.mydomain.com/artifactory/api/"\
                          "npm/my-repo"
                   }
@@ -335,7 +335,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                     file: "package.json",
                     groups: ["dependencies"],
                     source: {
-                      type: "private_registry",
+                      type: "registry",
                       url: "https://artifactory01.mydomain.com/artifactory/"\
                            "api/npm/my-repo"
                     }
@@ -359,7 +359,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                       file: "package.json",
                       groups: ["dependencies"],
                       source: {
-                        type: "private_registry",
+                        type: "registry",
                         url: "https://artifactory01.mydomain.com/artifactory/"\
                              "api/npm/my-repo"
                       }
@@ -383,7 +383,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   file: "package.json",
                   groups: ["devDependencies"],
                   source: {
-                    type: "private_registry",
+                    type: "registry",
                     url: "https://api.bintray.com/npm/dependabot/npm-private"
                   }
                 }]
@@ -409,7 +409,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "^1.0.0",
                   file: "package.json",
                   groups: ["optionalDependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.npmjs.org" }
                 }]
               )
             end
@@ -714,7 +714,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "^0.0.1",
                   file: "package.json",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.npmjs.org" }
                 }]
               )
             end
@@ -766,7 +766,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "^0.0.1",
                   file: "package.json",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.yarnpkg.com" }
                 }]
               )
             end
@@ -788,7 +788,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "next",
                   file: "package.json",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.yarnpkg.com" }
                 }]
               )
             end
@@ -810,7 +810,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "^1.0.0",
                   file: "package.json",
                   groups: ["devDependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.yarnpkg.com" }
                 }]
               )
             end
@@ -834,7 +834,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "^1.0.0",
                   file: "package.json",
                   groups: ["optionalDependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.yarnpkg.com" }
                 }]
               )
             end
@@ -860,7 +860,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "^0.1.0",
                   file: "package.json",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.yarnpkg.com" }
                 }]
               )
             end
@@ -943,7 +943,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   file: "package.json",
                   groups: ["dependencies"],
                   source: {
-                    type: "private_registry",
+                    type: "registry",
                     url: "http://registry.npm.taobao.org"
                   }
                 }]
@@ -964,7 +964,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   file: "package.json",
                   groups: ["devDependencies"],
                   source: {
-                    type: "private_registry",
+                    type: "registry",
                     url: "https://npm.fury.io/dependabot"
                   }
                 }]
@@ -1195,12 +1195,12 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "^1.1.0",
                   file: "packages/package1/package.json",
                   groups: ["devDependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.yarnpkg.com" }
                 }, {
                   requirement: "^1.0.0",
                   file: "other_package/package.json",
                   groups: ["devDependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.yarnpkg.com" }
                 }]
               )
             end
@@ -1218,17 +1218,17 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   requirement: "1.2.0",
                   file: "package.json",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.yarnpkg.com" }
                 }, {
                   requirement: "^1.2.1",
                   file: "other_package/package.json",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.yarnpkg.com" }
                 }, {
                   requirement: "^1.2.1",
                   file: "packages/package1/package.json",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.yarnpkg.com" }
                 }]
               )
             end
@@ -1249,7 +1249,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                 requirement: "^3.6.0",
                 file: "package.json",
                 groups: ["devDependencies"],
-                source: nil
+                source: { type: "registry", url: "https://registry.npmjs.org" }
               }]
             )
           end
@@ -1264,12 +1264,12 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                 requirement: "^1.1.0",
                 file: "packages/package1/package.json",
                 groups: ["devDependencies"],
-                source: nil
+                source: { type: "registry", url: "https://registry.npmjs.org" }
               }, {
                 requirement: "^1.0.0",
                 file: "packages/other_package/package.json",
                 groups: ["devDependencies"],
-                source: nil
+                source: { type: "registry", url: "https://registry.npmjs.org" }
               }]
             )
           end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/package_json_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/package_json_updater_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PackageJsonUpdater do
               requirement: "0.1.x",
               groups: ["dependencies"],
               source: {
-                type: "private_registry",
+                type: "registry",
                 url: "http://registry.npm.taobao.org"
               }
             }],

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
               requirement: "^1.0",
               groups: [],
               source: {
-                type: "private_registry",
+                type: "registry",
                 url: "https://npm.fury.io/dependabot"
               }
             }],

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
             requirement: "^1.0.0",
             groups: [],
             source: {
-              type: "private_registry",
+              type: "registry",
               url: "https://npm.fury.io/dependabot"
             }
           }],
@@ -551,7 +551,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
                 requirement: "^1.0.0",
                 groups: [],
                 source: {
-                  type: "private_registry",
+                  type: "registry",
                   url: "http://npm.fury.io/dependabot"
                 }
               }],

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/registry_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/registry_finder_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RegistryFinder do
 
     context "with a private registry source" do
       let(:source) do
-        { type: "private_registry", url: "https://npm.fury.io/dependabot" }
+        { type: "registry", url: "https://npm.fury.io/dependabot" }
       end
 
       it { is_expected.to eq("npm.fury.io/dependabot") }
@@ -281,7 +281,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RegistryFinder do
 
     context "with a private registry source" do
       let(:source) do
-        { type: "private_registry", url: "http://npm.mine.io/dependabot/" }
+        { type: "registry", url: "http://npm.mine.io/dependabot/" }
       end
 
       it { is_expected.to eq("http://npm.mine.io/dependabot/etag") }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^1.0.1",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }],
             package_manager: "npm_and_yarn"
           )
@@ -90,7 +90,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^15.2.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -110,7 +110,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^15.2.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -133,7 +133,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^2.1.8",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -170,7 +170,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "~1.8.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -206,7 +206,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^15.2.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -226,7 +226,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "0.14.2",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -247,7 +247,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^1.0.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }],
             package_manager: "npm_and_yarn"
           )
@@ -296,7 +296,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^15.2.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -323,7 +323,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                 file: "package.json",
                 requirement: "^2.1.8",
                 groups: ["dependencies"],
-                source: nil
+                source: { type: "registry", url: "https://registry.npmjs.org" }
               }]
             )
           end
@@ -360,7 +360,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                 file: "package.json",
                 requirement: "~1.8.0",
                 groups: ["dependencies"],
-                source: nil
+                source: { type: "registry", url: "https://registry.npmjs.org" }
               }]
             )
           end
@@ -396,7 +396,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^15.2.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -414,7 +414,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                 file: "package.json",
                 requirement: "0.14.2",
                 groups: ["dependencies"],
-                source: nil
+                source: { type: "registry", url: "https://registry.npmjs.org" }
               }]
             )
           end
@@ -439,7 +439,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^15.2.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -460,7 +460,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "2.5.20",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }],
             package_manager: "npm_and_yarn"
           )
@@ -488,7 +488,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^1.0.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }],
             package_manager: "npm_and_yarn"
           )
@@ -536,7 +536,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^15.2.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -589,7 +589,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^15.2.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -611,7 +611,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                 file: "package.json",
                 requirement: "^15.2.0",
                 groups: ["dependencies"],
-                source: nil
+                source: { type: "registry", url: "https://registry.npmjs.org" }
               }]
             )
           end
@@ -630,7 +630,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                 file: "package.json",
                 requirement: "^0.0.1",
                 groups: ["dependencies"],
-                source: nil
+                source: { type: "registry", url: "https://registry.npmjs.org" }
               }]
             )
           end
@@ -649,7 +649,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                   file: "package.json",
                   requirement: "^99.0.0",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.npmjs.org" }
                 }]
               )
             end
@@ -675,7 +675,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^1.0.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }],
             package_manager: "npm_and_yarn"
           )
@@ -723,7 +723,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^15.2.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -742,7 +742,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                 file: "package.json",
                 requirement: "~1.8.0",
                 groups: ["dependencies"],
-                source: nil
+                source: { type: "registry", url: "https://registry.npmjs.org" }
               }]
             )
           end
@@ -778,7 +778,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^15.2.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -796,7 +796,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                 file: "package.json",
                 requirement: "0.14.2",
                 groups: ["dependencies"],
-                source: nil
+                source: { type: "registry", url: "https://registry.npmjs.org" }
               }]
             )
           end
@@ -821,7 +821,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
             file: "package.json",
             requirement: "2.5.20",
             groups: ["dependencies"],
-            source: nil
+            source: { type: "registry", url: "https://registry.npmjs.org" }
           }],
           package_manager: "npm_and_yarn"
         )
@@ -868,7 +868,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
             file: "package.json",
             requirement: "^15.2.0",
             groups: ["dependencies"],
-            source: nil
+            source: { type: "registry", url: "https://registry.npmjs.org" }
           }]
         )
       end
@@ -887,7 +887,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "0.14.2",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -924,7 +924,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
             file: "package.json",
             requirement: "^15.2.0",
             groups: ["dependencies"],
-            source: nil
+            source: { type: "registry", url: "https://registry.npmjs.org" }
           }]
         )
       end
@@ -943,7 +943,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
             file: "package.json",
             requirement: "2.5.20",
             groups: ["dependencies"],
-            source: nil
+            source: { type: "registry", url: "https://registry.npmjs.org" }
           }],
           package_manager: "npm_and_yarn"
         )
@@ -989,7 +989,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
             file: "package.json",
             requirement: "^15.2.0",
             groups: ["dependencies"],
-            source: nil
+            source: { type: "registry", url: "https://registry.npmjs.org" }
           }]
         )
       end
@@ -1008,7 +1008,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "0.14.2",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -1045,7 +1045,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
             file: "package.json",
             requirement: "^15.2.0",
             groups: ["dependencies"],
-            source: nil
+            source: { type: "registry", url: "https://registry.npmjs.org" }
           }]
         )
       end
@@ -1068,7 +1068,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
             file: "package.json",
             requirement: "2.5.20",
             groups: ["dependencies"],
-            source: nil
+            source: { type: "registry", url: "https://registry.npmjs.org" }
           }],
           package_manager: "npm_and_yarn"
         )
@@ -1149,7 +1149,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
             file: "package.json",
             requirement: "^15.2.0",
             groups: ["dependencies"],
-            source: nil
+            source: { type: "registry", url: "https://registry.npmjs.org" }
           }]
         )
       end
@@ -1166,7 +1166,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                   file: "package.json",
                   requirement: "^15.2.0",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.npmjs.org" }
                 }]
               ),
               version: Dependabot::NpmAndYarn::Version.new("16.3.1"),
@@ -1180,7 +1180,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                   file: "package.json",
                   requirement: "^15.2.0",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.npmjs.org" }
                 }]
               ),
               version: Dependabot::NpmAndYarn::Version.new("16.6.0"),
@@ -1202,7 +1202,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
             file: "package.json",
             requirement: "^15.2.0",
             groups: ["dependencies"],
-            source: nil
+            source: { type: "registry", url: "https://registry.npmjs.org" }
           }]
         )
       end
@@ -1219,7 +1219,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                   file: "package.json",
                   requirement: "^15.2.0",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.npmjs.org" }
                 }]
               ),
               version: Dependabot::NpmAndYarn::Version.new("16.3.1"),
@@ -1233,7 +1233,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                   file: "package.json",
                   requirement: "^15.2.0",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.npmjs.org" }
                 }]
               ),
               version: Dependabot::NpmAndYarn::Version.new("16.6.0"),
@@ -1255,9 +1255,12 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
             file: "packages/package1/package.json",
             requirement: "15.6.2",
             groups: ["dependencies"],
-            source: nil
+            source: { type: "registry", url: "https://registry.yarnpkg.com" }
           }]
         )
+      end
+      let(:react_dom_registry_listing_url) do
+        "https://registry.yarnpkg.com/react-dom"
       end
 
       it "gets the right list of dependencies to update" do
@@ -1272,7 +1275,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                   file: "packages/package1/package.json",
                   requirement: "15.6.2",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.yarnpkg.com" }
                 }]
               ),
               version: Dependabot::NpmAndYarn::Version.new("16.3.1"),
@@ -1286,7 +1289,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
                   file: "packages/package1/package.json",
                   requirement: "15.6.2",
                   groups: ["dependencies"],
-                  source: nil
+                  source: { type: "registry", url: "https://registry.yarnpkg.com" }
                 }]
               ),
               version: Dependabot::NpmAndYarn::Version.new("16.6.0"),
@@ -1369,7 +1372,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
             file: "package.json",
             requirement: "0.3.0",
             groups: ["dependencies"],
-            source: nil
+            source: { type: "registry", url: "https://registry.npmjs.org" }
           }]
         )
       end
@@ -1407,7 +1410,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "0.3.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -1439,7 +1442,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "15.3",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -1471,12 +1474,12 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^15.4.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }, {
               file: "other/package.json",
               requirement: "< 15.0.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -1510,7 +1513,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^1.1.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -1542,7 +1545,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^1.1.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -1574,7 +1577,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^0.7.1",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -1606,7 +1609,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "0.3.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -1644,7 +1647,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: "^0.2.0",
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end
@@ -1662,7 +1665,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
               file: "package.json",
               requirement: nil,
               groups: ["dependencies"],
-              source: nil
+              source: { type: "registry", url: "https://registry.npmjs.org" }
             }]
           )
         end

--- a/npm_and_yarn/spec/fixtures/projects/npm6/peer_dependency/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/peer_dependency/package-lock.json
@@ -11,7 +11,7 @@
         },
         "core-js": {
             "version": "1.2.7",
-            "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
             "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "encoding": {
@@ -95,7 +95,7 @@
         },
         "react": {
             "version": "15.2.0",
-            "resolved": "http://registry.npmjs.org/react/-/react-15.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/react/-/react-15.2.0.tgz",
             "integrity": "sha1-y4VEmxDHS6jNS94M0oZ7Xu4JqXQ=",
             "requires": {
                 "fbjs": "^0.8.1",
@@ -105,7 +105,7 @@
         },
         "react-dom": {
             "version": "15.2.0",
-            "resolved": "http://registry.npmjs.org/react-dom/-/react-dom-15.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.2.0.tgz",
             "integrity": "sha1-zJuaL1HkYNanJ8eyMFj+lPQsh0w="
         },
         "safer-buffer": {

--- a/npm_and_yarn/spec/fixtures/projects/npm6/peer_dependency_multiple/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/peer_dependency_multiple/package-lock.json
@@ -76,7 +76,7 @@
     },
     "core-js": {
       "version": "1.2.7",
-      "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "defined": {
@@ -119,7 +119,7 @@
     },
     "fbjs": {
       "version": "0.6.1",
-      "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz",
       "integrity": "sha1-lja3cF9bqWhNRLcveDISVK/IYPc=",
       "requires": {
         "core-js": "^1.0.0",
@@ -277,12 +277,12 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -351,7 +351,7 @@
     },
     "react-modal": {
       "version": "0.6.1",
-      "resolved": "http://registry.npmjs.org/react-modal/-/react-modal-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-0.6.1.tgz",
       "integrity": "sha1-KGRE2A866KCs66lwNxycc6qBKEk=",
       "requires": {
         "element-class": "^0.2.0",
@@ -406,7 +406,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "ua-parser-js": {
@@ -416,7 +416,7 @@
     },
     "whatwg-fetch": {
       "version": "0.9.0",
-      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
       "integrity": "sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA="
     },
     "wrappy": {


### PR DESCRIPTION
Previously there was some logic in place to determine if a package came
from a public package repo or not, and if it came from a registry
considered central/public, we would not parse its source.

However, in the case of private packages that specify yarnpkg.com as
their source, this resulted in some calls expecting that package to
exist on npmjs.org, which it technically is (yarnpkg.com is a proxy for
it), but we would have no credentials configured for npmjs.org, so those
requests will fail.

This PR changes that behavior to always parse a package's source and add
it to the requirement if it exists. We previously only did this for
registries we considered "private", hence the name `private_registry`,
but since we cannot reliably determine if a package hosted on
`yarnpkg.com` or `npmjs.org` is private or not, this has been renamed to
just `registry`.

This means we no longer fall back to `npmjs.org` for private packages
that go through `yarnpkg.com`, so any credentials that are configured
can be reliably used.

I considered always configuring creds for `npmjs.org` for `yarnpkg.com`
and vice versa, but it seemed a little gnarly, and I think this change
is more clear.