### PR TITLE
Dockerfile: split up native helper build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -225,17 +225,17 @@ ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt" \
 
 USER dependabot
 RUN mkdir -p /opt/bundler/v1 \
-  && mkdir -p /opt/bundler/v2 \
-  && bash /opt/bundler/helpers/v1/build /opt/bundler/v1 \
-  && bash /opt/bundler/helpers/v2/build /opt/bundler/v2 \
-  && bash /opt/dep/helpers/build /opt/dep \
-  && bash /opt/go_modules/helpers/build /opt/go_modules \
-  && bash /opt/hex/helpers/build /opt/hex \
-  && bash /opt/npm_and_yarn/helpers/build /opt/npm_and_yarn \
-  && bash /opt/python/helpers/build /opt/python \
-  && bash /opt/terraform/helpers/build /opt/terraform \
-  && bash /opt/composer/helpers/v1/build /opt/composer/v1 \
-  && bash /opt/composer/helpers/v2/build /opt/composer/v2
+  && mkdir -p /opt/bundler/v2
+RUN bash /opt/bundler/helpers/v1/build /opt/bundler/v1
+RUN bash /opt/bundler/helpers/v2/build /opt/bundler/v2
+RUN bash /opt/dep/helpers/build /opt/dep
+RUN bash /opt/go_modules/helpers/build /opt/go_modules
+RUN bash /opt/hex/helpers/build /opt/hex
+RUN bash /opt/npm_and_yarn/helpers/build /opt/npm_and_yarn
+RUN bash /opt/python/helpers/build /opt/python
+RUN bash /opt/terraform/helpers/build /opt/terraform
+RUN bash /opt/composer/helpers/v1/build /opt/composer/v1
+RUN bash /opt/composer/helpers/v2/build /opt/composer/v2
 
 # Allow further gem installs as the dependabot user
 ENV HOME="/home/dependabot"


### PR DESCRIPTION
This allows for better caching and also gives us more information when
one of these build steps fails.