### PR TITLE
v0.148.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Terraform: Support provider updates
 - Terraform: Extract RegistryClient for communicating with terraform registry
-- Go modules: Replace custom helper with `go get -d lib@version`
+- Go modules: Replace custom helper with `go get -d lib@version` @jeffwidman
 
 ## v0.147.1, 18 May 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.148.0, 19 May 2021
+
+- Terraform: Support provider updates
+- Terraform: Extract RegistryClient for communicating with terraform registry
+- Go modules: Replace custom helper with `go get -d lib@version`
+
 ## v0.147.1, 18 May 2021
 
 - Terraform: remove legacy terraform feature flag

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.147.1"
+  VERSION = "0.148.0"
 end


### PR DESCRIPTION
- Terraform: Support provider updates
- Terraform: Extract RegistryClient for communicating with terraform registry
- Go modules: Replace custom helper with `go get -d lib@version`