### PR TITLE
Terraform: Do not set dependency.version for version ranges

### DIFF
--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -88,16 +88,16 @@ module Dependabot
 
       def build_provider_dependency(file, name, details = {})
         source_address = details.fetch("source", nil)
-        version = details["version"]&.strip
+        version_req = details["version"]&.strip
         hostname, namespace, name = provider_source_from(source_address, name)
         dependency_name = source_address ? "#{namespace}/#{name}" : name
 
         Dependency.new(
           name: dependency_name,
-          version: determine_version_for(hostname, namespace, name, version),
+          version: determine_version_for(hostname, namespace, name, version_req),
           package_manager: "terraform",
           requirements: [
-            requirement: version,
+            requirement: version_req,
             groups: [],
             file: file.name,
             source: {

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -578,6 +578,22 @@ RSpec.describe Dependabot::Terraform::FileParser do
 
         expect(dependency.version).to eq("0.1.0")
       end
+
+      it "handles version ranges correctly" do
+        dependency = dependencies.find { |d| d.name == "hashicorp/http" }
+
+        expect(dependency.version).to be_nil
+        expect(dependency.requirements).to eq([{
+          requirement: "~> 2.0",
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "provider",
+            registry_hostname: "registry.terraform.io",
+            module_identifier: "hashicorp/http"
+          }
+        }])
+      end
     end
 
     context "with a required provider block with multiple versions" do


### PR DESCRIPTION
When a dependency specifies a version range, we do not want to set the
dependency objects version, as we cannot reliably determine it. Instead,
we need to rely on the _requirement_. For example, `~> 2.0` is not a
valid _version_, so when parsing it, we should set the `version`
attribute to nil.

This was already handled by #3756, this adds a test to verify setting
to nil when no lockfile is present.