### PR TITLE
v0.145.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.145.4, 10 May 2021
+
+- Actions: accept semver versions
+- Actions: detect workflow steps pinned to semver versions
+
 ## v0.145.3, 7 May 2021
 
 - go_modules: Gracefully handle +incompatible versions when checking for updates

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.145.3"
+  VERSION = "0.145.4"
 end


### PR DESCRIPTION
Release [these commits](https://github.com/dependabot/dependabot-core/compare/v0.145.3...v0.145.4-release-notes)

Which is limited to this PR:
* https://github.com/dependabot/dependabot-core/pull/3662