### PR TITLE
Check the err returned by AddRequire

### DIFF
--- a/go_modules/helpers/updater/main.go
+++ b/go_modules/helpers/updater/main.go
@@ -28,7 +28,10 @@ func UpdateDependencyFile(args *Args) (interface{}, error) {
 	}
 
 	for _, dep := range args.Dependencies {
-		f.AddRequire(dep.Name, dep.Version)
+		err := f.AddRequire(dep.Name, dep.Version)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	for _, r := range f.Require {

--- a/go_modules/helpers/updater/main.go
+++ b/go_modules/helpers/updater/main.go
@@ -28,8 +28,7 @@ func UpdateDependencyFile(args *Args) (interface{}, error) {
 	}
 
 	for _, dep := range args.Dependencies {
-		err := f.AddRequire(dep.Name, dep.Version)
-		if err != nil {
+		if err := f.AddRequire(dep.Name, dep.Version); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Looking at the source of `AddRequire`, it looks like it never actually returns a non-`nil` error: https://github.com/golang/mod/blob/858fdbee9c245c8109c359106e89c6b8d321f19c/modfile/rule.go#L828-L846

However, they wrote the func signature to return an `err` to give themselves future flexibility.

So we should respect that and check for any unexpected errors. This way future updates that
suddenly start returning errors will be caught rather than insidiously slipping by and causing
difficult-to-debug issues elsewhere.