### PR TITLE
Update providers versions in terraform lock files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -208,6 +208,16 @@ RUN mkdir -p "$RUSTUP_HOME" && chown dependabot:dependabot "$RUSTUP_HOME"
 USER dependabot
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
   && rustup toolchain install 1.51.0 && rustup default 1.51.0
+
+### Terraform
+
+USER root
+RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
+RUN apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
+  && apt-get update -y \
+  && apt-get install terraform \
+  && terraform -help
+
 USER root
 
 COPY --chown=dependabot:dependabot composer/helpers /opt/composer/helpers

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -3,3 +3,4 @@
 /tmp
 /dependabot-*.gem
 Gemfile.lock
+.terraform

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -128,11 +128,11 @@ module Dependabot
       end
 
       def lock_file?
-        dependency_files.find { |file| file.name == LOCK_FILE_NAME }
+        !lock_file.nil?
       end
 
       def lock_file
-        dependency_files.find { |file| file.name == LOCK_FILE_NAME }
+        @lock_file ||= dependency_files.find { |file| file.name == LOCK_FILE_NAME }
       end
 
       def updated_lock_file

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -50,7 +50,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.38.0"
   constraints = "~> 3.27"
   hashes = [
-    "h1:qKEjN/EM56XT46vGY33eoq7nD6JuGqRqFp7tkzTrRM0=",
+    "h1:ARuS11ThIcUfmAQKWNXGPLOa1GheaIwkeCnMh9Mjvao=",
     "zh:20476d4c1b0c0efc55226bcbd85fbd948638fd9860a0edcdb7875cbb2b449e46",
     "zh:7102622e6549cc3fc46b9ad68cbf4c50b162ce1013d4da817d05d1edf1f12fae",
     "zh:74ff7f1610065e14c043cd9d74b3d5e0de4474f09a1a81e0b126b920b5cf6a27",

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -22,6 +22,52 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
   describe "#updated_dependency_files" do
     subject { updater.updated_dependency_files }
 
+    context "when updating to the latest version of the aws provider" do
+      let(:files) { project_dependency_files("aws") }
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "aws",
+            version: "3.38.0",
+            previous_version: "3.27.0",
+            requirements: [],
+            previous_requirements: [],
+            package_manager: "terraform"
+          )
+        ]
+      end
+
+      specify { expect(subject.count).to eql(1) }
+
+      it "updates the `.terraform.lock.hcl` file" do
+        lock_file = subject.find { |file| file.name == ".terraform.lock.hcl" }
+
+        expect(lock_file.content).to eql(<<~LOCKFILE)
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.38.0"
+  constraints = "~> 3.27"
+  hashes = [
+    "h1:qKEjN/EM56XT46vGY33eoq7nD6JuGqRqFp7tkzTrRM0=",
+    "zh:20476d4c1b0c0efc55226bcbd85fbd948638fd9860a0edcdb7875cbb2b449e46",
+    "zh:7102622e6549cc3fc46b9ad68cbf4c50b162ce1013d4da817d05d1edf1f12fae",
+    "zh:74ff7f1610065e14c043cd9d74b3d5e0de4474f09a1a81e0b126b920b5cf6a27",
+    "zh:800e1b168149d507d23845f7a8b7e598c7dc16d2ee0f47848cf85d3e7458884f",
+    "zh:81ac3c68d6230b77740ca367e0c05a32ebb9be0fe5478c836573218a84eb3e46",
+    "zh:86536598796ba65539816f08351ac0ab32988ab84fa8f100049579996fafc800",
+    "zh:b9985c64f0f0b5bafb7067a60381fd807f7c3dd952c5d9f531385e464867bdd5",
+    "zh:c19c692896469724c6320fa7d87532ec3935e14e0e0fa0a8a0f1cf28ae7a0b0a",
+    "zh:cb8b14f246953a275ada562f5275a0d1a4938b7d20597e62fabe264012410f53",
+    "zh:cdbfa0ad87ff4d7451cfb89e53692a651d4c9cadece6845e60d986fd454b52b3",
+    "zh:ed5c4c8ae5adda37942bb15ef058c0811a95cb4c87259ae822627756dcb90efc",
+  ]
+}
+        LOCKFILE
+      end
+    end
+
     context "with a valid dependency file" do
       let(:files) { project_dependency_files("git_tags") }
       let(:dependencies) do

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -42,29 +42,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       it "updates the `.terraform.lock.hcl` file" do
         lock_file = subject.find { |file| file.name == ".terraform.lock.hcl" }
 
-        expect(lock_file.content).to eql(<<~LOCKFILE)
-# This file is maintained automatically by "terraform init".
-# Manual edits may be lost in future updates.
-
-provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.38.0"
-  constraints = "~> 3.27"
-  hashes = [
-    "h1:ARuS11ThIcUfmAQKWNXGPLOa1GheaIwkeCnMh9Mjvao=",
-    "zh:20476d4c1b0c0efc55226bcbd85fbd948638fd9860a0edcdb7875cbb2b449e46",
-    "zh:7102622e6549cc3fc46b9ad68cbf4c50b162ce1013d4da817d05d1edf1f12fae",
-    "zh:74ff7f1610065e14c043cd9d74b3d5e0de4474f09a1a81e0b126b920b5cf6a27",
-    "zh:800e1b168149d507d23845f7a8b7e598c7dc16d2ee0f47848cf85d3e7458884f",
-    "zh:81ac3c68d6230b77740ca367e0c05a32ebb9be0fe5478c836573218a84eb3e46",
-    "zh:86536598796ba65539816f08351ac0ab32988ab84fa8f100049579996fafc800",
-    "zh:b9985c64f0f0b5bafb7067a60381fd807f7c3dd952c5d9f531385e464867bdd5",
-    "zh:c19c692896469724c6320fa7d87532ec3935e14e0e0fa0a8a0f1cf28ae7a0b0a",
-    "zh:cb8b14f246953a275ada562f5275a0d1a4938b7d20597e62fabe264012410f53",
-    "zh:cdbfa0ad87ff4d7451cfb89e53692a651d4c9cadece6845e60d986fd454b52b3",
-    "zh:ed5c4c8ae5adda37942bb15ef058c0811a95cb4c87259ae822627756dcb90efc",
-  ]
-}
-        LOCKFILE
+        expect(lock_file.content).to eql(fixture("projects/aws/.terraform.lock.hcl.expected"))
       end
     end
 

--- a/terraform/spec/fixtures/projects/aws/.terraform.lock.hcl
+++ b/terraform/spec/fixtures/projects/aws/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.27.0"
+  constraints = "3.27.0"
+  hashes = [
+    "h1:lJaA23rrNSgLEumcW7Y0KKvno5isVVNNIEV5pT92O8E=",
+    "zh:2986eb5a1ffbb0336c6390aad533b62efc832aa8aa5460d523e1f2daa4f42f79",
+    "zh:825317cdb80860833125a856c0befc877cba22d41c631c5a7ca22400693d4356",
+    "zh:a47aad668cc74058f508c56c5407cd715dbb9b6389aa68d37543e897895db43f",
+    "zh:c0011502d0eb4637918127c3987a8cc07a015ea00f74f4956fd111c736286a4d",
+    "zh:d5088ab51043bb2239132f4ed3760292b6aa4f7296232e4b8017f8c5c34f051a",
+    "zh:d893658e983eb17a23a8124c79a910cc729cb1d751d5509b8e756101c828ad91",
+    "zh:dcc4384ee79ea9492c87eb01e664f7f6b1f1d156471476f30b28336c9d9a4aec",
+    "zh:e4abfaf013f31791cd029af7b6f989f73e3efca28fe2917057b428d051c4085f",
+    "zh:f2a4d9446d23afe2a42421e7d5f902d34451fb31b7787b5e3aef95c08fec5ced",
+    "zh:f54a6af10b077db9dc11556c27f59ba5c60e1b2ba96fe3aa9cd90d8c67d980f6",
+  ]
+}

--- a/terraform/spec/fixtures/projects/aws/.terraform.lock.hcl.expected
+++ b/terraform/spec/fixtures/projects/aws/.terraform.lock.hcl.expected
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.39.0"
+  constraints = "~> 3.27"
+  hashes = [
+    "h1:goOMfGE4SjLps+hpxJFEM/pZFiNgvi6BMG8/w86+f6k=",
+    "zh:2014b397dd93fa55f2f2d1338c19e5b2b77b025a76a6b1fceea0b8696e984b9c",
+    "zh:23d59c68ab50148a0f5c911a801734e9934a1fccd41118a8efb5194135cbd360",
+    "zh:412eab41d4934ca9c47083faa128e4cd585c3bb44ad718e40d67091aebc02f4e",
+    "zh:4b75e0a259b56d97e66b7d69f3f25bd4cc7be2440c0fe35529f46de7d40a49d3",
+    "zh:694a32519dcca5bd8605d06481d16883d55160d97c1f4039deb13c6ca8de8427",
+    "zh:6a0bcef43c2d9a97aeaaac3c5d1d6728dc2464a51a014f118c691c79029d0903",
+    "zh:6d78fc7c663247ca2a80f276008dcdafece4cac75e2639bbce188c08b796040a",
+    "zh:78f846a505d7b64b67feed1527d4d2b40130dadaf8e3112113685e148f49b156",
+    "zh:881bc969432d3ef6ec70f5a762c3415e037904338579b0a360c6818b74d26e59",
+    "zh:96c1ca80c1d693a3eef80489adb45c076ee8e6878e461d6c29b05388d4b95f48",
+    "zh:9be5fa342272586fc6e319e20f21c0c5c801b05dcf7d59e473ad0882c9ecfa70",
+  ]
+}

--- a/terraform/spec/fixtures/projects/aws/main.tf
+++ b/terraform/spec/fixtures/projects/aws/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 3.27"
+    }
+  }
+
+  required_version = ">= 0.14.9"
+}
+
+provider "aws" {
+  profile = "default"
+  region = "us-west-2"
+}


### PR DESCRIPTION
# Why is this needed?

To be able to update providers to the latest version.

## What does this do?

Nothing yet. It adds a test that reproduces the desired outcome.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
