### PR TITLE
gradle: only commit versions are git sourced

### DIFF
--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -211,7 +211,7 @@ module Dependabot
       end
 
       def source_from(group, name, version)
-        return nil unless group&.start_with?("com.github")
+        return nil unless group&.start_with?("com.github") && version.match?(/\A[0-9a-f]{40}\Z/)
 
         account = group.sub("com.github.", "")
 

--- a/gradle/spec/dependabot/gradle/file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser_spec.rb
@@ -123,6 +123,30 @@ RSpec.describe Dependabot::Gradle::FileParser do
         end
       end
 
+      describe "the non-git github.com dependency" do
+        subject(:dependency) do
+          dependencies.find do |dep|
+            dep.name == "com.github.salomonbrys.kotson:kotson"
+          end
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).
+            to eq("com.github.salomonbrys.kotson:kotson")
+          expect(dependency.version).to eq("2.5.0")
+          expect(dependency.requirements).to eq(
+            [{
+              requirement: "2.5.0",
+              file: "build.gradle",
+              groups: [],
+              source: nil,
+              metadata: nil
+            }]
+          )
+        end
+      end
+
       context "when the name uses a property" do
         let(:buildfile_fixture_name) { "name_property.gradle" }
 
@@ -497,6 +521,30 @@ RSpec.describe Dependabot::Gradle::FileParser do
                   branch: nil,
                   ref: "be5d2cd6deb8cf3ca2c9a740bdacec816871d4f7"
                 },
+                metadata: nil
+              }]
+            )
+          end
+        end
+
+        describe "the non-git github.com dependency" do
+          subject(:dependency) do
+            dependencies.find do |dep|
+              dep.name == "com.github.salomonbrys.kotson:kotson"
+            end
+          end
+
+          it "has the right details" do
+            expect(dependency).to be_a(Dependabot::Dependency)
+            expect(dependency.name).
+              to eq("com.github.salomonbrys.kotson:kotson")
+            expect(dependency.version).to eq("2.5.0")
+            expect(dependency.requirements).to eq(
+              [{
+                requirement: "2.5.0",
+                file: "build.gradle.kts",
+                groups: [],
+                source: nil,
                 metadata: nil
               }]
             )


### PR DESCRIPTION
In `Dependabot::Gradle::FileParser`, there's an assumption that any package that begins with `com.github.*` is backed by a git repository.

This has implications in `Dependabot::Gradle::UpdateChecker`, where it means Dependabot will prefer to [check the git repository's commit history](https://github.com/dependabot/dependabot-core/blob/cd9fb4106bf9176304fe549532edc1249d57abcc/gradle/lib/dependabot/gradle/update_checker.rb#L147-L150) in place of querying the maven repository for the latest version.

This was intended to integrate with https://jitpack.io/ , a service that builds Java artifacts directly from commits. This can be confirmed by inspecting the repository in the test case: https://github.com/heremaps/oksse suggests Jitpack to consume artifacts.

Using the `GitCommitChecker` makes sense for Jitpack:
* https://jitpack.io/com/github/heremaps/oksse/maven-metadata.xml reports `0.9.0`, which is tagged from https://github.com/heremaps/oksse/commit/c92d0556f01e769d7c06c650941107642ce98fb5 
* https://jitpack.io/com/github/heremaps/oksse/0.9.0/oksse-0.9.0.jar is a valid artifact. Typical maven and semver.
* https://jitpack.io/com/github/heremaps/oksse/c92d0556f01e769d7c06c650941107642ce98fb5/oksse-c92d0556f01e769d7c06c650941107642ce98fb5.jar is functionally equivalent artifact:
```
3c5ce3564bef98a86d66157f7c2369e57cbd0318a2664a6b3f4b1bb333087be4  oksse-0.9.0/com/here/oksse/ServerSentEvent$Listener.class
3c5ce3564bef98a86d66157f7c2369e57cbd0318a2664a6b3f4b1bb333087be4  oksse-c92d0556f01e769d7c06c650941107642ce98fb5/com/here/oksse/ServerSentEvent$Listener.class
4b0a94a69032fca01808d0b7769ff367a7d1acabe5a6fa2b0d7196f25afbcae1  oksse-0.9.0/com/here/oksse/RealServerSentEvent$1.class
4b0a94a69032fca01808d0b7769ff367a7d1acabe5a6fa2b0d7196f25afbcae1  oksse-c92d0556f01e769d7c06c650941107642ce98fb5/com/here/oksse/RealServerSentEvent$1.class
677d50d35ba31b342493464eecdf94c26354d9534b200e0a3f39fe1b12f13e3b  oksse-0.9.0/com/here/oksse/ServerSentEvent.class
677d50d35ba31b342493464eecdf94c26354d9534b200e0a3f39fe1b12f13e3b  oksse-c92d0556f01e769d7c06c650941107642ce98fb5/com/here/oksse/ServerSentEvent.class
bde96a7bfa78787480a3b8d98a5dee437c230fd9c4966fae3fe6cba6694be6fa  oksse-0.9.0/com/here/oksse/OkSse.class
bde96a7bfa78787480a3b8d98a5dee437c230fd9c4966fae3fe6cba6694be6fa  oksse-c92d0556f01e769d7c06c650941107642ce98fb5/com/here/oksse/OkSse.class
d1801b1c9e99b7471a8945fc1e3483182a4410f6e58f23ec15649849fa4319af  oksse-0.9.0/com/here/oksse/RealServerSentEvent$Reader.class
d1801b1c9e99b7471a8945fc1e3483182a4410f6e58f23ec15649849fa4319af  oksse-c92d0556f01e769d7c06c650941107642ce98fb5/com/here/oksse/RealServerSentEvent$Reader.class
fe1847cc916399a23b27e32b7622c281a3a12dc68182c1b1083302c30dbad4ad  oksse-0.9.0/com/here/oksse/RealServerSentEvent.class
fe1847cc916399a23b27e32b7622c281a3a12dc68182c1b1083302c30dbad4ad  oksse-c92d0556f01e769d7c06c650941107642ce98fb5/com/here/oksse/RealServerSentEvent.class
```
* https://jitpack.io/com/github/heremaps/oksse/be5d2cd6deb8cf3ca2c9a740bdacec816871d4f7/oksse-be5d2cd6deb8cf3ca2c9a740bdacec816871d4f7.jar is the artifact Dependabot is expected to propose (e.g. the latest commit in the repository).

This has unintended consequences for the the [36,180 packages on maven central that begin with com.github.*](https://search.maven.org/search?q=com.github). Or [GitHub Packages users like me!](https://github.com/thepwagner/test-java/packages/236611)

This PR amends the check so that only versions that are already git commits are routed through the git commit checker.