### PR TITLE
Transform update_types in IgnoreCondition

### DIFF
--- a/common/lib/dependabot/config/file.rb
+++ b/common/lib/dependabot/config/file.rb
@@ -55,22 +55,13 @@ module Dependabot
         "terraform" => "terraform"
       }.freeze
 
-      UPDATE_TYPE_LOOKUP = {
-        "version-update:semver-patch" => :ignore_patch_versions,
-        "version-update:semver-minor" => :ignore_minor_versions,
-        "version-update:semver-major" => :ignore_major_versions
-      }.freeze
-
       def ignore_conditions(cfg)
         ignores = cfg&.dig(:ignore) || []
         ignores.map do |ic|
-          update_types = ic[:"update-types"]&.
-                         map { |t| UPDATE_TYPE_LOOKUP[t.downcase.strip] }&.
-                         compact
           Dependabot::Config::IgnoreCondition.new(
             dependency_name: ic[:"dependency-name"],
             versions: ic[:versions],
-            update_types: update_types
+            update_types: ic[:"update-types"]
           )
         end
       end

--- a/common/spec/dependabot/config/file_spec.rb
+++ b/common/spec/dependabot/config/file_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe Dependabot::Config::File do
         expect(update_config.ignore_conditions.length).to eq(3)
       end
 
-      it "maps update-types string" do
+      it "passes update-types" do
         types_ignore = update_config.ignore_conditions.find { |ic| ic.dependency_name == "@types/node" }
-        expect(types_ignore.update_types).to eq([:ignore_patch_versions])
+        expect(types_ignore.update_types).to eq(["version-update:semver-patch"])
       end
     end
   end

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
       let(:major_upgrades) { %w(2 2.0 2.0.0) }
 
       context "with ignore_patch_versions" do
-        let(:update_types) { [:ignore_patch_versions] }
+        let(:update_types) { ["version-update:semver-patch"] }
 
         it "ignores expected versions" do
           expect_allowed(minor_upgrades + major_upgrades)
@@ -81,7 +81,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
       end
 
       context "with ignore_minor_versions" do
-        let(:update_types) { [:ignore_minor_versions] }
+        let(:update_types) { ["version-update:semver-minor"] }
 
         it "ignores expected versions" do
           expect_allowed(patch_upgrades + major_upgrades)
@@ -94,7 +94,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
       end
 
       context "with ignore_major_versions" do
-        let(:update_types) { [:ignore_major_versions] }
+        let(:update_types) { ["version-update:semver-major"] }
 
         it "ignores expected versions" do
           expect_allowed(patch_upgrades + minor_upgrades)
@@ -107,7 +107,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
       end
 
       context "with ignore_major_versions and ignore_patch_versions" do
-        let(:update_types) { %i(ignore_major_versions ignore_patch_versions) }
+        let(:update_types) { %w(version-update:semver-major version-update:semver-patch) }
 
         it "ignores expected versions" do
           expect_allowed(minor_upgrades)
@@ -119,7 +119,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         let(:dependency_version) { "1.2" }
 
         context "with ignore_major_versions" do
-          let(:update_types) { [:ignore_major_versions] }
+          let(:update_types) { ["version-update:semver-major"] }
 
           it "ignores expected versions" do
             expect_allowed(patch_upgrades + minor_upgrades)
@@ -132,7 +132,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         end
 
         context "with ignore_minor_versions" do
-          let(:update_types) { [:ignore_minor_versions] }
+          let(:update_types) { ["version-update:semver-minor"] }
 
           it "ignores expected versions" do
             expect_allowed(patch_upgrades + major_upgrades)
@@ -145,7 +145,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         end
 
         context "with ignore_patch_versions" do
-          let(:update_types) { [:ignore_patch_versions] }
+          let(:update_types) { ["version-update:semver-patch"] }
 
           it "ignores expected versions" do
             expect_allowed(patch_upgrades + major_upgrades + minor_upgrades)
@@ -161,7 +161,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         let(:dependency_version) { "1" }
 
         context "with ignore_major_versions" do
-          let(:update_types) { [:ignore_major_versions] }
+          let(:update_types) { ["version-update:semver-major"] }
 
           it "returns the expected range" do
             expect(ignored_versions).to eq([])
@@ -169,7 +169,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         end
 
         context "with ignore_minor_versions" do
-          let(:update_types) { [:ignore_minor_versions] }
+          let(:update_types) { ["version-update:semver-minor"] }
 
           it "returns the expected range" do
             expect(ignored_versions).to eq([])
@@ -177,7 +177,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         end
 
         context "with ignore_patch_versions" do
-          let(:update_types) { [:ignore_patch_versions] }
+          let(:update_types) { ["version-update:semver-patch"] }
 
           it "returns the expected range" do
             expect(ignored_versions).to eq([])
@@ -189,14 +189,14 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         let(:dependency_version) { "Finchley.SR3" }
 
         context "with ignore_patch_versions" do
-          let(:update_types) { [:ignore_patch_versions] }
+          let(:update_types) { ["version-update:semver-patch"] }
           it "returns the expected range" do
             expect(ignored_versions).to eq([])
           end
         end
 
         context "with ignore_minor_versions" do
-          let(:update_types) { [:ignore_minor_versions] }
+          let(:update_types) { ["version-update:semver-minor"] }
           it "returns the expected range" do
             expect(ignored_versions).to eq([">= Finchley.a, < Finchley.999999"])
           end

--- a/common/spec/dependabot/config/update_config_spec.rb
+++ b/common/spec/dependabot/config/update_config_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Dependabot::Config::UpdateConfig do
       let(:ignore_conditions) do
         [Dependabot::Config::IgnoreCondition.new(dependency_name: "@types/node",
                                                  versions: [">= 14.14.x, < 15"],
-                                                 update_types: [:ignore_minor_versions])]
+                                                 update_types: ["version-update:semver-minor"])]
       end
 
       it "returns versions" do
@@ -74,11 +74,11 @@ RSpec.describe Dependabot::Config::UpdateConfig do
         [
           Dependabot::Config::IgnoreCondition.new(
             dependency_name: "@types/node",
-            update_types: [:ignore_minor_versions]
+            update_types: ["version-update:semver-minor"]
           ),
           Dependabot::Config::IgnoreCondition.new(
             dependency_name: "@types/node",
-            update_types: [:ignore_minor_versions]
+            update_types: ["version-update:semver-minor"]
           )
         ]
       end
@@ -93,11 +93,11 @@ RSpec.describe Dependabot::Config::UpdateConfig do
         [
           Dependabot::Config::IgnoreCondition.new(
             dependency_name: "@types/*",
-            update_types: [:ignore_major_versions]
+            update_types: ["version-update:semver-major"]
           ),
           Dependabot::Config::IgnoreCondition.new(
             dependency_name: "@types/node",
-            update_types: [:ignore_minor_versions]
+            update_types: ["version-update:semver-minor"]
           )
         ]
       end


### PR DESCRIPTION
Moving the update_types transform from the config file parser to the
ignore condition making it easier to initialize IgnoreCondition without
fetching a config file.

Working towards being able to do this:

```ruby
ignore_conditions = ignore_conditions.map do |ic|
  Dependabot::Config::IgnoreCondition.new(
    dependency_name: ic["dependency-name"],
    versions: [ic["version-requirement"]],
    update_types: ic["update-types"],
  )
end
Dependabot::Config::UpdateConfig.
  new(ignore_conditions: ignore_conditions).
  ignored_versions_for(dependency)
```