### PR TITLE
IgnoreCondition: support `!!` sha ignores

### DIFF
--- a/common/lib/dependabot/config/ignore_condition.rb
+++ b/common/lib/dependabot/config/ignore_condition.rb
@@ -136,7 +136,7 @@ module Dependabot
                                 end
       end
 
-      # Custom requirement for ignoring specific git commit SHAs
+      # Custom requirement for ignoring all versions expect a specific SHA
       class ShaRequirement < Gem::Requirement
         def initialize(*requirements)
           requirements = requirements.flatten.flat_map do |req_string|
@@ -155,9 +155,11 @@ module Dependabot
         end
 
         def satisfied_by?(version)
+          return super if version.nil?
+
           if requirements.any? { |op, _| op == GIT_SHA_IGNORE_PREFIX }
             rv = requirements.find { |op, _| op == GIT_SHA_IGNORE_PREFIX }.last
-            return rv == version.to_s
+            return rv != version.to_s
           end
           super
         end

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -269,8 +269,8 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
       end
 
       it "ignores specific shas" do
-        expect(ignore_condition.ignored?(dependency, false, "0000000000000000000000000000000000000001")).to eq(true)
-        expect(ignore_condition.ignored?(dependency, false, "0000000000000000000000000000000000000002")).to eq(false)
+        expect(ignore_condition.ignored?(dependency, false, "0000000000000000000000000000000000000001")).to eq(false)
+        expect(ignore_condition.ignored?(dependency, false, "0000000000000000000000000000000000000002")).to eq(true)
       end
     end
   end

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
           expect(ignored_versions).to eq([">= 2.0.0"])
         end
       end
+
+      context "and a sha requirement" do
+        let(:ignore_condition) { described_class.new(dependency_name: dependency_name, versions: ["!! abcdef"]) }
+
+        it "does not include in ignored_versions" do
+          expect(ignored_versions).to eq([])
+        end
+      end
     end
 
     context "with update_types" do
@@ -253,6 +261,17 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
       expect { ignore_condition.ignored?(dependency, false, "foo") }.
         to raise_error(ArgumentError)
       expect(DummyPackageManager::Version).to have_received(:new)
+    end
+
+    context "and a sha requirement" do
+      let(:ignore_condition) do
+        described_class.new(dependency_name: dependency_name, versions: ["!! 0000000000000000000000000000000000000001"])
+      end
+
+      it "ignores specific shas" do
+        expect(ignore_condition.ignored?(dependency, false, "0000000000000000000000000000000000000001")).to eq(true)
+        expect(ignore_condition.ignored?(dependency, false, "0000000000000000000000000000000000000002")).to eq(false)
+      end
     end
   end
 end


### PR DESCRIPTION
Amend `Dependabot::Config::IgnoreCondition` to support `!!` requirements for git dependencies.

This is a syntax previously used internally by Dependabot's backing service: if you `@dependabot ignore` an update from one Git SHA to another, one of these was created.

Since the syntax isn't supported by `Gem::Requirement`, care is taken to avoid parsing it as such: it's not returned in `ignored_versions,` but _is_ included in a new helper: `Dependabot::Config::IgnoreCondition#ignored?`.