### PR TITLE
Drop GO111MODULE env var now that it defaults to `on`

### DIFF
--- a/go_modules/helpers/Makefile
+++ b/go_modules/helpers/Makefile
@@ -3,7 +3,7 @@
 all: darwin linux
 
 darwin:
-	GO111MODULE=on GOOS=darwin GOARCH=amd64 go build -o go-helpers.darwin64 .
+	GOOS=darwin GOARCH=amd64 go build -o go-helpers.darwin64 .
 
 linux:
-	GO111MODULE=on GOOS=linux GOARCH=amd64  go build -o go-helpers.linux64 .
+	GOOS=linux GOARCH=amd64  go build -o go-helpers.linux64 .

--- a/go_modules/helpers/build
+++ b/go_modules/helpers/build
@@ -23,5 +23,5 @@ cd $helpers_dir
 os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 echo "building $install_dir/bin/helper"
 
-GO111MODULE=on GOOS="$os" GOARCH=amd64 go build -o "$install_dir/bin/helper" .
+GOOS="$os" GOARCH=amd64 go build -o "$install_dir/bin/helper" .
 go clean -cache -modcache


### PR DESCRIPTION
`go` `1.16` flipped the default for `GO111MODULE` to `on`. So now that
ci targets `go` `1.16`, this is no longer needed.

Similar cleanup could be done for `dep`, but that is deprecated and will
soon be deleted, so I skipped it.