### PR TITLE
v0.149.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.149.4, 1 June 2021
+
+- fix(Terraform): use service discovery protocol
+- fix(Terraform): parse optional hostname from module/provider source address
+- Bump composer/composer from 2.0.12 to 2.0.14 in /composer/helpers/v2
+- poetry: support pyproject.toml indentation
+
 ## v0.149.3, 28 May 2021
 
 - Bundler: handle required ruby version ranges in gemspecs

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.149.3"
+  VERSION = "0.149.4"
 end


### PR DESCRIPTION
## v0.149.4, 1 June 2021

- fix(Terraform): use service discovery protocol
- fix(Terraform): parse optional hostname from module/provider source address
- Bump composer/composer from 2.0.12 to 2.0.14 in /composer/helpers/v2
- poetry: support pyproject.toml indentation

https://github.com/dependabot/dependabot-core/compare/v0.149.3...49da5405304a3d286761addd0845102b10ab8286
