### PR TITLE
Check version is correct before filtering ignored

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -84,7 +84,7 @@ module Dependabot
         end
 
         def filter_lower_versions(versions_array)
-          return versions_array unless dependency.version
+          return versions_array unless dependency.version && Gem::Version.correct?(dependency.version)
 
           versions_array.
             select { |version| version > Gem::Version.new(dependency.version) }

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -133,6 +133,17 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
         end
       end
 
+      context "when the dependency is a git dependency" do
+        let(:current_version) { "a1b78a929dac93a52f08db4f2847d76d6cfe39bd" }
+
+        context "raise_on_ignored" do
+          let(:raise_on_ignored) { true }
+          it "doesn't raise an error" do
+            expect { subject }.to_not raise_error
+          end
+        end
+      end
+
       context "when the user has ignored all later versions" do
         let(:ignored_versions) { ["> 1.3.0"] }
 

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -69,7 +69,7 @@ module Dependabot
         end
 
         def filter_lower_versions(versions_array)
-          return versions_array unless dependency.version
+          return versions_array unless dependency.version && version_class.correct?(dependency.version)
 
           versions_array.
             select { |version| version > version_class.new(dependency.version) }

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -75,7 +75,7 @@ module Dependabot
         end
 
         def filter_lower_versions(versions_array)
-          return versions_array unless dependency.version
+          return versions_array unless dependency.version && version_class.correct?(dependency.version)
 
           versions_array.
             select { |version| version > version_class.new(dependency.version) }

--- a/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
@@ -104,6 +104,17 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
       end
     end
 
+    context "when the dependency version isn't known" do
+      let(:dependency_version) { nil }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
+
     context "when the user is ignoring all versions" do
       let(:ignored_versions) { [">= 0"] }
       it "returns nil" do

--- a/elm/lib/dependabot/elm/update_checker.rb
+++ b/elm/lib/dependabot/elm/update_checker.rb
@@ -87,7 +87,7 @@ module Dependabot
       end
 
       def filter_lower_versions(versions_array)
-        return versions_array unless dependency.version
+        return versions_array unless dependency.version && version_class.correct?(dependency.version)
 
         versions_array.
           select { |version| version > version_class.new(dependency.version) }

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -109,6 +109,8 @@ module Dependabot
         end
 
         def filter_lower_versions(versions_array)
+          return versions_array unless dependency.version && version_class.correct?(dependency.version)
+
           versions_array.
             select { |version| version > version_class.new(dependency.version) }
         end

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -124,7 +124,7 @@ module Dependabot
         end
 
         def filter_lower_versions(possible_versions)
-          return possible_versions unless dependency.version
+          return possible_versions unless dependency.version && version_class.correct?(dependency.version)
 
           possible_versions.select do |v|
             v.fetch(:version) > version_class.new(dependency.version)

--- a/hex/lib/dependabot/hex/update_checker.rb
+++ b/hex/lib/dependabot/hex/update_checker.rb
@@ -231,7 +231,7 @@ module Dependabot
       # rubocop:enable Metrics/PerceivedComplexity
 
       def filter_lower_versions(versions_array)
-        return versions_array unless current_version
+        return versions_array unless current_version && version_class.correct?(current_version)
 
         versions_array.select do |version|
           version > current_version

--- a/hex/spec/dependabot/hex/update_checker_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker_spec.rb
@@ -114,6 +114,28 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
       end
     end
 
+    context "when the current version isn't known" do
+      let(:current_version) { nil }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
+
+    context "when the dependency is a git dependency" do
+      let(:dependency_version) { "a1b78a929dac93a52f08db4f2847d76d6cfe39bd" }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
+
     context "when the user is ignoring all later versions" do
       let(:ignored_versions) { ["> 1.3.0"] }
       it { is_expected.to eq(Gem::Version.new("1.3.0")) }

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -120,7 +120,7 @@ module Dependabot
         end
 
         def filter_lower_versions(possible_versions)
-          return possible_versions unless dependency.version
+          return possible_versions unless dependency.version && version_class.correct?(dependency.version)
 
           possible_versions.select do |v|
             v.fetch(:version) > version_class.new(dependency.version)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -138,7 +138,7 @@ module Dependabot
         end
 
         def filter_lower_versions(versions_array)
-          return versions_array unless dependency.version
+          return versions_array unless dependency.version && version_class.correct?(dependency.version)
 
           versions_array.
             select { |version, _| version > version_class.new(dependency.version) }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/latest_version_finder_spec.rb
@@ -118,6 +118,17 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::LatestVersionFinder do
       end
     end
 
+    context "when the dependency is a git dependency" do
+      let(:dependency_version) { "a1b78a929dac93a52f08db4f2847d76d6cfe39bd" }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
+
     context "when the user wants a dist tag" do
       let(:dependency) do
         Dependabot::Dependency.new(

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -96,6 +96,8 @@ module Dependabot
         end
 
         def filter_lower_versions(possible_versions)
+          return possible_versions unless dependency.version && version_class.correct?(dependency.version)
+
           possible_versions.select do |v|
             v.fetch(:version) > version_class.new(dependency.version)
           end

--- a/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
@@ -120,6 +120,28 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
       end
     end
 
+    context "when the current version isn't known" do
+      let(:dependency_version) { nil }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
+
+    context "when the dependency is a git dependency" do
+      let(:dependency_version) { "a1b78a929dac93a52f08db4f2847d76d6cfe39bd" }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
+
     context "when the user is ignoring all later versions" do
       let(:ignored_versions) { ["> 1.1.1"] }
       its([:version]) { is_expected.to eq(version_class.new("1.1.1")) }

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -114,7 +114,7 @@ module Dependabot
         end
 
         def filter_lower_versions(versions_array)
-          return versions_array unless dependency.version
+          return versions_array unless dependency.version && version_class.correct?(dependency.version)
 
           versions_array.select { |version| version > version_class.new(dependency.version) }
         end


### PR DESCRIPTION
This is yet another patch to handle edge-cases around filtering ignored
versions where the dependency is a git dependency and the version has
been initialised as a sha and therefore can't be used to filter ignored
versions.