### PR TITLE
Create changelog from merge commits

### DIFF
--- a/bin/bump-version.rb
+++ b/bin/bump-version.rb
@@ -9,7 +9,7 @@ component = ARGV[0].to_sym
 
 unless `which gh` && $?.success?
   puts "Please install the gh cli: brew install gh"
-  exut 1
+  exit 1
 end
 
 unless `gh auth status > /dev/null 2>&1` && $?.success?

--- a/bin/bump-version.rb
+++ b/bin/bump-version.rb
@@ -78,10 +78,10 @@ puts
 puts "Double check the changes (editing CHANGELOG.md where necessary), then"
 puts "commit, tag, and push the release:"
 puts
+puts "git checkout -b v#{new_version}-release-notes"
 puts "git add CHANGELOG.md common/lib/dependabot/version.rb"
 puts "git commit -m 'v#{new_version}'"
 puts "git push origin HEAD:v#{new_version}-release-notes"
-puts "git checkout v#{new_version}-release-notes"
 puts "# ... create PR, verify, merge, for example:"
 puts "gh pr create"
 puts "# tag the approved release notes:"


### PR DESCRIPTION
Build the changelog entries from merge commit PR details instead of the individual commits, automating attribution to non-team members and including a link to the PR.

Example:

```
## v0.146.0, 5 May 2021

- fix(Go mod): detect when remote end hangs up [#3469](https://github.com/dependabot/dependabot-core/pull/3469)
- Final pass on bundler1 test cruft [#3466](https://github.com/dependabot/dependabot-core/pull/3466)
- Handle repo not found errors for go modules [#3456](https://github.com/dependabot/dependabot-core/pull/3456)
- Disabled poetry experimental new installer (@honnix) [#3459](https://github.com/dependabot/dependabot-core/pull/3459)
- Implement delete/create action in GitLab Client (@jerbob92) [#3414](https://github.com/dependabot/dependabot-core/pull/3414)
```
