### PR TITLE
poetry: support pyproject.toml indentation

### DIFF
--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -269,7 +269,7 @@ module Dependabot
 
         def declaration_regex(dep)
           escaped_name = Regexp.escape(dep.name).gsub("\\-", "[-_.]")
-          /(?:^|["'])#{escaped_name}["']?\s*=.*$/i
+          /(?:^\s*|["'])#{escaped_name}["']?\s*=.*$/i
         end
 
         def file_changed?(file)

--- a/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/poetry_file_updater_spec.rb
@@ -148,6 +148,38 @@ RSpec.describe Dependabot::Python::FileUpdater::PoetryFileUpdater do
       end
     end
 
+    context "without a lockfile and with an indented pyproject.toml" do
+      let(:dependency_files) { [pyproject] }
+      let(:pyproject_fixture_name) { "indented.toml" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "2.19.1",
+          previous_version: nil,
+          package_manager: "pip",
+          requirements: [{
+            requirement: "^2.19.1",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dependencies"]
+          }],
+          previous_requirements: [{
+            requirement: "^1.0.0",
+            file: "pyproject.toml",
+            source: nil,
+            groups: ["dependencies"]
+          }]
+        )
+      end
+
+      it "updates the pyproject.toml" do
+        expect(updated_files.map(&:name)).to eq(%w(pyproject.toml))
+
+        updated_lockfile = updated_files.find { |f| f.name == "pyproject.toml" }
+        expect(updated_lockfile.content).to include('  requests = "^2.19.1"')
+      end
+    end
+
     context "with a poetry.lock" do
       let(:lockfile) do
         Dependabot::DependencyFile.new(

--- a/python/spec/fixtures/pyproject_files/indented.toml
+++ b/python/spec/fixtures/pyproject_files/indented.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "pendulum"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+description = "Python datetimes made easy"
+
+  [tool.poetry.dependencies]
+  python = "^3.7"
+  requests = "^1.0.0"


### PR DESCRIPTION
Some projects indent the `tool.poetry.dependencies` section of the `pyproject.toml`. The regex for updating `pyproject.toml` requirements didn't account for this which results in a "Content did not change!" error when indentation is used.

This adjusts the regex to handle indentation.