### PR TITLE
Sync copy/pasted private methods with upstream

### DIFF
--- a/go_modules/helpers/updater/helpers.go
+++ b/go_modules/helpers/updater/helpers.go
@@ -6,7 +6,9 @@ import (
 	"golang.org/x/mod/modfile"
 )
 
-// Private methods lifted from the `modfile` package
+// Private methods lifted from the `modfile` package.
+// Last synced: 4/28/2021 from:
+// https://github.com/golang/mod/blob/858fdbee9c245c8109c359106e89c6b8d321f19c/modfile/rule.go
 
 // setIndirect sets line to have (or not have) a "// indirect" comment.
 func setIndirect(line *modfile.Line, indirect bool) {
@@ -20,13 +22,17 @@ func setIndirect(line *modfile.Line, indirect bool) {
 			line.Suffix = []modfile.Comment{{Token: "// indirect", Suffix: true}}
 			return
 		}
-		// Insert at beginning of existing comment.
+
 		com := &line.Suffix[0]
-		space := " "
-		if len(com.Token) > 2 && com.Token[2] == ' ' || com.Token[2] == '\t' {
-			space = ""
+		text := strings.TrimSpace(strings.TrimPrefix(com.Token, string(slashSlash)))
+		if text == "" {
+			// Empty comment.
+			com.Token = "// indirect"
+			return
 		}
-		com.Token = "// indirect;" + space + com.Token[2:]
+
+		// Insert at beginning of existing comment.
+		com.Token = "// indirect; " + text
 		return
 	}
 
@@ -52,6 +58,6 @@ func isIndirect(line *modfile.Line) bool {
 	if len(line.Suffix) == 0 {
 		return false
 	}
-	f := strings.Fields(line.Suffix[0].Token)
-	return (len(f) == 2 && f[1] == "indirect" || len(f) > 2 && f[1] == "indirect;") && f[0] == "//"
+	f := strings.Fields(strings.TrimPrefix(line.Suffix[0].Token, string(slashSlash)))
+	return (len(f) == 1 && f[0] == "indirect" || len(f) > 1 && f[0] == "indirect;")
 }

--- a/go_modules/helpers/updater/helpers.go
+++ b/go_modules/helpers/updater/helpers.go
@@ -10,6 +10,8 @@ import (
 // Last synced: 4/28/2021 from:
 // https://github.com/golang/mod/blob/858fdbee9c245c8109c359106e89c6b8d321f19c/modfile/rule.go
 
+var slashSlash = []byte("//")
+
 // setIndirect sets line to have (or not have) a "// indirect" comment.
 func setIndirect(line *modfile.Line, indirect bool) {
 	if isIndirect(line) == indirect {


### PR DESCRIPTION
`git blame` looks like the only change was https://github.com/golang/mod/commit/788aebd06792f833c387fcee8647edac94108a98

Added a "sync date/commit sha" so that it's easier to see when these were last updated.