### PR TITLE
v0.143.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.143.6, 30 April 2021
+
+- Common: version-update:semver-major ignores all major version updates
+- Document how to run tests within the dev docker container
+- go_modules: Make error output more idiomatic
+- Create CODE_OF_CONDUCT.md
+- Common: IgnoreCondition: handle multi-length semver ranges
+- Common: IgnoreCondition: don't ignore current version when ignoring patches
+
 ## v0.143.5, 29 April 2021
 
 - gradle: only treat commit-like versions as git repositories

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.143.5"
+  VERSION = "0.143.6"
 end


### PR DESCRIPTION
Commits: https://github.com/dependabot/dependabot-core/compare/v0.143.5...v0.143.6-release-notes

## v0.143.6, 30 April 2021

- Common: version-update:semver-major ignores all major version updates
- Document how to run tests within the dev docker container
- go_modules: Make error output more idiomatic
- Create CODE_OF_CONDUCT.md
- Common: IgnoreCondition: handle multi-length semver ranges
- Common: IgnoreCondition: don't ignore current version when ignoring patches