### PR TITLE
Bump the go directive to 1.16

### DIFF
--- a/go_modules/helpers/go.mod
+++ b/go_modules/helpers/go.mod
@@ -1,6 +1,6 @@
 module github.com/dependabot/dependabot-core/go_modules/helpers
 
-go 1.13
+go 1.16
 
 require (
 	github.com/Masterminds/vcs v1.13.1

--- a/go_modules/helpers/go.mod
+++ b/go_modules/helpers/go.mod
@@ -4,13 +4,6 @@ go 1.13
 
 require (
 	github.com/Masterminds/vcs v1.13.1
-	github.com/dependabot/dependabot-core/go_modules/helpers/updater v0.0.0
 	github.com/dependabot/gomodules-extracted v1.2.0
 	golang.org/x/mod v0.4.2
 )
-
-replace github.com/dependabot/dependabot-core/go_modules/helpers/importresolver => ./importresolver
-
-replace github.com/dependabot/dependabot-core/go_modules/helpers/updater => ./updater
-
-replace github.com/dependabot/dependabot-core/go_modules/helpers/updatechecker => ./updatechecker

--- a/go_modules/helpers/go.sum
+++ b/go_modules/helpers/go.sum
@@ -1,6 +1,5 @@
 github.com/Masterminds/vcs v1.13.1 h1:NL3G1X7/7xduQtA2sJLpVpfHTNBALVNSjob6KEjPXNQ=
 github.com/Masterminds/vcs v1.13.1/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
-github.com/dependabot/gomodules-extracted v0.0.0-20181020215834-1b2f850478a3/go.mod h1:+dRXSrUymjpT4yzKtn1QmeknT1S/yAHRr35en18dHp8=
 github.com/dependabot/gomodules-extracted v1.2.0 h1:K/gTyOyhasOt4cjULvOPNiD3MAFGytp4F7e39aB+0Y0=
 github.com/dependabot/gomodules-extracted v1.2.0/go.mod h1:3NWkH8KcZVDM87JuZI8hCZzYbjfUSz98EZI53qjgMgY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/go_modules/helpers/updater/go.mod
+++ b/go_modules/helpers/updater/go.mod
@@ -1,3 +1,0 @@
-module github.com/dependabot/dependabot-core/helpers/go/updater
-
-require github.com/dependabot/gomodules-extracted v0.0.0-20181020215834-1b2f850478a3

--- a/go_modules/helpers/updater/go.sum
+++ b/go_modules/helpers/updater/go.sum
@@ -1,2 +1,0 @@
-github.com/dependabot/gomodules-extracted v0.0.0-20181020215834-1b2f850478a3 h1:Xj2leY0FVyZuo+p59vkIWG3dIqo+QtjskT5O1iTiywA=
-github.com/dependabot/gomodules-extracted v0.0.0-20181020215834-1b2f850478a3/go.mod h1:+dRXSrUymjpT4yzKtn1QmeknT1S/yAHRr35en18dHp8=


### PR DESCRIPTION
This isn't strictly required, but it makes life simpler in some edge
cases... and also later someone is considering updating, it's easier if
this has been kept up to date all along so the delta is smaller down the
road. I ran `go mod tidy` and it didn't update the `go.sum` file here
(sometimes it does when you bump this directive).

Note: This depends on https://github.com/dependabot/dependabot-core/pull/3576, as that reduced the number of `go.mod` files that needed this update. 
If that is rejected, then this change should be applied to the other `go.mod` files that weren't removed.