### PR TITLE
v0.143.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.143.5, 29 April 2021
+
+- gradle: only treat commit-like versions as git repositories
+- dry-run: change SECURITY_ADVISORIES to kebab-case
+- go_modules: helper improvements @jeffwidman
+- go_modules: require go.16 for helpers @jeffwidman
+- go_modules: use go1.16.3 @jeffwidman
+- docker: handle versions generated with `git describe --tags --long` @kd7lxl
+- build(deps): bump composer/composer in /composer/helpers/v1
+- build(deps-dev): bump phpstan/phpstan in /composer/helpers
+
 ## v0.143.4, 26 April 2021
 
 - Common: Add IgnoreCondition.security_updates_only, which disables version updates filtering

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.143.4"
+  VERSION = "0.143.5"
 end


### PR DESCRIPTION
Release [these commits](https://github.com/dependabot/dependabot-core/compare/v0.143.4...v0.143.5-release-notes)

Which means these PRs:
* https://github.com/dependabot/dependabot-core/pull/3576
* https://github.com/dependabot/dependabot-core/pull/3571
* https://github.com/dependabot/dependabot-core/pull/3577
* https://github.com/dependabot/dependabot-core/pull/3581
* https://github.com/dependabot/dependabot-core/pull/3580
* https://github.com/dependabot/dependabot-core/pull/3578
* https://github.com/dependabot/dependabot-core/pull/3586
* https://github.com/dependabot/dependabot-core/pull/3575
* https://github.com/dependabot/dependabot-core/pull/3572
* https://github.com/dependabot/dependabot-core/pull/3574
* https://github.com/dependabot/dependabot-core/pull/3585
* https://github.com/dependabot/dependabot-core/pull/3541
* https://github.com/dependabot/dependabot-core/pull/3583
