### PR TITLE
Refactoring new_branch_name function in branch_namer

### DIFF
--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -34,15 +34,7 @@ module Dependabot
                   tr("@", "")
               end
 
-            dep = dependencies.first
-
-            if library? && ref_changed?(dep) && new_ref(dep)
-              "#{dependency_name_part}-#{new_ref(dep)}"
-            elsif library?
-              "#{dependency_name_part}-#{sanitized_requirement(dep)}"
-            else
-              "#{dependency_name_part}-#{new_version(dep)}"
-            end
+            "#{dependency_name_part}-#{branch_version_suffix}"
           end
 
         # Some users need branch names without slashes
@@ -96,6 +88,18 @@ module Dependabot
         raise "No dependency set!" unless @dependency_set
 
         @dependency_set
+      end
+
+      def branch_version_suffix
+        dep = dependencies.first
+
+        if library? && ref_changed?(dep) && new_ref(dep)
+          new_ref(dep)
+        elsif library?
+          sanitized_requirement(dep)
+        else
+          new_version(dep)
+        end
       end
 
       def sanitized_requirement(dependency)


### PR DESCRIPTION
Added a separate method name `branch_version_suffix` which basically gets the version related suffix for the branch name. We need to use this function in our own service hence created a separate method for this. @feelepxyz @jurre Does adding this refactoring in dependabot-core make sense?