### PR TITLE
dependabot.yml: enable github_actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,7 @@ updates:
     directory: "/go_modules/helpers"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot version updates [supports updating GitHub Actions workflow files](https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#package-ecosystem).
Dependabot-core [has GitHub Actions workflow files](https://github.com/dependabot/dependabot-core/tree/main/.github/workflows).
We should use Dependabot version updates to maintain dependabot-core's workflow files!

This feels good, but shouldn't have any immediate impact (as all actions use major-level tags).
```
.github/workflows/gems.yml:        uses: actions/checkout@v2
.github/workflows/gems.yml:      - uses: actions/setup-ruby@v1
.github/workflows/docker.yml:        uses: actions/checkout@v2
.github/workflows/ci.yml:        uses: actions/checkout@v2
```

# Related
- Discovered https://github.com/dependabot/dependabot-core/pull/3662#issuecomment-834632886