### PR TITLE
Composer: handle unreachable git vcs source

### DIFF
--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -37,6 +37,8 @@ module Dependabot
         VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-_]+)*/.freeze
         SOURCE_TIMED_OUT_REGEX =
           /The "(?<url>[^"]+packages\.json)".*timed out/.freeze
+        FAILED_GIT_CLONE_WITH_MIRROR = /Failed to execute git clone --mirror[^']*'(?<url>.*?)'/.freeze
+        FAILED_GIT_CLONE = /Failed to clone (?<url>.*?) via/.freeze
 
         def initialize(credentials:, dependency:, dependency_files:,
                        requirements_to_unlock:, latest_allowable_version:)
@@ -244,15 +246,11 @@ module Dependabot
             raise PrivateSourceAuthenticationFailure, "nova.laravel.com"
           end
 
-          if error.message.start_with?("Failed to execute git clone")
-            dependency_url =
-              error.message.match(/--mirror '(?<url>.*?)'/).
-              named_captures.fetch("url")
+          if error.message.match?(FAILED_GIT_CLONE_WITH_MIRROR)
+            dependency_url = error.message.match(FAILED_GIT_CLONE_WITH_MIRROR).named_captures.fetch("url")
             raise Dependabot::GitDependenciesNotReachable, dependency_url
-          elsif error.message.start_with?("Failed to clone")
-            dependency_url =
-              error.message.match(/Failed to clone (?<url>.*?) via/).
-              named_captures.fetch("url")
+          elsif error.message.match?(FAILED_GIT_CLONE)
+            dependency_url = error.message.match(FAILED_GIT_CLONE).named_captures.fetch("url")
             raise Dependabot::GitDependenciesNotReachable, dependency_url
           elsif unresolvable_error?(error)
             raise Dependabot::DependencyFileNotResolvable, sanitized_message
@@ -304,13 +302,10 @@ module Dependabot
             nil
           elsif error.message.include?("URL required authentication") ||
                 error.message.include?("403 Forbidden")
-            source =
-              error.message.match(%r{https?://(?<source>[^/]+)/}).
-              named_captures.fetch("source")
+            source = error.message.match(%r{https?://(?<source>[^/]+)/}).named_captures.fetch("source")
             raise Dependabot::PrivateSourceAuthenticationFailure, source
           elsif error.message.match?(SOURCE_TIMED_OUT_REGEX)
-            url = error.message.match(SOURCE_TIMED_OUT_REGEX).
-                  named_captures.fetch("url")
+            url = error.message.match(SOURCE_TIMED_OUT_REGEX).named_captures.fetch("url")
             raise if url.include?("packagist.org")
 
             source = url.gsub(%r{/packages.json$}, "")

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -228,6 +228,52 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       end
     end
 
+    context "with a missing vcs repository source (composer v1)" do
+      let(:project_name) { "v1/vcs_source_unreachable" }
+
+      it "raises a Dependabot::DependencyFileNotResolvable error" do
+        expect { resolver.latest_resolvable_version }.
+          to raise_error(Dependabot::GitDependenciesNotReachable) do |error|
+            expect(error.dependency_urls).
+              to eq(["https://github.com/dependabot-fixtures/this-repo-does-not-exist.git"])
+          end
+      end
+    end
+
+    context "with a missing vcs repository source" do
+      let(:project_name) { "vcs_source_unreachable" }
+
+      it "raises a Dependabot::DependencyFileNotResolvable error" do
+        expect { resolver.latest_resolvable_version }.
+          to raise_error(Dependabot::GitDependenciesNotReachable) do |error|
+            expect(error.dependency_urls).
+              to eq(["https://github.com/dependabot-fixtures/this-repo-does-not-exist.git"])
+          end
+      end
+    end
+
+    context "with a missing git repository source" do
+      let(:project_name) { "git_source_unreachable" }
+      let(:dependency_name) { "symfony/polyfill-mbstring" }
+      let(:dependency_version) { "1.0.1" }
+      let(:requirements) do
+        [{
+          file: "composer.json",
+          requirement: "1.0.*",
+          groups: [],
+          source: nil
+        }]
+      end
+
+      it "raises a Dependabot::DependencyFileNotResolvable error" do
+        expect { resolver.latest_resolvable_version }.
+          to raise_error(Dependabot::GitDependenciesNotReachable) do |error|
+            expect(error.dependency_urls).
+              to eq(["https://github.com/no-exist-sorry/monolog.git"])
+          end
+      end
+    end
+
     # This test is extremely slow, as it needs to wait for Composer to time out.
     # As a result we currently keep it commented out.
     # context "with an unreachable private registry" do

--- a/composer/spec/fixtures/projects/v1/vcs_source_unreachable/composer.json
+++ b/composer/spec/fixtures/projects/v1/vcs_source_unreachable/composer.json
@@ -1,0 +1,12 @@
+{
+  "require": {
+      "jazz/phpunit-test-extension": "1.2.2",
+      "symfony/polyfill-mbstring": "1.0.1"
+  },
+  "repositories": [
+    {
+        "type": "vcs",
+        "url": "git@github.com:dependabot-fixtures/this-repo-does-not-exist.git"
+    }
+  ]
+}

--- a/composer/spec/fixtures/projects/v1/vcs_source_unreachable/composer.lock
+++ b/composer/spec/fixtures/projects/v1/vcs_source_unreachable/composer.lock
@@ -1,0 +1,119 @@
+{
+  "_readme": [
+      "This file locks the dependencies of your project to a known state",
+      "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+      "This file is @generated automatically"
+  ],
+  "content-hash": "487e925ea7a1432a4eb8ace699e73ef1",
+  "packages": [
+      {
+          "name": "monolog/monolog",
+          "version": "dev-example",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/no-exist-sorry/monolog.git",
+              "reference": "303b8a83c87d5c6d749926cf02620465a5dcd0f2"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/no-exist-sorry/monolog/zipball/303b8a83c87d5c6d749926cf02620465a5dcd0f2",
+              "reference": "303b8a83c87d5c6d749926cf02620465a5dcd0f2",
+              "shasum": ""
+          },
+          "require": {
+              "php": ">=5.3.0"
+          },
+          "type": "library",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Jordi Boggiano",
+                  "email": "j.boggiano@seld.be",
+                  "homepage": "http://seld.be"
+              }
+          ],
+          "description": "Logging for PHP 5.3",
+          "homepage": "http://github.com/Seldaek/monolog",
+          "keywords": [
+              "log",
+              "logging"
+          ],
+          "support": {
+              "source": "https://github.com/no-exist-sorry/monolog/tree/1.0.1"
+          },
+          "time": "2011-08-25 20:42:58"
+      },
+      {
+          "name": "symfony/polyfill-mbstring",
+          "version": "v1.0.1",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/symfony/polyfill-mbstring.git",
+              "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/49ff736bd5d41f45240cec77b44967d76e0c3d25",
+              "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25",
+              "shasum": ""
+          },
+          "require": {
+              "php": ">=5.3.3"
+          },
+          "suggest": {
+              "ext-mbstring": "For best performance"
+          },
+          "type": "library",
+          "extra": {
+              "branch-alias": {
+                  "dev-master": "1.0-dev"
+              }
+          },
+          "autoload": {
+              "psr-4": {
+                  "Symfony\\Polyfill\\Mbstring\\": ""
+              },
+              "files": [
+                  "bootstrap.php"
+              ]
+          },
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Nicolas Grekas",
+                  "email": "p@tchwork.com"
+              },
+              {
+                  "name": "Symfony Community",
+                  "homepage": "https://symfony.com/contributors"
+              }
+          ],
+          "description": "Symfony polyfill for the Mbstring extension",
+          "homepage": "https://symfony.com",
+          "keywords": [
+              "compatibility",
+              "mbstring",
+              "polyfill",
+              "portable",
+              "shim"
+          ],
+          "time": "2015-11-20T09:19:13+00:00"
+      }
+  ],
+  "packages-dev": [],
+  "aliases": [],
+  "minimum-stability": "stable",
+  "stability-flags": {
+      "monolog/monolog": 20
+  },
+  "prefer-stable": false,
+  "prefer-lowest": false,
+  "platform": [],
+  "platform-dev": [],
+  "plugin-api-version": "1.0.0"
+}

--- a/composer/spec/fixtures/projects/vcs_source_unreachable/composer.json
+++ b/composer/spec/fixtures/projects/vcs_source_unreachable/composer.json
@@ -1,0 +1,12 @@
+{
+  "require": {
+      "jazz/phpunit-test-extension": "1.2.2",
+      "symfony/polyfill-mbstring": "1.0.1"
+  },
+  "repositories": [
+    {
+        "type": "vcs",
+        "url": "git@github.com:dependabot-fixtures/this-repo-does-not-exist.git"
+    }
+  ]
+}

--- a/composer/spec/fixtures/projects/vcs_source_unreachable/composer.lock
+++ b/composer/spec/fixtures/projects/vcs_source_unreachable/composer.lock
@@ -1,0 +1,118 @@
+{
+  "_readme": [
+      "This file locks the dependencies of your project to a known state",
+      "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+      "This file is @generated automatically"
+  ],
+  "content-hash": "487e925ea7a1432a4eb8ace699e73ef1",
+  "packages": [
+      {
+          "name": "monolog/monolog",
+          "version": "dev-example",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/no-exist-sorry/monolog.git",
+              "reference": "303b8a83c87d5c6d749926cf02620465a5dcd0f2"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/no-exist-sorry/monolog/zipball/303b8a83c87d5c6d749926cf02620465a5dcd0f2",
+              "reference": "303b8a83c87d5c6d749926cf02620465a5dcd0f2",
+              "shasum": ""
+          },
+          "require": {
+              "php": ">=5.3.0"
+          },
+          "type": "library",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Jordi Boggiano",
+                  "email": "j.boggiano@seld.be",
+                  "homepage": "http://seld.be"
+              }
+          ],
+          "description": "Logging for PHP 5.3",
+          "homepage": "http://github.com/Seldaek/monolog",
+          "keywords": [
+              "log",
+              "logging"
+          ],
+          "support": {
+              "source": "https://github.com/no-exist-sorry/monolog/tree/1.0.1"
+          },
+          "time": "2011-08-25 20:42:58"
+      },
+      {
+          "name": "symfony/polyfill-mbstring",
+          "version": "v1.0.1",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/symfony/polyfill-mbstring.git",
+              "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/49ff736bd5d41f45240cec77b44967d76e0c3d25",
+              "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25",
+              "shasum": ""
+          },
+          "require": {
+              "php": ">=5.3.3"
+          },
+          "suggest": {
+              "ext-mbstring": "For best performance"
+          },
+          "type": "library",
+          "extra": {
+              "branch-alias": {
+                  "dev-master": "1.0-dev"
+              }
+          },
+          "autoload": {
+              "psr-4": {
+                  "Symfony\\Polyfill\\Mbstring\\": ""
+              },
+              "files": [
+                  "bootstrap.php"
+              ]
+          },
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Nicolas Grekas",
+                  "email": "p@tchwork.com"
+              },
+              {
+                  "name": "Symfony Community",
+                  "homepage": "https://symfony.com/contributors"
+              }
+          ],
+          "description": "Symfony polyfill for the Mbstring extension",
+          "homepage": "https://symfony.com",
+          "keywords": [
+              "compatibility",
+              "mbstring",
+              "polyfill",
+              "portable",
+              "shim"
+          ],
+          "time": "2015-11-20T09:19:13+00:00"
+      }
+  ],
+  "packages-dev": [],
+  "aliases": [],
+  "minimum-stability": "stable",
+  "stability-flags": {
+      "monolog/monolog": 20
+  },
+  "prefer-stable": false,
+  "prefer-lowest": false,
+  "platform": [],
+  "platform-dev": []
+}


### PR DESCRIPTION
Relax the error message matching when a git source is unreachable as
it's subtly different when speciyfing the source under `repositories`
with `type: git` (erroring with `... --mirror 'url..'`) and `type: vcs`
(erroring with `... --mirror -- 'url..'`).