### PR TITLE
v0.143.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v0.143.0, 21 April 2021
+
+- Python: Add support for updating `setup.cfg` files @honnix
+- Gomod: Run `go mod tidy` with flag to allow errors
+- Handle ruby and package manager specific version requirements from ignore conditions
+- build(deps): bump poetry from 1.1.4 to 1.1.6 in /python/helpers
+- build(deps-dev): update rubocop requirement from ~> 1.12.0 to ~> 1.13.0
+- build(deps-dev): bump friendsofphp/php-cs-fixer in /composer/helpers/v1
+- build(deps-dev): bump friendsofphp/php-cs-fixer in /composer/helpers/v2
+- build(deps-dev): bump phpstan/phpstan in /composer/helpers/v1
+- build(deps-dev): bump phpstan/phpstan in /composer/helpers/v2
+- dry-run: fetch ignore conditions and commit_message_options from `dependabot.yml` config file
+- dry-run: set ignore conditions from `IGNORE_CONDITIONS` env
+- Chore: Refactor `new_branch_name` function in branch_namer @milind009
+- Bundler: Remove unused `using_bundler2` arg from v1 helpers
+
 ## v0.142.1, 16 April 2021
 
 - Update npm from 7.7.4 to 7.10.0

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.142.1"
+  VERSION = "0.143.0"
 end


### PR DESCRIPTION
## v0.143.0, 21 April 2021

- Python: Add support for updating `setup.cfg` files @honnix
- Gomod: Run `go mod tidy` with flag to allow errors
- Handle ruby and package manager specific version requirements from ignore conditions
- build(deps): bump poetry from 1.1.4 to 1.1.6 in /python/helpers
- build(deps-dev): update rubocop requirement from ~> 1.12.0 to ~> 1.13.0
- build(deps-dev): bump friendsofphp/php-cs-fixer in /composer/helpers/v1
- build(deps-dev): bump friendsofphp/php-cs-fixer in /composer/helpers/v2
- build(deps-dev): bump phpstan/phpstan in /composer/helpers/v1
- build(deps-dev): bump phpstan/phpstan in /composer/helpers/v2
- dry-run: fetch ignore conditions and commit_message_options from `dependabot.yml` config file
- dry-run: set ignore conditions from `IGNORE_CONDITIONS` env
- Chore: Refactor `new_branch_name` function in branch_namer @milind009
- Bundler: Remove unused `using_bundler2` arg from v1 helpers