### PR TITLE
v0.148.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.148.6, 21 May 2021
+
+- Handle nil dependency version when raising AllVersionsIgnored
+
 ## v0.148.5, 21 May 2021
 
 - Terraform: Fix updating multiple providers

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.148.5"
+  VERSION = "0.148.6"
 end


### PR DESCRIPTION
## v0.148.6, 21 May 2021

- Handle nil dependency version when raising AllVersionsIgnored
