### PR TITLE
branch_namer PerceivedComplexity

### DIFF
--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -17,7 +17,6 @@ module Dependabot
         @prefix        = prefix
       end
 
-      # rubocop:disable Metrics/PerceivedComplexity
       def new_branch_name
         @name ||=
           begin
@@ -40,8 +39,6 @@ module Dependabot
         # Some users need branch names without slashes
         sanitize_ref(File.join(prefixes, @name).gsub("/", separator))
       end
-
-      # rubocop:enable Metrics/PerceivedComplexity
 
       private
 


### PR DESCRIPTION
This is an automated `rubocop -A` addressing a no longer necessary lint disabling.

I thought it was just a hiccup in my environment, but https://github.com/dependabot/dependabot-core/pull/3521/files#diff-cb18ce6ed14510cf237cf0615d847f2f84564cd4b13c438dbffbb6a2702eb1e1 does this too. It's not just me!