### PR TITLE
v0.148.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.148.1, 19 May 2021
+
+- npm: Handle nested workspace dependencies installed in the top-level
+  `node_modules` folder
+
 ## v0.148.0, 19 May 2021
 
 - Terraform: Support provider updates

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.148.0"
+  VERSION = "0.148.1"
 end


### PR DESCRIPTION
## v0.148.1, 19 May 2021

- npm: Handle nested workspace dependencies installed in the top-level
  `node_modules` folder