### PR TITLE
Restrict permissions for actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - "**"
+permissions:
+  contents: read
 jobs:
   ci:
     name: CI

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,8 @@ on:
       - main
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
-permissions: none
+permissions:
+  contents: read
 jobs:
   push-core-image:
     name: Push dependabot-core image to docker hub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
       - main
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
-
+permissions: none
 jobs:
   push-core-image:
     name: Push dependabot-core image to docker hub

--- a/.github/workflows/gems.yml
+++ b/.github/workflows/gems.yml
@@ -3,7 +3,7 @@ on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
-
+permissions: none
 jobs:
   release-gems:
     name: Release gems to rubygems.org

--- a/.github/workflows/gems.yml
+++ b/.github/workflows/gems.yml
@@ -3,7 +3,8 @@ on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
-permissions: none
+permissions:
+  contents: read
 jobs:
   release-gems:
     name: Release gems to rubygems.org


### PR DESCRIPTION
Following this change: https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/

We only need to clone repos in `ci.yml` tests so `contents: read` should
be enough.