### PR TITLE
Fix typo to clarify meaning

### DIFF
--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -121,7 +121,7 @@ module Dependabot
       end
 
       def version_from_tag(tag)
-        # To compare with the current version we either use the commit SHA
+        # To compare with the current version we use the commit SHA
         # (if that's what the parser picked up) of the tag name.
         return tag&.fetch(:commit_sha) if dependency.version&.match?(/^[0-9a-f]{40}$/)
 

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -121,8 +121,8 @@ module Dependabot
       end
 
       def version_from_tag(tag)
-        # To compare with the current version we use the commit SHA
-        # (if that's what the parser picked up) of the tag name.
+        # To compare with the current version we either use the commit SHA
+        # (if that's what the parser picked up) or the tag name.
         return tag&.fetch(:commit_sha) if dependency.version&.match?(/^[0-9a-f]{40}$/)
 
         tag&.fetch(:tag)


### PR DESCRIPTION
There's clearly a typo here, but I'm less clear on what the intended wording was:
* we either use the commit sha or the tag name
* we use the commit sha of the tag name

These have very different meanings... I picked one, but I may be wrong, as I've never written Ruby, so kinda spitballin' here.

Let me know if I should reword different.