### PR TITLE
v0.147.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.147.0, 13 May 2021
+
+- Switch HCL2 parser to be the default for Terraform. Supports Terraform v0.12+
+
 ## v0.146.1, 12 May 2021
 
 - Actions: skip equivalent shorter semver tags, such as `v2` and `v2.1.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v0.147.0, 13 May 2021
 
-- Switch HCL2 parser to be the default for Terraform. Supports Terraform v0.12+
+- Switch HCL2 parser to be the default for Terraform. Supports Terraform v0.12+ [(#3716)](https://github.com/dependabot/dependabot-core/pull/3716)
 
 ## v0.146.1, 12 May 2021
 
@@ -36,7 +36,6 @@
 
 - go_modules: don't filter the current version
 - terraform: move fixtures to project folders
-
 ## v0.145.0, 5 May 2021
 
 - go_modules: support version ignores

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.146.1"
+  VERSION = "0.147.0"
 end


### PR DESCRIPTION
https://github.com/dependabot/dependabot-core/compare/v0.146.1...v0.147.0-release-notes

Enables support for Terraform v0.12+ (#3716)
- The legacy HCL1 parser can be enabled by setting the LEGACY_TERRAFORM environment variable to true.