### PR TITLE
Detect optional hostname in module/provider source declaration

### DIFF
--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -109,7 +109,7 @@ module Dependabot
         /
           (?<=\{)
           (?:(?!^\}).)*
-          source\s*=\s*["']#{Regexp.escape(dependency.name)}["']
+          source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}\/)?#{Regexp.escape(dependency.name)}["']
           (?:(?!^\}).)*
         /mx
       end
@@ -125,6 +125,10 @@ module Dependabot
           module\s+["']#{Regexp.escape(dependency.name)}["']\s*\{
           (?:(?!^\}).)*
         /mx
+      end
+
+      def registry_host_for(dependency)
+        dependency.requirements[0][:source][:registry_hostname] || "registry.terraform.io"
       end
     end
   end

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -106,12 +106,12 @@ module Dependabot
       end
 
       def registry_declaration_regex
-        /
+        %r{
           (?<=\{)
           (?:(?!^\}).)*
-          source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}\/)?#{Regexp.escape(dependency.name)}["']
+          source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)?#{Regexp.escape(dependency.name)}["']
           (?:(?!^\}).)*
-        /mx
+        }mx
       end
 
       def git_declaration_regex(filename)
@@ -128,7 +128,8 @@ module Dependabot
       end
 
       def registry_host_for(dependency)
-        dependency.requirements[0][:source][:registry_hostname] || "registry.terraform.io"
+        info = dependency.requirements.map { |r| r[:source] }.compact.first
+        info[:registry_hostname] || info["registry_hostname"] || "registry.terraform.io"
       end
     end
   end

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -100,7 +100,7 @@ module Dependabot
       def provider_declaration_regex
         name = Regexp.escape(dependency.name)
         /
-          ((source\s*=\s*["']#{name}["']|\s*#{name}\s*=\s*\{.*)
+          ((source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}\/)?#{name}["']|\s*#{name}\s*=\s*\{.*)
           (?:(?!^\}).)+)
         /mx
       end

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -128,8 +128,8 @@ module Dependabot
       end
 
       def registry_host_for(dependency)
-        info = dependency.requirements.map { |r| r[:source] }.compact.first
-        info[:registry_hostname] || info["registry_hostname"] || "registry.terraform.io"
+        source = dependency.requirements.map { |r| r[:source] }.compact.first
+        source[:registry_hostname] || source["registry_hostname"] || "registry.terraform.io"
       end
     end
   end

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -99,10 +99,10 @@ module Dependabot
 
       def provider_declaration_regex
         name = Regexp.escape(dependency.name)
-        /
-          ((source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}\/)?#{name}["']|\s*#{name}\s*=\s*\{.*)
+        %r{
+          ((source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)?#{name}["']|\s*#{name}\s*=\s*\{.*)
           (?:(?!^\}).)+)
-        /mx
+        }mx
       end
 
       def registry_declaration_regex

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -22,6 +22,54 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
   describe "#updated_dependency_files" do
     subject { updater.updated_dependency_files }
 
+    context "with a private module" do
+      let(:files) { project_dependency_files("private_module") }
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "example-org-5d3190/s3-webapp/aws",
+            version: "1.0.1",
+            previous_version: "1.0.0",
+            requirements: [{
+              requirement: nil,
+              groups: [],
+              file: "main.tf",
+              source: {
+                type: "registry",
+                registry_hostname: "app.terraform.io",
+                module_identifier: "example-org-5d3190/s3-webapp/aws"
+              }
+            }],
+            previous_requirements: [{
+              requirement: nil,
+              groups: [],
+              file: "main.tf",
+              source: {
+                type: "registry",
+                registry_hostname: "app.terraform.io",
+                module_identifier: "example-org-5d3190/s3-webapp/aws"
+              }
+            }],
+            package_manager: "terraform"
+          )
+        ]
+      end
+
+      it "updates the private module version" do
+        updated_file = subject.find { |file| file.name == "main.tf" }
+
+        expect(updated_file.content).to include(<<~HCL)
+          module "s3-webapp" {
+            source  = "app.terraform.io/example-org-5d3190/s3-webapp/aws"
+            name   = var.name
+            region = var.region
+            prefix = var.prefix
+            version = "1.0.1"
+          }
+        HCL
+      end
+    end
+
     context "with a valid legacy dependency file" do
       let(:files) { project_dependency_files("git_tags_011") }
       let(:dependencies) do

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
 
     context "with a private module" do
       let(:files) { project_dependency_files("private_module") }
+
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -31,7 +32,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
             version: "1.0.1",
             previous_version: "1.0.0",
             requirements: [{
-              requirement: nil,
+              requirement: "1.0.1",
               groups: [],
               file: "main.tf",
               source: {
@@ -41,7 +42,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
               }
             }],
             previous_requirements: [{
-              requirement: nil,
+              requirement: "1.0.0",
               groups: [],
               file: "main.tf",
               source: {

--- a/terraform/spec/fixtures/projects/private_module/main.tf
+++ b/terraform/spec/fixtures/projects/private_module/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ca-central-1"
+}
+
+module "s3-webapp" {
+  source  = "app.terraform.io/example-org-5d3190/s3-webapp/aws"
+  name   = var.name
+  region = var.region
+  prefix = var.prefix
+  version = "1.0.0"
+}

--- a/terraform/spec/fixtures/projects/private_module/main.tf
+++ b/terraform/spec/fixtures/projects/private_module/main.tf
@@ -1,20 +1,4 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.0"
-    }
-  }
-}
-
-provider "aws" {
-  region = "ca-central-1"
-}
-
 module "s3-webapp" {
   source  = "app.terraform.io/example-org-5d3190/s3-webapp/aws"
-  name   = var.name
-  region = var.region
-  prefix = var.prefix
   version = "1.0.0"
 }

--- a/terraform/spec/fixtures/projects/private_provider/main.tf
+++ b/terraform/spec/fixtures/projects/private_provider/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    example = {
+      source  = "registry.example.org/namespace/name"
+      version = "1.0.0"
+    }
+  }
+}


### PR DESCRIPTION
# Why is this needed?

To fix a bug that prevents the update of a Terraform module/provider versions that include the optional hostname in the source address. 

* https://www.terraform.io/docs/language/modules/sources.html#terraform-registry
* https://www.terraform.io/docs/language/providers/requirements.html#source-addresses

## What does this do?

It adds a test that reproduces the defect and updates the regex to look for an optional hostname.

```bash
[dependabot-core-dev] ~/dependabot-core/terraform $ export LOCAL_CONFIG_VARIABLES="[{\"type\":\"terraform_registry\",\"host\":\"app.terraform.io\",\"token\":\"snip\"}]"
[dependabot-core-dev] ~/dependabot-core $ ./bin/dry-run.rb terraform dsp-testing/dependabot-updates-1480
Resolving dependencies...
=> fetching dependency files
=> dumping fetched dependency files: ./dry-run/dsp-testing/dependabot-updates-1480/
=> parsing dependency files
=> updating 2 dependencies: example-org-5d3190/s3-webapp/aws, hashicorp/aws

=== example-org-5d3190/s3-webapp/aws (1.0.0)
 => checking for updates 1/2
 => latest available version is 1.0.1
 => latest allowed version is 1.0.1
 => requirements to unlock: own
 => requirements update strategy:
 => updating example-org-5d3190/s3-webapp/aws from 1.0.0 to 1.0.1

    ± main.tf
    ~~~
    23c23
    <   version = "1.0.0"
    ---
    >   version = "1.0.1"
    ~~~

=== hashicorp/aws ()
 => checking for updates 2/2
 => latest available version is 3.42.0
 => latest allowed version is 3.42.0
 => requirements to unlock: update_not_possible
 => requirements update strategy:
    (no update possible 🙅‍♀️)
```

/xref: https://github.com/github/dependabot-updates/issues/1480

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
