### PR TITLE
Bundler: handle gemspec required ruby version ranges

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
@@ -2,6 +2,7 @@
 
 require "parser/current"
 require "dependabot/bundler/file_updater"
+require "dependabot/bundler/requirement"
 
 module Dependabot
   module Bundler
@@ -49,7 +50,11 @@ module Dependabot
         end
 
         def ruby_version
-          requirement = Gem::Requirement.new(ruby_requirement)
+          requirement = if !ruby_requirement.is_a?(Gem::Requirement)
+                          Dependabot::Bundler::Requirement.new(ruby_requirement)
+                        else
+                          ruby_requirement
+                        end
 
           ruby_version =
             RUBY_VERSIONS.

--- a/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
@@ -197,8 +197,8 @@ module Dependabot
           # required Ruby version.
           return false unless ruby_requirement
 
-          ruby_requirement = Gem::Requirement.new(ruby_requirement)
-          current_ruby_version = Gem::Version.new(details[:ruby_version])
+          ruby_requirement = Dependabot::Bundler::Requirement.new(ruby_requirement)
+          current_ruby_version = Dependabot::Bundler::Version.new(details[:ruby_version])
 
           !ruby_requirement.satisfied_by?(current_ruby_version)
         rescue JSON::ParserError, Excon::Error::Socket, Excon::Error::Timeout

--- a/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
@@ -38,6 +38,41 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RubyRequirementSetter do
         bundler_project_dependency_file("gemfile_old_required_ruby", filename: "example.gemspec")
       end
 
+      context "with a required ruby version range" do
+        let(:gemspec) do
+          bundler_project_dependency_file("gemspec_required_ruby_version_range", filename: "example.gemspec")
+        end
+        let(:content) do
+          bundler_project_dependency_file("gemspec_required_ruby_version_range", filename: "Gemfile").content
+        end
+        it { is_expected.to include("ruby '2.2.10'\n") }
+        it { is_expected.to include(%(gem "statesman", "~> 1.2.0")) }
+      end
+
+      context "with a required ruby version range array" do
+        let(:gemspec) do
+          bundler_project_dependency_file("gemspec_required_ruby_version_range_array", filename: "example.gemspec")
+        end
+        let(:content) do
+          bundler_project_dependency_file("gemspec_required_ruby_version_range_array", filename: "Gemfile").content
+        end
+        it { is_expected.to include("ruby '2.2.10'\n") }
+        it { is_expected.to include(%(gem "statesman", "~> 1.2.0")) }
+      end
+
+      context "with a required ruby version requirement class" do
+        let(:gemspec) do
+          bundler_project_dependency_file("gemspec_required_ruby_version_requirement_class",
+                                          filename: "example.gemspec")
+        end
+        let(:content) do
+          bundler_project_dependency_file("gemspec_required_ruby_version_requirement_class",
+                                          filename: "Gemfile").content
+        end
+        it { is_expected.to include("ruby '2.1.10'\n") }
+        it { is_expected.to include(%(gem "statesman", "~> 1.2.0")) }
+      end
+
       context "without an existing ruby version" do
         let(:content) do
           bundler_project_dependency_file("gemfile", filename: "Gemfile").content

--- a/bundler/spec/fixtures/projects/bundler1/gemspec_required_ruby_version_range/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/gemspec_required_ruby_version_range/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/gemspec_required_ruby_version_range/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/gemspec_required_ruby_version_range/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 2.2, < 4.0"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler1/gemspec_required_ruby_version_range_array/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/gemspec_required_ruby_version_range_array/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/gemspec_required_ruby_version_range_array/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/gemspec_required_ruby_version_range_array/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = [">= 2.2", "< 4.0"]
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler1/gemspec_required_ruby_version_requirement_class/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/gemspec_required_ruby_version_requirement_class/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/gemspec_required_ruby_version_requirement_class/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/gemspec_required_ruby_version_requirement_class/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.1.8", "< 4.0.0")
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_range/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_range/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_range/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_range/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 2.2, < 4.0"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_range_array/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_range_array/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_range_array/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_range_array/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = [">= 2.2", "< 4.0"]
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_requirement_class/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_requirement_class/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_requirement_class/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler2/gemspec_required_ruby_version_requirement_class/example.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.1.8", "< 4.0.0")
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end


### PR DESCRIPTION
Handle `required_ruby_version` ranges in gemspecs:
`required_ruby_version = ">= 2.2, < 4.0"` and
`required_ruby_version = Gem::Requirement.new(">= 2.1.8", "< 4.0.0")`

This would previously raise a `Gem::Requirement::BadRequirementError`.

Note: The `Bundler::Requirement` class splits requirements by `,`.

I've done an audit of other uses of `Gem::Requirement` but these seem ok
as we control the range we create so shouldn't run into similar bugs
there.

Fixes https://github.com/dependabot/dependabot-core/issues/2963