### PR TITLE
v0.143.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.143.3, 23 April 2021
+
+- Common: Transform update_types in IgnoreCondition
+- build(deps): bump @npmcli/arborist in /npm_and_yarn/helpers
+
 ## v0.143.2, 22 April 2021
 
 - Dependabot::Config::IgnoreCondition support dependency wildcards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v0.143.3, 23 April 2021
 
-- Common: Transform update_types in IgnoreCondition
+- Common: Do not transform update_types in IgnoreCondition
 - build(deps): bump @npmcli/arborist in /npm_and_yarn/helpers
 
 ## v0.143.2, 22 April 2021

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.143.2"
+  VERSION = "0.143.3"
 end


### PR DESCRIPTION
## v0.143.3, 23 April 2021

- Common: Transform update_types in IgnoreCondition
- build(deps): bump @npmcli/arborist in /npm_and_yarn/helpers
