### PR TITLE
pyenv: shallow clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,11 +80,11 @@ ENV PYENV_ROOT=/usr/local/.pyenv \
   PATH="/usr/local/.pyenv/bin:$PATH"
 RUN mkdir -p "$PYENV_ROOT" && chown dependabot:dependabot "$PYENV_ROOT"
 USER dependabot
-RUN git clone https://github.com/pyenv/pyenv.git /usr/local/.pyenv \
-  && cd /usr/local/.pyenv && git checkout 1.2.26 && cd - \
+RUN git clone https://github.com/pyenv/pyenv.git --branch 1.2.26 --single-branch --depth=1 /usr/local/.pyenv \
   && pyenv install 3.9.4 \
   && pyenv install 2.7.18 \
-  && pyenv global 3.9.4
+  && pyenv global 3.9.4 \
+  && rm -Rf /tmp/python-build*
 USER root
 
 


### PR DESCRIPTION
Continuing Dockerfile cleanup, let's do a shallow clone of `pyenv`.
That means instead of fetching the repository and checking out the branch we'd like to use, we'll fetch only the branch we'd like to use.

<details><summary>this only trims 4MB, but is trivial</summary>
<p>

<img width="3195" alt="Screen Shot 2021-04-14 at 8 34 47 AM" src="https://user-images.githubusercontent.com/1559510/114711124-95920b00-9cfc-11eb-9d63-8f39b2e6f64c.png">


</p>
</details> 