### PR TITLE
Ignored update types: handle nil dep version

### DIFF
--- a/common/lib/dependabot/config/ignore_condition.rb
+++ b/common/lib/dependabot/config/ignore_condition.rb
@@ -32,6 +32,8 @@ module Dependabot
       end
 
       def versions_by_type(dependency)
+        return [] unless dependency.version
+
         transformed_update_types.flat_map do |t|
           case t
           when PATCH_VERSION_TYPE

--- a/common/lib/dependabot/config/update_config.rb
+++ b/common/lib/dependabot/config/update_config.rb
@@ -14,7 +14,7 @@ module Dependabot
 
       def ignored_versions_for(dependency, security_updates_only: false)
         normalizer = name_normaliser_for(dependency)
-        dep_name = name_normaliser_for(dependency).call(dependency.name)
+        dep_name = normalizer.call(dependency.name)
 
         @ignore_conditions.
           select { |ic| self.class.wildcard_match?(normalizer.call(ic.dependency_name), dep_name) }.

--- a/common/spec/dependabot/config/ignore_condition_spec.rb
+++ b/common/spec/dependabot/config/ignore_condition_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
   let(:ignore_condition) { described_class.new(dependency_name: dependency_name) }
   let(:security_updates_only) { false }
 
-  describe "#versions" do
+  describe "#ignored_versions" do
     subject(:ignored_versions) { ignore_condition.ignored_versions(dependency, security_updates_only) }
     let(:dependency) do
       Dependabot::Dependency.new(
@@ -284,6 +284,25 @@ RSpec.describe Dependabot::Config::IgnoreCondition do
           it "returns the expected range" do
             expect(ignored_versions).to eq([])
           end
+        end
+      end
+
+      context "when the dependency version isn't known" do
+        let(:dependency_version) { nil }
+
+        context "with ignore_major_versions" do
+          let(:update_types) { ["version-update:semver-major"] }
+          it { is_expected.to eq([]) }
+        end
+
+        context "with ignore_minor_versions" do
+          let(:update_types) { ["version-update:semver-minor"] }
+          it { is_expected.to eq([]) }
+        end
+
+        context "with ignore_patch_versions" do
+          let(:update_types) { ["version-update:semver-patch"] }
+          it { is_expected.to eq([]) }
         end
       end
 

--- a/common/spec/dependabot/config/update_config_spec.rb
+++ b/common/spec/dependabot/config/update_config_spec.rb
@@ -148,6 +148,26 @@ RSpec.describe Dependabot::Config::UpdateConfig do
         end
       end
     end
+
+    context "when the dependency version isn't known" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "actions/checkout",
+          requirements: [],
+          version: nil,
+          package_manager: "go_modules"
+        )
+      end
+
+      let(:ignore_conditions) do
+        [Dependabot::Config::IgnoreCondition.new(dependency_name: "actions/checkout",
+                                                 versions: [], update_types: ["version-update:semver-major"])]
+      end
+
+      it "returns no ignored versions" do
+        expect(ignored_versions).to eq([])
+      end
+    end
   end
 
   describe "#commit_message_options" do

--- a/common/spec/dependabot/config/update_config_spec.rb
+++ b/common/spec/dependabot/config/update_config_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Dependabot::Config::UpdateConfig do
           name: "actions/checkout",
           requirements: [],
           version: nil,
-          package_manager: "go_modules"
+          package_manager: "github_actions"
         )
       end
 


### PR DESCRIPTION
Handle a `nil` dependency version when computing ignored versions from
ignored update types.

When we can't reliably figure out the exact version of a dependency
(e.g. it doesn't have a lockfile), we just leave the
`dependency.version` as nil.