### PR TITLE
Terraform: Improve updating provider requirements

### DIFF
--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -74,7 +74,7 @@ module Dependabot
 
       def update_registry_declaration(new_req, old_req, updated_content)
         updated_content.sub!(registry_declaration_regex) do |regex_match|
-          regex_match.sub(/version\s*=.*/) do |req_line_match|
+          regex_match.sub(/^\s*version\s*=.*/) do |req_line_match|
             req_line_match.sub(old_req[:requirement], new_req[:requirement])
           end
         end

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -376,6 +376,8 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
         expect(updated_file.content).to include(
           <<~DEP
             terraform {
+              required_version = ">= 0.12"
+
               required_providers {
                 aws = {
                   source  = "hashicorp/aws"

--- a/terraform/spec/fixtures/projects/registry_provider/main.tf
+++ b/terraform/spec/fixtures/projects/registry_provider/main.tf
@@ -1,8 +1,19 @@
 terraform {
+  required_version = ">= 0.12"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "0.1.0"
     }
+
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 2.0"
+    }
   }
+}
+
+provider "aws" {
+  region = "eu-west-1"
 }


### PR DESCRIPTION
Previously we would match for any `version` string, and this would end
up matching on `required_version`, and we'd fail to update these
configs.