### PR TITLE
GitHub actions: skip equivalent shorter semver tags

### DIFF
--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -63,11 +63,13 @@ module Dependabot
 
         # If the dependency is pinned to a tag that looks like a version then
         # we want to update that tag.
-
         if git_commit_checker.pinned_ref_looks_like_version? &&
            git_commit_checker.local_tag_for_latest_version
           latest_tag = git_commit_checker.local_tag_for_latest_version
-          return latest_tag.fetch(:version)
+          latest_version = latest_tag.fetch(:version)
+          return version_class.new(dependency.version) if shortened_semver_eq?(dependency.version, latest_version.to_s)
+
+          return latest_version
         end
 
         # If the dependency is pinned to a commit SHA and the latest
@@ -139,6 +141,16 @@ module Dependabot
           ignored_versions: ignored_versions,
           raise_on_ignored: raise_on_ignored
         )
+      end
+
+      def shortened_semver_eq?(base, other)
+        return false unless base
+
+        base_split = base.split(".")
+        other_split = other.split(".")
+        return false unless base_split.length <= other_split.length
+
+        other_split[0..base_split.length - 1] == base_split
       end
     end
   end


### PR DESCRIPTION
This corrects a regression in the `github_actions` ecosystem, where a change to extend semver support had an unintended effect:

In Actions, it's common to maintain a mutable tag, like [actions/setup-node@v2](https://github.com/actions/setup-node/releases/tag/v2), in addition to full semver tags like [v2.1.5](https://github.com/actions/setup-node/releases/tag/v2.1.5).
By more aggressively interpreting refs as semver, Dependabot began proposing those mutable semver tags be upgraded to the "latest" version, since `v2 == v2.0.0`, which is `< v2.1.5`.

To resolve this, there's an added check in `Dependabot::GithubActions::UpdateChecker`, such that if the specified version is a shortened but equivalent semver tag,  any potential upgrade is ignored.

Corrected case, `actions/setup-node@v2`
```
=== actions/setup-node (2)
 => checking for updates 1/1
 => latest available version is 2
 => latest allowed version is 2
    (no update needed as it's already up-to-date)
```

Regression case, `actions/setup-node@v2.1.1`:
```
=== actions/setup-node (2.1.1)
 => checking for updates 1/1
 => latest available version is 2.1.5
 => latest allowed version is 2.1.5
 => requirements to unlock: own
 => requirements update strategy:
 => updating actions/setup-node from 2.1.1 to 2.1.5

    ± .github/workflows/pinned.yaml
    ~~~
    7c7
    <     - uses: actions/setup-node@v2.1.1
    ---
    >     - uses: actions/setup-node@v2.1.5
    ~~~
```

Regression case, `actions/setup-node@v1`
```
=== actions/setup-node (1)
 => checking for updates 1/1
 => latest available version is 2.1.5
 => latest allowed version is 2.1.5
 => requirements to unlock: own
 => requirements update strategy:
 => updating actions/setup-node from 1 to 2.1.5

    ± .github/workflows/pinned.yaml
    ~~~
    7c7
    <     - uses: actions/setup-node@v1
    ---
    >     - uses: actions/setup-node@v2.1.5
    ~~~
```




# Related
- Follows https://github.com/dependabot/dependabot-core/pull/3662
- Closes https://github.com/dependabot/dependabot-core/issues/3704
