### PR TITLE
Hex tests: Use git dependencies of repositories we own

### DIFF
--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe Dependabot::Hex::FileParser do
               groups: [],
               source: {
                 type: "git",
-                url: "https://github.com/phoenixframework/phoenix.git",
+                url: "https://github.com/dependabot-fixtures/phoenix.git",
                 branch: "master",
                 ref: "v1.2.0"
               }
@@ -269,7 +269,7 @@ RSpec.describe Dependabot::Hex::FileParser do
                 groups: [],
                 source: {
                   type: "git",
-                  url: "https://github.com/phoenixframework/phoenix.git",
+                  url: "https://github.com/dependabot-fixtures/phoenix.git",
                   branch: "master",
                   ref: "v1.2.0"
                 }

--- a/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
@@ -314,7 +314,7 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
             groups: [],
             source: {
               type: "git",
-              url: "https://github.com/phoenixframework/phoenix.git",
+              url: "https://github.com/dependabot-fixtures/phoenix.git",
               branch: "master",
               ref: nil
             }
@@ -325,7 +325,7 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
             groups: [],
             source: {
               type: "git",
-              url: "https://github.com/phoenixframework/phoenix.git",
+              url: "https://github.com/dependabot-fixtures/phoenix.git",
               branch: "master",
               ref: nil
             }

--- a/hex/spec/dependabot/hex/file_updater/mixfile_git_pin_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater/mixfile_git_pin_updater_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Dependabot::Hex::FileUpdater::MixfileGitPinUpdater do
     it "updates the right dependency" do
       expect(updated_content).to include(%({:plug, "1.3.3"},))
       expect(updated_content).to include(
-        %({:phoenix, github: "phoenixframework/phoenix", ref: "v1.3.0"})
+        %({:phoenix, github: "dependabot-fixtures/phoenix", ref: "v1.3.0"})
       )
     end
 
@@ -39,7 +39,7 @@ RSpec.describe Dependabot::Hex::FileUpdater::MixfileGitPinUpdater do
         expect(updated_content).to include(%({:plug, "1.3.3"},))
         expect(updated_content).to include(
           "{:phoenix,\n"\
-          '       github: "phoenixframework/phoenix", tag: "v1.3.0"}'
+          '       github: "dependabot-fixtures/phoenix", tag: "v1.3.0"}'
         )
       end
     end

--- a/hex/spec/dependabot/hex/file_updater/mixfile_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater/mixfile_updater_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Dependabot::Hex::FileUpdater::MixfileUpdater do
             groups: [],
             source: {
               type: "git",
-              url: "https://github.com/phoenixframework/phoenix.git",
+              url: "https://github.com/dependabot-fixtures/phoenix.git",
               branch: "master",
               ref: "v1.3.0"
             }
@@ -66,7 +66,7 @@ RSpec.describe Dependabot::Hex::FileUpdater::MixfileUpdater do
             groups: [],
             source: {
               type: "git",
-              url: "https://github.com/phoenixframework/phoenix.git",
+              url: "https://github.com/dependabot-fixtures/phoenix.git",
               branch: "master",
               ref: "v1.2.0"
             }
@@ -78,7 +78,7 @@ RSpec.describe Dependabot::Hex::FileUpdater::MixfileUpdater do
       it "updates the right dependency" do
         expect(updated_mixfile_content).to include(%({:plug, "1.3.3"},))
         expect(updated_mixfile_content).to include(
-          %({:phoenix, github: "phoenixframework/phoenix", ref: "v1.3.0"})
+          %({:phoenix, github: "dependabot-fixtures/phoenix", ref: "v1.3.0"})
         )
       end
     end

--- a/hex/spec/dependabot/hex/update_checker/file_preparer_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker/file_preparer_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker::FilePreparer do
             groups: [],
             source: {
               type: "git",
-              url: "https://github.com/phoenixframework/phoenix.git",
+              url: "https://github.com/dependabot-fixtures/phoenix.git",
               branch: "master",
               ref: "v1.2.0"
             }
@@ -181,7 +181,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker::FilePreparer do
 
         it "updates the pin" do
           expect(prepared_mixfile.content).to include(
-            '{:phoenix, ">= 0", github: "phoenixframework/phoenix", '\
+            '{:phoenix, ">= 0", github: "dependabot-fixtures/phoenix", '\
             'ref: "v1.2.1"}'
           )
         end
@@ -191,7 +191,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker::FilePreparer do
 
           it "updates the pin" do
             expect(prepared_mixfile.content).to include(
-              '{:phoenix, ">= 0", github: "phoenixframework/phoenix", '\
+              '{:phoenix, ">= 0", github: "dependabot-fixtures/phoenix", '\
               "ref: \'v1.2.1\'}"
             )
           end

--- a/hex/spec/dependabot/hex/update_checker/requirements_updater_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker/requirements_updater_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker::RequirementsUpdater do
           groups: [],
           source: {
             type: "git",
-            url: "https://github.com/phoenixframework/phoenix.git",
+            url: "https://github.com/dependabot-fixtures/phoenix.git",
             branch: "master",
             ref: nil
           }
@@ -60,7 +60,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker::RequirementsUpdater do
       let(:updated_source) do
         {
           type: "git",
-          url: "https://github.com/phoenixframework/phoenix.git",
+          url: "https://github.com/dependabot-fixtures/phoenix.git",
           branch: "master",
           ref: nil
         }

--- a/hex/spec/dependabot/hex/update_checker_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
           groups: [],
           source: {
             type: "git",
-            url: "https://github.com/phoenixframework/phoenix.git",
+            url: "https://github.com/dependabot-fixtures/phoenix.git",
             branch: "master",
             ref: "v1.2.0"
           }
@@ -199,7 +199,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
       end
 
       before do
-        git_url = "https://github.com/phoenixframework/phoenix.git"
+        git_url = "https://github.com/dependabot-fixtures/phoenix.git"
         git_header = {
           "content-type" => "application/x-git-upload-pack-advertisement"
         }
@@ -382,7 +382,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
             groups: [],
             source: {
               type: "git",
-              url: "https://github.com/phoenixframework/phoenix.git",
+              url: "https://github.com/dependabot-fixtures/phoenix.git",
               branch: "master",
               ref: ref
             }
@@ -393,7 +393,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
           let(:ref) { "v1.2.0" }
 
           before do
-            git_url = "https://github.com/phoenixframework/phoenix.git"
+            git_url = "https://github.com/dependabot-fixtures/phoenix.git"
             git_header = {
               "content-type" => "application/x-git-upload-pack-advertisement"
             }
@@ -552,7 +552,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
             groups: [],
             source: {
               type: "git",
-              url: "https://github.com/phoenixframework/phoenix.git",
+              url: "https://github.com/dependabot-fixtures/phoenix.git",
               branch: "master",
               ref: ref
             }
@@ -639,7 +639,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
           groups: [],
           source: {
             type: "git",
-            url: "https://github.com/phoenixframework/phoenix.git",
+            url: "https://github.com/dependabot-fixtures/phoenix.git",
             branch: "master",
             ref: "v1.2.0"
           }
@@ -647,7 +647,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
       end
 
       before do
-        git_url = "https://github.com/phoenixframework/phoenix.git"
+        git_url = "https://github.com/dependabot-fixtures/phoenix.git"
         git_header = {
           "content-type" => "application/x-git-upload-pack-advertisement"
         }
@@ -667,7 +667,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
             requirements: dependency_requirements,
             updated_source: {
               type: "git",
-              url: "https://github.com/phoenixframework/phoenix.git",
+              url: "https://github.com/dependabot-fixtures/phoenix.git",
               branch: "master",
               ref: "v1.3.2"
             },
@@ -682,7 +682,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
               groups: [],
               source: {
                 type: "git",
-                url: "https://github.com/phoenixframework/phoenix.git",
+                url: "https://github.com/dependabot-fixtures/phoenix.git",
                 branch: "master",
                 ref: "v1.3.2"
               }

--- a/hex/spec/fixtures/lockfiles/git_source
+++ b/hex/spec/fixtures/lockfiles/git_source
@@ -1,5 +1,5 @@
 %{"mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [], [], "hexpm"},
-  "phoenix": {:git, "https://github.com/phoenixframework/phoenix.git", "178ce1a2344515e9145599970313fcc190d4b881", [ref: "v1.2.0"]},
+  "phoenix": {:git, "https://github.com/dependabot-fixtures/phoenix.git", "178ce1a2344515e9145599970313fcc190d4b881", [ref: "v1.2.0"]},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [], [], "hexpm"},
   "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [], [], "hexpm"}}

--- a/hex/spec/fixtures/lockfiles/git_source_no_tag
+++ b/hex/spec/fixtures/lockfiles/git_source_no_tag
@@ -1,6 +1,6 @@
 %{"cors_plug": {:hex, :cors_plug, "1.2.1", "bbe1381a52e4a16e609cf3c4cbfde6884726a58b9a1a205db104dbdfc542f447", [:mix], [{:plug, "> 0.8.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [], [], "hexpm"},
-  "phoenix": {:git, "https://github.com/phoenixframework/phoenix.git", "178ce1a2344515e9145599970313fcc190d4b881", [ref: "v1.2.0"]},
+  "phoenix": {:git, "https://github.com/dependabot-fixtures/phoenix.git", "178ce1a2344515e9145599970313fcc190d4b881", [ref: "v1.2.0"]},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [], [], "hexpm"},
   "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [], [], "hexpm"}}

--- a/hex/spec/fixtures/lockfiles/git_source_no_tag_blocked
+++ b/hex/spec/fixtures/lockfiles/git_source_no_tag_blocked
@@ -1,5 +1,5 @@
 %{"mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [], [], "hexpm"},
-  "phoenix": {:git, "https://github.com/phoenixframework/phoenix.git", "178ce1a2344515e9145599970313fcc190d4b881", []},
+  "phoenix": {:git, "https://github.com/dependabot-fixtures/phoenix.git", "178ce1a2344515e9145599970313fcc190d4b881", []},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [], [], "hexpm"},
   "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [], [], "hexpm"}}

--- a/hex/spec/fixtures/lockfiles/git_source_tag_can_update
+++ b/hex/spec/fixtures/lockfiles/git_source_tag_can_update
@@ -1,6 +1,6 @@
 %{"cors_plug": {:hex, :cors_plug, "1.2.1", "bbe1381a52e4a16e609cf3c4cbfde6884726a58b9a1a205db104dbdfc542f447", [:mix], [{:plug, "> 0.8.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [], [], "hexpm"},
-  "phoenix": {:git, "https://github.com/phoenixframework/phoenix.git", "178ce1a2344515e9145599970313fcc190d4b881", [ref: "v1.2.0"]},
+  "phoenix": {:git, "https://github.com/dependabot-fixtures/phoenix.git", "178ce1a2344515e9145599970313fcc190d4b881", [ref: "v1.2.0"]},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [], [], "hexpm"},
   "plug": {:hex, :plug, "1.3.3", "d9be189924379b4e9d470caef87380d09549aea1ceafe6a0d41292c8c317c923", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [], [], "hexpm"}}

--- a/hex/spec/fixtures/lockfiles/git_source_with_charlist
+++ b/hex/spec/fixtures/lockfiles/git_source_with_charlist
@@ -1,5 +1,5 @@
 %{"mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [], [], "hexpm"},
-  "phoenix": {:git, "https://github.com/phoenixframework/phoenix.git", "178ce1a2344515e9145599970313fcc190d4b881", [tag: 'v1.2.0']},
+  "phoenix": {:git, "https://github.com/dependabot-fixtures/phoenix.git", "178ce1a2344515e9145599970313fcc190d4b881", [tag: 'v1.2.0']},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [], [], "hexpm"},
   "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [], [], "hexpm"}}

--- a/hex/spec/fixtures/mixfiles/git_source
+++ b/hex/spec/fixtures/mixfiles/git_source
@@ -18,7 +18,7 @@ defmodule DependabotTest.Mixfile do
   defp deps do
     [
       {:plug, "1.2.0"},
-      {:phoenix, github: "phoenixframework/phoenix", ref: "v1.2.0"}
+      {:phoenix, github: "dependabot-fixtures/phoenix", ref: "v1.2.0"}
     ]
   end
 end

--- a/hex/spec/fixtures/mixfiles/git_source_multiple_lines
+++ b/hex/spec/fixtures/mixfiles/git_source_multiple_lines
@@ -19,7 +19,7 @@ defmodule DependabotTest.Mixfile do
     [
       {:plug, "1.3.3"},
       {:phoenix,
-       github: "phoenixframework/phoenix", tag: "v1.2.0"}
+       github: "dependabot-fixtures/phoenix", tag: "v1.2.0"}
     ]
   end
 end

--- a/hex/spec/fixtures/mixfiles/git_source_no_tag
+++ b/hex/spec/fixtures/mixfiles/git_source_no_tag
@@ -18,7 +18,7 @@ defmodule DependabotTest.Mixfile do
   defp deps do
     [
       {:cors_plug, "~> 1.2.0"},
-      {:phoenix, github: "phoenixframework/phoenix"}
+      {:phoenix, github: "dependabot-fixtures/phoenix"}
     ]
   end
 end

--- a/hex/spec/fixtures/mixfiles/git_source_no_tag_blocked
+++ b/hex/spec/fixtures/mixfiles/git_source_no_tag_blocked
@@ -18,7 +18,7 @@ defmodule DependabotTest.Mixfile do
   defp deps do
     [
       {:plug, "1.2.0"},
-      {:phoenix, github: "phoenixframework/phoenix"}
+      {:phoenix, github: "dependabot-fixtures/phoenix"}
     ]
   end
 end

--- a/hex/spec/fixtures/mixfiles/git_source_tag_can_update
+++ b/hex/spec/fixtures/mixfiles/git_source_tag_can_update
@@ -18,7 +18,7 @@ defmodule DependabotTest.Mixfile do
   defp deps do
     [
       {:plug, "1.3.3"},
-      {:phoenix, github: "phoenixframework/phoenix", ref: "v1.2.0"}
+      {:phoenix, github: "dependabot-fixtures/phoenix", ref: "v1.2.0"}
     ]
   end
 end

--- a/hex/spec/fixtures/mixfiles/git_source_with_charlist
+++ b/hex/spec/fixtures/mixfiles/git_source_with_charlist
@@ -18,7 +18,7 @@ defmodule DependabotTest.Mixfile do
   defp deps do
     [
       {:plug, "1.2.0"},
-      {:phoenix, github: "phoenixframework/phoenix", ref: 'v1.2.0'}
+      {:phoenix, github: "dependabot-fixtures/phoenix", ref: 'v1.2.0'}
     ]
   end
 end


### PR DESCRIPTION
To prevent these repositories from being squatted or from otherwise changing
under our feet in unexpected ways, prefer using repositories that we own
as git dependencies in our tests.