### PR TITLE
Handle nil version when raising AllVersionsIgnored

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -84,6 +84,8 @@ module Dependabot
         end
 
         def filter_lower_versions(versions_array)
+          return versions_array unless dependency.version
+
           versions_array.
             select { |version| version > Gem::Version.new(dependency.version) }
         end

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -122,6 +122,17 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
         end
       end
 
+      context "when the current version isn't known" do
+        let(:current_version) { nil }
+
+        context "raise_on_ignored" do
+          let(:raise_on_ignored) { true }
+          it "doesn't raise an error" do
+            expect { subject }.to_not raise_error
+          end
+        end
+      end
+
       context "when the user has ignored all later versions" do
         let(:ignored_versions) { ["> 1.3.0"] }
 

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -69,6 +69,8 @@ module Dependabot
         end
 
         def filter_lower_versions(versions_array)
+          return versions_array unless dependency.version
+
           versions_array.
             select { |version| version > version_class.new(dependency.version) }
         end

--- a/cargo/spec/dependabot/cargo/update_checker/latest_version_finder_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/latest_version_finder_spec.rb
@@ -160,6 +160,17 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::LatestVersionFinder do
         end
       end
     end
+
+    context "when the dependency version isn't known" do
+      let(:dependency_version) { nil }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
   end
 
   describe "#lowest_security_fix_version" do

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -75,6 +75,8 @@ module Dependabot
         end
 
         def filter_lower_versions(versions_array)
+          return versions_array unless dependency.version
+
           versions_array.
             select { |version| version > version_class.new(dependency.version) }
         end

--- a/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
@@ -93,6 +93,17 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
       it { is_expected.to eq(Gem::Version.new("1.21.0")) }
     end
 
+    context "when the dependency version isn't known" do
+      let(:dependency_version) { nil }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
+
     context "when the user is ignoring all versions" do
       let(:ignored_versions) { [">= 0"] }
       it "returns nil" do

--- a/elm/lib/dependabot/elm/update_checker.rb
+++ b/elm/lib/dependabot/elm/update_checker.rb
@@ -87,6 +87,8 @@ module Dependabot
       end
 
       def filter_lower_versions(versions_array)
+        return versions_array unless dependency.version
+
         versions_array.
           select { |version| version > version_class.new(dependency.version) }
       end

--- a/elm/spec/dependabot/elm/update_checker_spec.rb
+++ b/elm/spec/dependabot/elm/update_checker_spec.rb
@@ -203,5 +203,16 @@ RSpec.describe Dependabot::Elm::UpdateChecker do
         end
       end
     end
+
+    context "when the dependency version isn't known" do
+      let(:dependency_version) { nil }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
   end
 end

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -124,6 +124,8 @@ module Dependabot
         end
 
         def filter_lower_versions(possible_versions)
+          return possible_versions unless dependency.version
+
           possible_versions.select do |v|
             v.fetch(:version) > version_class.new(dependency.version)
           end

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -186,6 +186,17 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
       end
     end
 
+    context "when the dependency version isn't known" do
+      let(:dependency_version) { nil }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
+
     context "when the current version isn't normal" do
       let(:dependency_version) { "RELEASE802" }
       its([:version]) { is_expected.to eq(version_class.new("23.0")) }

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -120,6 +120,8 @@ module Dependabot
         end
 
         def filter_lower_versions(possible_versions)
+          return possible_versions unless dependency.version
+
           possible_versions.select do |v|
             v.fetch(:version) > version_class.new(dependency.version)
           end

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -562,6 +562,17 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
         end
       end
     end
+
+    context "when the dependency version isn't known" do
+      let(:dependency_version) { nil }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
   end
 
   describe "#versions" do

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -138,6 +138,8 @@ module Dependabot
         end
 
         def filter_lower_versions(versions_array)
+          return versions_array unless dependency.version
+
           versions_array.
             select { |version, _| version > version_class.new(dependency.version) }
         end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
@@ -107,6 +107,17 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
       it { is_expected.to eq(Gem::Version.new("1.6.0")) }
     end
 
+    context "when the current version isn't known" do
+      let(:dependency_version) { nil }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
+
     context "when the user wants a dist tag" do
       let(:dependency) do
         Dependabot::Dependency.new(

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -114,8 +114,9 @@ module Dependabot
         end
 
         def filter_lower_versions(versions_array)
-          versions_array.
-            select { |version| version > version_class.new(dependency.version) }
+          return versions_array unless dependency.version
+
+          versions_array.select { |version| version > version_class.new(dependency.version) }
         end
 
         def filter_out_of_range_versions(versions_array)

--- a/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
@@ -212,6 +212,17 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
       end
     end
 
+    context "when the dependency version isn't known" do
+      let(:dependency_version) { nil }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
+
     context "when the user is ignoring all later versions" do
       let(:ignored_versions) { ["> 2.0.0"] }
       it { is_expected.to eq(Gem::Version.new("2.0.0")) }


### PR DESCRIPTION
Handle the `dependency.version` being nil, which it might be when the
version isn't known because there's now lockfile.