### PR TITLE
v0.143.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.143.2, 22 April 2021
+
+- Dependabot::Config::IgnoreCondition support `update-types`
+
 ## v0.143.1, 21 April 2021
 
 - Gradle/Maven: Handle ruby style requirements with maven version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## v0.143.2, 22 April 2021
 
+- Dependabot::Config::IgnoreCondition support dependency wildcards
 - Dependabot::Config::IgnoreCondition support `update-types`
+- go_modules: clarify comment @jeffwidman
 
 ## v0.143.1, 21 April 2021
 
 - Gradle/Maven: Handle ruby style requirements with maven version
-- Bundler: Add missing requirement_class for bundler latest veersion checker
+- Bundler: Add missing requirement_class for bundler latest version checker
 - Add IgnoreCondition#dependency_name
 - Dependabot::Config::File parse ignore_conditions
 - Dependabot::Config::File parse commit_message_options

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.143.1"
+  VERSION = "0.143.2"
 end


### PR DESCRIPTION
Release [these commits](https://github.com/dependabot/dependabot-core/compare/v0.143.1...v0.143.2-release-notes)

These pull requests:
* https://github.com/dependabot/dependabot-core/pull/3513
* https://github.com/dependabot/dependabot-core/pull/3543
* https://github.com/dependabot/dependabot-core/pull/3536
* https://github.com/dependabot/dependabot-core/pull/3528

Some if which weren't included in the initial changelog...