### PR TITLE
style: use consistent indentation for first element

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,12 @@ Layout/DotPosition:
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: false
 
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
 Layout/LineLength:
   Max: 120
 


### PR DESCRIPTION
# Why is this needed?

To respect line widths, ensure consistent indentation and help those who
need to use a bigger font to read code.

## What does this do?

It enforces a `consistent` indentation setting via RuboCop.
