### PR TITLE
go_modules: don't filter the current version

### DIFF
--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -108,7 +108,7 @@ module Dependabot
 
         def filter_lower_versions(versions_array)
           versions_array.
-            select { |version| version > version_class.new(dependency.version) }
+            select { |version| version >= version_class.new(dependency.version) }
         end
 
         def filter_ignored_versions(versions_array)

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -215,5 +215,15 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
         end
       end
     end
+
+    context "when already on the latest version for the major" do
+      let(:dependency_name) { "github.com/dependabot-fixtures/go-modules-lib/v2" }
+      let(:dependency_version) { "2.0.0" }
+
+      it "returns the current version" do
+        expect(latest_resolvable_version).
+          to eq(Dependabot::GoModules::Version.new("2.0.0"))
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes a change in behavior introduced in https://github.com/dependabot/dependabot-core/pull/3631.

The previous behavior filtered lower versions but did not filter out the current version of the dependency. This adjusts the ruby implementation of the filter to allow the current version.