### PR TITLE
Run all pip-compile commands with options

### DIFF
--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -169,7 +169,7 @@ module Dependabot
 
               filenames_to_compile.each do |filename|
                 run_pip_compile_command(
-                  "pyenv exec pip-compile --allow-unsafe #{filename}"
+                  "pyenv exec pip-compile #{pip_compile_options(filename)} --allow-unsafe #{filename}"
                 )
               end
 


### PR DESCRIPTION
I believe I have stumbled across a bug in check_original_requirements_resolvable in the pip-compile version resolver.

I think the error is that the pip-compile command runs here without the relevant options that it runs with in all other contexts. This can mean, for example, that this command can fail when requirements contain libraries that are present only in a private repository and not on the public PyPi.

I can see three ways to resolve this:
1. Add the call to the relevant function when running pip-compile. This is the simplest and what I've opened initially, for discussion.
2. Make a function that returns the full pip-compile-with-options command that should be used everywhere, so you don't have to remember to add the option
3. Write a local pip.conf file and ensure it's picked up by the relevant commands to avoid having to pass them in as arguments each time.

WDYT, in terms of whether this is indeed a bug and what the fix should be?