### PR TITLE
Composer: fix git clone error in lockfile updater

### DIFF
--- a/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
@@ -8,6 +8,7 @@ require "dependabot/composer/version"
 require "dependabot/composer/requirement"
 require "dependabot/composer/native_helpers"
 require "dependabot/composer/helpers"
+require "dependabot/composer/update_checker/version_resolver"
 
 # rubocop:disable Metrics/ClassLength
 module Dependabot
@@ -125,6 +126,8 @@ module Dependabot
           error.message.start_with?("Could not authenticate against")
         end
 
+        # TODO: Extract error handling and share between the version resolver
+        #
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/MethodLength
@@ -167,18 +170,16 @@ module Dependabot
             raise PrivateSourceAuthenticationFailure, "nova.laravel.com"
           end
 
-          if error.message.start_with?("Failed to execute git clone")
-            dependency_url =
-              error.message.match(/(?:mirror|checkout) '(?<url>.*?)'/).
-              named_captures.fetch("url")
-            raise GitDependenciesNotReachable, dependency_url
+          if error.message.match?(UpdateChecker::VersionResolver::FAILED_GIT_CLONE_WITH_MIRROR)
+            dependency_url = error.message.match(UpdateChecker::VersionResolver::FAILED_GIT_CLONE_WITH_MIRROR).
+                             named_captures.fetch("url")
+            raise Dependabot::GitDependenciesNotReachable, dependency_url
           end
 
-          if error.message.start_with?("Failed to clone")
-            dependency_url =
-              error.message.match(/Failed to clone (?<url>.*?) via/).
-              named_captures.fetch("url")
-            raise GitDependenciesNotReachable, dependency_url
+          if error.message.match?(UpdateChecker::VersionResolver::FAILED_GIT_CLONE)
+            dependency_url = error.message.match(UpdateChecker::VersionResolver::FAILED_GIT_CLONE).
+                             named_captures.fetch("url")
+            raise Dependabot::GitDependenciesNotReachable, dependency_url
           end
 
           # NOTE: This matches an error message from composer plugins used to install ACF PRO

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -37,7 +37,7 @@ module Dependabot
         VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-_]+)*/.freeze
         SOURCE_TIMED_OUT_REGEX =
           /The "(?<url>[^"]+packages\.json)".*timed out/.freeze
-        FAILED_GIT_CLONE_WITH_MIRROR = /Failed to execute git clone --mirror[^']*'(?<url>.*?)'/.freeze
+        FAILED_GIT_CLONE_WITH_MIRROR = /Failed to execute git clone --(mirror|checkout)[^']*'(?<url>.*?)'/.freeze
         FAILED_GIT_CLONE = /Failed to clone (?<url>.*?) via/.freeze
 
         def initialize(credentials:, dependency:, dependency_files:,
@@ -233,6 +233,8 @@ module Dependabot
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/PerceivedComplexity
 
+        # TODO: Extract error handling and share between the lockfile updater
+        #
         # rubocop:disable Metrics/PerceivedComplexity
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/CyclomaticComplexity

--- a/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
@@ -856,5 +856,69 @@ RSpec.describe Dependabot::Composer::FileUpdater::LockfileUpdater do
         expect(updated_lockfile_content).to include("e244eda135819216ac3044146")
       end
     end
+
+    context "with a missing git repository source" do
+      let(:project_name) { "git_source_unreachable" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "symfony/polyfill-mbstring",
+          version: "1.0.1",
+          requirements: [{
+            file: "composer.json",
+            requirement: "1.0.1",
+            groups: ["runtime"],
+            source: nil
+          }],
+          previous_version: "1.0.1",
+          previous_requirements: [{
+            file: "composer.json",
+            requirement: "1.0.1",
+            groups: ["runtime"],
+            source: nil
+          }],
+          package_manager: "composer"
+        )
+      end
+
+      it "raises a Dependabot::DependencyFileNotResolvable error" do
+        expect { updated_lockfile_content }.
+          to raise_error(Dependabot::GitDependenciesNotReachable) do |error|
+            expect(error.dependency_urls).
+              to eq(["https://github.com/no-exist-sorry/monolog.git"])
+          end
+      end
+    end
+
+    context "with a missing vcs repository source" do
+      let(:project_name) { "vcs_source_unreachable" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "symfony/polyfill-mbstring",
+          version: "1.0.1",
+          requirements: [{
+            file: "composer.json",
+            requirement: "1.0.1",
+            groups: ["runtime"],
+            source: nil
+          }],
+          previous_version: "1.0.1",
+          previous_requirements: [{
+            file: "composer.json",
+            requirement: "1.0.1",
+            groups: ["runtime"],
+            source: nil
+          }],
+          package_manager: "composer"
+        )
+      end
+
+      it "raises a Dependabot::DependencyFileNotResolvable error" do
+        expect { updated_lockfile_content }.
+          to raise_error(Dependabot::GitDependenciesNotReachable) do |error|
+            expect(error.dependency_urls).
+              to eq(["https://github.com/dependabot-fixtures/this-repo-does-not-exist.git"])
+          end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix error matching for `GitDependenciesNotReachable` in the lockfile
updater.

We're still seeing the error I tried to fix in the version resolver:
https://github.com/dependabot/dependabot-core/pull/3779

It looks like we need to match the same error in the lockfile updater as
it might raise for a dependency we're not trying to update.

Sharing the constant doesn't feel ideal. It would be better to extract
the error handling to something we can share between the lockfile
updater and version resolver but wanted to get this fix in to improve
our error rate.