### PR TITLE
Terraform: Fix updating multiple providers

### DIFF
--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -73,7 +73,8 @@ module Dependabot
       end
 
       def update_registry_declaration(new_req, old_req, updated_content)
-        updated_content.sub!(registry_declaration_regex) do |regex_match|
+        regex = new_req[:source][:type] == "provider" ? provider_declaration_regex : registry_declaration_regex
+        updated_content.sub!(regex) do |regex_match|
           regex_match.sub(/^\s*version\s*=.*/) do |req_line_match|
             req_line_match.sub(old_req[:requirement], new_req[:requirement])
           end
@@ -94,6 +95,14 @@ module Dependabot
         return if [*terraform_files, *terragrunt_files].any?
 
         raise "No Terraform configuration file!"
+      end
+
+      def provider_declaration_regex
+        /
+          (?:required_providers\s\{)*
+          (source\s*=\s*["']#{Regexp.escape(dependency.name)}["']
+          (?:(?!^\}).)+)
+        /mx
       end
 
       def registry_declaration_regex

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -514,9 +514,8 @@ RSpec.describe Dependabot::Terraform::FileParser do
       let(:files) { project_dependency_files("registry_provider") }
 
       it "has the right details" do
-        dependency = dependencies.first
+        dependency = dependencies.find { |d| d.name == "hashicorp/aws" }
 
-        expect(dependency.name).to eq("hashicorp/aws")
         expect(dependency.version).to eq("0.1.0")
       end
     end

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -379,6 +379,11 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
               required_version = ">= 0.12"
 
               required_providers {
+                http = {
+                  source  = "hashicorp/http"
+                  version = "~> 2.0"
+                }
+
                 aws = {
                   source  = "hashicorp/aws"
                   version = "3.40.0"

--- a/terraform/spec/fixtures/projects/registry_provider/main.tf
+++ b/terraform/spec/fixtures/projects/registry_provider/main.tf
@@ -2,14 +2,14 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "0.1.0"
-    }
-
     http = {
       source  = "hashicorp/http"
       version = "~> 2.0"
+    }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "0.1.0"
     }
   }
 }


### PR DESCRIPTION
Previously, the regex we used to figure out which part of the codebase
to run the replace on was too broad, and would include the entire
`required_providers` block, which results in the replace only working on
the first provider in the file.

This adds a new regex to use for provider updates, which will find the
specific provider within the `required_providers` block.

Fixes https://github.com/dependabot/dependabot-core/issues/3760