### PR TITLE
Hex: Fix version resolver specs

### DIFF
--- a/hex/lib/dependabot/hex/update_checker/version_resolver.rb
+++ b/hex/lib/dependabot/hex/update_checker/version_resolver.rb
@@ -101,8 +101,7 @@ module Dependabot
           result = error.message&.split("\n")&.last
           return false unless result
 
-          JSON.parse(error.message&.split("\n")&.last)["result"]
-          true
+          JSON.parse(error.message&.split("\n")&.last).key?("result")
         rescue JSON::ParserError
           false
         end

--- a/hex/lib/dependabot/hex/update_checker/version_resolver.rb
+++ b/hex/lib/dependabot/hex/update_checker/version_resolver.rb
@@ -74,8 +74,10 @@ module Dependabot
             raise Dependabot::PrivateSourceAuthenticationFailure, org if org
           end
 
-          # TODO: This isn't pretty. It would be much nicer to catch the
-          # warnings as part of the Elixir module.
+          # TODO: Catch the warnings as part of the Elixir module. This happens
+          # when elixir throws warnings from the manifest files that end up in
+          # stdout and cause run_helper_subprocess to fail parsing the result as
+          # JSON.
           return error_result(error) if includes_result?(error)
 
           # Ignore dependencies which don't resolve due to mis-matching
@@ -121,6 +123,12 @@ module Dependabot
 
           true
         rescue SharedHelpers::HelperSubprocessFailed => e
+          # TODO: Catch the warnings as part of the Elixir module. This happens
+          # when elixir throws warnings from the manifest files that end up in
+          # stdout and cause run_helper_subprocess to fail parsing the result as
+          # JSON.
+          return error_result(e) if includes_result?(e)
+
           raise Dependabot::DependencyFileNotResolvable, e.message
         end
 


### PR DESCRIPTION
Fixes broken hex specs: https://github.com/dependabot/dependabot-core/pull/3719/checks?check_run_id=2581264410

Handle hex errors that return valid json, e.g. `{"error":"Dependency resolution failed: Can't continue due to errors on dependencies"}`

Previously we only checked if the sub-process output was parseable and tried to get the `result` key, but this will just return nil if the json is valid.

For context, valid results look like `{"result":"1.3.6"}`