### PR TITLE
IgnoreCondition: don't ignore current version when ignoring patches and handle multi-length semver ranges

### DIFF
--- a/common/lib/dependabot/config/ignore_condition.rb
+++ b/common/lib/dependabot/config/ignore_condition.rb
@@ -62,7 +62,7 @@ module Dependabot
         return [] unless rubygems_compatible?(version)
 
         parts = version.split(".")
-        version_parts = parts.fill(0, parts.length...3)
+        version_parts = parts.fill(0, parts.length...2)
         lower_parts = version_parts.first(1) + [version_parts[1].to_i + 1] + ["a"]
         upper_parts = version_parts.first(0) + [version_parts[0].to_i + 1]
         lower_bound = ">= #{lower_parts.join('.')}"
@@ -74,8 +74,7 @@ module Dependabot
       def ignore_major(version)
         return [] unless rubygems_compatible?(version)
 
-        parts = version.split(".")
-        version_parts = parts.fill(0, parts.length...2)
+        version_parts = version.split(".")
         lower_parts = [version_parts[0].to_i + 1] + ["a"]
         upper_parts = [version_parts[0].to_i + 2]
         lower_bound = ">= #{lower_parts.join('.')}"

--- a/common/lib/dependabot/config/ignore_condition.rb
+++ b/common/lib/dependabot/config/ignore_condition.rb
@@ -50,10 +50,10 @@ module Dependabot
         parts = version.split(".")
         return [] unless parts.size > 2
 
-        lower_parts = parts.first(2) + ["a"]
+        lower_parts = parts.first(3)
         upper_parts = parts.first(2)
         upper_parts[1] = upper_parts[1].to_i + 1
-        lower_bound = ">= #{lower_parts.join('.')}"
+        lower_bound = "> #{lower_parts.join('.')}"
         upper_bound = "< #{upper_parts.join('.')}"
         ["#{lower_bound}, #{upper_bound}"]
       end

--- a/common/lib/dependabot/config/ignore_condition.rb
+++ b/common/lib/dependabot/config/ignore_condition.rb
@@ -47,60 +47,45 @@ module Dependabot
       end
 
       def ignore_patch(version)
+        return [] unless rubygems_compatible?(version)
+
         parts = version.split(".")
         version_parts = parts.fill(0, parts.length...4)
-        lower_parts = if numeric_version?(version)
-                        version_parts.first(3) + [version_parts[3].to_i + 1] + ["a"]
-                      else
-                        version_parts.first(2) + [version_parts[2].to_i + 1] + ["a"]
-                      end
-        upper_parts = if numeric_version?(version)
-                        version_parts.first(1) + [version_parts[1].to_i + 1]
-                      else
-                        version_parts.first(2) + [999_999]
-                      end
+        lower_parts = version_parts.first(3) + [version_parts[3].to_i + 1] + ["a"]
+        upper_parts = version_parts.first(1) + [version_parts[1].to_i + 1]
         lower_bound = ">= #{lower_parts.join('.')}"
         upper_bound = "< #{upper_parts.join('.')}"
+
         ["#{lower_bound}, #{upper_bound}"]
       end
 
       def ignore_minor(version)
+        return [] unless rubygems_compatible?(version)
+
         parts = version.split(".")
         version_parts = parts.fill(0, parts.length...3)
-        lower_parts = if numeric_version?(version)
-                        version_parts.first(1) + [version_parts[1].to_i + 1] + ["a"]
-                      else
-                        version_parts.first(1) + ["a"]
-                      end
-        upper_parts = if numeric_version?(version)
-                        version_parts.first(0) + [version_parts[0].to_i + 1]
-                      else
-                        version_parts.first(1) + [999_999]
-                      end
+        lower_parts = version_parts.first(1) + [version_parts[1].to_i + 1] + ["a"]
+        upper_parts = version_parts.first(0) + [version_parts[0].to_i + 1]
         lower_bound = ">= #{lower_parts.join('.')}"
         upper_bound = "< #{upper_parts.join('.')}"
+
         ["#{lower_bound}, #{upper_bound}"]
       end
 
       def ignore_major(version)
+        return [] unless rubygems_compatible?(version)
+
         parts = version.split(".")
         version_parts = parts.fill(0, parts.length...2)
-        lower_parts = if numeric_version?(version)
-                        [version_parts[0].to_i + 1] + ["a"]
-                      else
-                        version_parts.first(1) + [999_999]
-                      end
-        upper_parts = if numeric_version?(version)
-                        [version_parts[0].to_i + 2]
-                      else
-                        [999_999]
-                      end
+        lower_parts = [version_parts[0].to_i + 1] + ["a"]
+        upper_parts = [version_parts[0].to_i + 2]
         lower_bound = ">= #{lower_parts.join('.')}"
         upper_bound = "< #{upper_parts.join('.')}"
+
         ["#{lower_bound}, #{upper_bound}"]
       end
 
-      def numeric_version?(version)
+      def rubygems_compatible?(version)
         return false if version.nil? || version.empty?
 
         Gem::Version.correct?(version)

--- a/common/lib/dependabot/config/ignore_condition.rb
+++ b/common/lib/dependabot/config/ignore_condition.rb
@@ -50,10 +50,9 @@ module Dependabot
         return [] unless rubygems_compatible?(version)
 
         parts = version.split(".")
-        version_parts = parts.fill(0, parts.length...4)
-        lower_parts = version_parts.first(3) + [version_parts[3].to_i + 1] + ["a"]
+        version_parts = parts.fill(0, parts.length...2)
         upper_parts = version_parts.first(1) + [version_parts[1].to_i + 1]
-        lower_bound = ">= #{lower_parts.join('.')}"
+        lower_bound = "> #{version}"
         upper_bound = "< #{upper_parts.join('.')}"
 
         ["#{lower_bound}, #{upper_bound}"]

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
           let(:update_types) { ["version-update:semver-patch"] }
 
           it "ignores expected updates" do
-            expect_ignored(["1.2.3.2", "1.2.4.0"])
+            expect_ignored(patch_upgrades + ["1.2.3.2", "1.2.4.0"])
             expect_allowed(minor_upgrades + major_upgrades)
             expect_allowed([dependency_version])
           end

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
 
         context "with ignore_patch_versions" do
           let(:update_types) { ["version-update:semver-patch"] }
-          let(:patch_upgrades) { %w(1.0.0.1 1.0.2 1.0.5 1.0.4-rc0) }
+          let(:patch_upgrades) { %w(1.0.2 1.0.5 1.0.4-rc0) }
           let(:minor_upgrades) { %w(1.1 1.2.0 1.3 1.4.0) }
 
           it "does not attempt to ignore any versions" do

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -263,6 +263,52 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         end
       end
 
+      context "with a pre-release semver version" do
+        let(:dependency_version) { "1.2.3-alpha" }
+
+        context "with ignore_major_versions" do
+          let(:update_types) { ["version-update:semver-major"] }
+
+          it "ignores expected versions" do
+            expect_allowed(patch_upgrades + minor_upgrades)
+            expect_ignored(major_upgrades)
+            expect_allowed([dependency_version])
+          end
+
+          it "returns the expected range" do
+            expect(ignored_versions).to eq([">= 2.a, < 3"])
+          end
+        end
+
+        context "with ignore_minor_versions" do
+          let(:update_types) { ["version-update:semver-minor"] }
+
+          it "ignores expected versions" do
+            expect_allowed(patch_upgrades + major_upgrades)
+            expect_ignored(minor_upgrades)
+            expect_allowed([dependency_version])
+          end
+
+          it "returns the expected range" do
+            expect(ignored_versions).to eq([">= 1.3.a, < 2"])
+          end
+        end
+
+        context "with ignore_patch_versions" do
+          let(:update_types) { ["version-update:semver-patch"] }
+
+          it "ignores expected updates" do
+            expect_ignored(patch_upgrades + ["1.2.3-alpha.2", "1.2.3-beta"])
+            expect_allowed(minor_upgrades + major_upgrades)
+            expect_allowed([dependency_version])
+          end
+
+          it "returns the expected range" do
+            expect(ignored_versions).to eq([">= 1.2.3-alpha.1.a, < 1.3"])
+          end
+        end
+      end
+
       context "with a non-semver dependency" do
         let(:dependency_version) { "Finchley.SR3" }
 

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
           let(:update_types) { ["version-update:semver-patch"] }
 
           it "ignores expected updates" do
-            expect_ignored(patch_upgrades + ["1.2.3.2", "1.2.4.0"])
+            expect_ignored(patch_upgrades - [dependency_version] + ["1.2.3.2", "1.2.4.0"])
             expect_allowed(minor_upgrades + major_upgrades)
             expect_allowed([dependency_version])
           end

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         end
 
         it "returns the expected range" do
-          expect(ignored_versions).to eq([">= 1.2.3.1.a, < 1.3"])
+          expect(ignored_versions).to eq(["> 1.2.3, < 1.3"])
         end
       end
 
@@ -169,7 +169,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
           end
 
           it "returns the expected range" do
-            expect(ignored_versions).to eq([">= 1.2.3.2.a, < 1.3"])
+            expect(ignored_versions).to eq(["> 1.2.3.1, < 1.3"])
           end
         end
       end
@@ -216,7 +216,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
           end
 
           it "returns the expected range" do
-            expect(ignored_versions).to eq([">= 1.2.0.1.a, < 1.3"])
+            expect(ignored_versions).to eq(["> 1.2, < 1.3"])
           end
         end
       end
@@ -258,13 +258,13 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
           end
 
           it "returns the expected range" do
-            expect(ignored_versions).to eq([">= 1.0.0.1.a, < 1.1"])
+            expect(ignored_versions).to eq(["> 1, < 1.1"])
           end
         end
       end
 
       context "with a pre-release semver version" do
-        let(:dependency_version) { "1.2.3-alpha" }
+        let(:dependency_version) { "1.2.3-alpha.1" }
 
         context "with ignore_major_versions" do
           let(:update_types) { ["version-update:semver-major"] }
@@ -298,13 +298,13 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
           let(:update_types) { ["version-update:semver-patch"] }
 
           it "ignores expected updates" do
-            expect_ignored(patch_upgrades + ["1.2.3-alpha.2", "1.2.3-beta"])
+            expect_ignored(patch_upgrades + ["1.2.3-alpha.2", "1.2.3-alpha.1.1", "1.2.3-beta"])
             expect_allowed(minor_upgrades + major_upgrades)
             expect_allowed([dependency_version])
           end
 
           it "returns the expected range" do
-            expect(ignored_versions).to eq([">= 1.2.3-alpha.1.a, < 1.3"])
+            expect(ignored_versions).to eq(["> 1.2.3-alpha.1, < 1.3"])
           end
         end
       end

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -263,55 +263,27 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         end
       end
 
-      context "with a `major.minor.patch` semver-compatible git tag version" do
-        let(:dependency_version) { "v1.2.3" }
-
-        context "with ignore_patch_versions" do
-          let(:update_types) { ["version-update:semver-patch"] }
-
-          it "returns the expected range" do
-            expect(ignored_versions).to eq([">= v1.2.4.a, < v1.2.999999"])
-          end
-        end
-
-        context "with ignore_minor_versions" do
-          let(:update_types) { ["version-update:semver-minor"] }
-
-          it "returns the expected range" do
-            expect(ignored_versions).to eq([">= v1.a, < v1.999999"])
-          end
-        end
-
-        context "with ignore_major_versions" do
-          let(:update_types) { ["version-update:semver-major"] }
-
-          it "returns the expected range" do
-            expect(ignored_versions).to eq([">= v1.999999, < 999999"])
-          end
-        end
-      end
-
       context "with a non-semver dependency" do
         let(:dependency_version) { "Finchley.SR3" }
 
         context "with ignore_patch_versions" do
           let(:update_types) { ["version-update:semver-patch"] }
           it "returns the expected range" do
-            expect(ignored_versions).to eq([">= Finchley.SR3.1.a, < Finchley.SR3.999999"])
+            expect(ignored_versions).to eq([])
           end
         end
 
         context "with ignore_minor_versions" do
           let(:update_types) { ["version-update:semver-minor"] }
           it "returns the expected range" do
-            expect(ignored_versions).to eq([">= Finchley.a, < Finchley.999999"])
+            expect(ignored_versions).to eq([])
           end
         end
 
         context "with ignore_major_versions" do
           let(:update_types) { ["version-update:semver-major"] }
           it "returns the expected range" do
-            expect(ignored_versions).to eq([">= Finchley.999999, < 999999"])
+            expect(ignored_versions).to eq([])
           end
         end
       end

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
     context "with update_types" do
       let(:ignore_condition) { described_class.new(dependency_name: dependency_name, update_types: update_types) }
       let(:dependency_version) { "1.2.3" }
-      let(:patch_upgrades) { %w(1.2.3.1 1.2.4 1.2.5 1.2.4-rc0) }
+      let(:patch_upgrades) { %w(1.2.4 1.2.5 1.2.4-rc0) }
       let(:minor_upgrades) { %w(1.3 1.3.0 1.4 1.4.0) }
       let(:major_upgrades) { %w(2 2.0 2.0.0) }
 
@@ -128,52 +128,6 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         end
       end
 
-      context "with a `major.minor.patch.extra` version" do
-        let(:dependency_version) { "1.2.3.1" }
-
-        context "with ignore_major_versions" do
-          let(:update_types) { ["version-update:semver-major"] }
-
-          it "ignores expected versions" do
-            expect_allowed(patch_upgrades + minor_upgrades)
-            expect_ignored(major_upgrades)
-            expect_allowed([dependency_version])
-          end
-
-          it "returns the expected range" do
-            expect(ignored_versions).to eq([">= 2.a, < 3"])
-          end
-        end
-
-        context "with ignore_minor_versions" do
-          let(:update_types) { ["version-update:semver-minor"] }
-
-          it "ignores expected versions" do
-            expect_allowed(patch_upgrades + major_upgrades)
-            expect_ignored(minor_upgrades)
-            expect_allowed([dependency_version])
-          end
-
-          it "returns the expected range" do
-            expect(ignored_versions).to eq([">= 1.3.a, < 2"])
-          end
-        end
-
-        context "with ignore_patch_versions" do
-          let(:update_types) { ["version-update:semver-patch"] }
-
-          it "ignores expected updates" do
-            expect_ignored(patch_upgrades - [dependency_version] + ["1.2.3.2", "1.2.4.0"])
-            expect_allowed(minor_upgrades + major_upgrades)
-            expect_allowed([dependency_version])
-          end
-
-          it "returns the expected range" do
-            expect(ignored_versions).to eq(["> 1.2.3.1, < 1.3"])
-          end
-        end
-      end
-
       context "with a 'major.minor' semver dependency" do
         let(:dependency_version) { "1.2" }
 
@@ -209,9 +163,8 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
           let(:update_types) { ["version-update:semver-patch"] }
 
           it "ignores expected versions" do
-            expect_ignored(["1.2.1.a", "1.2.1.1"])
             expect_allowed(major_upgrades + minor_upgrades)
-            expect_ignored(patch_upgrades)
+            expect_ignored(patch_upgrades + ["1.2.1"])
             expect_allowed([dependency_version, "1.2.0"])
           end
 

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
     context "with update_types" do
       let(:ignore_condition) { described_class.new(dependency_name: dependency_name, update_types: update_types) }
       let(:dependency_version) { "1.2.3" }
-      let(:patch_upgrades) { %w(1.2.3 1.2.4 1.2.5 1.2.4-rc0) }
+      let(:patch_upgrades) { %w(1.2.3.1 1.2.4 1.2.5 1.2.4-rc0) }
       let(:minor_upgrades) { %w(1.3 1.3.0 1.4 1.4.0) }
       let(:major_upgrades) { %w(2 2.0 2.0.0) }
 
@@ -82,10 +82,11 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         it "ignores expected versions" do
           expect_allowed(minor_upgrades + major_upgrades)
           expect_ignored(patch_upgrades)
+          expect_allowed([dependency_version])
         end
 
         it "returns the expected range" do
-          expect(ignored_versions).to eq([">= 1.2.a, < 1.3"])
+          expect(ignored_versions).to eq(["> 1.2.3, < 1.3"])
         end
       end
 
@@ -95,6 +96,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         it "ignores expected versions" do
           expect_allowed(patch_upgrades + major_upgrades)
           expect_ignored(minor_upgrades)
+          expect_allowed([dependency_version])
         end
 
         it "returns the expected range" do
@@ -108,6 +110,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         it "ignores expected versions" do
           expect_allowed(patch_upgrades + minor_upgrades)
           expect_ignored(major_upgrades)
+          expect_allowed([dependency_version])
         end
 
         it "returns the expected range" do
@@ -121,6 +124,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         it "ignores expected versions" do
           expect_allowed(minor_upgrades)
           expect_ignored(patch_upgrades + major_upgrades)
+          expect_allowed([dependency_version])
         end
       end
 
@@ -133,6 +137,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
           it "ignores expected versions" do
             expect_allowed(patch_upgrades + minor_upgrades)
             expect_ignored(major_upgrades)
+            expect_allowed([dependency_version])
           end
 
           it "returns the expected range" do
@@ -146,6 +151,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
           it "ignores expected versions" do
             expect_allowed(patch_upgrades + major_upgrades)
             expect_ignored(minor_upgrades)
+            expect_allowed([dependency_version])
           end
 
           it "returns the expected range" do
@@ -158,6 +164,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
 
           it "ignores expected versions" do
             expect_allowed(patch_upgrades + major_upgrades + minor_upgrades)
+            expect_allowed([dependency_version])
           end
 
           it "returns the expected range" do

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
         end
       end
 
-      context "with a `major.minor.patch.patch` semver version" do
+      context "with a `major.minor.patch.extra` version" do
         let(:dependency_version) { "1.2.3.1" }
 
         context "with ignore_major_versions" do

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -182,8 +182,9 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
 
           # TODO: We probably want to ignore all major version, e.g. v2, v3 etc
           it "ignores expected versions" do
-            expect_ignored(["2.0.0", "2.0.0.a", "2.9.9"])
-            expect_allowed([dependency_version, "1.2.2", "1.2.0.a", "3.0.0"])
+            expect_allowed(patch_upgrades + minor_upgrades)
+            expect_ignored(major_upgrades)
+            expect_allowed([dependency_version])
           end
 
           it "returns the expected range" do
@@ -204,10 +205,10 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
           let(:patch_upgrades) { %w(1.0.2 1.0.5 1.0.4-rc0) }
           let(:minor_upgrades) { %w(1.1 1.2.0 1.3 1.4.0) }
 
-          it "does not attempt to ignore any versions" do
+          it "ignores expected versions" do
+            expect_allowed(major_upgrades + minor_upgrades)
             expect_ignored(patch_upgrades)
-            expect_allowed(minor_upgrades + major_upgrades)
-            expect_allowed([dependency_version])
+            expect_allowed([dependency_version, "1.0.0"])
           end
 
           it "returns the expected range" do


### PR DESCRIPTION
When handling the relative `version-update:semver-patch` ignore condition we were generating an ignored version range that included the current version. This was causing the latest allowed version to resolve to a prior version when running an update:
```
=== ssri (8.0.0)
 => checking for updates 1/1
 => latest available version is 7.1.0
 => latest allowed version is 7.1.0
```

This tweaks the starting range of the ignore condition so that the current version is excluded:
```
=== ssri (8.0.0)
 => checking for updates 1/1
 => latest available version is 8.0.0
 => latest allowed version is 8.0.0
```

I also added some tests to verify we didn't exclude the current version when ignoring minor or major ranges.