### PR TITLE
Gomod: Run `go mod tidy` with flag to allow errors

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -134,9 +134,7 @@ module Dependabot
         def run_go_mod_tidy
           return unless tidy?
 
-          # NOTE(arslan): use `go mod tidy -e` once Go 1.16 is out:
-          # https://github.com/golang/go/commit/3aa09489ab3aa13a3ac78b1ff012b148ffffe367
-          command = "go mod tidy"
+          command = "go mod tidy -e"
 
           # we explicitly don't raise an error for 'go mod tidy' and silently
           # continue here. `go mod tidy` shouldn't block updating versions


### PR DESCRIPTION
Go 1.16 added an option to instruct `go mod tidy` to make a best effort
to update the `go.sum` file in spite of errors for specific packages as
described in the commit the old comment pointed to:  https://github.com/golang/go/commit/3aa09489ab3aa13a3ac78b1ff012b148ffffe367

This adds said flag, now that we're on go 1.16

Edit: should we add a test that demonstates the new behavior?