### PR TITLE
v0.142.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.142.1, 16 April 2021
+
+- Update npm from 7.7.4 to 7.10.0
+- build(deps): bump flake8 from 3.9.0 to 3.9.1 in /python/helpers
+- Azure: Raise PullRequestUpdateFailed error when failing to update PR @milind009
+- Fix Dockerfile.development
+- build(deps): bump cython from 0.29.22 to 0.29.23 in /python/helpers
+
 ## v0.142.0, 15 April 2021
 
 - Dockerfile: set WORKDIR to /home/dependabot to avoid permission errors when

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.142.0"
+  VERSION = "0.142.1"
 end


### PR DESCRIPTION
## v0.142.1, 16 April 2021

- Update npm from 7.7.4 to 7.10.0
- build(deps): bump flake8 from 3.9.0 to 3.9.1 in /python/helpers
- Azure: Raise PullRequestUpdateFailed error when failing to update PR @milind009
- Fix Dockerfile.development
- build(deps): bump cython from 0.29.22 to 0.29.23 in /python/helpers
