### PR TITLE
set Dockerfile WORKDIR to /home/dependabot to avoid permission errors when consumers of the dependabot-core image run bundle install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -239,8 +239,9 @@ RUN mkdir -p /opt/bundler/v1 \
   && bash /opt/composer/helpers/v2/build /opt/composer/v2
 
 # Allow further gem installs as the dependabot user
-ENV HOME=/home/dependabot
-WORKDIR $HOME
+ENV HOME="/home/dependabot"
 ENV BUNDLE_PATH="$HOME/.bundle" \
-    BUNDLE_BIN="$HOME/.bundle/bin" \
-    PATH="$BUNDLE_BIN:$PATH"
+    BUNDLE_BIN=".bundle/bin"
+ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
+
+WORKDIR ${HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -224,6 +224,8 @@ RUN mkdir -p /opt/bundler/v1 \
   && bash /opt/composer/helpers/v2/build /opt/composer/v2
 
 # Allow further gem installs as the dependabot user
-ENV BUNDLE_PATH="/home/dependabot/.bundle" \
-    BUNDLE_BIN=".bundle/bin" \
-    PATH=".bundle/bin:$PATH:/home/dependabot/.bundle/bin"
+ENV HOME=/home/dependabot
+WORKDIR $HOME
+ENV BUNDLE_PATH="$HOME/.bundle" \
+    BUNDLE_BIN="$HOME/.bundle/bin" \
+    PATH="$BUNDLE_BIN:$PATH"


### PR DESCRIPTION
Seems like https://github.com/dependabot/dependabot-core/pull/3398 ended up breaking some scripts that were using the dependabot-core image (such as https://github.com/wemake-services/kira-dependencies and https://github.com/dependabot/dependabot-script). Seems like someone just forgot to set the `WORKDIR` which causes `pwd` to be `/`, which causes dependabot to fail to bundle install, since it doesn't have permission to write to `/`. This just sets the `WORKDIR` to the dependabot's home directory so that all of the bundler stuff ends up in a place that dependabot owns.

~~Note that now the bundler env variables are no longer needed, since they will just go into dependabots home directory.~~ They are still needed, but I moved the directories to be in dependabot's home directory.

I tested that this fixes https://github.com/wemake-services/kira-dependencies/issues/265, and I strongly suspect that it will also fix https://github.com/dependabot/dependabot-script/issues/574 as well.