### PR TITLE
v0.148.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.148.10, 26 May 2021
+
+- Yarn: use .yarnrc file if present
+- npm: handle latest version requirement
+
 ## v0.148.9, 26 May 2021
 
 - Terraform: Do not set dependency.version for version ranges

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.148.9"
+  VERSION = "0.148.10"
 end


### PR DESCRIPTION
## v0.148.10, 26 May 2021

- Yarn: use .yarnrc file if present
- npm: handle latest version requirement