### PR TITLE
v0.149.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.149.0, 26 May 2021
+
+- Terraform: Use registry credentials
+
 ## v0.148.10, 26 May 2021
 
 - Yarn: use .yarnrc file if present

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.148.10"
+  VERSION = "0.149.0"
 end


### PR DESCRIPTION
## v0.149.0, 26 May 2021

- Terraform: Use registry credentials

https://github.com/dependabot/dependabot-core/compare/v0.148.10...3e076e6