### PR TITLE
Terraform: support parsing HCL based terragrunt files

### DIFF
--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -29,8 +29,10 @@ module Dependabot
         end
 
         terragrunt_files.each do |file|
-          modules = parsed_file(file).fetch("terragrunt", []).first || {}
-          modules = modules.fetch("terraform", [])
+          # legacy terragrunt (.tfvars) files have a top-level "terragrunt" key
+          # that has since been removed.
+          legacy_modules = (parsed_file(file).fetch("terragrunt", []).first || {}).fetch("terraform", [])
+          modules = parsed_file(file).fetch("terraform", []) + legacy_modules
           modules.each do |details|
             next unless details["source"]
 
@@ -315,7 +317,7 @@ module Dependabot
       end
 
       def terragrunt_files
-        dependency_files.select { |f| f.name.end_with?(".tfvars") }
+        dependency_files.select { |f| f.name.end_with?(".tfvars") || f.name.end_with?(".hcl") }
       end
 
       def check_required_files

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
         }])
       end
 
-      context "with v0.12+ git sources" do
+      context "with git sources" do
         let(:files) { project_dependency_files("git_tags_012") }
 
         specify { expect(subject.length).to eq(6) }
@@ -388,7 +388,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
         end
       end
 
-      context "with registry sources for 0.12" do
+      context "with registry sources" do
         let(:files) { project_dependency_files("registry_012") }
 
         its(:length) { is_expected.to eq(5) }
@@ -506,6 +506,29 @@ RSpec.describe Dependabot::Terraform::FileParser do
             expect(dependency.version).to eq("0.9.3")
             expect(dependency.requirements).to eq(expected_requirements)
           end
+        end
+      end
+
+      context "with terragrunt files" do
+        let(:files) { project_dependency_files("terragrunt_hcl") }
+
+        specify { expect(subject.length).to eq(1) }
+        specify { expect(subject).to all(be_a(Dependabot::Dependency)) }
+
+        it "has the right details for the first dependency" do
+          expect(subject[0].name).to eq("gruntwork-io/modules-example")
+          expect(subject[0].version).to eq("0.0.2")
+          expect(subject[0].requirements).to eq([{
+            requirement: nil,
+            groups: [],
+            file: "terragrunt.hcl",
+            source: {
+              type: "git",
+              url: "git@github.com:gruntwork-io/modules-example.git",
+              branch: nil,
+              ref: "v0.0.2"
+            }
+          }])
         end
       end
     end

--- a/terraform/spec/fixtures/projects/terragrunt_hcl/terragrunt.hcl
+++ b/terraform/spec/fixtures/projects/terragrunt_hcl/terragrunt.hcl
@@ -1,0 +1,30 @@
+
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that supports locking and enforces best
+# practices: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+# working directory, into a temporary folder, and execute your Terraform commands in that folder.
+terraform {
+  source = "git::git@github.com:gruntwork-io/modules-example.git//consul?ref=v0.0.2"
+}
+
+# Include all settings from the root terraform.tfvars file
+include = {
+  path = "${find_in_parent_folders()}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  aws_region   = "us-east-1"
+  cluster_name = "consul-prod"
+
+  num_servers = 3
+  num_clients = 6
+}


### PR DESCRIPTION
Since v0.19 (released in June 2019), terragrunt is configured using a
`terragrunt.hcl` file: https://terragrunt.gruntwork.io/docs/upgrade/upgrading_to_terragrunt_0.19.x/

This change adds support for _parsing_ those files. We still need to
make a few minor tweaks to also support fetching and updating these
files.