### PR TITLE
v0.145.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.145.3, 7 May 2021
+
+- go_modules: Gracefully handle +incompatible versions when checking for updates
+
 ## v0.145.2, 7 May 2021
 
 - Nuget: Handle paginated v2 nuget api responses

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.145.2"
+  VERSION = "0.145.3"
 end


### PR DESCRIPTION
## v0.145.3, 7 May 2021

- go_modules: Gracefully handle +incompatible versions when checking for updates
