### PR TITLE
v0.143.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.143.4, 26 April 2021
+
+- Common: Add IgnoreCondition.security_updates_only, which disables version updates filtering
+- build(deps-dev): bump eslint-config-prettier in /npm_and_yarn/helpers
+- build(deps-dev): bump eslint in /npm_and_yarn/helpers
+
 ## v0.143.3, 23 April 2021
 
 - Common: Do not transform update_types in IgnoreCondition

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.143.3"
+  VERSION = "0.143.4"
 end


### PR DESCRIPTION
Release [these commits](https://github.com/dependabot/dependabot-core/compare/v0.143.3...v0.143.4-release-notes).

* https://github.com/dependabot/dependabot-core/pull/3551
* https://github.com/dependabot/dependabot-core/pull/3556
* https://github.com/dependabot/dependabot-core/pull/3553
* https://github.com/dependabot/dependabot-core/pull/3557
* https://github.com/dependabot/dependabot-core/pull/3561