### PR TITLE
v0.148.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.148.3, 19 May 2021
+
+- fix(common): skip validation on non-git sources
+- fix(npm/yarn): prefer private registries over public ones
+
 ## v0.148.2, 19 May 2021
 
 - Terraform: Fix finding metadata for providers

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.148.2"
+  VERSION = "0.148.3"
 end


### PR DESCRIPTION
## v0.148.3, 19 May 2021

- fix(common): skip validation on non-git sources
- fix(npm/yarn): prefer private registries over public ones

https://github.com/dependabot/dependabot-core/compare/v0.148.2...71046cae9e803b62d651fb850cef978c89aa62f1