### PR TITLE
v0.148.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.148.9, 26 May 2021
+
+- Terraform: Do not set dependency.version for version ranges
+- Terraform: Parse lockfiles to get exact version when present
+
 ## v0.148.8, 25 May 2021
 
 - Composer: handle unreachable git vcs source

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.148.8"
+  VERSION = "0.148.9"
 end


### PR DESCRIPTION
- Terraform: Do not set dependency.version for version ranges
- Terraform: Parse lockfiles to get exact version when present