### PR TITLE
UpdateConfig ruby-er model

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -727,7 +727,7 @@ dependencies.each do |dep|
       files: updated_files,
       credentials: $options[:credentials],
       source: $source,
-      commit_message_options: $update_config.commit_message_options,
+      commit_message_options: $update_config.commit_message_options.to_h,
       github_redirection_service: Dependabot::PullRequestCreator::DEFAULT_GITHUB_REDIRECTION_SERVICE
     ).message
     puts "Pull Request Title: #{msg.pr_name}"

--- a/common/lib/dependabot/config/file.rb
+++ b/common/lib/dependabot/config/file.rb
@@ -20,7 +20,10 @@ module Dependabot
           u[:"package-ecosystem"] == package_ecosystem && u[:directory] == dir &&
             (target_branch.nil? || u[:"target-branch"] == target_branch)
         end
-        Dependabot::Config::UpdateConfig.new(cfg)
+        Dependabot::Config::UpdateConfig.new(
+          cfg,
+          commit_message_options: commit_message_options(cfg)
+        )
       end
 
       PACKAGE_MANAGER_LOOKUP = {
@@ -48,6 +51,17 @@ module Dependabot
         raise InvalidConfigError, "invalid version #{version}" if version && version != 2
 
         File.new(updates: parsed[:updates], registries: parsed[:registries])
+      end
+
+      private
+
+      def commit_message_options(cfg)
+        commit_message = cfg&.dig(:"commit-message") || {}
+        Dependabot::Config::UpdateConfig::CommitMessageOptions.new(
+          prefix: commit_message[:prefix],
+          prefix_development: commit_message[:"prefix-development"],
+          include: commit_message[:include]
+        )
       end
     end
   end

--- a/common/lib/dependabot/config/file.rb
+++ b/common/lib/dependabot/config/file.rb
@@ -59,7 +59,7 @@ module Dependabot
         ignores = cfg&.dig(:ignore) || []
         ignores.map do |ic|
           Dependabot::Config::UpdateConfig::IgnoreCondition.new(
-            name: ic[:"dependency-name"],
+            dependency_name: ic[:"dependency-name"],
             versions: ic[:versions]
           )
         end

--- a/common/lib/dependabot/config/file.rb
+++ b/common/lib/dependabot/config/file.rb
@@ -21,7 +21,7 @@ module Dependabot
             (target_branch.nil? || u[:"target-branch"] == target_branch)
         end
         Dependabot::Config::UpdateConfig.new(
-          cfg,
+          ignore_conditions: ignore_conditions(cfg),
           commit_message_options: commit_message_options(cfg)
         )
       end
@@ -54,6 +54,16 @@ module Dependabot
       end
 
       private
+
+      def ignore_conditions(cfg)
+        ignores = cfg&.dig(:ignore) || []
+        ignores.map do |ic|
+          Dependabot::Config::UpdateConfig::IgnoreCondition.new(
+            name: ic[:"dependency-name"],
+            versions: ic[:versions]
+          )
+        end
+      end
 
       def commit_message_options(cfg)
         commit_message = cfg&.dig(:"commit-message") || {}

--- a/common/lib/dependabot/config/update_config.rb
+++ b/common/lib/dependabot/config/update_config.rb
@@ -6,18 +6,24 @@ module Dependabot
     class UpdateConfig
       attr_reader :commit_message_options
 
-      def initialize(config, commit_message_options: nil)
-        @config = config || {}
+      def initialize(ignore_conditions: nil, commit_message_options: nil)
+        @ignore_conditions = ignore_conditions || []
         @commit_message_options = commit_message_options
       end
 
       def ignored_versions_for(dep)
-        return [] unless @config[:ignore]
-
-        @config[:ignore].
-          select { |ic| ic[:"dependency-name"] == dep.name }. # FIXME: wildcard support
-          map { |ic| ic[:versions] }.
+        @ignore_conditions.
+          select { |ic| ic.name == dep.name }. # FIXME: wildcard support
+          map(&:versions).
           flatten
+      end
+
+      class IgnoreCondition
+        attr_reader :name, :versions
+        def initialize(name:, versions:)
+          @name = name
+          @versions = versions
+        end
       end
 
       class CommitMessageOptions

--- a/common/lib/dependabot/config/update_config.rb
+++ b/common/lib/dependabot/config/update_config.rb
@@ -4,12 +4,6 @@ module Dependabot
   module Config
     # Configuration for a single ecosystem
     class UpdateConfig
-      module Interval
-        DAILY = "daily"
-        WEEKLY = "weekly"
-        MONTHLY = "monthly"
-      end
-
       attr_reader :commit_message_options
 
       def initialize(config, commit_message_options: nil)
@@ -24,19 +18,6 @@ module Dependabot
           select { |ic| ic[:"dependency-name"] == dep.name }. # FIXME: wildcard support
           map { |ic| ic[:versions] }.
           flatten
-      end
-
-      def interval
-        return unless @config[:schedule]
-        return unless @config[:schedule][:interval]
-
-        interval = @config[:schedule][:interval]
-        case interval.downcase
-        when Interval::DAILY, Interval::WEEKLY, Interval::MONTHLY
-          interval.downcase
-        else
-          raise InvalidConfigError, "unknown interval: #{interval}"
-        end
       end
 
       class CommitMessageOptions

--- a/common/lib/dependabot/config/update_config.rb
+++ b/common/lib/dependabot/config/update_config.rb
@@ -10,8 +10,11 @@ module Dependabot
         MONTHLY = "monthly"
       end
 
-      def initialize(config)
+      attr_reader :commit_message_options
+
+      def initialize(config, commit_message_options: nil)
         @config = config || {}
+        @commit_message_options = commit_message_options
       end
 
       def ignored_versions_for(dep)
@@ -21,15 +24,6 @@ module Dependabot
           select { |ic| ic[:"dependency-name"] == dep.name }. # FIXME: wildcard support
           map { |ic| ic[:versions] }.
           flatten
-      end
-
-      def commit_message_options
-        commit_message = @config[:"commit-message"] || {}
-        {
-          prefix: commit_message[:prefix],
-          prefix_development: commit_message[:"prefix-development"],
-          include_scope: commit_message[:include] == "scope"
-        }
       end
 
       def interval
@@ -42,6 +36,28 @@ module Dependabot
           interval.downcase
         else
           raise InvalidConfigError, "unknown interval: #{interval}"
+        end
+      end
+
+      class CommitMessageOptions
+        attr_reader :prefix, :prefix_development, :include
+
+        def initialize(prefix:, prefix_development:, include:)
+          @prefix = prefix
+          @prefix_development = prefix_development
+          @include = include
+        end
+
+        def include_scope?
+          @include == "scope"
+        end
+
+        def to_h
+          {
+            prefix: @prefix,
+            prefix_development: @prefix_development,
+            include_scope: include_scope?
+          }
         end
       end
     end

--- a/common/lib/dependabot/config/update_config.rb
+++ b/common/lib/dependabot/config/update_config.rb
@@ -13,15 +13,16 @@ module Dependabot
 
       def ignored_versions_for(dep)
         @ignore_conditions.
-          select { |ic| ic.name == dep.name }. # FIXME: wildcard support
+          select { |ic| ic.dependency_name == dep.name }. # FIXME: wildcard support
           map(&:versions).
-          flatten
+          flatten.
+          compact
       end
 
       class IgnoreCondition
-        attr_reader :name, :versions
-        def initialize(name:, versions:)
-          @name = name
+        attr_reader :dependency_name, :versions
+        def initialize(dependency_name:, versions:)
+          @dependency_name = dependency_name
           @versions = versions
         end
       end

--- a/common/spec/dependabot/config/file_spec.rb
+++ b/common/spec/dependabot/config/file_spec.rb
@@ -25,25 +25,25 @@ RSpec.describe Dependabot::Config::File do
       it "maps package_manager to package-ecosystem" do
         update_config = config.update_config("npm_and_yarn")
         expect(update_config).to be_a(Dependabot::Config::UpdateConfig)
-        expect(update_config.interval).to eq("weekly")
+        expect(update_config.commit_message_options.prefix).to eq("no directory")
       end
 
       it "matches directory" do
-        update_config = config.update_config("npm_and_yarn", directory: "/monthly")
+        update_config = config.update_config("npm_and_yarn", directory: "/target")
         expect(update_config).to be_a(Dependabot::Config::UpdateConfig)
-        expect(update_config.interval).to eq("monthly")
+        expect(update_config.commit_message_options.prefix).to eq("with directory")
       end
 
       it "matches target-branch" do
         update_config = config.update_config("npm_and_yarn", directory: "/target", target_branch: "the-awesome-branch")
         expect(update_config).to be_a(Dependabot::Config::UpdateConfig)
-        expect(update_config.interval).to eq("daily")
+        expect(update_config.commit_message_options.prefix).to eq("with directory and branch")
       end
 
       it "returns empty when not found" do
         update_config = config.update_config("bundler")
         expect(update_config).to be_a(Dependabot::Config::UpdateConfig)
-        expect(update_config.interval).to be_nil
+        expect(update_config.commit_message_options.prefix).to be_nil
       end
     end
   end

--- a/common/spec/dependabot/config/update_config_spec.rb
+++ b/common/spec/dependabot/config/update_config_spec.rb
@@ -63,19 +63,19 @@ RSpec.describe Dependabot::Config::UpdateConfig do
     let(:config) { Dependabot::Config::File.parse(fixture("configfile", "commit-message-options.yml")) }
 
     it "parses prefix" do
-      expect(config.update_config("npm_and_yarn").commit_message_options[:prefix]).to eq("npm")
+      expect(config.update_config("npm_and_yarn").commit_message_options.prefix).to eq("npm")
     end
 
     it "parses prefix-development" do
-      expect(config.update_config("pip").commit_message_options[:prefix_development]).to eq("pip dev")
+      expect(config.update_config("pip").commit_message_options.prefix_development).to eq("pip dev")
     end
 
     it "includes scope" do
-      expect(config.update_config("composer").commit_message_options[:include_scope]).to eq(true)
+      expect(config.update_config("composer").commit_message_options.include_scope?).to eq(true)
     end
 
     it "does not include scope" do
-      expect(config.update_config("npm_and_yarn").commit_message_options[:include_scope]).to eq(false)
+      expect(config.update_config("npm_and_yarn").commit_message_options.include_scope?).to eq(false)
     end
   end
 end

--- a/common/spec/dependabot/config/update_config_spec.rb
+++ b/common/spec/dependabot/config/update_config_spec.rb
@@ -9,30 +9,6 @@ RSpec.describe Dependabot::Config::UpdateConfig do
   let(:data) { nil }
   let(:config) { Dependabot::Config::UpdateConfig.new(data) }
 
-  describe "#interval" do
-    subject(:interval) { config.interval }
-
-    it "returns nil if not specified" do
-      expect(interval).to be_nil
-    end
-
-    context "with denormalized interval" do
-      let(:data) { { schedule: { interval: "WeeKLY" } } }
-
-      it "returns normalized value" do
-        expect(interval).to eq(Dependabot::Config::UpdateConfig::Interval::WEEKLY)
-      end
-    end
-
-    context "with invalid interval" do
-      let(:data) { { schedule: { interval: "gibbous moon" } } }
-      it "raises error" do
-        expect { interval }.
-          to raise_error(Dependabot::Config::InvalidConfigError)
-      end
-    end
-  end
-
   describe "#ignored_versions_for" do
     subject(:ignored_versions) { config.ignored_versions_for(dependency) }
     let(:dependency) do

--- a/common/spec/dependabot/config/update_config_spec.rb
+++ b/common/spec/dependabot/config/update_config_spec.rb
@@ -6,9 +6,6 @@ require "dependabot/config/file"
 require "dependabot/config/update_config"
 
 RSpec.describe Dependabot::Config::UpdateConfig do
-  let(:data) { nil }
-  let(:config) { Dependabot::Config::UpdateConfig.new(data) }
-
   describe "#ignored_versions_for" do
     subject(:ignored_versions) { config.ignored_versions_for(dependency) }
     let(:dependency) do
@@ -19,14 +16,16 @@ RSpec.describe Dependabot::Config::UpdateConfig do
         package_manager: "npm_and_yarn"
       )
     end
+    let(:ignore_conditions) { [] }
+    let(:config) { Dependabot::Config::UpdateConfig.new(ignore_conditions: ignore_conditions) }
 
     it "returns empty when not defined" do
       expect(ignored_versions).to eq([])
     end
 
     context "with ignored versions" do
-      let(:data) do
-        { ignore: [{ "dependency-name": "@types/node", versions: [">= 14.14.x, < 15"] }] }
+      let(:ignore_conditions) do
+        [Dependabot::Config::UpdateConfig::IgnoreCondition.new(name: "@types/node", versions: [">= 14.14.x, < 15"])]
       end
 
       it "returns versions" do

--- a/common/spec/dependabot/config/update_config_spec.rb
+++ b/common/spec/dependabot/config/update_config_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Dependabot::Config::UpdateConfig do
 
     context "with ignored versions" do
       let(:ignore_conditions) do
-        [Dependabot::Config::UpdateConfig::IgnoreCondition.new(name: "@types/node", versions: [">= 14.14.x, < 15"])]
+        [Dependabot::Config::UpdateConfig::IgnoreCondition.new(dependency_name: "@types/node",
+                                                               versions: [">= 14.14.x, < 15"])]
       end
 
       it "returns versions" do

--- a/common/spec/fixtures/configfile/npm-weekly.yml
+++ b/common/spec/fixtures/configfile/npm-weekly.yml
@@ -1,15 +1,22 @@
+# NOTE: prefix: values are used by file_spec.rb
 version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/monthly"
-    schedule:
-      interval: "monthly"
+    commit-message:
+      prefix: "no directory"
   - package-ecosystem: "npm"
     directory: "/target"
-    target-branch: "the-awesome-branch"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    commit-message:
+      prefix: "with directory"
+  - package-ecosystem: "npm"
+    directory: "/target"
+    schedule:
+      interval: "weekly"
+    target-branch: "the-awesome-branch"
+    commit-message:
+      prefix: "with directory and branch"


### PR DESCRIPTION
This shifts the `Dependabot::Config::UpdateConfig` class introduced by https://github.com/dependabot/dependabot-core/pull/3512 from being a shallow facade over an entry in the `updates:` configuration, to a plain old ruby object.

Parsing is migrated to the `Dependabot::Config::File` class, which makes sense as the owner of parsing+translation.

I also removed `Dependabot::Config::UpdateConfig#interval`. As discussed in the earlier PR, it only existed to provide a unique attribute on `.updates[]` parsed from the config file. By using the `#commit_message_options` this can be accomplished with less cruft.

# Related
- Continues https://github.com/dependabot/dependabot-core/pull/3512
- Discussed https://github.com/dependabot/dependabot-core/pull/3521
- Conflicts https://github.com/dependabot/dependabot-core/pull/3513