### PR TITLE
Make error output more idiomatic

### DIFF
--- a/go_modules/helpers/main.go
+++ b/go_modules/helpers/main.go
@@ -46,7 +46,7 @@ func main() {
 		parseArgs(helperParams.Args, &args)
 		funcOut, funcErr = importresolver.VCSRemoteForImport(&args)
 	default:
-		abort(fmt.Errorf("Unrecognised function '%s'", helperParams.Function))
+		abort(fmt.Errorf("unrecognised function '%s'", helperParams.Function))
 	}
 
 	if funcErr != nil {


### PR DESCRIPTION
idiomatic `go` generally prefers uncapitalized error strings:
https://github.com/golang/go/wiki/CodeReviewComments#error-strings