### PR TITLE
Switch HCL2 parser to be the default

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -112,7 +112,8 @@ $options = {
   security_advisories: [],
   security_updates_only: false,
   ignore_conditions: [],
-  pull_request: false
+  pull_request: false,
+  legacy_terraform: false
 }
 
 unless ENV["LOCAL_GITHUB_ACCESS_TOKEN"].to_s.strip.empty?
@@ -144,6 +145,10 @@ unless ENV["IGNORE_CONDITIONS"].to_s.strip.empty?
   # For example:
   # [{"dependency-name":"ruby","version-requirement":">= 3.a, < 4"}]
   $options[:ignore_conditions] = JSON.parse(ENV["IGNORE_CONDITIONS"])
+end
+
+unless ENV["LEGACY_TERRAFORM"].to_s.strip.empty?
+  $options[:legacy_terraform] = true
 end
 
 # rubocop:disable Metrics/BlockLength
@@ -492,7 +497,8 @@ parser = Dependabot::FileParsers.for_package_manager($package_manager).new(
   repo_contents_path: $repo_contents_path,
   source: $source,
   credentials: $options[:credentials],
-  reject_external_code: $options[:reject_external_code]
+  reject_external_code: $options[:reject_external_code],
+  options: {legacy_terraform: $options[:legacy_terraform]}
 )
 
 dependencies = cached_read("dependencies") { parser.parse }

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -290,10 +290,10 @@ module Dependabot
       def parsed_file(file)
         @parsed_buildfile ||= {}
         @parsed_buildfile[file.name] ||=
-          if options[:terraform_hcl2]
-            parsed_file_hcl2(file)
-          else
+          if options[:legacy_terraform]
             parsed_file_hcl1(file)
+          else
+            parsed_file_hcl2(file)
           end
       rescue SharedHelpers::HelperSubprocessFailed => e
         msg = e.message.strip

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
       dependency_files: files,
       source: source,
       options: {
-        terraform_hcl2: PackageManagerHelper.use_terraform_hcl2?
+        legacy_terraform: PackageManagerHelper.use_terraform_hcl1?
       }
     )
   end

--- a/terraform/spec/spec_helper.rb
+++ b/terraform/spec/spec_helper.rb
@@ -11,12 +11,12 @@ end
 require "#{common_dir}/spec/spec_helper.rb"
 
 module PackageManagerHelper
-  def self.use_terraform_hcl2?
-    ENV["SUITE_NAME"] == "terraform-hcl2"
+  def self.use_terraform_hcl1?
+    ENV["LEGACY_TERRAFORM"]
   end
 
-  def self.use_terraform_hcl1?
-    !use_terraform_hcl2?
+  def self.use_terraform_hcl2?
+    !use_terraform_hcl1?
   end
 end
 


### PR DESCRIPTION
Switches the feature flag for HCL to use HCL2 as the default in Terraform's `FileParser`.

- The HCL1 parser can be enabled by setting the LEGACY_TERRAFORM environment variable to 'true'.