### PR TITLE
Python: allow comments when parsing setup.cfg

### DIFF
--- a/python/helpers/lib/parser.py
+++ b/python/helpers/lib/parser.py
@@ -11,7 +11,9 @@ from pip._internal.req.constructors import (
     install_req_from_line,
     install_req_from_parsed_requirement,
 )
-
+# Inspired by pips internal check:
+# https://github.com/pypa/pip/blob/0bb3ac87f5bb149bd75cceac000844128b574385/src/pip/_internal/req/req_file.py#L35
+COMMENT_RE = re.compile(r'(^|\s+)#.*$')
 
 def parse_requirements(directory):
     # Parse the requirements.txt
@@ -80,6 +82,8 @@ def parse_setup(directory):
 
     def parse_requirements(requires, req_type, filename):
         for req in requires:
+            req = COMMENT_RE.sub('', req)
+            req = req.strip()
             parse_requirement(req, req_type, filename)
 
     # Parse the setup.py and setup.cfg

--- a/python/spec/dependabot/python/file_parser/setup_file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/setup_file_parser_spec.rb
@@ -260,6 +260,25 @@ RSpec.describe Dependabot::Python::FileParser::SetupFileParser do
             end
         end
       end
+
+      context "with comments in the setup.cfg file" do
+        let(:setup_cfg_file_fixture_name) { "with_comments.cfg" }
+        subject(:dependency) { dependencies.find { |d| d.name == "boto3" } }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("boto3")
+          expect(dependency.version).to eq("1.3.1")
+          expect(dependency.requirements).to eq(
+            [{
+              requirement: "==1.3.1",
+              file: "setup.cfg",
+              groups: ["install_requires"],
+              source: nil
+            }]
+          )
+        end
+      end
     end
   end
 end

--- a/python/spec/fixtures/setup_files/with_comments.cfg
+++ b/python/spec/fixtures/setup_files/with_comments.cfg
@@ -1,0 +1,31 @@
+[metadata]
+name = python-package
+version = 0.0
+description = Example setup.cfg
+url = httos://github.com/example/python-package
+author = Dependabot
+
+[options]
+packages = find:
+setup_requires =
+    numpy==1.11.0
+    pytest-runner
+install_requires =
+    boto3==1.3.1 # this is a comment
+    flake8 > 2.5.4, < 3.0.0
+    gocardless_pro
+    pandas==0.19.2
+    pep8==1.7.0
+    psycopg2==2.6.1
+    # there is also a comment here
+    raven == 5.32.0
+    requests==2.12.*
+    scipy==0.18.1
+    scikit-learn==0.18.1
+
+tests_require =
+    pytest==2.9.1
+    responses==0.5.1
+
+[options.extras_require]
+API = flask==0.12.2


### PR DESCRIPTION
Currently any comments in a setup.cfg file will raise an error in
Dependabot. Pip handles this fine, so let's make sure Dependabot does as
well.

Fixes https://github.com/dependabot/dependabot-core/issues/3619