### PR TITLE
npm: Handle workspace deps installed top-level

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -56,10 +56,11 @@ module Dependabot
           parsed_lockfile = parse_package_lock(lockfile)
 
           if Helpers.npm_version(lockfile.content) == "npm7"
-            parsed_lockfile.dig(
-              "packages",
-              node_modules_path(manifest_name, dependency_name)
-            )&.slice("version", "resolved", "integrity", "dev")
+            # NOTE: npm 7 sometimes doesn't install workspace dependencies in the
+            # workspace folder so we need to fallback to checking top-level
+            nested_details = parsed_lockfile.dig("packages", node_modules_path(manifest_name, dependency_name))
+            details = nested_details || parsed_lockfile.dig("packages", "node_modules/#{dependency_name}")
+            details&.slice("version", "resolved", "integrity", "dev")
           else
             parsed_lockfile.dig("dependencies", dependency_name)
           end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
       end
     end
 
-    context "for an npm7 workspace project with a direct dependency in the workspace" do
+    context "for an npm7 workspace project with a direct dependency that's installed in the workspace's node_modules" do
       let(:dependency_files) { project_dependency_files("npm7/workspace_nested_package") }
       let(:dependency_name) { "yargs" }
       let(:manifest_name) { "packages/build/package.json" }
@@ -278,6 +278,21 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
           "resolved" => "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
           "integrity" =>
             "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="
+        )
+      end
+    end
+
+    context "for an npm7 workspace project with a direct dependency that's installed in the top-level node_modules" do
+      let(:dependency_files) { project_dependency_files("npm7/workspace_nested_package_top_level") }
+      let(:dependency_name) { "uuid" }
+      let(:manifest_name) { "api/package.json" }
+
+      it "finds the correct dependency" do
+        expect(lockfile_details).to eq(
+          "version" => "8.3.2",
+          "resolved" => "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity" =>
+            "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         )
       end
     end

--- a/npm_and_yarn/spec/fixtures/projects/npm7/workspace_nested_package_top_level/api/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/workspace_nested_package_top_level/api/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "api-test",
+	"version": "0.0.0",
+	"homepage": "https://github.com/dependabot/test",
+	"description": "Test",
+	"dependencies": {
+		"uuid": "^8.3.2"
+	}
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/workspace_nested_package_top_level/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/workspace_nested_package_top_level/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "workspaces": [
+        "./api"
+      ]
+    },
+    "api": {
+      "name": "api-test",
+      "version": "0.0.0",
+      "dependencies": {
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/api-test": {
+      "resolved": "api",
+      "link": true
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  },
+  "dependencies": {
+    "api-test": {
+      "version": "file:api",
+      "requires": {
+        "uuid": "^8.3.2"
+      }
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm7/workspace_nested_package_top_level/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/workspace_nested_package_top_level/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "workspaces": [
+    "./api"
+  ],
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Handle nested workspace dependencies that have been installed in the
top-level `node_modules` folder instead of the nested
`workspace/node_modules` folder.

While this case returned `nil` previously, we still ended up extracting
lockfile details for the dependency by checking all instances of the
same dependency and picking the lowest version, meaning the `from`
version in updates was incorrect.

It seems this happens when the package is only installed once, so
doesn't end up having several versions across different pacakges.