### PR TITLE
v0.148.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.148.7, 25 May 2021
+
+- npm: Handle multiple sources in the update checker
+- Composer: handle invalid composer.json
+
 ## v0.148.6, 21 May 2021
 
 - Handle nil dependency version when raising AllVersionsIgnored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.148.7, 25 May 2021
 
 - npm: Handle multiple sources in the update checker
-- Composer: handle invalid composer.json
+- Composer: Handle invalid composer.json
 
 ## v0.148.6, 21 May 2021
 

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.148.6"
+  VERSION = "0.148.7"
 end


### PR DESCRIPTION
## v0.148.7, 25 May 2021

- npm: Handle multiple sources in the update checker
- Composer: Handle invalid composer.json