### PR TITLE
v0.146.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.146.1, 12 May 2021
 
 - Actions: skip equivalent shorter semver tags, such as `v2` and `v2.1.0`
+- Python: Run all pip-compile commands with options @JimNero009
 - Terraform (prerelease): Handle terragrunt HCL files
 
 ## v0.146.0, 10 May 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.146.1, 12 May 2021
+
+- Actions: skip equivalent shorter semver tags, such as `v2` and `v2.1.0`
+- Terraform (prerelease): Handle terragrunt HCL files
+
 ## v0.146.0, 10 May 2021
 
 - go_modules: Refactor go module version finder specs

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.146.0"
+  VERSION = "0.146.1"
 end


### PR DESCRIPTION
https://github.com/dependabot/dependabot-core/compare/v0.146.0...v0.146.1-release-notes

* https://github.com/dependabot/dependabot-core/pull/3688
* https://github.com/dependabot/dependabot-core/pull/3692
* https://github.com/dependabot/dependabot-core/pull/3693
* https://github.com/dependabot/dependabot-core/pull/3697
* https://github.com/dependabot/dependabot-core/pull/3696
* https://github.com/dependabot/dependabot-core/pull/3695
* https://github.com/dependabot/dependabot-core/pull/3674
* https://github.com/dependabot/dependabot-core/pull/3708