### PR TITLE
v0.145.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.145.0, 5 May 2021
+
+- go_modules: support version ignores
+- Dev env: mount go helper source in dev shell
+- docker: FileParser unique suffixes
+- go_modules: helper updates
+- GitHub PullRequestCreator: prepend refs/
+- build(deps): bump github.com/dependabot/gomodules-extracted
+
 ## v0.144.0, 5 May 2021
 
 - Elm: Drop support for Elm 0.18

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.144.0"
+  VERSION = "0.145.0"
 end


### PR DESCRIPTION
Contains these commits: https://github.com/dependabot/dependabot-core/compare/v0.144.0...v0.145.0-release-notes

## v0.145.0, 5 May 2021

- go_modules: support version ignores
- Dev env: mount go helper source in dev shell
- docker: FileParser unique suffixes
- go_modules: helper updates
- GitHub PullRequestCreator: prepend refs/
- build(deps): bump github.com/dependabot/gomodules-extracted