### PR TITLE
go_modules: stub consistently and ignore invalid modules

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -4,6 +4,7 @@ require "open3"
 require "dependabot/dependency"
 require "dependabot/file_parsers/base/dependency_set"
 require "dependabot/go_modules/path_converter"
+require "dependabot/go_modules/replace_stubber"
 require "dependabot/errors"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
@@ -109,11 +110,8 @@ module Dependabot
             # we can use in their place. Using generated paths is safer as it
             # means we don't need to worry about references to parent
             # directories, etc.
-            (JSON.parse(stdout)["Replace"] || []).
-              map { |r| r["New"]["Path"] }.
-              compact.
-              select { |p| p.start_with?(".") || p.start_with?("/") }.
-              map { |p| [p, "./" + Digest::SHA2.hexdigest(p)] }
+            manifest = JSON.parse(stdout)
+            ReplaceStubber.new(repo_contents_path).stub_paths(manifest, go_mod.directory)
           end
       end
 

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -18,7 +18,7 @@ module Dependabot
         dependency_set = Dependabot::FileParsers::Base::DependencySet.new
 
         required_packages.each do |dep|
-          dependency_set << dependency_from_details(dep) unless dep["Indirect"]
+          dependency_set << dependency_from_details(dep) unless skip_dependency?(dep)
         end
 
         dependency_set.dependencies
@@ -160,6 +160,17 @@ module Dependabot
         return raw_version unless raw_version.match?(GIT_VERSION_REGEX)
 
         raw_version.match(GIT_VERSION_REGEX).named_captures.fetch("sha")
+      end
+
+      def skip_dependency?(dep)
+        return true if dep["Indirect"]
+
+        begin
+          path_uri = URI.parse("https://#{dep['Path']}")
+          !path_uri.host.include?(".")
+        rescue URI::InvalidURIError
+          false
+        end
       end
     end
   end

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -4,6 +4,7 @@ require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/go_modules/file_updater"
 require "dependabot/go_modules/native_helpers"
+require "dependabot/go_modules/replace_stubber"
 require "dependabot/go_modules/resolvability_errors"
 
 module Dependabot
@@ -222,37 +223,8 @@ module Dependabot
         # process afterwards.
         def replace_directive_substitutions(manifest)
           @replace_directive_substitutions ||=
-            (manifest["Replace"] || []).
-            map { |r| r["New"]["Path"] }.
-            compact.
-            select { |p| stub_replace_path?(p) }.
-            map { |p| [p, "./" + Digest::SHA2.hexdigest(p)] }.
-            to_h
-        end
-
-        # returns true if the provided path should be replaced with a stub
-        def stub_replace_path?(path)
-          return true if absolute_path?(path)
-          return false unless relative_replacement_path?(path)
-
-          resolved_path = module_pathname.join(path).realpath
-          inside_repo_contents_path = resolved_path.to_s.start_with?(repo_contents_path.to_s)
-          !inside_repo_contents_path
-        rescue Errno::ENOENT
-          true
-        end
-
-        def absolute_path?(path)
-          path.start_with?("/")
-        end
-
-        def relative_replacement_path?(path)
-          # https://golang.org/ref/mod#go-mod-file-replace
-          path.start_with?("./") || path.start_with?("../")
-        end
-
-        def module_pathname
-          @module_pathname ||= Pathname.new(repo_contents_path).join(directory.sub(%r{^/}, ""))
+            Dependabot::GoModules::ReplaceStubber.new(repo_contents_path).
+            stub_paths(manifest, directory)
         end
 
         def substitute_all(substitutions)

--- a/go_modules/lib/dependabot/go_modules/replace_stubber.rb
+++ b/go_modules/lib/dependabot/go_modules/replace_stubber.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Dependabot
+  module GoModules
+    # Given a go.mod file, find all `replace` directives pointing to a path
+    # on the local filesystem outside of the current checkout, and return a hash
+    # mapping the original path to a hash of the path.
+    #
+    # This lets us substitute all parts of the go.mod that are dependent on
+    # the layout of the filesystem with a structure we can reproduce (i.e.
+    # no paths such as ../../../foo), run the Go tooling, then reverse the
+    # process afterwards.
+    class ReplaceStubber
+      def initialize(repo_contents_path)
+        @repo_contents_path = repo_contents_path
+      end
+
+      def stub_paths(manifest, directory)
+        (manifest["Replace"] || []).
+          map { |r| r["New"]["Path"] }.
+          compact.
+          select { |p| stub_replace_path?(p, directory) }.
+          map { |p| [p, "./" + Digest::SHA2.hexdigest(p)] }.
+          to_h
+      end
+
+      private
+
+      def stub_replace_path?(path, directory)
+        return true if absolute_path?(path)
+        return false unless relative_replacement_path?(path)
+
+        resolved_path = module_pathname(directory).join(path).realpath
+        inside_repo_contents_path = resolved_path.to_s.start_with?(@repo_contents_path.to_s)
+        !inside_repo_contents_path
+      rescue Errno::ENOENT
+        true
+      end
+
+      def absolute_path?(path)
+        path.start_with?("/")
+      end
+
+      def relative_replacement_path?(path)
+        # https://golang.org/ref/mod#go-mod-file-replace
+        path.start_with?("./") || path.start_with?("../")
+      end
+
+      def module_pathname(directory)
+        @module_pathname ||= Pathname.new(@repo_contents_path).join(directory.sub(%r{^/}, ""))
+      end
+    end
+  end
+end

--- a/go_modules/lib/dependabot/go_modules/replace_stubber.rb
+++ b/go_modules/lib/dependabot/go_modules/replace_stubber.rb
@@ -29,6 +29,7 @@ module Dependabot
       def stub_replace_path?(path, directory)
         return true if absolute_path?(path)
         return false unless relative_replacement_path?(path)
+        return true if @repo_contents_path.nil?
 
         resolved_path = module_pathname(directory).join(path).realpath
         inside_repo_contents_path = resolved_path.to_s.start_with?(@repo_contents_path.to_s)

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -16,7 +16,8 @@ module Dependabot
         /no go-import meta tags/,
         # Package url 404s
         /404 Not Found/,
-        /Repository not found/
+        /Repository not found/,
+        /unrecognized import path/
       ].freeze
 
       def latest_resolvable_version

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe Dependabot::GoModules::FileParser do
           to raise_error do |err|
             expect(err).to be_a(Dependabot::DependencyFileNotResolvable)
             expect(err.message).
-              to start_with("Cannot detect VCS for unknown/vcs")
+              to start_with("Cannot detect VCS for unknown.doesnotexist/vcs")
           end
       end
     end

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -300,10 +300,11 @@ RSpec.describe Dependabot::GoModules::FileParser do
       let(:go_mod_content) { fixture("projects", project_name, "go.mod") }
 
       it "parses root file" do
-        expect(dependencies.map(&:name)).to eq(%w(
-                                                 github.com/dependabot/vgotest/common
-                                                 rsc.io/qr
-                                               ))
+        expect(dependencies.map(&:name)).
+          to eq(%w(
+                  github.com/dependabot/vgotest/common
+                  rsc.io/qr
+                ))
       end
 
       context "nested file" do
@@ -311,11 +312,22 @@ RSpec.describe Dependabot::GoModules::FileParser do
         let(:go_mod_content) { fixture("projects", project_name, "cmd", "go.mod") }
 
         it "parses nested file" do
-          expect(dependencies.map(&:name)).to eq(%w(
-                                                   github.com/dependabot/vgotest/common
-                                                   rsc.io/qr
-                                                 ))
+          expect(dependencies.map(&:name)).
+            to eq(%w(
+                    github.com/dependabot/vgotest/common
+                    rsc.io/qr
+                  ))
         end
+      end
+    end
+
+    context "dependency without hostname" do
+      let(:project_name) { "unrecognized_import" }
+      let(:repo_contents_path) { build_tmp_repo(project_name) }
+      let(:go_mod_content) { fixture("projects", project_name, "go.mod") }
+
+      it "parses ignores invalid dependency" do
+        expect(dependencies.map(&:name)).to eq([])
       end
     end
   end

--- a/go_modules/spec/dependabot/go_modules/replace_stubber_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/replace_stubber_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/go_modules/replace_stubber"
+
+RSpec.describe Dependabot::GoModules::ReplaceStubber do
+  subject(:stubbed) { described_class.new(repo_contents_path).stub_paths(manifest, directory) }
+
+  let(:directory) { "/" }
+  let(:repo_contents_path) { build_tmp_repo(project_name) }
+
+  let(:manifest) do
+    Dir.chdir("#{repo_contents_path}#{directory}") do
+      JSON.parse(`go mod edit -json`)
+    end
+  end
+
+  describe "#stub_paths" do
+    context "replaced module as child" do
+      let(:project_name) { "monorepo" }
+      it { is_expected.to eq({}) }
+    end
+
+    context "replaced module as sibling" do
+      let(:project_name) { "monorepo" }
+      let(:directory) { "/cmd" }
+      it { is_expected.to eq({}) }
+    end
+
+    context "replaced module outside of checkout" do
+      let(:project_name) { "replace" }
+      it {
+        expected = { "../../../../../../foo" => "./381363a4e394c2f6ca00811041688e9d27392a475483e843808b32a2f01a1088" }
+        is_expected.to eq(expected)
+      }
+    end
+  end
+end

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -178,5 +178,27 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
         end
       end
     end
+
+    context "when the package url is internal/invalid" do
+      let(:dependency_files) { [go_mod] }
+      let(:project_name) { "unrecognized_import" }
+      let(:repo_contents_path) { build_tmp_repo(project_name) }
+
+      let(:dependency_name) { "pkg-errors" }
+      let(:dependency_version) { "1.0.0" }
+
+      let(:go_mod) do
+        Dependabot::DependencyFile.new(name: "go.mod", content: go_mod_body)
+      end
+      let(:go_mod_body) { fixture("projects", project_name, "go.mod") }
+
+      it "raises a DependencyFileNotResolvable error" do
+        error_class = Dependabot::DependencyFileNotResolvable
+        expect { latest_resolvable_version }.
+          to raise_error(error_class) do |error|
+          expect(error.message).to include("pkg-errors")
+        end
+      end
+    end
   end
 end

--- a/go_modules/spec/fixtures/projects/unknown_vcs/go.mod
+++ b/go_modules/spec/fixtures/projects/unknown_vcs/go.mod
@@ -3,9 +3,9 @@ module unknown/vcs/go
 go 1.12
 
 require (
-	unknown/vcs v0.0.0-00010101000000-000000000000
+	unknown.doesnotexist/vcs v0.0.0-00010101000000-000000000000
 )
 
 replace (
-	unknown/vcs => ../../
+	unknown.doesnotexist/vcs => ../monorepo/common
 )

--- a/go_modules/spec/fixtures/projects/unknown_vcs/main.go
+++ b/go_modules/spec/fixtures/projects/unknown_vcs/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	_ "unknown/vcs/go"
+	_ "unknown.doesnotexist/vcs"
 )
 
 func main() {

--- a/go_modules/spec/fixtures/projects/unrecognized_import/go.mod
+++ b/go_modules/spec/fixtures/projects/unrecognized_import/go.mod
@@ -1,0 +1,9 @@
+module github.com/dependabot/vgotest
+
+require (
+	pkg-errors v1.0.0
+)
+
+replace pkg-errors => github.com/pkg/errors v0.8.0
+
+go 1.16

--- a/go_modules/spec/fixtures/projects/unrecognized_import/go.sum
+++ b/go_modules/spec/fixtures/projects/unrecognized_import/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go_modules/spec/fixtures/projects/unrecognized_import/main.go
+++ b/go_modules/spec/fixtures/projects/unrecognized_import/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	errors "pkg-errors"
+)
+
+func main() {
+	err := errors.New("kaboom")
+	fmt.Println(err)
+}


### PR DESCRIPTION
This PR makes two adjustments to the handling of `go_modules` updates.

1. Introduce `Dependabot::GoModules::ReplacementStubber` as shared logic for how local paths outside of the current checkout should be stubbed. This wasn't _too_ bad, until https://github.com/dependabot/dependabot-core/pull/2848 upgraded the `GoModUpdater` implementation without updating the `FileParser`. Bring them back in sync.

2. Ignore any dependencies in `go.mod` that aren't valid hosts, since they'll be [rejected by the go SDK](https://github.com/golang/go/blob/2ebe77a2fda1ee9ff6fd9a3e08933ad1ebaea039/src/cmd/go/internal/vcs/vcs.go#L931-L933).

This fixes projects like [cloudfoundry-incubator/backup-and-restore-sdk-release/src/s3-blobstore-backup-restore](https://github.com/cloudfoundry-incubator/backup-and-restore-sdk-release/blob/a9638a5dd6b9e7f94fc0c0019f465e8a29c16fd0/src/s3-blobstore-backup-restore/go.mod#L13), which combines an invalid module name (`system-tests`) with a local path replacement.

The change to the `UpdateChecker` would have Dependabot raise a resolution error in this case, but the job would still fail.
The change to `FileParser#skip_dependency?` aims more aggressively to succeed the job - by filtering problematic dependencies from consideration.

Functional test case:
`./bin/dry-run.rb go_modules "cloudfoundry-incubator/backup-and-restore-sdk-release" --dir="/src/s3-blobstore-backup-restore" --commit=5d92709d259f6fef64675e68dbf8eb59e2c72862`

<details><summary>Pre</summary>
<p>

```
[dependabot-core-dev] ~/dependabot-core $ ./bin/dry-run.rb go_modules "cloudfoundry-incubator/backup-and-restore-sdk-release" --dir="/src/s3-blobstore-backup-restore" --commit=5d92709d259f6fef64675e68dbf8eb59e2c72862
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.7-compliant syntax, but you are running 2.6.6.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=&gt; cloning into /tmp/d20210503-16942-1dvjm2x
=&gt; parsing dependency files
=&gt; updating 5 dependencies: github.com/aws/aws-sdk-go, github.com/cloudfoundry-incubator/bosh-backup-and-restore, github.com/onsi/ginkgo, github.com/onsi/gomega, system-tests

=== github.com/aws/aws-sdk-go (1.38.22)
 =&gt; checking for updates 1/5
 =&gt; latest available version is 1.38.30
 =&gt; latest allowed version is 1.38.30
 =&gt; requirements to unlock: own
 =&gt; requirements update strategy:
 =&gt; updating github.com/aws/aws-sdk-go from 1.38.22 to 1.38.30

    ± go.mod
    ~~~
    6c6
    &lt; 	github.com/aws/aws-sdk-go v1.38.22
    ---
    &gt; 	github.com/aws/aws-sdk-go v1.38.30
    ~~~

    ± go.sum
    ~~~
    4,5c4,5
    &lt; github.com/aws/aws-sdk-go v1.38.22 h1:hJwaMazDt7EP4Rz/T4RQmdchWWv+YB3+/i6AOUWjVL0=
    &lt; github.com/aws/aws-sdk-go v1.38.22/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
    ---
    &gt; github.com/aws/aws-sdk-go v1.38.30 h1:X+JDSwkpSQfoLqH4fBLmS0rou8W/cdCCCD5lntTk9Vs=
    &gt; github.com/aws/aws-sdk-go v1.38.30/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
    ~~~
added vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go
added vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
added vendor/github.com/aws/aws-sdk-go/aws/version.go
added vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/error.go
added vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/writer.go
added vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/build.go
added vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/xml_to_struct.go
added vendor/modules.txt
added vendor/system-tests/go.mod
added vendor/system-tests/go.sum

=== github.com/cloudfoundry-incubator/bosh-backup-and-restore (1.9.7)
 =&gt; checking for updates 2/5
 =&gt; latest available version is 1.9.7
 =&gt; latest allowed version is 1.9.7
    (no update needed as it's already up-to-date)

=== github.com/onsi/ginkgo (1.16.1)
 =&gt; checking for updates 3/5
 =&gt; latest available version is 1.16.1
 =&gt; latest allowed version is 1.16.1
    (no update needed as it's already up-to-date)

=== github.com/onsi/gomega (1.11.0)
 =&gt; checking for updates 4/5
 =&gt; latest available version is 1.11.0
 =&gt; latest allowed version is 1.11.0
    (no update needed as it's already up-to-date)

=== system-tests (0.0.0)
 =&gt; checking for updates 5/5
Traceback (most recent call last):
	14: from ./bin/dry-run.rb:599:in `</p><main>'
	13: from ./bin/dry-run.rb:599:in `each'
	12: from ./bin/dry-run.rb:607:in `block in <main>'
	11: from /home/dependabot/dependabot-core/go_modules/lib/dependabot/go_modules/update_checker.rb:42:in `latest_version'
	10: from /home/dependabot/dependabot-core/go_modules/lib/dependabot/go_modules/update_checker.rb:35:in `latest_resolvable_version'
	 9: from /home/dependabot/dependabot-core/go_modules/lib/dependabot/go_modules/update_checker.rb:59:in `find_latest_resolvable_version'
	 8: from /home/dependabot/dependabot-core/common/lib/dependabot/shared_helpers.rb:42:in `in_a_temporary_directory'
	 7: from /usr/lib/ruby/2.6.0/tmpdir.rb:93:in `mktmpdir'
	 6: from /home/dependabot/dependabot-core/common/lib/dependabot/shared_helpers.rb:45:in `block in in_a_temporary_directory'
	 5: from /home/dependabot/dependabot-core/common/lib/dependabot/shared_helpers.rb:45:in `chdir'
	 4: from /home/dependabot/dependabot-core/common/lib/dependabot/shared_helpers.rb:45:in `block (2 levels) in in_a_temporary_directory'
	 3: from /home/dependabot/dependabot-core/go_modules/lib/dependabot/go_modules/update_checker.rb:60:in `block in find_latest_resolvable_version'
	 2: from /home/dependabot/dependabot-core/common/lib/dependabot/shared_helpers.rb:159:in `with_git_configured'
	 1: from /home/dependabot/dependabot-core/go_modules/lib/dependabot/go_modules/update_checker.rb:67:in `block (2 levels) in find_latest_resolvable_version'
/home/dependabot/dependabot-core/common/lib/dependabot/shared_helpers.rb:115:in `run_helper_subprocess': unrecognized import path "system-tests": import path does not begin with hostname (Dependabot::SharedHelpers::HelperSubprocessFailed)
```

<p></p>
</main></main></details> 

<details><summary>Post</summary>
<p>

```
[dependabot-core-dev] ~/dependabot-core $ ./bin/dry-run.rb go_modules "cloudfoundry-incubator/backup-and-restore-sdk-release" --dir="/src/s3-blobstore-backup-restore" --commit=5d92709d259f6fef64675e68dbf8eb59e2c72862
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.7-compliant syntax, but you are running 2.6.6.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=&gt; cloning into /tmp/d20210503-15862-18c0fbb
=&gt; parsing dependency files
=&gt; updating 4 dependencies: github.com/aws/aws-sdk-go, github.com/cloudfoundry-incubator/bosh-backup-and-restore, github.com/onsi/ginkgo, github.com/onsi/gomega

=== github.com/aws/aws-sdk-go (1.38.22)
 =&gt; checking for updates 1/4
 =&gt; latest available version is 1.38.30
 =&gt; latest allowed version is 1.38.30
 =&gt; requirements to unlock: own
 =&gt; requirements update strategy:
 =&gt; updating github.com/aws/aws-sdk-go from 1.38.22 to 1.38.30

    ± go.mod
    ~~~
    6c6
    &lt; 	github.com/aws/aws-sdk-go v1.38.22
    ---
    &gt; 	github.com/aws/aws-sdk-go v1.38.30
    ~~~

    ± go.sum
    ~~~
    4,5c4,5
    &lt; github.com/aws/aws-sdk-go v1.38.22 h1:hJwaMazDt7EP4Rz/T4RQmdchWWv+YB3+/i6AOUWjVL0=
    &lt; github.com/aws/aws-sdk-go v1.38.22/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
    ---
    &gt; github.com/aws/aws-sdk-go v1.38.30 h1:X+JDSwkpSQfoLqH4fBLmS0rou8W/cdCCCD5lntTk9Vs=
    &gt; github.com/aws/aws-sdk-go v1.38.30/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
    ~~~
added vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go
added vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
added vendor/github.com/aws/aws-sdk-go/aws/version.go
added vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/error.go
added vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/writer.go
added vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/build.go
added vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/xml_to_struct.go
added vendor/modules.txt
added vendor/system-tests/go.mod
added vendor/system-tests/go.sum

=== github.com/cloudfoundry-incubator/bosh-backup-and-restore (1.9.7)
 =&gt; checking for updates 2/4
 =&gt; latest available version is 1.9.7
 =&gt; latest allowed version is 1.9.7
    (no update needed as it's already up-to-date)

=== github.com/onsi/ginkgo (1.16.1)
 =&gt; checking for updates 3/4
 =&gt; latest available version is 1.16.1
 =&gt; latest allowed version is 1.16.1
    (no update needed as it's already up-to-date)

=== github.com/onsi/gomega (1.11.0)
 =&gt; checking for updates 4/4
 =&gt; latest available version is 1.11.0
 =&gt; latest allowed version is 1.11.0
    (no update needed as it's already up-to-date)
```

<p></p>
</main></main></details> 