### PR TITLE
GitHub PullRequestCreator: prepend refs/

### DIFF
--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -226,12 +226,12 @@ module Dependabot
       end
 
       def create_branch(commit)
-        ref = "heads/#{branch_name}"
+        ref = "refs/heads/#{branch_name}"
 
         begin
           branch =
             github_client_for_source.create_ref(source.repo, ref, commit.sha)
-          @branch_name = ref.gsub(%r{^heads/}, "")
+          @branch_name = ref.gsub(%r{^refs/heads/}, "")
           branch
         rescue Octokit::UnprocessableEntity => e
           # Return quietly in the case of a race
@@ -244,7 +244,7 @@ module Dependabot
 
           # Branch creation will fail if a branch called `dependabot` already
           # exists, since git won't be able to create a dir with the same name
-          ref = "heads/#{SecureRandom.hex[0..3] + branch_name}"
+          ref = "refs/heads/#{SecureRandom.hex[0..3] + branch_name}"
           retry
         end
       end


### PR DESCRIPTION
This is a workaround to the proposed upstream fix, https://github.com/octokit/octokit.rb/pull/1336.

Consider a dependency named `github.com/football-refs/league-rules`.
As part of an upgrade, Dependabot might attempt a branch like `dependabot/go_modules/github.com/football-refs/league-rules/2.0.0`.

Since that matches `refs/`, it won't automatically have `refs/` prepended, ultimately resulting in a `Octokit::UnprocessableEntity`.