### PR TITLE
v0.145.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.145.1, 5 May 2021
+
+- go_modules: don't filter the current version
+- terraform: move fixtures to project folders
+
 ## v0.145.0, 5 May 2021
 
 - go_modules: support version ignores

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.145.0"
+  VERSION = "0.145.1"
 end


### PR DESCRIPTION
## v0.145.1, 5 May 2021

- go_modules: don't filter the current version
- terraform: move fixtures to project folders