### PR TITLE
Run terraform specs against both old and new HCL2 compatible binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         - { path: omnibus, name: omnibus }
         - { path: python, name: python }
         - { path: terraform, name: terraform }
+        - { path: terraform, name: terraform-hcl2 }  
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/terraform/helpers/build
+++ b/terraform/helpers/build
@@ -13,7 +13,17 @@ if [ ! -d "$install_dir/bin" ]; then
 fi
 
 os="$(uname -s | tr '[:upper:]' '[:lower:]')"
-github_url="https://github.com/kvz/json2hcl"
-url="${github_url}/releases/download/v0.0.6/json2hcl_v0.0.6_${os}_amd64"
-wget -O "$install_dir/bin/json2hcl" "$url"
+
+json2hcl_checksum="d124ed13f3538c465fcab19e6015d311d3cd56f7dc2db7609b6e72fec666482d"
+json2hcl_url="https://github.com/kvz/json2hcl/releases/download/v0.0.6/json2hcl_v0.0.6_${os}_amd64"
+json2hcl_path="$install_dir/bin/json2hcl"
+wget -O "$json2hcl_path"  "$json2hcl_url"
+echo "$json2hcl_checksum  $json2hcl_path" | sha256sum -c
 chmod +x "$install_dir/bin/json2hcl"
+
+hcl2json_checksum="24068f1e25a34d8f8ca763f34fce11527472891bfa834d1504f665855021d5d4"
+hcl2json_url="https://github.com/tmccombs/hcl2json/releases/download/v0.3.3/hcl2json_${os}_amd64"
+hcl2json_path="$install_dir/bin/hcl2json"
+wget -O "$hcl2json_path" "$hcl2json_url"
+echo "$hcl2json_checksum  $hcl2json_path" | sha256sum -c
+chmod +x "$install_dir/bin/hcl2json"

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -230,7 +230,7 @@ module Dependabot
             )
           end
 
-          JSON.parse(stdout)#.fetch('module', {})
+          JSON.parse(stdout)
         end
       end
 

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -255,7 +255,7 @@ module Dependabot
           end
 
           json = JSON.parse(stdout)
-          json['module'] = json.fetch("module", []).inject({}) { |memo, item| memo.merge(item) }
+          json["module"] = json.fetch("module", []).inject({}) { |memo, item| memo.merge(item) }
           json
         end
       end

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -38,7 +38,7 @@ module Dependabot
           end
         end
 
-        dependency_set.dependencies
+        dependency_set.dependencies.sort_by(&:name)
       end
 
       private

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -64,10 +64,10 @@ V1 output:                             | V2 output:
       specify { expect(subject.length).to eq(5) }
       specify { expect(subject).to all(be_a(Dependabot::Dependency)) }
 
-      it "has the right details for the first dependency (default registry with version)" do
-        expect(subject[0].name).to eq("hashicorp/consul/aws")
-        expect(subject[0].version).to eq("0.1.0")
-        expect(subject[0].requirements).to eq([{
+      it "has the right details for the dependency (default registry with version)" do
+        expect(subject[2].name).to eq("hashicorp/consul/aws")
+        expect(subject[2].version).to eq("0.1.0")
+        expect(subject[2].requirements).to eq([{
           requirement: "0.1.0",
           groups: [],
           file: "main.tf",
@@ -94,10 +94,10 @@ V1 output:                             | V2 output:
         }])
       end
 
-      it "has the right details for the third dependency (default registry with version req)" do
-        expect(subject[2].name).to eq("terraform-aws-modules/rds/aws")
-        expect(subject[2].version).to be_nil
-        expect(subject[2].requirements).to eq([{
+      it "has the right details for the dependency (default registry with version req)" do
+        expect(subject[4].name).to eq("terraform-aws-modules/rds/aws")
+        expect(subject[4].version).to be_nil
+        expect(subject[4].requirements).to eq([{
           requirement: "~> 1.0.0",
           groups: [],
           file: "main.tf",
@@ -109,10 +109,10 @@ V1 output:                             | V2 output:
         }])
       end
 
-      it "has the right details for the fourth dependency (default registry with no version)" do
-        expect(subject[3].name).to eq("devops-workflow/members/github")
-        expect(subject[3].version).to be_nil
-        expect(subject[3].requirements).to eq([{
+      it "has the right details for the dependency (default registry with no version)" do
+        expect(subject[0].name).to eq("devops-workflow/members/github")
+        expect(subject[0].version).to be_nil
+        expect(subject[0].requirements).to eq([{
           requirement: nil,
           groups: [],
           file: "main.tf",
@@ -124,10 +124,10 @@ V1 output:                             | V2 output:
         }])
       end
 
-      it "has the right details for the fifth dependency (default registry with a sub-directory)" do
-        expect(subject[4].name).to eq("mongodb/ecs-task-definition/aws")
-        expect(subject[4].version).to be_nil
-        expect(subject[4].requirements).to eq([{
+      it "has the right details for the dependency (default registry with a sub-directory)" do
+        expect(subject[3].name).to eq("mongodb/ecs-task-definition/aws")
+        expect(subject[3].version).to be_nil
+        expect(subject[3].requirements).to eq([{
           requirement: nil,
           groups: [],
           file: "main.tf",
@@ -146,10 +146,10 @@ V1 output:                             | V2 output:
       specify { expect(subject.length).to eq(6) }
       specify { expect(subject).to all(be_a(Dependabot::Dependency)) }
 
-      it "has the right details for the first dependency (which uses git:: with a tag)" do
-        expect(subject[0].name).to eq("origin_label")
-        expect(subject[0].version).to eq("0.3.7")
-        expect(subject[0].requirements).to match_array([{
+      it "has the right details for the dependency (which uses git:: with a tag)" do
+        expect(subject[5].name).to eq("origin_label")
+        expect(subject[5].version).to eq("0.3.7")
+        expect(subject[5].requirements).to match_array([{
           requirement: nil,
           groups: [],
           file: "main.tf",
@@ -162,10 +162,10 @@ V1 output:                             | V2 output:
         }])
       end
 
-      it "has the right details for the second dependency (which uses github.com with a tag)" do
-        expect(subject[1].name).to eq("logs")
-        expect(subject[1].version).to eq("0.2.2")
-        expect(subject[1].requirements).to match_array([{
+      it "has the right details for the dependency (which uses github.com with a tag)" do
+        expect(subject[4].name).to eq("logs")
+        expect(subject[4].version).to eq("0.2.2")
+        expect(subject[4].requirements).to match_array([{
           requirement: nil,
           groups: [],
           file: "main.tf",
@@ -178,10 +178,10 @@ V1 output:                             | V2 output:
         }])
       end
 
-      it "has the right details for the third dependency (which uses bitbucket.org with no tag)" do
-        expect(subject[2].name).to eq("distribution_label")
-        expect(subject[2].version).to be_nil
-        expect(subject[2].requirements).to eq([{
+      it "has the right details for the dependency (which uses bitbucket.org with no tag)" do
+        expect(subject[0].name).to eq("distribution_label")
+        expect(subject[0].version).to be_nil
+        expect(subject[0].requirements).to eq([{
           requirement: nil,
           groups: [],
           file: "main.tf",
@@ -194,10 +194,10 @@ V1 output:                             | V2 output:
         }])
       end
 
-      it "has the right details the fourth dependency (which has a subdirectory and a tag)" do
-        expect(subject[3].name).to eq("dns")
-        expect(subject[3].version).to eq("0.2.5")
-        expect(subject[3].requirements).to eq([{
+      it "has the right details for the dependency (which has a subdirectory and a tag)" do
+        expect(subject[1].name).to eq("dns")
+        expect(subject[1].version).to eq("0.2.5")
+        expect(subject[1].requirements).to eq([{
           requirement: nil,
           groups: [],
           file: "main.tf",
@@ -210,10 +210,10 @@ V1 output:                             | V2 output:
         }])
       end
 
-      it "has the right details the fifth dependency)" do
-        expect(subject[4].name).to eq("duplicate_label")
-        expect(subject[4].version).to eq("0.3.7")
-        expect(subject[4].requirements).to eq([{
+      it "has the right details for the dependency" do
+        expect(subject[2].name).to eq("duplicate_label")
+        expect(subject[2].version).to eq("0.3.7")
+        expect(subject[2].requirements).to eq([{
           requirement: nil,
           groups: [],
           file: "main.tf",
@@ -226,10 +226,10 @@ V1 output:                             | V2 output:
         }])
       end
 
-     it "has the right details for the sixth dependency (which uses git@github.com)" do
-        expect(subject[5].name).to eq("github_ssh_without_protocol")
-        expect(subject[5].version).to eq("0.4.0")
-        expect(subject[5].requirements).to eq([{
+      it "has the right details for the dependency (which uses git@github.com)" do
+        expect(subject[3].name).to eq("github_ssh_without_protocol")
+        expect(subject[3].version).to eq("0.4.0")
+        expect(subject[3].requirements).to eq([{
           requirement: nil,
           groups: [],
           file: "main.tf",
@@ -243,7 +243,7 @@ V1 output:                             | V2 output:
       end
     end
 
-    context "with a terragrunt file" do
+    context "with a terragrunt file", :hcl1_only do
       let(:files) { project_dependency_files("terragrunt") }
 
       specify { expect(subject.length).to eq(1) }

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -263,10 +263,10 @@ RSpec.describe Dependabot::Terraform::FileParser do
       end
     end
 
-    context "with the hcl2 option", :hcl2_only do
+    context "hcl2 files" do
       let(:files) { project_dependency_files("hcl2") }
 
-      it "has the right source for the dependency" do
+      it "has the right source for the dependency", :hcl2_only do
         expect(subject[0].requirements).to eq([{
           requirement: nil,
           groups: [],
@@ -279,9 +279,10 @@ RSpec.describe Dependabot::Terraform::FileParser do
           }
         }])
       end
-    end
 
-    context "with the hcl1_only option", :hcl1_only do
+      it "fails to parse hcl2 files without the flag set", :hcl1_only do
+        expect { subject }.to raise_error(Dependabot::DependencyFileNotParseable)
+      end
     end
   end
 end

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -9,27 +9,33 @@ require_common_spec "file_parsers/shared_examples_for_file_parsers"
 RSpec.describe Dependabot::Terraform::FileParser do
   it_behaves_like "a dependency file parser"
 
-  subject(:parser) { described_class.new(dependency_files: files, source: source, options: {terraform_hcl2: PackageManagerHelper.use_terraform_hcl2?} ) }
+  subject(:parser) do
+    described_class.new(
+      dependency_files: files,
+      source: source,
+      options: {
+        terraform_hcl2: PackageManagerHelper.use_terraform_hcl2?
+      }
+    )
+  end
 
   let(:files) { [] }
   let(:source) { Dependabot::Source.new(provider: "github", repo: "gocardless/bump", directory: "/") }
 
-=begin
-V1 output:                             | V2 output:
-=======================================|==================================
-{                                      | {
-  "module": [                          |   "module": {
-    {                                  |     "consul": [
-      "consul": [                      |       {
-        {                              |         "source": "consul/aws",
-          "source": "consul/aws",      |         "version": "0.1.0"
-          "version": "0.1.0"           |       }
-        }                              |     ]
-      ]                                |   }
-    }                                  | }
-  ]                                    |
-}                                      |
-=end
+  # V1 output:                             | V2 output:
+  # =======================================|==================================
+  # {                                      | {
+  #   "module": [                          |   "module": {
+  #     {                                  |     "consul": [
+  #       "consul": [                      |       {
+  #         {                              |         "source": "consul/aws",
+  #           "source": "consul/aws",      |         "version": "0.1.0"
+  #           "version": "0.1.0"           |       }
+  #         }                              |     ]
+  #       ]                                |   }
+  #     }                                  | }
+  #   ]                                    |
+  # }                                      |
   describe "#parse" do
     subject { parser.parse }
 
@@ -50,7 +56,10 @@ V1 output:                             | V2 output:
         expect { subject }.to raise_error(Dependabot::DependencyFileNotParseable) do |boom|
           expect(boom.file_path).to eq("/main.tf")
           if PackageManagerHelper.use_terraform_hcl2?
-            expect(boom.message).to eq("Failed to convert file: parse config: [:18,1-1: Argument or block definition required; An argument or block definition is required here.]")
+            expect(boom.message).to eq(
+              "Failed to convert file: parse config: [:18,1-1: Argument or block definition required; " \
+              "An argument or block definition is required here.]"
+            )
           else
             expect(boom.message).to eq("unable to parse HCL: object expected closing RBRACE got: EOF")
           end
@@ -284,7 +293,7 @@ V1 output:                             | V2 output:
       end
     end
 
-    context "with the hcl1_only option", :hcl1_only do 
+    context "with the hcl1_only option", :hcl1_only do
     end
   end
 end

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -9,7 +9,7 @@ require_common_spec "file_parsers/shared_examples_for_file_parsers"
 RSpec.describe Dependabot::Terraform::FileParser do
   it_behaves_like "a dependency file parser"
 
-  subject(:parser) { described_class.new(dependency_files: files, source: source) }
+  subject(:parser) { described_class.new(dependency_files: files, source: source, options: {terraform_hcl2: PackageManagerHelper.use_terraform_hcl2?} ) }
 
   let(:files) { [] }
   let(:source) { Dependabot::Source.new(provider: "github", repo: "gocardless/bump", directory: "/") }
@@ -206,7 +206,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
         }])
       end
 
-      it "has the right details for the sixth dependency (which uses git@github.com)" do
+     it "has the right details for the sixth dependency (which uses git@github.com)" do
         expect(subject[5].name).to eq("github_ssh_without_protocol")
         expect(subject[5].version).to eq("0.4.0")
         expect(subject[5].requirements).to eq([{
@@ -245,5 +245,27 @@ RSpec.describe Dependabot::Terraform::FileParser do
         }])
       end
     end
+
+    context "with the hcl2 option", :hcl2_only do
+      let(:files) { project_dependency_files("hcl2") }
+      it "has the right source for the dependency" do
+        expect(subject[0].requirements).to eq([{
+          requirement: nil,
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "git",
+            url: "git@github.com:cloudposse/terraform-aws-jenkins.git",
+            branch: nil,
+            ref: "0.4.0"
+          }
+        }])
+      end
+    end
+
+    context "with the hcl1_only option", :hcl1_only do 
+      
+    end
+
   end
 end

--- a/terraform/spec/fixtures/projects/hcl2/main.tf
+++ b/terraform/spec/fixtures/projects/hcl2/main.tf
@@ -1,0 +1,12 @@
+module "github_ssh_without_protocol" {
+  source                       = "git@github.com:cloudposse/terraform-aws-jenkins.git?ref=0.4.0"
+  namespace                    = var.namespace
+  stage                        = var.stage
+  name                         = var.name
+  delimiter                    = var.delimiter
+  attributes                   = [compact(concat(var.attributes, ["origin"]))]
+  tags                         = var.tags
+  availability_zone            = ""
+  loadbalancer_certificate_arn = ""
+  public_subnets               = []
+}

--- a/terraform/spec/spec_helper.rb
+++ b/terraform/spec/spec_helper.rb
@@ -10,6 +10,28 @@ end
 
 require "#{common_dir}/spec/spec_helper.rb"
 
+module PackageManagerHelper
+  def self.use_terraform_hcl2?
+    ENV["SUITE_NAME"] == "terraform-hcl2"
+  end
+
+  def self.use_terraform_hcl1?
+    !use_terraform_hcl2?
+  end
+end
+
+RSpec.configure do |config|
+  config.around do |example|
+    if PackageManagerHelper.use_terraform_hcl2? && example.metadata[:hcl1_only]
+      example.skip
+    elsif PackageManagerHelper.use_terraform_hcl1? && example.metadata[:hcl2_only]
+      example.skip
+    else
+      example.run
+    end
+  end
+end
+
 if ENV["COVERAGE"]
   # TODO: Bring branch coverage up
   SimpleCov.minimum_coverage line: 80, branch: 55


### PR DESCRIPTION
# Why is this needed?

To gradually introduce tooling and changes needed to support HCL v2.0.

This change will let us run the old codepath in production, while we merge in small portions of tests and functionality for HCL2 support, keeping those PRs small and  focussed to make them easier to review.

We currently do not plan to toggle/feature flag between the codepaths in production, but once hcl2 support is ready, we'll flip the option to default to the new binary and code, and once we verify that runs successfully in production we can clean out the old code.

## What does this do?

This inserts a test suite and feature toggles that can be used to toggle between
which parsing tools to use.

/xref: https://github.com/github/dependabot-updates/issues/1422

HCL1:

```bash
[dependabot-core-dev] ~/dependabot-core/terraform $ SUITE_NAME=terraform-hcl1 bundle exec rspec spec/dependabot/terraform/file_parser_spec.rb

Randomized with seed 26818
.............*...........

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Dependabot::Terraform::FileParser#parse with the hcl2 option has the right source for the dependency
     # around hook at ./spec/spec_helper.rb:24 did not execute the example
     # ./spec/dependabot/terraform/file_parser_spec.rb:272


Finished in 0.11525 seconds (files took 1.62 seconds to load)
25 examples, 0 failures, 1 pending

Randomized with seed 26818
```

HCL2:

```bash
[dependabot-core-dev] ~/dependabot-core/terraform $ SUITE_NAME=terraform-hcl2 bundle exec rspec spec/dependabot/terraform/file_parser_spec.rb

Randomized with seed 59844
.....................***.

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Dependabot::Terraform::FileParser#parse with a terragrunt file
     # around hook at ./spec/spec_helper.rb:24 did not execute the example
     # ./spec/dependabot/terraform/file_parser_spec.rb:249

  2) Dependabot::Terraform::FileParser#parse with a terragrunt file has the right details for the first dependency
     # around hook at ./spec/spec_helper.rb:24 did not execute the example
     # ./spec/dependabot/terraform/file_parser_spec.rb:252

  3) Dependabot::Terraform::FileParser#parse with a terragrunt file
     # around hook at ./spec/spec_helper.rb:24 did not execute the example
     # ./spec/dependabot/terraform/file_parser_spec.rb:250


Finished in 0.13334 seconds (files took 1.61 seconds to load)
25 examples, 0 failures, 3 pending

Randomized with seed 59844
```

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Verification Plan

- [ ] Deploy
- [ ] Verify old updates still work: https://github.com/dsp-testing/dependabot-all-updates-test/blob/master/main.tf
