### PR TITLE
Add a preview-migration issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/migration-issue.md
+++ b/.github/ISSUE_TEMPLATE/migration-issue.md
@@ -1,0 +1,43 @@
+---
+name: "Dependabot Preview migration issue"
+about: Having issues migrating from Dependabaot Preview? Here's the place to get help!
+title: ''
+labels: 'E: preview-migration'
+assignees: '@dependabot/preview-migration-reviewers'
+
+---
+
+<!--
+Please search existing issues to avoid creating duplicates. Several issues for common feature requests already exist, including:
+ - `live` schedule support: https://github.com/dependabot/dependabot-core/issues/3488
+ - `automerge` support: https://github.com/dependabot/dependabot-core/issues/2268
+-->
+
+<!-- If your issue is unrelated to the above, please provide us as much information as possible to help us provide a quick fix -->
+
+## Basic info:
+
+**Package ecosystem**
+<!-- npm, docker, bundler, etc. -->
+**Package manager version**
+<!-- If applicable, specify the package manager version you're using (e.g., npm 7.1, pip-compile 5.0, etc.) -->
+**Language version**
+<!-- If applicable, specify the language version you're using (e.g., node 14.1, Ruby 2.7, etc. ) -->
+**Manifest location and content prior to update**
+<!-- If applicable, specify the path to each manifest file (/client/package.json, /Gemfile, etc.) -->
+<!-- If applicable, attach each manifest file or provide a link to each manifest file -->
+**Updated dependency**
+<!-- If applicable, the dependency name and to and from versions -->
+**Native package manager behavior**
+<!-- If applicable, what output do you see when you update the dependency using the native package manager (e.g., bundler, npm, etc.)? -->
+**Images of the diff or a link to the PR, issue or logs**
+<!-- If applicable, add links to public PR's or Issues that Dependabot opened, and/or paste in any related logs -->
+
+## Previous behavior in Dependabot Preview:
+
+<!-- Please include your `.dependabot/config.yml` as well as logs, etc. -->
+
+## Current behavior in GitHub-native Dependabot:
+
+<!-- Please include your `.github/dependabot.yml` as well as logs, etc. -->
+


### PR DESCRIPTION
Template to point folks to for any issues that may arise when migrating from Preview to GitHub-native Dependabot (e.g. via clicking "Update config file" on https://app.dependabot.com).

Captures general information about the ecosystem/manifest/etc. as well as Preview and GitHub-native behavior.