### PR TITLE
npm: Handle multiple sources in the update checker

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -297,9 +297,8 @@ module Dependabot
 
       def dependency_source_details
         sources =
-          dependency.requirements.map { |r| r.fetch(:source) }.uniq.compact
-
-        raise "Multiple sources! #{sources.join(', ')}" if sources.count > 1
+          dependency.requirements.map { |r| r.fetch(:source) }.uniq.compact.
+          sort_by { |source| RegistryFinder.central_registry?(source[:url]) ? 1 : 0 }
 
         sources.first
       end


### PR DESCRIPTION
Handle multiple sources in the update checker, following on from https://github.com/dependabot/dependabot-core/pull/3718 where we started doing this.