### PR TITLE
Parse version from terraform lock file

### DIFF
--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -184,15 +184,6 @@ module Dependabot
         end
       end
 
-      def provider_source_from(source_address)
-        matches = source_address.match(PROVIDER_SOURCE_ADDRESS)
-        [
-          matches[:hostname] || DEFAULT_REGISTRY,
-          matches[:namespace],
-          matches[:name]
-        ]
-      end
-
       def git_source_details_from(source_string)
         git_url = source_string.strip.gsub(/^git::/, "")
         git_url = "https://" + git_url unless git_url.start_with?("git@") || git_url.include?("://")

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -336,11 +336,11 @@ module Dependabot
       def determine_version_for(hostname, namespace, name, constraint)
         return constraint if constraint&.match?(/\A\d/)
 
-        return lock_file_content.dig(
-          'provider',
+        lock_file_content.dig(
+          "provider",
           "#{hostname}/#{namespace}/#{name}",
           0,
-          'version'
+          "version"
         )
       end
 
@@ -348,7 +348,7 @@ module Dependabot
         @lock_file_content ||=
           begin
             lock_file = dependency_files.find do |file|
-              file.name == '.terraform.lock.hcl'
+              file.name == ".terraform.lock.hcl"
             end
             lock_file ? parsed_file(lock_file) : {}
           end

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -341,23 +341,17 @@ module Dependabot
           "#{hostname}/#{namespace}/#{name}",
           0,
           'version'
-        ) if lock_file?
-      end
-
-      def lock_file?
-        lock_file
-      end
-
-      def lock_file
-        return @lock_file if defined?(@lock_file)
-
-        @lock_file ||= dependency_files.find do |file|
-          file.name == '.terraform.lock.hcl'
-        end
+        )
       end
 
       def lock_file_content
-        @lock_file_content ||= parsed_file(lock_file)
+        @lock_file_content ||=
+          begin
+            lock_file = dependency_files.find do |file|
+              file.name == '.terraform.lock.hcl'
+            end
+            lock_file ? parsed_file(lock_file) : {}
+          end
       end
     end
   end

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -64,7 +64,7 @@ module Dependabot
 
         Dependency.new(
           name: "#{namespace}/#{name}",
-          version: version,
+          version: version, # resolved version should come from `.terraform.lock.hcl`.
           package_manager: "terraform",
           requirements: [
             requirement: version,

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -336,12 +336,8 @@ module Dependabot
       def determine_version_for(hostname, namespace, name, constraint)
         return constraint if constraint&.match?(/\A\d/)
 
-        lock_file_content.dig(
-          "provider",
-          "#{hostname}/#{namespace}/#{name}",
-          0,
-          "version"
-        )
+        lock_file_content.
+          dig("provider", "#{hostname}/#{namespace}/#{name}", 0, "version")
       end
 
       def lock_file_content

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -94,7 +94,7 @@ module Dependabot
 
         Dependency.new(
           name: dependency_name,
-          version: version, # resolved version should come from `.terraform.lock.hcl`.
+          version: resolve_version_from(version),
           package_manager: "terraform",
           requirements: [
             requirement: version,
@@ -331,6 +331,10 @@ module Dependabot
         return if [*terraform_files, *terragrunt_files].any?
 
         raise "No Terraform configuration file!"
+      end
+
+      def resolve_version_from(constraint)
+        constraint&.match?(/\A\d/) ? constraint : nil
       end
     end
   end

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -167,6 +167,26 @@ RSpec.describe Dependabot::Terraform::FileParser do
       end
     end
 
+    context "with a pessimistic constraint and a lockfile" do
+      let(:files) { project_dependency_files("pessimistic_constraint_lock_file") }
+
+      it "parses the dependency correctly" do
+        expect(subject.length).to eq(1)
+        expect(subject[0].name).to eq("hashicorp/http")
+        expect(subject[0].version).to eq("2.1.0")
+        expect(subject[0].requirements).to eq([{
+          requirement: "~> 2.0",
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "provider",
+            registry_hostname: "registry.terraform.io",
+            module_identifier: "hashicorp/http"
+          }
+        }])
+      end
+    end
+
     context "with git sources" do
       let(:files) { project_dependency_files("git_tags_011") }
       specify { expect(subject.length).to eq(6) }

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -130,12 +130,32 @@ RSpec.describe Dependabot::Terraform::FileParser do
     context "with a private registry" do
       let(:files) { project_dependency_files("private_registry") }
 
-      it "parses the host correctly" do
+      it "parses the dependency correctly" do
         expect(subject.length).to eq(1)
         expect(subject[0].name).to eq("namespace/name")
         expect(subject[0].version).to eq("0.1.0")
         expect(subject[0].requirements).to eq([{
           requirement: "0.1.0",
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "provider",
+            registry_hostname: "registry.example.org",
+            module_identifier: "namespace/name"
+          }
+        }])
+      end
+    end
+
+    context "with a private registry using a pessimistic version constraint" do
+      let(:files) { project_dependency_files("private_registry_pessimistic_constraint") }
+
+      it "parses the dependency correctly" do
+        expect(subject.length).to eq(1)
+        expect(subject[0].name).to eq("namespace/name")
+        expect(subject[0].version).to be_nil
+        expect(subject[0].requirements).to eq([{
+          requirement: "~> 0.1",
           groups: [],
           file: "main.tf",
           source: {

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -127,6 +127,28 @@ RSpec.describe Dependabot::Terraform::FileParser do
       end
     end
 
+    context "with a private registry" do
+      let(:files) { project_dependency_files("private_registry") }
+
+      specify { expect(subject.length).to eq(1) }
+      specify { expect(subject).to all(be_a(Dependabot::Dependency)) }
+
+      it "parses the host correctly" do
+        expect(subject[0].name).to eq("namespace/name")
+        expect(subject[0].version).to be_nil
+        expect(subject[0].requirements).to eq([{
+          requirement: nil,
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "provider",
+            registry_hostname: "registry.example.org",
+            module_identifier: "namespace/name"
+          }
+        }])
+      end
+    end
+
     context "with git sources" do
       let(:files) { project_dependency_files("git_tags_011") }
       specify { expect(subject.length).to eq(6) }

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -130,14 +130,12 @@ RSpec.describe Dependabot::Terraform::FileParser do
     context "with a private registry" do
       let(:files) { project_dependency_files("private_registry") }
 
-      specify { expect(subject.length).to eq(1) }
-      specify { expect(subject).to all(be_a(Dependabot::Dependency)) }
-
       it "parses the host correctly" do
+        expect(subject.length).to eq(1)
         expect(subject[0].name).to eq("namespace/name")
-        expect(subject[0].version).to be_nil
+        expect(subject[0].version).to eq("0.1.0")
         expect(subject[0].requirements).to eq([{
-          requirement: nil,
+          requirement: "0.1.0",
           groups: [],
           file: "main.tf",
           source: {

--- a/terraform/spec/fixtures/projects/pessimistic_constraint_lock_file/.terraform.lock.hcl
+++ b/terraform/spec/fixtures/projects/pessimistic_constraint_lock_file/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/http" {
+  version     = "2.1.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:GYoVrTtiSAE3AlP1fad3fFmHoPaXAPhm/DJyMcVCwZA=",
+    "zh:03d82dc0887d755b8406697b1d27506bc9f86f93b3e9b4d26e0679d96b802826",
+    "zh:0704d02926393ddc0cfad0b87c3d51eafeeae5f9e27cc71e193c141079244a22",
+    "zh:095ea350ea94973e043dad2394f10bca4a4bf41be775ba59d19961d39141d150",
+    "zh:0b71ac44e87d6964ace82979fc3cbb09eb876ed8f954449481bcaa969ba29cb7",
+    "zh:0e255a170db598bd1142c396cefc59712ad6d4e1b0e08a840356a371e7b73bc4",
+    "zh:67c8091cfad226218c472c04881edf236db8f2dc149dc5ada878a1cd3c1de171",
+    "zh:75df05e25d14b5101d4bc6624ac4a01bb17af0263c9e8a740e739f8938b86ee3",
+    "zh:b4e36b2c4f33fdc44bf55fa1c9bb6864b5b77822f444bd56f0be7e9476674d0e",
+    "zh:b9b36b01d2ec4771838743517bc5f24ea27976634987c6d5529ac4223e44365d",
+    "zh:ca264a916e42e221fddb98d640148b12e42116046454b39ede99a77fc52f59f4",
+    "zh:fe373b2fb2cc94777a91ecd7ac5372e699748c455f44f6ea27e494de9e5e6f92",
+  ]
+}

--- a/terraform/spec/fixtures/projects/pessimistic_constraint_lock_file/main.tf
+++ b/terraform/spec/fixtures/projects/pessimistic_constraint_lock_file/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    http = {
+      source  = "registry.terraform.io/hashicorp/http"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/terraform/spec/fixtures/projects/private_registry/main.tf
+++ b/terraform/spec/fixtures/projects/private_registry/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    example = {
+      source  = "registry.example.org/namespace/name"
+      version = "0.1.0"
+    }
+  }
+}

--- a/terraform/spec/fixtures/projects/private_registry_pessimistic_constraint/main.tf
+++ b/terraform/spec/fixtures/projects/private_registry_pessimistic_constraint/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    example = {
+      source = "registry.example.org/namespace/name"
+      version = "~> 0.1"
+    }
+  }
+}


### PR DESCRIPTION
# Why is this needed?

To parse the version from the [terraform lock file][lock_file] so that
the correct version is compared against the eligible versions.

fixes:

```bash
updater | INFO <job_139154747> Starting job processing
updater | INFO <job_139154747> Starting update job for dsp-testing/dependabot-updates-1480
updater | INFO <job_139154747> Checking if hashicorp/aws ~> 3.0 needs updating
  proxy | 2021/05/25 19:31:39 [012] GET https://registry.terraform.io:443/v1/providers/hashicorp/aws/versions
  proxy | 2021/05/25 19:31:39 [012] 200 https://registry.terraform.io:443/v1/providers/hashicorp/aws/versions
updater | INFO <job_139154747> Latest version is 3.42.0
updater | I, [2021-05-25T19:31:39.299128 #7]  INFO -- sentry: ** [Raven] Sending event 2930bd6eaf7e4716bbf3ed064fb224f7 to Sentry
  proxy | 2021/05/25 19:31:39 [014] POST https://sentry.io:443/api/1451818/store/
  proxy | 2021/05/25 19:31:39 [014] 200 https://sentry.io:443/api/1451818/store/
updater | ERROR <job_139154747> Error processing hashicorp/aws (ArgumentError)
updater | ERROR <job_139154747> Malformed version number string ~> 3.0
updater | ERROR <job_139154747> /usr/lib/ruby/2.6.0/rubygems/version.rb:212:in `initialize'
updater | ERROR <job_139154747> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-terraform-0.148.8/lib/dependabot/terraform/version.rb:14:in `initialize'
updater | ERROR <job_139154747> /usr/lib/ruby/2.6.0/rubygems/version.rb:201:in `new'
updater | ERROR <job_139154747> /usr/lib/ruby/2.6.0/rubygems/version.rb:201:in `new'
updater | ERROR <job_139154747> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-common-0.148.8/lib/dependabot/update_checkers/base.rb:238:in `numeric_version_up_to_date?'
updater | ERROR <job_139154747> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-common-0.148.8/lib/dependabot/update_checkers/base.rb:189:in `version_up_to_date?'
updater | ERROR <job_139154747> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-common-0.148.8/lib/dependabot/update_checkers/base.rb:33:in `up_to_date?'
updater | ERROR <job_139154747> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:205:in `check_and_create_pull_request'
updater | ERROR <job_139154747> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:80:in `check_and_create_pr_with_error_handling'
updater | ERROR <job_139154747> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:56:in `block in run'
updater | ERROR <job_139154747> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:56:in `each'
updater | ERROR <job_139154747> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:56:in `run'
updater | ERROR <job_139154747> /home/dependabot/dependabot-updater/lib/dependabot/update_files_job.rb:17:in `perform_job'
updater | ERROR <job_139154747> /home/dependabot/dependabot-updater/lib/dependabot/base_job.rb:28:in `run'
updater | ERROR <job_139154747> bin/update_files.rb:21:in `<main>'
updater | INFO <job_139154747> Checking if namespace/name ~> 0.1 needs updating
updater | INFO <job_139154747> Latest version is 
updater | INFO <job_139154747> Requirements to unlock update_not_possible
updater | INFO <job_139154747> Requirements update strategy 
updater | INFO <job_139154747> No update possible for namespace/name ~> 0.1
updater | INFO <job_139154747> Finished job processing
```

## What does this do?

It parses the version from the [lock file][lock_file].

/xref: https://github.com/github/dependabot-updates/issues/1480

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Verification Plan

- [ ] `.deploy ` this PR
- [ ] Re-run update job for [test repo](https://github.com/dsp-testing/dependabot-updates-1480/network/updates/)

[source_address]: https://www.terraform.io/docs/language/providers/requirements.html#source-addresses
[lock_file]: https://www.terraform.io/docs/language/dependency-lock.html
