### PR TITLE
v0.145.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.145.2, 7 May 2021
+
+- Nuget: Handle paginated v2 nuget api responses
+- maven: allow security updates to multi-dependency properties
+- build(deps): bump lodash
+- build(deps): bump @npmcli/arborist in /npm_and_yarn/helpers
+- build(deps-dev): update rubocop requirement from ~> 1.13.0 to ~> 1.14.0
+
 ## v0.145.1, 5 May 2021
 
 - go_modules: don't filter the current version

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.145.1"
+  VERSION = "0.145.2"
 end


### PR DESCRIPTION
## v0.145.2, 7 May 2021

- Nuget: Handle paginated v2 nuget api responses
- maven: allow security updates to multi-dependency properties
- build(deps): bump lodash
- build(deps): bump @npmcli/arborist in /npm_and_yarn/helpers
- build(deps-dev): update rubocop requirement from ~> 1.13.0 to ~> 1.14.0
