### PR TITLE
Add error handling for failure while updating Pull request in azure

### DIFF
--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -201,9 +201,11 @@ module Dependabot
           }
         ]
 
-        post(source.api_endpoint + source.organization + "/" + source.project +
-          "/_apis/git/repositories/" + source.unscoped_repo +
-          "/refs?api-version=5.0", content.to_json)
+        response = post(source.api_endpoint + source.organization + "/" + source.project +
+                        "/_apis/git/repositories/" + source.unscoped_repo +
+                        "/refs?api-version=5.0", content.to_json)
+
+        JSON.parse(response.body).fetch("value").first
       end
       # rubocop:enable Metrics/ParameterLists
 

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -71,15 +71,6 @@ module Dependabot
     end
   end
 
-  class PullRequestUpdateFailed < DependabotError
-    attr_reader :pull_request_id
-
-    def initialize(pull_request_id, msg = nil)
-      @pull_request_id = pull_request_id
-      super(msg)
-    end
-  end
-
   #####################
   # File level errors #
   #####################

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -71,7 +71,7 @@ module Dependabot
     end
   end
 
-  class PullRequestUpdatefailed < DependabotError
+  class PullRequestUpdateFailed < DependabotError
     attr_reader :pull_request_id
 
     def initialize(pull_request_id, msg = nil)

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -71,6 +71,15 @@ module Dependabot
     end
   end
 
+  class PullRequestUpdatefailed < DependabotError
+    attr_reader :pull_request_id
+
+    def initialize(pull_request_id, msg = nil)
+      @pull_request_id = pull_request_id
+      super(msg)
+    end
+  end
+
   #####################
   # File level errors #
   #####################

--- a/common/lib/dependabot/pull_request_updater/azure.rb
+++ b/common/lib/dependabot/pull_request_updater/azure.rb
@@ -55,9 +55,11 @@ module Dependabot
         # 1) Push the file changes to a newly created temporary branch (from base commit)
         new_commit = create_temp_branch
         # 2) Update PR source branch to point to the temp branch head commit.
-        update_branch(source_branch_name, old_source_branch_commit, new_commit)
+        response = update_branch(source_branch_name, old_source_branch_commit, new_commit)
         # 3) Delete temp branch
         update_branch(temp_branch_name, new_commit, OBJECT_ID_FOR_BRANCH_DELETE)
+
+        raise Dependabot::PullRequestUpdateFailed.new(pull_request_number, response.fetch('customMessage', nil)) unless response.fetch('success', false)
       end
 
       def pull_request

--- a/common/lib/dependabot/pull_request_updater/azure.rb
+++ b/common/lib/dependabot/pull_request_updater/azure.rb
@@ -59,9 +59,7 @@ module Dependabot
         # 3) Delete temp branch
         update_branch(temp_branch_name, new_commit, OBJECT_ID_FOR_BRANCH_DELETE)
 
-        unless response.fetch(
-          "success", false
-        )
+        unless response.fetch("success", false)
           raise Dependabot::PullRequestUpdateFailed.new(pull_request_number,
                                                         response.fetch("customMessage", nil))
         end

--- a/common/lib/dependabot/pull_request_updater/azure.rb
+++ b/common/lib/dependabot/pull_request_updater/azure.rb
@@ -6,6 +6,8 @@ require "securerandom"
 module Dependabot
   class PullRequestUpdater
     class Azure
+      class PullRequestUpdateFailed < Dependabot::DependabotError; end
+
       OBJECT_ID_FOR_BRANCH_DELETE = "0000000000000000000000000000000000000000"
 
       attr_reader :source, :files, :base_commit, :old_commit, :credentials,
@@ -59,10 +61,7 @@ module Dependabot
         # 3) Delete temp branch
         update_branch(temp_branch_name, new_commit, OBJECT_ID_FOR_BRANCH_DELETE)
 
-        unless response.fetch("success", false)
-          raise Dependabot::PullRequestUpdateFailed.new(pull_request_number,
-                                                        response.fetch("customMessage", nil))
-        end
+        raise PullRequestUpdateFailed, response.fetch("customMessage", nil) unless response.fetch("success", false)
       end
 
       def pull_request

--- a/common/lib/dependabot/pull_request_updater/azure.rb
+++ b/common/lib/dependabot/pull_request_updater/azure.rb
@@ -59,7 +59,12 @@ module Dependabot
         # 3) Delete temp branch
         update_branch(temp_branch_name, new_commit, OBJECT_ID_FOR_BRANCH_DELETE)
 
-        raise Dependabot::PullRequestUpdateFailed.new(pull_request_number, response.fetch('customMessage', nil)) unless response.fetch('success', false)
+        unless response.fetch(
+          "success", false
+        )
+          raise Dependabot::PullRequestUpdateFailed.new(pull_request_number,
+                                                        response.fetch("customMessage", nil))
+        end
       end
 
       def pull_request

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe Dependabot::Clients::Azure do
     it "sends update branch request with old and new commit id" do
       stub_request(:post, update_ref_url).
         with(basic_auth: [username, password]).
-        to_return(status: 200)
+        to_return(status: 200, body: fixture("azure", "update_ref.json"))
 
       update_ref
 

--- a/common/spec/dependabot/pull_request_updater/azure_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/azure_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Dependabot::PullRequestUpdater::Azure do
         stub_request(:post, branch_update_url).
           to_return(status: 200, body: fixture("azure", "update_ref_failed.json"))
 
-        expect { updater.update }.to raise_error(Dependabot::PullRequestUpdateFailed)
+        expect { updater.update }.to raise_error(Dependabot::PullRequestUpdater::Azure::PullRequestUpdateFailed)
       end
     end
   end

--- a/common/spec/dependabot/pull_request_updater/azure_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/azure_spec.rb
@@ -113,57 +113,71 @@ RSpec.describe Dependabot::PullRequestUpdater::Azure do
       end
     end
 
-    it "updates source branch head commit in AzureDevOps" do
-      stub_request(:get, source_branch_commits_url).
-        to_return(status: 200,
-                  body: fixture("azure", "commits.json"),
-                  headers: json_header)
-      stub_request(:get, repo_contents_tree_url).
-        to_return(status: 200,
-                  body: fixture("azure", "repo_contents_treeroot.json"),
-                  headers: json_header)
-      stub_request(:get, repo_contents_url).
-        to_return(status: 200,
-                  body: fixture("azure", "repo_contents.json"),
-                  headers: json_header)
-      stub_request(:post, create_commit_url).
-        with(body: {
-               refUpdates: [
-                 { name: "refs/heads/#{temp_branch}", oldObjectId: base_commit }
-               ],
-               commits: [
-                 {
-                   comment: commit_message,
-                   changes: files.map do |file|
-                     {
-                       changeType: "edit",
-                       item: { path: file.path },
-                       newContent: {
-                         content: Base64.encode64(file.content),
-                         contentType: "base64encoded"
+    context "tries updating source branch head commit in AzureDevOps" do
+      before do
+        stub_request(:get, source_branch_commits_url).
+          to_return(status: 200,
+                    body: fixture("azure", "commits.json"),
+                    headers: json_header)
+        stub_request(:get, repo_contents_tree_url).
+          to_return(status: 200,
+                    body: fixture("azure", "repo_contents_treeroot.json"),
+                    headers: json_header)
+        stub_request(:get, repo_contents_url).
+          to_return(status: 200,
+                    body: fixture("azure", "repo_contents.json"),
+                    headers: json_header)
+        stub_request(:post, create_commit_url).
+          with(body: {
+                 refUpdates: [
+                   { name: "refs/heads/#{temp_branch}", oldObjectId: base_commit }
+                 ],
+                 commits: [
+                   {
+                     comment: commit_message,
+                     changes: files.map do |file|
+                       {
+                         changeType: "edit",
+                         item: { path: file.path },
+                         newContent: {
+                           content: Base64.encode64(file.content),
+                           contentType: "base64encoded"
+                         }
                        }
-                     }
-                   end
-                 }
-               ]
-             }).
-        to_return(status: 201,
-                  body: fixture("azure", "create_new_branch.json"),
-                  headers: json_header)
-      stub_request(:post, branch_update_url).
-        to_return(status: 201)
+                     end
+                   }
+                 ]
+               }).
+          to_return(status: 201,
+                    body: fixture("azure", "create_new_branch.json"),
+                    headers: json_header)
 
-      allow(updater).to receive(:temp_branch_name).and_return(temp_branch)
-      updater.update
+        allow(updater).to receive(:temp_branch_name).and_return(temp_branch)
+      end
 
-      expect(WebMock).
-        to(
-          have_requested(:post, branch_update_url).
-              with(body: [
-                { name: "refs/heads/#{source_branch}", oldObjectId: source_branch_old_commit,
-                  newObjectId: source_branch_new_commit }
-              ].to_json)
-        )
+      it "sends request to AzureDevOps to update source branch head commit" do
+        stub_request(:post, branch_update_url).
+          to_return(status: 201, body: fixture("azure", "update_ref.json"))
+
+        allow(updater).to receive(:temp_branch_name).and_return(temp_branch)
+        updater.update
+
+        expect(WebMock).
+          to(
+            have_requested(:post, branch_update_url).
+                with(body: [
+                  { name: "refs/heads/#{source_branch}", oldObjectId: source_branch_old_commit,
+                    newObjectId: source_branch_new_commit }
+                ].to_json)
+          )
+      end
+
+      it "raises a helpful error when source branch update is unsuccessful" do
+        stub_request(:post, branch_update_url).
+          to_return(status: 200, body: fixture("azure", "update_ref_failed.json"))
+
+        expect { updater.update }.to raise_error(Dependabot::PullRequestUpdateFailed)
+      end
     end
   end
 end

--- a/common/spec/fixtures/azure/update_ref.json
+++ b/common/spec/fixtures/azure/update_ref.json
@@ -1,0 +1,14 @@
+{
+    "value": [
+        {
+            "repositoryId": "d3d1760b-311c-4175-a726-20dfc6a7f885",
+            "name": "refs/heads/vsts-api-sample/answer-woman-flame",
+            "oldObjectId": "ggf0dcb632e11e8e71f433956183349746fec562",
+            "newObjectId": "ffe9cba521f00d7f60e322845072238635edb451",
+            "isLocked": false,
+            "updateStatus": "succeeded",
+            "success": true
+        }
+    ],
+    "count": 1
+}

--- a/common/spec/fixtures/azure/update_ref_failed.json
+++ b/common/spec/fixtures/azure/update_ref_failed.json
@@ -1,0 +1,14 @@
+{
+    "value": [
+        {
+            "repositoryId": "d3d1760b-311c-4175-a726-20dfc6a7f885",
+            "name": "refs/heads/vsts-api-sample/answer-woman-flame",
+            "oldObjectId": "ggf0dcb632e11e8e71f433956183349746fec562",
+            "customMessage": "The user does not have force push permissions",
+            "isLocked": false,
+            "updateStatus": "failed",
+            "success": false
+        }
+    ],
+    "count": 1
+}


### PR DESCRIPTION
Added logic in the azure PR updater to raise an error of type `Dependabot::PullRequestUpdateFailed` when the update ref call to update the source branch is unsuccessful. Currently the update_ref API in azure returns a 200 response code even when the update operation is unsuccessful hence need to check the response body to verify if the update operation is successful
@feelepxyz @jurre Does this way of error handling makes sense? Apologies for creating a separate PR for this small change