### PR TITLE
v0.146.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.146.0, 10 May 2021
+
+- go_modules: Refactor go module version finder specs
+- all: Filter lower versions when checking ignored versions
+- Terraform: Document and improve coverage for RequirementsUpdater
+- Revert "docker: FileParser consider image prefix/suffixes as unique"
+
 ## v0.145.4, 10 May 2021
 
 - Actions: accept semver versions

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.145.4"
+  VERSION = "0.146.0"
 end


### PR DESCRIPTION
## v0.146.0, 10 May 2021

- go_modules: Refactor go module version finder specs (https://github.com/dependabot/dependabot-core/pull/3687)
- all: Filter lower versions when checking ignored versions (https://github.com/dependabot/dependabot-core/pull/3658)
- Terraform: Document and improve coverage for RequirementsUpdater (https://github.com/dependabot/dependabot-core/pull/3685)
- Revert "docker: FileParser consider image prefix/suffixes as unique" (https://github.com/dependabot/dependabot-core/pull/3686)