### PR TITLE
gomod: UpdateChecker - handle invalid module path error on update

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -39,7 +39,7 @@ module Dependabot
         ].freeze
 
         MODULE_PATH_MISMATCH_REGEXES = [
-          /go: ([^@\s]+)(?:@[^\s]+)?: .* has non-.* module path "(.*)" at/,
+          /go(?: get)?: ([^@\s]+)(?:@[^\s]+)?: .* has non-.* module path "(.*)" at/,
           /go: ([^@\s]+)(?:@[^\s]+)?: .* unexpected module path "(.*)"/,
           /go(?: get)?: ([^@\s]+)(?:@[^\s]+)?:? .* declares its path as: ([\S]*)/m
         ].freeze

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -110,6 +110,43 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
           it { is_expected.to include("retract v1.0.5") }
         end
 
+        describe "a dependency who's module path has changed during an update" do
+          let(:project_name) { "module_path_and_version_changed_during_update" }
+          let(:dependency_name) { "gopkg.in/DATA-DOG/go-sqlmock.v1" }
+          let(:dependency_version) { "v1.3.3" }
+          let(:dependency_previous_version) { "v1.3.0" }
+          let(:requirements) do
+            [{
+              file: "go.mod",
+              requirement: dependency_version,
+              groups: [],
+              source: {
+                type: "default",
+                source: dependency_name
+              }
+            }]
+          end
+          let(:previous_requirements) do
+            [{
+              file: "go.mod",
+              requirement: dependency_previous_version,
+              groups: [],
+              source: {
+                type: "default",
+                source: dependency_name
+              }
+            }]
+          end
+
+          it "raises the correct error" do
+            error_class = Dependabot::GoModulePathMismatch
+            expect { updater.updated_go_sum_content }.
+              to raise_error(error_class) do |error|
+              expect(error.message).to include("github.com/DATA-DOG")
+            end
+          end
+        end
+
         describe "a dependency who's module path has changed (inc version)" do
           let(:project_name) { "module_path_and_version_changed" }
 

--- a/go_modules/spec/fixtures/projects/module_path_and_version_changed_during_update/go.mod
+++ b/go_modules/spec/fixtures/projects/module_path_and_version_changed_during_update/go.mod
@@ -1,0 +1,7 @@
+module github.com/dependabot/vgotest
+
+go 1.12
+
+require (
+		gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0
+)

--- a/go_modules/spec/fixtures/projects/module_path_and_version_changed_during_update/main.go
+++ b/go_modules/spec/fixtures/projects/module_path_and_version_changed_during_update/main.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	_ "gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+func main() {
+}


### PR DESCRIPTION
This handles a slight variation in error message when using `go get <module>@<version>` and the module path doesn't match in the new version. This can happen when you were previously on a version that didn't support go modules.

```
# v1.3.0 has no go.mod
% go get gopkg.in/DATA-DOG/go-sqlmock.v1@v1.3.0
go: downloading gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0

# v1.3.3 has a go.mod but the path is github.com/DATA-DOG/go-sqlmock
% go get -d gopkg.in/DATA-DOG/go-sqlmock.v1@v1.3.3
go get: gopkg.in/DATA-DOG/go-sqlmock.v1@v1.3.3: invalid version: go.mod has non-....v1 module path "github.com/DATA-DOG/go-sqlmock" at revision v1.3.3
```