### PR TITLE
Draft: Go modules ignore conditions using `go list -m -versions`

### DIFF
--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -67,8 +67,9 @@ module Dependabot
             # Turn off the module proxy for now, as it's causing issues with private git dependencies
             env = { "GOPRIVATE" => "*" }
 
-            json, stderr, status = Open3.capture3(env, SharedHelpers.escape_command("go list -m -versions --json #{dependency.name}"))
+            json, stderr, status = Open3.capture3(env, SharedHelpers.escape_command("go list -m -mod=mod -versions --json #{dependency.name}"))
             if !status.success?
+
               # TODO: Should we populate an error_context here?
               handle_subprocess_error(SharedHelpers::HelperSubprocessFailed.new(message: stderr, error_context: {}))
             end

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -178,5 +178,21 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
         end
       end
     end
+
+    context "with a retracted update version" do
+      # latest release v1.0.1 is retracted
+      let(:dependency_name) { "github.com/dependabot-fixtures/go-modules-retracted" }
+      let(:go_mod_content) do
+        <<~GOMOD
+          module foobar
+          require #{dependency_name} v#{dependency_version}
+        GOMOD
+      end
+
+      it "doesn't update to the retracted version" do
+        expect(latest_resolvable_version).
+          to eq(Dependabot::GoModules::Version.new("1.0.0"))
+      end
+    end
   end
 end


### PR DESCRIPTION
This is an initial exploration of moving go_module latest version selection out of the [`updatechecker`](https://github.com/dependabot/dependabot-core/blob/c3c87bb90042cf5b3d3af50d42b0e83fe3267041/go_modules/helpers/updatechecker/main.go#L34) helper and into the ruby code. The goal is to support the upcoming `update_type` ignore conditions.

Instead of modifying the `updatechecker` helper we started down the route of using `go list -m -versions --json <module>` to fetch the list of available versions and then added any extra filtering that was needed to make the tests pass.

```
% go list -m -versions --json github.com/dependabot-fixtures/go-modules-lib
{
	"Path": "github.com/dependabot-fixtures/go-modules-lib",
	"Version": "v1.1.0",
	"Versions": [
		"v1.0.0",
		"v1.0.1",
		"v1.1.0",
		"v1.2.0-pre1",
		"v1.2.0-pre2"
	],
	"Time": "2018-10-18T21:48:48Z"
}
```

This appeared to work pretty well and had some benefits:
- The result omits major version upgrades (since they would have a different module path) so we didn't need to reimplement the [major version filter](https://github.com/dependabot/dependabot-core/blob/c3c87bb90042cf5b3d3af50d42b0e83fe3267041/go_modules/helpers/updatechecker/main.go#L67)
- The command is aware of retracted go modules so we gained filtering of them for free
- No longer need to maintain the `updatechecker` code

However, we hit one snag. While pairing with @jasonrudolph we discovered that his dev shell was out of date and using go 1.15. When I tried this under 1.16 the `go list` command started to report this error:
```
go: github.com/dependabot-fixtures/go-modules-lib@v1.0.0: missing go.sum entry; to add it:
    go mod download github.com/dependabot-fixtures/go-modules-lib
```

A workaround I came up with was to change the command to `go list -m -mod=mod -versions --json github.com/dependabot-fixtures/go-modules-lib`. This works but takes much more time as it ends up downloading the module into the module cache. For `update_checker_spec.rb` this increased the runtime from ~2s to ~10s when run with an empty module cache. In practice this change would mean we need to download every dependency we check for updates instead of only downloading dependencies that need to be updated.

Because of the potential performance impact I'm not feeling good about rolling out the `go list` change as part of supporting ignore conditions but wanted to put this out for feedback in case I missed something. I'm also going to put up a draft of an alternate approach which modifies the `updatechecker` helper to behave more like `go list` instead of switching to `go list`. That could make it easier to swap out the implementation in the future.

Alternate: https://github.com/dependabot/dependabot-core/pull/3631


