### PR TITLE
Add ignore conditions to update checker

### DIFF
--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -17,7 +17,6 @@ module Dependabot
         @prefix        = prefix
       end
 
-      # rubocop:disable Metrics/PerceivedComplexity
       def new_branch_name
         @name ||=
           begin
@@ -40,8 +39,6 @@ module Dependabot
         # Some users need branch names without slashes
         sanitize_ref(File.join(prefixes, @name).gsub("/", separator))
       end
-
-      # rubocop:enable Metrics/PerceivedComplexity
 
       private
 

--- a/common/lib/dependabot/utils.rb
+++ b/common/lib/dependabot/utils.rb
@@ -44,5 +44,15 @@ module Dependabot
     def self.register_always_clone(package_manager)
       @cloning_package_managers << package_manager
     end
+
+    def self.match_wildcard?(wildcard_string, candidate_string)
+      return false unless wildcard_string && candidate_string
+
+      regex_string = "a#{wildcard_string.downcase}a".split("*").
+                     map { |p| Regexp.quote(p) }.
+                     join(".*").gsub(/^a|a$/, "")
+      regex = /^#{regex_string}$/
+      regex.match?(candidate_string.downcase)
+    end
   end
 end

--- a/common/spec/dependabot/utils_spec.rb
+++ b/common/spec/dependabot/utils_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/utils"
+
+RSpec.describe Dependabot::Utils do
+  describe ".match_wildcard?" do
+    subject { described_class.match_wildcard?(wildcard_string, candidate_string) }
+
+    context "without a wildcard" do
+      let(:wildcard_string) { "bus" }
+
+      context "with a matching string" do
+        let(:candidate_string) { wildcard_string }
+        it { is_expected.to eq(true) }
+
+        context "with different capitalisation" do
+          let(:candidate_string) { "Bus" }
+          it { is_expected.to eq(true) }
+        end
+      end
+
+      context "with a superstring" do
+        let(:candidate_string) { wildcard_string + "iness" }
+        it { is_expected.to eq(false) }
+      end
+
+      context "with a substring" do
+        let(:candidate_string) { "bu" }
+        it { is_expected.to eq(false) }
+      end
+
+      context "with a string that ends in the same way" do
+        let(:candidate_string) { "blunderbus" }
+        it { is_expected.to eq(false) }
+      end
+
+      context "with a regex character" do
+        let(:wildcard_string) { "bus." }
+
+        context "with a matching string" do
+          let(:candidate_string) { wildcard_string }
+          it { is_expected.to eq(true) }
+        end
+
+        context "with a superstring" do
+          let(:candidate_string) { wildcard_string + "iness" }
+          it { is_expected.to eq(false) }
+        end
+      end
+    end
+
+    context "with a wildcard" do
+      context "at the start" do
+        let(:wildcard_string) { "*bus" }
+
+        context "with a matching string" do
+          let(:candidate_string) { wildcard_string }
+          it { is_expected.to eq(true) }
+        end
+
+        context "with a matching string (except the wildcard" do
+          let(:candidate_string) { "bus" }
+          it { is_expected.to eq(true) }
+        end
+
+        context "with a string that ends in the same way" do
+          let(:candidate_string) { "blunderbus" }
+          it { is_expected.to eq(true) }
+        end
+
+        context "with a superstring" do
+          let(:candidate_string) { wildcard_string + "iness" }
+          it { is_expected.to eq(false) }
+        end
+
+        context "with a substring" do
+          let(:candidate_string) { "bu" }
+          it { is_expected.to eq(false) }
+        end
+      end
+
+      context "at the end" do
+        let(:wildcard_string) { "bus*" }
+
+        context "with a matching string" do
+          let(:candidate_string) { wildcard_string }
+          it { is_expected.to eq(true) }
+        end
+
+        context "with a matching string (except the wildcard" do
+          let(:candidate_string) { "bus" }
+          it { is_expected.to eq(true) }
+        end
+
+        context "with a string that ends in the same way" do
+          let(:candidate_string) { "blunderbus" }
+          it { is_expected.to eq(false) }
+        end
+
+        context "with a superstring" do
+          let(:candidate_string) { wildcard_string + "iness" }
+          it { is_expected.to eq(true) }
+        end
+
+        context "with a substring" do
+          let(:candidate_string) { "bu" }
+          it { is_expected.to eq(false) }
+        end
+      end
+
+      context "in the middle" do
+        let(:wildcard_string) { "bu*s" }
+
+        context "with a matching string" do
+          let(:candidate_string) { wildcard_string }
+          it { is_expected.to eq(true) }
+        end
+
+        context "with a matching string (except the wildcard" do
+          let(:candidate_string) { "bus" }
+          it { is_expected.to eq(true) }
+        end
+
+        context "with a string that ends in the same way" do
+          let(:candidate_string) { "blunderbus" }
+          it { is_expected.to eq(false) }
+        end
+
+        context "with a superstring" do
+          let(:candidate_string) { wildcard_string + "y" }
+          it { is_expected.to eq(false) }
+        end
+
+        context "with a substring" do
+          let(:candidate_string) { "bu" }
+          it { is_expected.to eq(false) }
+        end
+
+        context "with a string that starts and ends in the right way" do
+          let(:candidate_string) { "business" }
+          it { is_expected.to eq(true) }
+        end
+      end
+
+      context "as the only character" do
+        let(:wildcard_string) { "*" }
+
+        context "with a matching string" do
+          let(:candidate_string) { wildcard_string }
+          it { is_expected.to eq(true) }
+        end
+
+        context "with any string" do
+          let(:candidate_string) { "bus" }
+          it { is_expected.to eq(true) }
+        end
+      end
+
+      context "with multiple wildcards" do
+        let(:wildcard_string) { "bu*in*ss" }
+
+        context "with a string that fits" do
+          let(:candidate_string) { "business" }
+          it { is_expected.to eq(true) }
+        end
+
+        context "with a string that doesn't" do
+          let(:candidate_string) { "buspass" }
+          it { is_expected.to eq(false) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding ignore conditions to the update checker to make it possible to
pass further types to core and filter relevant ones based on the
dependency name.

I've added this new attribute in a backwards compatible way. Once we're
passing it in we can drop `ignored_versions` from the interface.