### PR TITLE
Fix regressions from ignore version refactor

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -114,6 +114,12 @@ module Dependabot
           ignored_versions.flat_map { |req| requirement_class.requirements_array(req) }
         end
 
+        def requirement_class
+          Utils.requirement_class_for_package_manager(
+            dependency.package_manager
+          )
+        end
+
         def gemfile
           dependency_files.find { |f| f.name == "Gemfile" } ||
             dependency_files.find { |f| f.name == "gems.rb" }

--- a/gradle/lib/dependabot/gradle/version.rb
+++ b/gradle/lib/dependabot/gradle/version.rb
@@ -28,7 +28,7 @@ module Dependabot
       VERSION_PATTERN =
         "[0-9a-zA-Z]+"\
         '(?>\.[0-9a-zA-Z]*)*'\
-        '([_-][0-9A-Za-z_-]*(\.[0-9A-Za-z_-]*)*)?'
+        '([_\-\+][0-9A-Za-z_-]*(\.[0-9A-Za-z_-]*)*)?'
       ANCHORED_VERSION_PATTERN = /\A\s*(#{VERSION_PATTERN})?\s*\z/.freeze
 
       def self.correct?(version)

--- a/gradle/spec/dependabot/gradle/requirement_spec.rb
+++ b/gradle/spec/dependabot/gradle/requirement_spec.rb
@@ -64,6 +64,11 @@ RSpec.describe Dependabot::Gradle::Requirement do
         let(:requirement_string) { "+" }
         its(:to_s) { is_expected.to eq(Gem::Requirement.new(">= 0").to_s) }
       end
+
+      context "with a comma-separated dynamic version requirements" do
+        let(:requirement_string) { "1.+, 2.+" }
+        its(:to_s) { is_expected.to eq(Gem::Requirement.new("~> 1.0", "~> 2.0").to_s) }
+      end
     end
 
     context "with a hard requirement" do
@@ -105,6 +110,11 @@ RSpec.describe Dependabot::Gradle::Requirement do
     context "with a comma-separated ruby style version requirement" do
       let(:requirement_string) { "~> 4.2.5, >= 4.2.5.1" }
       it { is_expected.to eq([described_class.new("~> 4.2.5", ">= 4.2.5.1")]) }
+    end
+
+    context "with a comma-separated ruby style requirement with gradle versions" do
+      let(:requirement_string) { ">= Finchley.a, < Finchley.999999" }
+      it { is_expected.to eq([described_class.new(">= Finchley.a", "< Finchley.999999")]) }
     end
   end
 

--- a/gradle/spec/dependabot/gradle/version_spec.rb
+++ b/gradle/spec/dependabot/gradle/version_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Dependabot::Gradle::Version do
       let(:version_string) { "Finchley" }
       it { is_expected.to eq(true) }
     end
+
+    context "with a dynamic version" do
+      let(:version_string) { "1.+" }
+      it { is_expected.to eq(true) }
+    end
   end
 
   describe "#to_s" do

--- a/maven/lib/dependabot/maven/requirement.rb
+++ b/maven/lib/dependabot/maven/requirement.rb
@@ -33,14 +33,7 @@ module Dependabot
 
       def initialize(*requirements)
         requirements = requirements.flatten.flat_map do |req_string|
-          # NOTE: Support ruby-style version requirements that are created from
-          # PR ignore conditions
-          version_reqs = req_string.split(",").map(&:strip)
-          if version_reqs.all? { |s| Gem::Requirement::PATTERN.match?(s) }
-            version_reqs
-          else
-            convert_java_constraint_to_ruby_constraint(req_string)
-          end
+          convert_java_constraint_to_ruby_constraint(req_string)
         end
 
         super(requirements)
@@ -72,9 +65,14 @@ module Dependabot
           raise "Can't convert multiple Java reqs to a single Ruby one"
         end
 
-        return convert_java_range_to_ruby_range(req_string) if req_string&.include?(",")
-
-        convert_java_equals_req_to_ruby(req_string)
+        # NOTE: Support ruby-style version requirements that are created from
+        # PR ignore conditions
+        version_reqs = req_string.split(",").map(&:strip)
+        if req_string.include?(",") && !version_reqs.all? { |s| PATTERN.match?(s) }
+          convert_java_range_to_ruby_range(req_string) if req_string.include?(",")
+        else
+          version_reqs.map { |r| convert_java_equals_req_to_ruby(r) }
+        end
       end
 
       def convert_java_range_to_ruby_range(req_string)
@@ -105,10 +103,11 @@ module Dependabot
       end
 
       def convert_wildcard_req(req_string)
-        version = req_string.gsub(/(?:\.|^)\+/, "")
-        return ">= 0" if version.empty?
+        version = req_string.split("+").first
+        return ">= 0" if version.nil? || version.empty?
 
-        "~> #{version}.0"
+        version += "0" if version.end_with?(".")
+        "~> #{version}"
       end
     end
   end

--- a/maven/spec/dependabot/maven/requirement_spec.rb
+++ b/maven/spec/dependabot/maven/requirement_spec.rb
@@ -74,6 +74,21 @@ RSpec.describe Dependabot::Maven::Requirement do
     context "with a dynamic version requirement" do
       let(:requirement_string) { "1.+" }
       its(:to_s) { is_expected.to eq(Gem::Requirement.new("~> 1.0").to_s) }
+
+      context "that specifies a minimum" do
+        let(:requirement_string) { "1.5+" }
+        its(:to_s) { is_expected.to eq(Gem::Requirement.new("~> 1.5").to_s) }
+      end
+
+      context "that is just a +" do
+        let(:requirement_string) { "+" }
+        its(:to_s) { is_expected.to eq(Gem::Requirement.new(">= 0").to_s) }
+      end
+
+      context "with a comma-separated dynamic version requirements" do
+        let(:requirement_string) { "1.+, 2.+" }
+        its(:to_s) { is_expected.to eq(Gem::Requirement.new("~> 1.0", "~> 2.0").to_s) }
+      end
     end
 
     context "with a hard requirement" do
@@ -115,6 +130,11 @@ RSpec.describe Dependabot::Maven::Requirement do
     context "with a comma-separated ruby style version requirement" do
       let(:requirement_string) { "~> 4.2.5, >= 4.2.5.1" }
       it { is_expected.to eq([described_class.new("~> 4.2.5", ">= 4.2.5.1")]) }
+    end
+
+    context "with a comma-separated ruby style requirement with maven versions" do
+      let(:requirement_string) { ">= Finchley.a, < Finchley.999999" }
+      it { is_expected.to eq([described_class.new(">= Finchley.a", "< Finchley.999999")]) }
     end
   end
 

--- a/maven/spec/dependabot/maven/version_spec.rb
+++ b/maven/spec/dependabot/maven/version_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Dependabot::Maven::Version do
       let(:version_string) { "Finchley" }
       it { is_expected.to eq(true) }
     end
+
+    context "with a dynamic version" do
+      let(:version_string) { "1.+" }
+      it { is_expected.to eq(true) }
+    end
   end
 
   describe "#to_s" do


### PR DESCRIPTION
Fixes a few bugs discovered from https://github.com/dependabot/dependabot-core/pull/3368

For reasons I don't yet understand, the bundler latest version finder doesn't declare `requirement_class` but passes specs testing ignored versions but if I `byebug` inside the method during the test it explodes with an exception saying it's undefined.

I also discovered we didn't properly handle for the case where a maven/gradle version requirement is created from a pull request ignore with ruby style requirements but with a maven style version, e.g. `>= Finchley.a, < Finchley.999999`.

