### PR TITLE
IgnoreCondition: severity

### DIFF
--- a/common/lib/dependabot/config/ignore_condition.rb
+++ b/common/lib/dependabot/config/ignore_condition.rb
@@ -18,10 +18,10 @@ module Dependabot
         @update_types = update_types || []
       end
 
-      def ignored_versions(dependency)
+      def ignored_versions(dependency, security_severity)
         return [ALL_VERSIONS] if versions.empty? && transformed_update_types.empty?
 
-        versions_by_type(dependency) + versions
+        versions_by_type(dependency, security_severity) + versions
       end
 
       private
@@ -30,8 +30,10 @@ module Dependabot
         update_types.map(&:downcase).map(&:strip).compact
       end
 
-      def versions_by_type(dependency)
+      def versions_by_type(dependency, security_severity)
         transformed_update_types.flat_map do |t|
+          return [] if t.start_with?("version-update:") && !security_severity.nil?
+
           case t
           when PATCH_VERSION_TYPE
             ignore_patch(dependency.version)

--- a/common/lib/dependabot/config/update_config.rb
+++ b/common/lib/dependabot/config/update_config.rb
@@ -12,12 +12,12 @@ module Dependabot
         @commit_message_options = commit_message_options
       end
 
-      def ignored_versions_for(dependency)
+      def ignored_versions_for(dependency, security_severity: nil)
         normalizer = name_normaliser_for(dependency)
         dep_name = name_normaliser_for(dependency).call(dependency.name)
         @ignore_conditions.
           select { |ic| self.class.wildcard_match?(normalizer.call(ic.dependency_name), dep_name) }.
-          map { |ic| ic.ignored_versions(dependency) }.
+          map { |ic| ic.ignored_versions(dependency, security_severity) }.
           flatten.
           compact.
           uniq

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
   let(:ignore_condition) { described_class.new(dependency_name: dependency_name) }
 
   describe "#versions" do
-    subject(:ignored_versions) { ignore_condition.ignored_versions(dependency) }
+    subject(:ignored_versions) { ignore_condition.ignored_versions(dependency, security_severity) }
     let(:dependency) do
       Dependabot::Dependency.new(
         name: dependency_name,
@@ -19,6 +19,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         version: dependency_version
       )
     end
+    let(:security_severity) { nil }
 
     # Test helpers for reasoning about specific semver versions:
     def expect_allowed(versions)
@@ -200,6 +201,15 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
           it "returns the expected range" do
             expect(ignored_versions).to eq([">= Finchley.a, < Finchley.999999"])
           end
+        end
+      end
+
+      context "with a security update" do
+        let(:security_severity) { "low" }
+        let(:update_types) { ["version-update:semver-patch"] }
+
+        it "ignores ignores update-types" do
+          expect_allowed(patch_upgrades + minor_upgrades + major_upgrades)
         end
       end
     end

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         let(:security_severity) { "low" }
         let(:update_types) { ["version-update:semver-patch"] }
 
-        it "ignores ignores update-types" do
+        it "ignores update-types" do
           expect_allowed(patch_upgrades + minor_upgrades + major_upgrades)
         end
       end


### PR DESCRIPTION
Continuing https://github.com/dependabot/dependabot-core/pull/3513 and https://github.com/dependabot/dependabot-core/pull/3550 , as the string values like `version-updates:semver-*` suggest, "update types" should be bypassed when Dependabot is creating an update in response to a security alert.

This PR introduces the vapourware concept of `security_severity` to the lookup of ignored versions for a dependency: if set to a non-nil value, the current `version-updates:*` types will be ignored.
All we really need here is a boolean flag, like `security_updates_only` (as suggested by @feelepxyz). The idea of building the API around severity is to empower some fast-follow features like: `update-types: ["security-updates:low-severity"]`.