### PR TITLE
v0.149.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.149.5, 2 June 2021
+
+- build(deps): bump detect-indent in /npm_and_yarn/helpers
+- chore(deps): bump composer/composer in /composer/helpers/v2
+- chore(deps-dev): update rubocop requirement from ~> 1.15.0 to ~> 1.16.0
+- refactor(Terraform): raise PrivateSourceAuthenticationFailure instead of DependabotError
+- build(deps-dev): bump jest in /npm_and_yarn/helpers
+- build(deps): bump @npmcli/arborist in /npm_and_yarn/helpers
+
 ## v0.149.4, 1 June 2021
 
 - fix(Terraform): use service discovery protocol

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.149.4"
+  VERSION = "0.149.5"
 end


### PR DESCRIPTION
## v0.149.5, 2 June 2021

- build(deps): bump detect-indent in /npm_and_yarn/helpers
- chore(deps): bump composer/composer in /composer/helpers/v2
- chore(deps-dev): update rubocop requirement from ~> 1.15.0 to ~> 1.16.0
- refactor(Terraform): raise PrivateSourceAuthenticationFailure instead of DependabotError
- build(deps-dev): bump jest in /npm_and_yarn/helpers
- build(deps): bump @npmcli/arborist in /npm_and_yarn/helpers

https://github.com/dependabot/dependabot-core/compare/v0.149.4...1951378
