### PR TITLE
v0.148.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.148.5, 21 May 2021
+
+- Terraform: Fix updating multiple providers
+- Dockerfile: split up native helper build steps
+
 ## v0.148.4, 21 May 2021
 
 - Terraform: Improve updating provider requirements

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.148.4"
+  VERSION = "0.148.5"
 end


### PR DESCRIPTION
## v0.148.5, 21 May 2021

- Terraform: Fix updating multiple providers
- Dockerfile: split up native helper build steps
