### PR TITLE
multistage docker: FileParser unique versions

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -35,7 +35,7 @@ module Dependabot
       AWS_ECR_URL = /dkr\.ecr\.(?<region>[^.]+).amazonaws\.com/.freeze
 
       def parse
-        dependency_set = DependencySet.new
+        dependency_hash = {}
 
         dockerfiles.each do |dockerfile|
           dockerfile.content.each_line do |line|
@@ -47,8 +47,9 @@ module Dependabot
             version = version_from(parsed_from_line)
             next unless version
 
-            dependency_set << Dependency.new(
-              name: parsed_from_line.fetch("image"),
+            name = parsed_from_line.fetch("image")
+            dep =  Dependency.new(
+              name: name,
               version: version,
               package_manager: "docker",
               requirements: [
@@ -58,10 +59,11 @@ module Dependabot
                 source: source_from(parsed_from_line)
               ]
             )
+            dependency_hash["#{name}:#{version}"] = dep
           end
         end
 
-        dependency_set.dependencies
+        dependency_hash.values
       end
 
       private


### PR DESCRIPTION
This modifies the `Dependabot::Docker::FileParser` to treat each `image:tag` combination as a unique update.

Consider a [multistage Dockerfile like](https://github.com/nginxinc/kubernetes-ingress/blob/54e0b07503414ab0c28472646a681b0674d1f3b9/build/Dockerfile):
```
FROM nginx:1.19.9 AS debian
FROM nginx:1.19.9-alpine AS alpine
```

Previously, Dependabot would parse this as multiple requirements for an image called `nginx`, and update all `FROM` statements to a single image if available.

```
#<Dependabot::Dependency:0x000055591e6cac10 @name="nginx", @version="1.19.9", @requirements=[{:requirement=>nil, :groups=>[], :file=>"Dockerfile", :source=>{:tag=>"1.19.9"}}, {:requirement=>nil, :groups=>[], :file=>"Dockerfile", :source=>{:tag=>"1.19.9-alpine"}}], @previous_version=nil, @previous_requirements=nil, @package_manager="docker">
```

By switching the parsing to allow multiple versions, the existing suffix handling code "just works" 🎉 .

<details><summary>Pre</summary>
<p>

```
[dependabot-core-dev] ~/dependabot-core $ bin/dry-run.rb docker nginxinc/kubernetes-ingress --commit=54e0b07503414ab0c28472646a681b0674d1f3b9 --dir="/build" --dep="nginx"
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.7-compliant syntax, but you are running 2.6.6.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=&gt; fetching dependency files
=&gt; dumping fetched dependency files: ./dry-run/nginxinc/kubernetes-ingress/build
=&gt; parsing dependency files
=&gt; updating 1 dependencies: nginx

=== nginx (1.19.9)
 =&gt; checking for updates 1/1
 =&gt; latest available version is 1.19.10
 =&gt; latest allowed version is 1.19.10
 =&gt; requirements to unlock: own
 =&gt; requirements update strategy:
 =&gt; updating nginx from 1.19.9 to 1.19.10

    ± Dockerfile
    ~~~
    5c5
    &lt; FROM nginx:1.19.9 AS debian
    ---
    &gt; FROM nginx:1.19.10 AS debian
    17c17
    &lt; FROM nginx:1.19.9-alpine AS alpine
    ---
    &gt; FROM nginx:1.19.10 AS alpine
    ~~~
```

</p>
</details> 


<details><summary>Post</summary>
<p>

```
[dependabot-core-dev] ~/dependabot-core $ bin/dry-run.rb docker nginxinc/kubernetes-ingress --commit=54e0b07503414ab0c28472646a681b0674d1f3b9 --dir="/build" --dep="nginx"
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.7-compliant syntax, but you are running 2.6.6.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=&gt; fetching dependency files
=&gt; dumping fetched dependency files: ./dry-run/nginxinc/kubernetes-ingress/build
=&gt; parsing dependency files
=&gt; updating 2 dependencies: nginx, nginx

=== nginx (1.19.9)
 =&gt; checking for updates 1/2
 =&gt; latest available version is 1.19.10
 =&gt; latest allowed version is 1.19.10
 =&gt; requirements to unlock: own
 =&gt; requirements update strategy:
 =&gt; updating nginx from 1.19.9 to 1.19.10

    ± Dockerfile
    ~~~
    5c5
    &lt; FROM nginx:1.19.9 AS debian
    ---
    &gt; FROM nginx:1.19.10 AS debian
    ~~~

=== nginx (1.19.9-alpine)
 =&gt; checking for updates 2/2
 =&gt; latest available version is 1.19.10-alpine
 =&gt; latest allowed version is 1.19.10-alpine
 =&gt; requirements to unlock: own
 =&gt; requirements update strategy:
 =&gt; updating nginx from 1.19.9-alpine to 1.19.10-alpine

    ± Dockerfile
    ~~~
    17c17
    &lt; FROM nginx:1.19.9-alpine AS alpine
    ---
    &gt; FROM nginx:1.19.10-alpine AS alpine
    ~~~
```

</p>
</details> 