### PR TITLE
Terraform: handle implicit (v0.12 style) provider sources

### DIFF
--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -20,6 +20,10 @@ module Dependabot
       include FileSelector
 
       ARCHIVE_EXTENSIONS = %w(.zip .tbz2 .tgz .txz).freeze
+      DEFAULT_REGISTRY = "registry.terraform.io"
+      DEFAULT_NAMESPACE = "hashicorp"
+      # https://www.terraform.io/docs/language/providers/requirements.html#source-addresses
+      PROVIDER_SOURCE_ADDRESS = %r{\A((?<hostname>.+)/)?(?<namespace>.+)/(?<name>.+)\z}.freeze
 
       def parse
         dependency_set = DependencySet.new
@@ -27,14 +31,14 @@ module Dependabot
         terraform_files.each do |file|
           modules = parsed_file(file).fetch("module", {})
           modules.each do |name, details|
-            dependency_set << build_terraform_dependency(file, name, details, false)
+            dependency_set << build_terraform_dependency(file, name, details)
           end
 
           parsed_file(file).fetch("terraform", []).each do |terraform|
             required_providers = terraform.fetch("required_providers", {})
             required_providers.each do |provider|
               provider.each do |name, details|
-                dependency_set << build_terraform_dependency(file, name, details, true)
+                dependency_set << build_provider_dependency(file, name, details)
               end
             end
           end
@@ -54,10 +58,10 @@ module Dependabot
 
       private
 
-      def build_terraform_dependency(file, name, details, provider)
-        details = details.is_a?(Array) ? details.first : details
+      def build_terraform_dependency(file, name, details)
+        details = details.first
 
-        source = source_from(details, provider)
+        source = source_from(details)
         dep_name = case source[:type]
                    when "registry" then source[:module_identifier]
                    when "provider" then details["source"]
@@ -82,8 +86,31 @@ module Dependabot
         )
       end
 
+      def build_provider_dependency(file, name, details = {})
+        source_address = details.fetch("source", nil)
+        version = details["version"]&.strip
+        hostname, namespace, name = provider_source_from(source_address, name)
+        dependency_name = source_address ? "#{namespace}/#{name}" : name
+
+        Dependency.new(
+          name: dependency_name,
+          version: version, # resolved version should come from `.terraform.lock.hcl`.
+          package_manager: "terraform",
+          requirements: [
+            requirement: version,
+            groups: [],
+            file: file.name,
+            source: {
+              type: "provider",
+              registry_hostname: hostname,
+              module_identifier: "#{namespace}/#{name}"
+            }
+          ]
+        )
+      end
+
       def build_terragrunt_dependency(file, details)
-        source = source_from(details, false)
+        source = source_from(details)
         dep_name =
           if Source.from_url(source[:url])
             Source.from_url(source[:url]).repo
@@ -107,7 +134,7 @@ module Dependabot
       end
 
       # Full docs at https://www.terraform.io/docs/modules/sources.html
-      def source_from(details_hash, provider)
+      def source_from(details_hash)
         raw_source = details_hash.fetch("source")
         bare_source = get_proxied_source(raw_source)
 
@@ -118,23 +145,28 @@ module Dependabot
           when :github, :bitbucket, :git
             git_source_details_from(bare_source)
           when :registry
-            registry_source_details_from(bare_source, provider)
+            registry_source_details_from(bare_source)
           end
 
         source_details[:proxy_url] = raw_source if raw_source != bare_source
         source_details
       end
 
-      def registry_source_details_from(source_string, provider)
+      def provider_source_from(source_address, name)
+        return [DEFAULT_REGISTRY, DEFAULT_NAMESPACE, name] unless source_address
+
+        matches = source_address.match(PROVIDER_SOURCE_ADDRESS)
+        [
+          matches[:hostname] || DEFAULT_REGISTRY,
+          matches[:namespace],
+          matches[:name] || name
+        ]
+      end
+
+      def registry_source_details_from(source_string)
         parts = source_string.split("//").first.split("/")
 
-        if provider && parts.count == 2
-          {
-            "type": "provider",
-            "registry_hostname": "registry.terraform.io",
-            "module_identifier": source_string
-          }
-        elsif parts.count == 3
+        if parts.count == 3
           {
             type: "registry",
             registry_hostname: "registry.terraform.io",

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -98,9 +98,9 @@ module Dependabot
       end
 
       def provider_declaration_regex
+        name = Regexp.escape(dependency.name)
         /
-          (?:required_providers\s\{)*
-          (source\s*=\s*["']#{Regexp.escape(dependency.name)}["']
+          ((source\s*=\s*["']#{name}["']|\s*#{name}\s*=\s*\{.*)
           (?:(?!^\}).)+)
         /mx
       end

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -532,6 +532,17 @@ RSpec.describe Dependabot::Terraform::FileParser do
       end
     end
 
+    context "with a required provider that does not specify a source" do
+      let(:files) { project_dependency_files("provider_implicit_source") }
+
+      it "has the right details" do
+        dependency = dependencies.find { |d| d.name == "oci" }
+
+        expect(dependency.version).to eq("3.27")
+        expect(dependency.requirements.first[:source][:module_identifier]).to eq("hashicorp/oci")
+      end
+    end
+
     context "with a toplevel provider" do
       let(:files) { project_dependency_files("provider") }
 

--- a/terraform/spec/fixtures/projects/provider_implicit_source/main.tf
+++ b/terraform/spec/fixtures/projects/provider_implicit_source/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    http = {
+      source = "hashicorp/http"
+      version = "2.0.0"
+    }
+
+    oci = { // When no `source` is specified, use the implied `hashicorp/oci` source address
+      version = "3.27"
+    }
+  }
+}


### PR DESCRIPTION
When leaving out a `source = ..` declaration for a Terraform provider,
it falls back to assuming the default `hashicorp` namespace and the
declared local name as the package name.

This is unrecommended, but we do come across it.

Previously Dependabot would fail, with this change it parses + updates
these cases correctly.