### PR TITLE
Remove unused bundler v2 codepath 

### DIFF
--- a/bundler/helpers/v1/lib/functions.rb
+++ b/bundler/helpers/v1/lib/functions.rb
@@ -7,29 +7,25 @@ require "functions/conflicting_dependency_resolver"
 
 module Functions
   def self.parsed_gemfile(lockfile_name:, gemfile_name:, dir:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: [],
-                                      using_bundler2: false)
+    set_bundler_flags_and_credentials(dir: dir, credentials: [])
     FileParser.new(lockfile_name: lockfile_name).
       parsed_gemfile(gemfile_name: gemfile_name)
   end
 
   def self.parsed_gemspec(lockfile_name:, gemspec_name:, dir:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: [],
-                                      using_bundler2: false)
+    set_bundler_flags_and_credentials(dir: dir, credentials: [])
     FileParser.new(lockfile_name: lockfile_name).
       parsed_gemspec(gemspec_name: gemspec_name)
   end
 
   def self.vendor_cache_dir(dir:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: [],
-                                      using_bundler2: false)
+    set_bundler_flags_and_credentials(dir: dir, credentials: [])
     Bundler.app_cache
   end
 
-  def self.update_lockfile(dir:, gemfile_name:, lockfile_name:, using_bundler2:,
+  def self.update_lockfile(dir:, gemfile_name:, lockfile_name:,
                            credentials:, dependencies:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: using_bundler2)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
     LockfileUpdater.new(
       gemfile_name: gemfile_name,
       lockfile_name: lockfile_name,
@@ -38,10 +34,9 @@ module Functions
   end
 
   def self.force_update(dir:, dependency_name:, target_version:, gemfile_name:,
-                        lockfile_name:, using_bundler2:, credentials:,
+                        lockfile_name:, credentials:,
                         update_multiple_dependencies:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: using_bundler2)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
     ForceUpdater.new(
       dependency_name: dependency_name,
       target_version: target_version,
@@ -53,8 +48,7 @@ module Functions
 
   def self.dependency_source_type(gemfile_name:, dependency_name:, dir:,
                                   credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: false)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
 
     DependencySource.new(
       gemfile_name: gemfile_name,
@@ -66,8 +60,7 @@ module Functions
                                                 dir:, credentials:,
                                                 dependency_source_url:,
                                                 dependency_source_branch:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: false)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
     DependencySource.new(
       gemfile_name: gemfile_name,
       dependency_name: dependency_name
@@ -79,8 +72,7 @@ module Functions
 
   def self.private_registry_versions(gemfile_name:, dependency_name:, dir:,
                                      credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: false)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
 
     DependencySource.new(
       gemfile_name: gemfile_name,
@@ -89,10 +81,9 @@ module Functions
   end
 
   def self.resolve_version(dependency_name:, dependency_requirements:,
-                           gemfile_name:, lockfile_name:, using_bundler2:,
+                           gemfile_name:, lockfile_name:,
                            dir:, credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: using_bundler2)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
     VersionResolver.new(
       dependency_name: dependency_name,
       dependency_requirements: dependency_requirements,
@@ -101,10 +92,9 @@ module Functions
     ).version_details
   end
 
-  def self.jfrog_source(dir:, gemfile_name:, credentials:, using_bundler2:)
+  def self.jfrog_source(dir:, gemfile_name:, credentials:)
     # Set flags and credentials
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: using_bundler2)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
 
     Bundler::Definition.build(gemfile_name, nil, {}).
       send(:sources).
@@ -113,9 +103,8 @@ module Functions
       host
   end
 
-  def self.git_specs(dir:, gemfile_name:, credentials:, using_bundler2:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: using_bundler2)
+  def self.git_specs(dir:, gemfile_name:, credentials:)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
 
     git_specs = Bundler::Definition.build(gemfile_name, nil, {}).dependencies.
                 select do |spec|
@@ -136,8 +125,7 @@ module Functions
     end
   end
 
-  def self.set_bundler_flags_and_credentials(dir:, credentials:,
-                                             using_bundler2:)
+  def self.set_bundler_flags_and_credentials(dir:, credentials:)
     dir = dir ? Pathname.new(dir) : dir
     Bundler.instance_variable_set(:@root, dir)
 
@@ -154,12 +142,6 @@ module Functions
         cred.fetch("host"),
         token.gsub("@", "%40F").gsub("?", "%3F")
       )
-    end
-
-    # Use HTTPS for GitHub if lockfile was generated by Bundler 2
-    if using_bundler2
-      Bundler.settings.set_command_option("forget_cli_options", "true")
-      Bundler.settings.set_command_option("github.https", "true")
     end
   end
 
@@ -181,9 +163,8 @@ module Functions
   end
 
   def self.conflicting_dependencies(dir:, dependency_name:, target_version:,
-                                    lockfile_name:, using_bundler2:, credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: using_bundler2)
+                                    lockfile_name:, credentials:)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
     ConflictingDependencyResolver.new(
       dependency_name: dependency_name,
       target_version: target_version,

--- a/bundler/helpers/v1/lib/functions.rb
+++ b/bundler/helpers/v1/lib/functions.rb
@@ -6,107 +6,97 @@ require "functions/version_resolver"
 require "functions/conflicting_dependency_resolver"
 
 module Functions
-  def self.parsed_gemfile(lockfile_name:, gemfile_name:, dir:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: [])
-    FileParser.new(lockfile_name: lockfile_name).
-      parsed_gemfile(gemfile_name: gemfile_name)
+  def self.parsed_gemfile(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: [])
+    FileParser.new(lockfile_name: args.fetch(:lockfile_name)).
+      parsed_gemfile(gemfile_name: args.fetch(:gemfile_name))
   end
 
-  def self.parsed_gemspec(lockfile_name:, gemspec_name:, dir:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: [])
-    FileParser.new(lockfile_name: lockfile_name).
-      parsed_gemspec(gemspec_name: gemspec_name)
+  def self.parsed_gemspec(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: [])
+    FileParser.new(lockfile_name: args.fetch(:lockfile_name)).
+      parsed_gemspec(gemspec_name: args.fetch(:gemspec_name))
   end
 
-  def self.vendor_cache_dir(dir:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: [])
+  def self.vendor_cache_dir(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: [])
     Bundler.app_cache
   end
 
-  def self.update_lockfile(dir:, gemfile_name:, lockfile_name:,
-                           credentials:, dependencies:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.update_lockfile(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
     LockfileUpdater.new(
-      gemfile_name: gemfile_name,
-      lockfile_name: lockfile_name,
-      dependencies: dependencies
+      gemfile_name: args.fetch(:gemfile_name),
+      lockfile_name: args.fetch(:lockfile_name),
+      dependencies: args.fetch(:dependencies)
     ).run
   end
 
-  def self.force_update(dir:, dependency_name:, target_version:, gemfile_name:,
-                        lockfile_name:, credentials:,
-                        update_multiple_dependencies:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.force_update(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
     ForceUpdater.new(
-      dependency_name: dependency_name,
-      target_version: target_version,
-      gemfile_name: gemfile_name,
-      lockfile_name: lockfile_name,
-      update_multiple_dependencies: update_multiple_dependencies
+      dependency_name: args.fetch(:dependency_name),
+      target_version: args.fetch(:target_version),
+      gemfile_name: args.fetch(:gemfile_name),
+      lockfile_name: args.fetch(:lockfile_name),
+      update_multiple_dependencies: args.fetch(:update_multiple_dependencies)
     ).run
   end
 
-  def self.dependency_source_type(gemfile_name:, dependency_name:, dir:,
-                                  credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.dependency_source_type(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
 
     DependencySource.new(
-      gemfile_name: gemfile_name,
-      dependency_name: dependency_name
+      gemfile_name: args.fetch(:gemfile_name),
+      dependency_name: args.fetch(:dependency_name)
     ).type
   end
 
-  def self.depencency_source_latest_git_version(gemfile_name:, dependency_name:,
-                                                dir:, credentials:,
-                                                dependency_source_url:,
-                                                dependency_source_branch:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.depencency_source_latest_git_version(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
     DependencySource.new(
-      gemfile_name: gemfile_name,
-      dependency_name: dependency_name
+      gemfile_name: args.fetch(:gemfile_name),
+      dependency_name: args.fetch(:dependency_name)
     ).latest_git_version(
-      dependency_source_url: dependency_source_url,
-      dependency_source_branch: dependency_source_branch
+      dependency_source_url: args.fetch(:dependency_source_url),
+      dependency_source_branch: args.fetch(:dependency_source_branch)
     )
   end
 
-  def self.private_registry_versions(gemfile_name:, dependency_name:, dir:,
-                                     credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.private_registry_versions(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
 
     DependencySource.new(
-      gemfile_name: gemfile_name,
-      dependency_name: dependency_name
+      gemfile_name: args.fetch(:gemfile_name),
+      dependency_name: args.fetch(:dependency_name)
     ).private_registry_versions
   end
 
-  def self.resolve_version(dependency_name:, dependency_requirements:,
-                           gemfile_name:, lockfile_name:,
-                           dir:, credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.resolve_version(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
     VersionResolver.new(
-      dependency_name: dependency_name,
-      dependency_requirements: dependency_requirements,
-      gemfile_name: gemfile_name,
-      lockfile_name: lockfile_name
+      dependency_name: args.fetch(:dependency_name),
+      dependency_requirements: args.fetch(:dependency_requirements),
+      gemfile_name: args.fetch(:gemfile_name),
+      lockfile_name: args.fetch(:lockfile_name)
     ).version_details
   end
 
-  def self.jfrog_source(dir:, gemfile_name:, credentials:)
+  def self.jfrog_source(**args)
     # Set flags and credentials
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
 
-    Bundler::Definition.build(gemfile_name, nil, {}).
+    Bundler::Definition.build(args.fetch(:gemfile_name), nil, {}).
       send(:sources).
       rubygems_remotes.
       find { |uri| uri.host.include?("jfrog") }&.
       host
   end
 
-  def self.git_specs(dir:, gemfile_name:, credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.git_specs(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
 
-    git_specs = Bundler::Definition.build(gemfile_name, nil, {}).dependencies.
+    git_specs = Bundler::Definition.build(args.fetch(:gemfile_name), nil, {}).dependencies.
                 select do |spec|
       spec.source.is_a?(Bundler::Source::Git)
     end
@@ -124,6 +114,17 @@ module Functions
       }
     end
   end
+
+  def self.conflicting_dependencies(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
+    ConflictingDependencyResolver.new(
+      dependency_name: args.fetch(:dependency_name),
+      target_version: args.fetch(:target_version),
+      lockfile_name: args.fetch(:lockfile_name)
+    ).conflicting_dependencies
+  end
+
+  private
 
   def self.set_bundler_flags_and_credentials(dir:, credentials:)
     dir = dir ? Pathname.new(dir) : dir
@@ -160,15 +161,5 @@ module Functions
   def self.git_source_credentials(credentials)
     credentials.
       select { |cred| cred["type"] == "git_source" }
-  end
-
-  def self.conflicting_dependencies(dir:, dependency_name:, target_version:,
-                                    lockfile_name:, credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
-    ConflictingDependencyResolver.new(
-      dependency_name: dependency_name,
-      target_version: target_version,
-      lockfile_name: lockfile_name
-    ).conflicting_dependencies
   end
 end

--- a/bundler/helpers/v2/lib/functions.rb
+++ b/bundler/helpers/v2/lib/functions.rb
@@ -11,29 +11,25 @@ module Functions
   class NotImplementedError < StandardError; end
 
   def self.parsed_gemfile(lockfile_name:, gemfile_name:, dir:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: [],
-                                      using_bundler2: false)
+    set_bundler_flags_and_credentials(dir: dir, credentials: [])
     FileParser.new(lockfile_name: lockfile_name).
       parsed_gemfile(gemfile_name: gemfile_name)
   end
 
   def self.parsed_gemspec(lockfile_name:, gemspec_name:, dir:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: [],
-                                      using_bundler2: false)
+    set_bundler_flags_and_credentials(dir: dir, credentials: [])
     FileParser.new(lockfile_name: lockfile_name).
       parsed_gemspec(gemspec_name: gemspec_name)
   end
 
   def self.vendor_cache_dir(dir:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: [],
-                                      using_bundler2: false)
+    set_bundler_flags_and_credentials(dir: dir, credentials: [])
     Bundler.app_cache
   end
 
-  def self.update_lockfile(dir:, gemfile_name:, lockfile_name:, using_bundler2:,
+  def self.update_lockfile(dir:, gemfile_name:, lockfile_name:,
                            credentials:, dependencies:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: using_bundler2)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
     LockfileUpdater.new(
       gemfile_name: gemfile_name,
       lockfile_name: lockfile_name,
@@ -42,10 +38,9 @@ module Functions
   end
 
   def self.force_update(dir:, dependency_name:, target_version:, gemfile_name:,
-                        lockfile_name:, using_bundler2:, credentials:,
+                        lockfile_name:, credentials:,
                         update_multiple_dependencies:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: using_bundler2)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
     ForceUpdater.new(
       dependency_name: dependency_name,
       target_version: target_version,
@@ -57,8 +52,7 @@ module Functions
 
   def self.dependency_source_type(gemfile_name:, dependency_name:, dir:,
                                   credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: false)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
 
     DependencySource.new(
       gemfile_name: gemfile_name,
@@ -70,8 +64,7 @@ module Functions
                                                 dir:, credentials:,
                                                 dependency_source_url:,
                                                 dependency_source_branch:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: false)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
     DependencySource.new(
       gemfile_name: gemfile_name,
       dependency_name: dependency_name
@@ -83,8 +76,7 @@ module Functions
 
   def self.private_registry_versions(gemfile_name:, dependency_name:, dir:,
                                      credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: false)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
 
     DependencySource.new(
       gemfile_name: gemfile_name,
@@ -93,9 +85,9 @@ module Functions
   end
 
   def self.resolve_version(dependency_name:, dependency_requirements:,
-                           gemfile_name:, lockfile_name:, using_bundler2:,
+                           gemfile_name:, lockfile_name:,
                            dir:, credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials, using_bundler2: using_bundler2)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
     VersionResolver.new(
       dependency_name: dependency_name,
       dependency_requirements: dependency_requirements,
@@ -104,8 +96,8 @@ module Functions
     ).version_details
   end
 
-  def self.jfrog_source(dir:, gemfile_name:, credentials:, using_bundler2:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials, using_bundler2: using_bundler2)
+  def self.jfrog_source(dir:, gemfile_name:, credentials:)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
 
     Bundler::Definition.build(gemfile_name, nil, {}).
       send(:sources).
@@ -114,9 +106,8 @@ module Functions
       host
   end
 
-  def self.git_specs(dir:, gemfile_name:, credentials:, using_bundler2:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: using_bundler2)
+  def self.git_specs(dir:, gemfile_name:, credentials:)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
 
     git_specs = Bundler::Definition.build(gemfile_name, nil, {}).dependencies.
                 select do |spec|
@@ -137,8 +128,7 @@ module Functions
     end
   end
 
-  def self.set_bundler_flags_and_credentials(dir:, credentials:,
-                                             using_bundler2:)
+  def self.set_bundler_flags_and_credentials(dir:, credentials:)
     dir = dir ? Pathname.new(dir) : dir
     Bundler.instance_variable_set(:@root, dir)
 
@@ -183,9 +173,8 @@ module Functions
   end
 
   def self.conflicting_dependencies(dir:, dependency_name:, target_version:,
-                                    lockfile_name:, using_bundler2:, credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials,
-                                      using_bundler2: using_bundler2)
+                                    lockfile_name:, credentials:)
+    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
     ConflictingDependencyResolver.new(
       dependency_name: dependency_name,
       target_version: target_version,

--- a/bundler/helpers/v2/lib/functions.rb
+++ b/bundler/helpers/v2/lib/functions.rb
@@ -10,106 +10,97 @@ require "functions/version_resolver"
 module Functions
   class NotImplementedError < StandardError; end
 
-  def self.parsed_gemfile(lockfile_name:, gemfile_name:, dir:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: [])
-    FileParser.new(lockfile_name: lockfile_name).
-      parsed_gemfile(gemfile_name: gemfile_name)
+  def self.parsed_gemfile(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: [])
+    FileParser.new(lockfile_name: args.fetch(:lockfile_name)).
+      parsed_gemfile(gemfile_name: args.fetch(:gemfile_name))
   end
 
-  def self.parsed_gemspec(lockfile_name:, gemspec_name:, dir:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: [])
-    FileParser.new(lockfile_name: lockfile_name).
-      parsed_gemspec(gemspec_name: gemspec_name)
+  def self.parsed_gemspec(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: [])
+    FileParser.new(lockfile_name: args.fetch(:lockfile_name)).
+      parsed_gemspec(gemspec_name: args.fetch(:gemspec_name))
   end
 
-  def self.vendor_cache_dir(dir:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: [])
+  def self.vendor_cache_dir(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: [])
     Bundler.app_cache
   end
 
-  def self.update_lockfile(dir:, gemfile_name:, lockfile_name:,
-                           credentials:, dependencies:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.update_lockfile(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
     LockfileUpdater.new(
-      gemfile_name: gemfile_name,
-      lockfile_name: lockfile_name,
-      dependencies: dependencies
+      gemfile_name: args.fetch(:gemfile_name),
+      lockfile_name: args.fetch(:lockfile_name),
+      dependencies: args.fetch(:dependencies)
     ).run
   end
 
-  def self.force_update(dir:, dependency_name:, target_version:, gemfile_name:,
-                        lockfile_name:, credentials:,
-                        update_multiple_dependencies:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.force_update(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
     ForceUpdater.new(
-      dependency_name: dependency_name,
-      target_version: target_version,
-      gemfile_name: gemfile_name,
-      lockfile_name: lockfile_name,
-      update_multiple_dependencies: update_multiple_dependencies
+      dependency_name: args.fetch(:dependency_name),
+      target_version: args.fetch(:target_version),
+      gemfile_name: args.fetch(:gemfile_name),
+      lockfile_name: args.fetch(:lockfile_name),
+      update_multiple_dependencies: args.fetch(:update_multiple_dependencies)
     ).run
   end
 
-  def self.dependency_source_type(gemfile_name:, dependency_name:, dir:,
-                                  credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.dependency_source_type(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
 
     DependencySource.new(
-      gemfile_name: gemfile_name,
-      dependency_name: dependency_name
+      gemfile_name: args.fetch(:gemfile_name),
+      dependency_name: args.fetch(:dependency_name)
     ).type
   end
 
-  def self.depencency_source_latest_git_version(gemfile_name:, dependency_name:,
-                                                dir:, credentials:,
-                                                dependency_source_url:,
-                                                dependency_source_branch:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.depencency_source_latest_git_version(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
     DependencySource.new(
-      gemfile_name: gemfile_name,
-      dependency_name: dependency_name
+      gemfile_name: args.fetch(:gemfile_name),
+      dependency_name: args.fetch(:dependency_name)
     ).latest_git_version(
-      dependency_source_url: dependency_source_url,
-      dependency_source_branch: dependency_source_branch
+      dependency_source_url: args.fetch(:dependency_source_url),
+      dependency_source_branch: args.fetch(:dependency_source_branch)
     )
   end
 
-  def self.private_registry_versions(gemfile_name:, dependency_name:, dir:,
-                                     credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.private_registry_versions(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
 
     DependencySource.new(
-      gemfile_name: gemfile_name,
-      dependency_name: dependency_name
+      gemfile_name: args.fetch(:gemfile_name),
+      dependency_name: args.fetch(:dependency_name)
     ).private_registry_versions
   end
 
-  def self.resolve_version(dependency_name:, dependency_requirements:,
-                           gemfile_name:, lockfile_name:,
-                           dir:, credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.resolve_version(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
     VersionResolver.new(
-      dependency_name: dependency_name,
-      dependency_requirements: dependency_requirements,
-      gemfile_name: gemfile_name,
-      lockfile_name: lockfile_name
+      dependency_name: args.fetch(:dependency_name),
+      dependency_requirements: args.fetch(:dependency_requirements),
+      gemfile_name: args.fetch(:gemfile_name),
+      lockfile_name: args.fetch(:lockfile_name)
     ).version_details
   end
 
-  def self.jfrog_source(dir:, gemfile_name:, credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.jfrog_source(**args)
+    # Set flags and credentials
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
 
-    Bundler::Definition.build(gemfile_name, nil, {}).
+    Bundler::Definition.build(args.fetch(:gemfile_name), nil, {}).
       send(:sources).
       rubygems_remotes.
       find { |uri| uri.host.include?("jfrog") }&.
       host
   end
 
-  def self.git_specs(dir:, gemfile_name:, credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
+  def self.git_specs(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
 
-    git_specs = Bundler::Definition.build(gemfile_name, nil, {}).dependencies.
+    git_specs = Bundler::Definition.build(args.fetch(:gemfile_name), nil, {}).dependencies.
                 select do |spec|
       spec.source.is_a?(Bundler::Source::Git)
     end
@@ -127,6 +118,17 @@ module Functions
       }
     end
   end
+
+  def self.conflicting_dependencies(**args)
+    set_bundler_flags_and_credentials(dir: args.fetch(:dir), credentials: args.fetch(:credentials))
+    ConflictingDependencyResolver.new(
+      dependency_name: args.fetch(:dependency_name),
+      target_version: args.fetch(:target_version),
+      lockfile_name: args.fetch(:lockfile_name)
+    ).conflicting_dependencies
+  end
+
+  private
 
   def self.set_bundler_flags_and_credentials(dir:, credentials:)
     dir = dir ? Pathname.new(dir) : dir
@@ -170,15 +172,5 @@ module Functions
   def self.git_source_credentials(credentials)
     credentials.
       select { |cred| cred["type"] == "git_source" }
-  end
-
-  def self.conflicting_dependencies(dir:, dependency_name:, target_version:,
-                                    lockfile_name:, credentials:)
-    set_bundler_flags_and_credentials(dir: dir, credentials: credentials)
-    ConflictingDependencyResolver.new(
-      dependency_name: dependency_name,
-      target_version: target_version,
-      lockfile_name: lockfile_name
-    ).conflicting_dependencies
   end
 end

--- a/bundler/helpers/v2/spec/functions_spec.rb
+++ b/bundler/helpers/v2/spec/functions_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Functions do
           dir: tmp_path,
           gemfile_name: "Gemfile",
           credentials: {},
-          using_bundler2: true
         )
 
         expect(jfrog_source).to eq("test.jfrog.io")

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -72,7 +72,6 @@ module Dependabot
                 args: {
                   gemfile_name: gemfile.name,
                   lockfile_name: lockfile.name,
-                  using_bundler2: using_bundler2?,
                   dir: tmp_dir,
                   credentials: credentials,
                   dependencies: dependencies.map(&:to_h)
@@ -296,12 +295,6 @@ module Dependabot
 
         def specification_files
           dependency_files.select { |f| f.name.end_with?(".specification") }
-        end
-
-        def using_bundler2?
-          return unless lockfile
-
-          lockfile.content.match?(/BUNDLED WITH\s+2/m)
         end
 
         def bundler_version

--- a/bundler/lib/dependabot/bundler/update_checker/conflicting_dependency_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/conflicting_dependency_resolver.rb
@@ -41,7 +41,6 @@ module Dependabot
                 target_version: target_version,
                 credentials: credentials,
                 lockfile_name: lockfile.name,
-                using_bundler2: using_bundler2?
               }
             )
           end

--- a/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
@@ -57,7 +57,6 @@ module Dependabot
                 credentials: credentials,
                 gemfile_name: gemfile.name,
                 lockfile_name: lockfile.name,
-                using_bundler2: using_bundler2?,
                 update_multiple_dependencies: update_multiple_dependencies?
               }
             )
@@ -143,12 +142,6 @@ module Dependabot
           end
 
           File.write(lockfile.name, sanitized_lockfile_body) if lockfile
-        end
-
-        def using_bundler2?
-          return unless lockfile
-
-          lockfile.content.match?(/BUNDLED WITH\s+2/m)
         end
 
         def bundler_version

--- a/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
@@ -171,7 +171,6 @@ module Dependabot
                 dir: tmp_dir,
                 gemfile_name: gemfile.name,
                 credentials: credentials,
-                using_bundler2: using_bundler2?
               }
             )
             git_specs.reject do |spec|
@@ -197,7 +196,6 @@ module Dependabot
                 dir: dir,
                 gemfile_name: gemfile.name,
                 credentials: credentials,
-                using_bundler2: using_bundler2?
               }
             )
           end
@@ -232,12 +230,6 @@ module Dependabot
         def sanitized_lockfile_body
           re = FileUpdater::LockfileUpdater::LOCKFILE_ENDING
           lockfile.content.gsub(re, "")
-        end
-
-        def using_bundler2?
-          return unless lockfile
-
-          lockfile.content.match?(/BUNDLED WITH\s+2/m)
         end
       end
     end

--- a/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
@@ -87,7 +87,6 @@ module Dependabot
                   dependency_requirements: dependency.requirements,
                   gemfile_name: gemfile.name,
                   lockfile_name: lockfile&.name,
-                  using_bundler2: using_bundler2?,
                   dir: tmp_dir,
                   credentials: credentials
                 }
@@ -216,12 +215,6 @@ module Dependabot
         def lockfile
           dependency_files.find { |f| f.name == "Gemfile.lock" } ||
             dependency_files.find { |f| f.name == "gems.locked" }
-        end
-
-        def using_bundler2?
-          return unless lockfile
-
-          lockfile.content.match?(/BUNDLED WITH\s+2/m)
         end
 
         def bundler_version


### PR DESCRIPTION
Removing the bundler 2 config changes that we prevously did in the v1
helpers. This codepath should no longer be hit as we invoke the v2
helpers if the lockfile uses bunder 2.

I've also changed the native helper args to take a hash making it less brittle when removing attributes and you run a different version of the gem to the docker image, which was reported in the past https://github.com/dependabot/dependabot-core/issues/2879