### PR TITLE
feat(Terraform): Inject authorization header

### DIFF
--- a/terraform/lib/dependabot/terraform/metadata_finder.rb
+++ b/terraform/lib/dependabot/terraform/metadata_finder.rb
@@ -4,6 +4,7 @@ require "excon"
 require "json"
 require "dependabot/metadata_finders"
 require "dependabot/metadata_finders/base"
+require "dependabot/terraform/registry_client"
 require "dependabot/shared_helpers"
 
 module Dependabot
@@ -40,7 +41,9 @@ module Dependabot
         info = dependency.requirements.map { |r| r[:source] }.compact.first
         hostname = info[:registry_hostname] || info["registry_hostname"]
 
-        RegistryClient.new(hostname: hostname).source(dependency: dependency)
+        RegistryClient.
+          new(hostname: hostname, credentials: credentials).
+          source(dependency: dependency)
       end
     end
   end

--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -38,9 +38,6 @@ module Dependabot
       # @return [Array<Dependabot::Terraform::Version>]
       # @raise [RuntimeError] when the versions cannot be retrieved
       def all_module_versions(identifier:)
-        # TODO: Implement service discovery for custom registries
-        return [] unless hostname == PUBLIC_HOSTNAME
-
         response = get(endpoint: "modules/#{identifier}/versions")
 
         JSON.parse(response).

--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -11,7 +11,7 @@ module Dependabot
     class RegistryClient
       PUBLIC_HOSTNAME = "registry.terraform.io"
 
-      def initialize(hostname:)
+      def initialize(hostname: PUBLIC_HOSTNAME)
         @hostname = hostname
       end
 

--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -11,8 +11,9 @@ module Dependabot
     class RegistryClient
       PUBLIC_HOSTNAME = "registry.terraform.io"
 
-      def initialize(hostname: PUBLIC_HOSTNAME)
+      def initialize(hostname: PUBLIC_HOSTNAME, credentials: [])
         @hostname = hostname
+        @credentials = credentials
       end
 
       # Fetch all the versions of a provider, and return a Version

--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -23,9 +23,6 @@ module Dependabot
       # @return [Array<Dependabot::Terraform::Version>]
       # @raise [RuntimeError] when the versions cannot be retrieved
       def all_provider_versions(identifier:)
-        # TODO: Implement service discovery for custom registries
-        return [] unless hostname == PUBLIC_HOSTNAME
-
         response = get(endpoint: "providers/#{identifier}/versions")
 
         JSON.parse(response).

--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -61,9 +61,6 @@ module Dependabot
       # @return Dependabot::Source
       # @raise [RuntimeError] when the source cannot be retrieved
       def source(dependency:)
-        # TODO: Implement service discovery for custom registries
-        return unless hostname == PUBLIC_HOSTNAME
-
         type = dependency.requirements.first[:source][:type]
         endpoint = if type == "registry"
                      "modules/#{dependency.name}/#{dependency.version}"

--- a/terraform/lib/dependabot/terraform/update_checker.rb
+++ b/terraform/lib/dependabot/terraform/update_checker.rb
@@ -87,7 +87,7 @@ module Dependabot
       def registry_client
         @registry_client ||= begin
           hostname = dependency_source_details.fetch(:registry_hostname)
-          RegistryClient.new(hostname: hostname)
+          RegistryClient.new(hostname: hostname, credentials: credentials)
         end
       end
 

--- a/terraform/spec/dependabot/terraform/registry_client_spec.rb
+++ b/terraform/spec/dependabot/terraform/registry_client_spec.rb
@@ -33,35 +33,6 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
     )
   end
 
-  let(:provider_dependency) do
-    Dependabot::Dependency.new(
-      name: "hashicorp/aws",
-      version: "0.9.3",
-      package_manager: "terraform",
-      previous_version: "3.19.0",
-      requirements: [{
-        requirement: "3.40.0",
-        groups: [],
-        file: "main.tf",
-        source: {
-          type: "provider",
-          registry_hostname: "registry.terraform.io",
-          module_identifier: "hashicorp/aws"
-        }
-      }],
-      previous_requirements: [{
-        requirement: "3.19.0",
-        groups: [],
-        file: "main.tf",
-        source: {
-          type: "provider",
-          registry_hostname: "registry.terraform.io",
-          module_identifier: "hashicorp/aws"
-        }
-      }]
-    )
-  end
-
   it "fetches provider versions", :vcr do
     client = described_class.new(hostname: described_class::PUBLIC_HOSTNAME)
     response = client.all_provider_versions(identifier: "hashicorp/aws")

--- a/terraform/spec/dependabot/terraform/registry_client_spec.rb
+++ b/terraform/spec/dependabot/terraform/registry_client_spec.rb
@@ -102,4 +102,27 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
     expect(source).to be_a Dependabot::Source
     expect(source.url).to eq("https://github.com/hashicorp/terraform-aws-consul")
   end
+
+  it "fetches the source for a provider from a custom registry", :vcr do
+    client = described_class.new(hostname: 'terraform.example.org')
+    source = client.source(dependency: Dependabot::Dependency.new(
+        name: "hashicorp/ciscoasa",
+        version: "1.2.0",
+        package_manager: "terraform",
+        requirements: [{
+          requirement: "~> 1.2",
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "provider",
+            registry_hostname: "terraform.example.org",
+            module_identifier: "hashicorp/ciscoasa"
+          }
+        }]
+      )
+    )
+
+    expect(source).to be_a Dependabot::Source
+    expect(source.url).to eq("https://github.com/hashicorp/terraform-provider-ciscoasa")
+  end
 end

--- a/terraform/spec/dependabot/terraform/registry_client_spec.rb
+++ b/terraform/spec/dependabot/terraform/registry_client_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
   end
 
   it "fetches provider versions from a custom registry" do
-    hostname = 'registry.example.org'
+    hostname = "registry.example.org"
     stub_request(:get, "https://#{hostname}/v1/providers/hashicorp/aws/versions").and_return(
       status: 200,
       body: {
@@ -63,17 +63,16 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
   end
 
   it "fetches module versions from a custom registry" do
-    hostname = 'registry.example.org'
-    stub_request(:get, "https://#{hostname}/v1/modules/hashicorp/consul/aws/versions")
-      .and_return(status: 200, body: {
-          "modules": [
-            {
-              "source": "hashicorp/consul/aws",
-              "versions": [{ 'version': '0.1.0' }, { 'version': '0.2.0'}]
-            }
-          ]
-        }.to_json
-      )
+    hostname = "registry.example.org"
+    stub_request(:get, "https://#{hostname}/v1/modules/hashicorp/consul/aws/versions").
+      and_return(status: 200, body: {
+        "modules": [
+          {
+            "source": "hashicorp/consul/aws",
+            "versions": [{ 'version': "0.1.0" }, { 'version': "0.2.0" }]
+          }
+        ]
+      }.to_json)
     client = described_class.new(hostname: hostname)
     response = client.all_module_versions(identifier: "hashicorp/consul/aws")
     expect(response).to match_array([
@@ -106,23 +105,22 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
   end
 
   it "fetches the source for a provider from a custom registry", :vcr do
-    client = described_class.new(hostname: 'terraform.example.org')
+    client = described_class.new(hostname: "terraform.example.org")
     source = client.source(dependency: Dependabot::Dependency.new(
-        name: "hashicorp/ciscoasa",
-        version: "1.2.0",
-        package_manager: "terraform",
-        requirements: [{
-          requirement: "~> 1.2",
-          groups: [],
-          file: "main.tf",
-          source: {
-            type: "provider",
-            registry_hostname: "terraform.example.org",
-            module_identifier: "hashicorp/ciscoasa"
-          }
-        }]
-      )
-    )
+      name: "hashicorp/ciscoasa",
+      version: "1.2.0",
+      package_manager: "terraform",
+      requirements: [{
+        requirement: "~> 1.2",
+        groups: [],
+        file: "main.tf",
+        source: {
+          type: "provider",
+          registry_hostname: "terraform.example.org",
+          module_identifier: "hashicorp/ciscoasa"
+        }
+      }]
+    ))
 
     expect(source).to be_a Dependabot::Source
     expect(source.url).to eq("https://github.com/hashicorp/terraform-provider-ciscoasa")

--- a/terraform/spec/dependabot/terraform/registry_client_spec.rb
+++ b/terraform/spec/dependabot/terraform/registry_client_spec.rb
@@ -4,6 +4,8 @@ require "spec_helper"
 require "dependabot/terraform/registry_client"
 
 RSpec.describe Dependabot::Terraform::RegistryClient do
+  subject(:client) { described_class.new }
+
   let(:module_dependency) do
     Dependabot::Dependency.new(
       name: "hashicorp/consul/aws",
@@ -34,7 +36,6 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
   end
 
   it "fetches provider versions", :vcr do
-    client = described_class.new(hostname: described_class::PUBLIC_HOSTNAME)
     response = client.all_provider_versions(identifier: "hashicorp/aws")
     expect(response.max).to eq(Gem::Version.new("3.40.0"))
   end
@@ -57,7 +58,6 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
   end
 
   it "fetches module versions", :vcr do
-    client = described_class.new(hostname: described_class::PUBLIC_HOSTNAME)
     response = client.all_module_versions(identifier: "hashicorp/consul/aws")
     expect(response.max).to eq(Gem::Version.new("0.9.3"))
   end
@@ -82,14 +82,12 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
   end
 
   it "raises an error when it cannot find the dependency", :vcr do
-    client = described_class.new(hostname: described_class::PUBLIC_HOSTNAME)
     expect { client.all_module_versions(identifier: "does/not/exist") }.to raise_error(RuntimeError) do |error|
       expect(error.message).to eq("Response from registry was 404")
     end
   end
 
   it "fetches the source for a module dependency", :vcr do
-    client = described_class.new(hostname: described_class::PUBLIC_HOSTNAME)
     source = client.source(dependency: module_dependency)
 
     expect(source).to be_a Dependabot::Source
@@ -97,7 +95,6 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
   end
 
   it "fetches the source for a provider dependency", :vcr do
-    client = described_class.new(hostname: described_class::PUBLIC_HOSTNAME)
     source = client.source(dependency: module_dependency)
 
     expect(source).to be_a Dependabot::Source

--- a/terraform/spec/dependabot/terraform/registry_client_spec.rb
+++ b/terraform/spec/dependabot/terraform/registry_client_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
     expect(response.max).to eq(Gem::Version.new("3.40.0"))
   end
 
+  it "fetches provider versions from a custom registry" do
+    hostname = 'registry.example.org'
+    stub_request(:get, "https://#{hostname}/v1/providers/hashicorp/aws/versions").and_return(
+      status: 200,
+      body: {
+        "id": "hashicorp/aws",
+        "versions": [{ "version": "3.42.0" }]
+      }.to_json
+    )
+    client = described_class.new(hostname: hostname)
+    response = client.all_provider_versions(identifier: "hashicorp/aws")
+    expect(response.max).to eq(Gem::Version.new("3.42.0"))
+  end
+
   it "fetches module versions", :vcr do
     client = described_class.new(hostname: described_class::PUBLIC_HOSTNAME)
     response = client.all_module_versions(identifier: "hashicorp/consul/aws")

--- a/terraform/spec/dependabot/terraform/update_checker_spec.rb
+++ b/terraform/spec/dependabot/terraform/update_checker_spec.rb
@@ -105,19 +105,6 @@ RSpec.describe Dependabot::Terraform::UpdateChecker do
         let(:ignored_versions) { [">= 0.3.8, < 0.4.0"] }
         it { is_expected.to eq(Gem::Version.new("0.3.7")) }
       end
-
-      context "for a custom registry" do
-        let(:source) do
-          {
-            type: "registry",
-            registry_hostname: "app.terraform.io",
-            module_identifier: "hashicorp/consul/aws"
-          }
-        end
-
-        # See TODO on UpdateChecker on adding support for custom registries
-        it { is_expected.to be_nil }
-      end
     end
   end
 

--- a/terraform/spec/fixtures/vcr_cassettes/Dependabot_Terraform_RegistryClient/fetches_the_source_for_a_provider_from_a_custom_registry.yml
+++ b/terraform/spec/fixtures/vcr_cassettes/Dependabot_Terraform_RegistryClient/fetches_the_source_for_a_provider_from_a_custom_registry.yml
@@ -1,0 +1,19 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://terraform.example.org/v1/providers/hashicorp/ciscoasa/1.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: '{"id":"hashicorp/ciscoasa/1.2.0","owner":"hashicorp","namespace":"hashicorp","name":"ciscoasa","alias":"ciscoasa","version":"1.2.0","tag":"v1.2.0","description":"terraform-provider-ciscoasa","source":"https://github.com/hashicorp/terraform-provider-ciscoasa","published_at":"2019-06-11T19:06:48Z","downloads":5907,"tier":"official","logo_url":"/images/providers/cisco.svg?3","versions":["1.0.0","1.1.0","1.2.0"],"docs":[{"id":"16751","title":"overview","path":"website/docs/index.html.markdown","slug":"index","category":"overview","subcategory":""},{"id":"16752","title":"access_in_rules","path":"website/docs/r/access_in_rules.html.markdown","slug":"access_in_rules","category":"resources","subcategory":""},{"id":"16753","title":"access_out_rules","path":"website/docs/r/access_out_rules.html.markdown","slug":"access_out_rules","category":"resources","subcategory":""},{"id":"16754","title":"acl","path":"website/docs/r/acl.html.markdown","slug":"acl","category":"resources","subcategory":""},{"id":"16755","title":"network_object","path":"website/docs/r/network_object.html.markdown","slug":"network_object","category":"resources","subcategory":""},{"id":"16756","title":"network_object_group","path":"website/docs/r/network_object_group.html.markdown","slug":"network_object_group","category":"resources","subcategory":""},{"id":"16757","title":"network_service_group","path":"website/docs/r/network_service_group.html.markdown","slug":"network_service_group","category":"resources","subcategory":""},{"id":"16758","title":"static_route","path":"website/docs/r/static_route.html.markdown","slug":"static_route","category":"resources","subcategory":""}]}
+
+'
+  recorded_at: Tue, 25 May 2021 20:50:08 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
# Why is this needed?

We need this to be able to connect to private terraform registries that are
secured with a bearer token.

## What does this do?

This change searches for credentials that match the provided host and injects
that as an [Authorization header](https://www.terraform.io/docs/cloud/api/index.html#authentication).

## Type of change

- [X] New feature (non-breaking change which adds functionality)