### PR TITLE
npm: handle latest version requirement

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/requirement.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/requirement.rb
@@ -8,6 +8,7 @@ module Dependabot
     class Requirement < Gem::Requirement
       AND_SEPARATOR = /(?<=[a-zA-Z0-9*])\s+(?:&+\s+)?(?!\s*[|-])/.freeze
       OR_SEPARATOR = /(?<=[a-zA-Z0-9*])\s*\|+/.freeze
+      LATEST_REQUIREMENT = "latest"
 
       # Override the version pattern to allow a 'v' prefix
       quoted = OPS.keys.map { |k| Regexp.quote(k) }.join("|")
@@ -17,6 +18,7 @@ module Dependabot
       PATTERN = /\A#{PATTERN_RAW}\z/.freeze
 
       def self.parse(obj)
+        return ["=", nil] if obj.is_a?(String) && obj.strip == LATEST_REQUIREMENT
         return ["=", NpmAndYarn::Version.new(obj.to_s)] if obj.is_a?(Gem::Version)
 
         unless (matches = PATTERN.match(obj.to_s))

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/requirement_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/requirement_spec.rb
@@ -193,6 +193,11 @@ RSpec.describe Dependabot::NpmAndYarn::Requirement do
       let(:requirement_string) { ">=v1.0.0" }
       it { is_expected.to eq(described_class.new(">= v1.0.0")) }
     end
+
+    context "with a latest string" do
+      let(:requirement_string) { "latest" }
+      it { expect { subject }.not_to raise_error }
+    end
   end
 
   describe "#requirements_array" do
@@ -270,6 +275,11 @@ RSpec.describe Dependabot::NpmAndYarn::Requirement do
         context "that includes a local version" do
           let(:version_string) { "1.0.0+gc.1" }
           it { is_expected.to eq(true) }
+        end
+
+        context "with a 'latest' requirement" do
+          let(:requirement_string) { "latest" }
+          it { is_expected.to eq(false) }
         end
       end
     end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -79,6 +79,24 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         expect(checker.up_to_date?).to be_falsy
       end
     end
+
+    context "with a latest version requirement" do
+      let(:dependency_files) { project_dependency_files("npm7/latest_requirement") }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "etag",
+          version: nil,
+          requirements: [
+            { file: "package.json", requirement: "latest", groups: [], source: nil }
+          ],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      it "is up to date because there's nothing to update" do
+        expect(checker.up_to_date?).to be_truthy
+      end
+    end
   end
 
   describe "#can_update?" do

--- a/npm_and_yarn/spec/fixtures/projects/npm7/latest_requirement/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/latest_requirement/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "repository": {
+      "type": "git",
+      "url": "git+https://github.com/waltfy/PROTO_TEST.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+      "url": "https://github.com/waltfy/PROTO_TEST/issues"
+  },
+  "homepage": "https://github.com/waltfy/PROTO_TEST#readme",
+  "dependencies": {
+    "etag" : "latest"
+  }
+}


### PR DESCRIPTION
Handle `latest` version requirements which are valid in npm:

```
"dependencies": {
  "etag" : "latest"
}
```