### PR TITLE
fix(npm): Prevent unnecessary hash pinning in lock file constraint

### DIFF
--- a/npm_and_yarn/helpers/lib/npm6/updater.js
+++ b/npm_and_yarn/helpers/lib/npm6/updater.js
@@ -137,6 +137,8 @@ function installArgs(
     // requirement when installing the new version
     if (existingVersionRequirement.match(desiredVersion)) {
       return `${depName}@${existingVersionRequirement}`;
+    } else if (!existingVersionRequirement.includes("#")) {
+      return `${depName}@${existingVersionRequirement}`;
     } else {
       return `${depName}@${existingVersionRequirement.replace(
         /#.*/,

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -500,4 +500,44 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
       end
     end
   end
+
+  context "when updating a git source dependency that is not pinned to a hash" do
+    subject { JSON.parse(updated_npm_lock_content) }
+
+    let(:files) { project_dependency_files("npm6/ghpr_no_hash_pinning") }
+    let(:dependency_name) { "discord.js" }
+    let(:version) { "HEAD" }
+    let(:previous_version) { "ab82cafcde0ee259a32ef14303c1b4a64dea8fae" }
+    let(:requirements) do
+      [{
+        file: "package.json",
+        requirement: nil,
+        groups: ["dependencies"],
+        source: {
+          type: "git",
+          url: "https://github.com/discordjs/discord.js",
+          branch: nil,
+          ref: "master"
+        }
+      }]
+    end
+    let(:previous_requirements) do
+      [{
+        file: "package.json",
+        requirement: nil,
+        groups: ["dependencies"],
+        source: {
+          type: "git",
+          url: "https://github.com/discordjs/discord.js",
+          branch: nil,
+          ref: "master"
+        }
+      }]
+    end
+
+    it "pins the version to a hash and ensures that the `from` field matches the original constraint" do
+      expect(subject["dependencies"]["discord.js"]["version"]).to match(%r{github:discordjs/discord.js#[0-9a-z]{40}})
+      expect(subject["dependencies"]["discord.js"]["from"]).to eq("github:discordjs/discord.js")
+    end
+  end
 end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -335,7 +335,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           parsed_package_lock = JSON.parse(updated_npm_lock.content)
           expect(parsed_package_lock["dependencies"]["is-number"]["version"]).
             to eq("github:jonschlinkert/is-number#"\
-                  "0c6b15a88bc10cd47f67a09506399dfc9ddc075d")
+                  "98e8ff1da1a89f93d1397a24d7413ed15421c139")
 
           expect(updated_yarn_lock.content).to include(
             "is-number@jonschlinkert/is-number:"
@@ -357,7 +357,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
             parsed_package_lock = JSON.parse(updated_npm_lock.content)
             expect(parsed_package_lock["dependencies"]["is-number"]["version"]).
               to eq("git+https://github.com/jonschlinkert/is-number.git#"\
-                    "0c6b15a88bc10cd47f67a09506399dfc9ddc075d")
+                    "98e8ff1da1a89f93d1397a24d7413ed15421c139")
 
             expect(updated_yarn_lock.content).to include("is-number")
             expect(updated_yarn_lock.content).to include("0c6b15a88b")
@@ -436,7 +436,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
                 parsed_package_lock["dependencies"]["slick-carousel"]["version"]
               expect(npm_lockfile_version).
                 to eq("git://github.com/brianfryer/slick.git#"\
-                      "a2aa3fec335c50aceb58f6ef6d22df8e5f3238e1")
+                      "fc6f7d860844ad562df5b94b5918b58bab067751")
 
               expect(updated_yarn_lock.content).
                 to include('slick-carousel@git://github.com/brianfryer/slick":')
@@ -457,7 +457,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
                 parsed_package_lock["dependencies"]["is-number"]["version"]
               expect(npm_lockfile_version).
                 to eq("git+ssh://git@github.com/jonschlinkert/is-number.git#"\
-                      "0c6b15a88bc10cd47f67a09506399dfc9ddc075d")
+                      "98e8ff1da1a89f93d1397a24d7413ed15421c139")
 
               expect(updated_yarn_lock.content).to include("is-number")
               expect(updated_yarn_lock.content).to include("0c6b15a88bc")
@@ -1264,7 +1264,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           parsed_package_lock = JSON.parse(updated_npm_lock.content)
           expect(parsed_package_lock["dependencies"]["is-number"]["version"]).
             to eq("git+https://github.com/jonschlinkert/is-number.git#"\
-                  "0c6b15a88bc10cd47f67a09506399dfc9ddc075d")
+                  "98e8ff1da1a89f93d1397a24d7413ed15421c139")
         end
       end
 

--- a/npm_and_yarn/spec/fixtures/projects/npm6/ghpr_no_hash_pinning/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/ghpr_no_hash_pinning/package-lock.json
@@ -1,0 +1,100 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@discordjs/collection": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
+      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ=="
+    },
+    "@discordjs/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-ZfFsbgEXW71Rw/6EtBdrP5VxBJy4dthyC0tpQKGKmYFImlmmrykO14Za+BiIVduwjte0jXEBlhSKf0MWbFp9Eg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "discord.js": {
+      "version": "github:discordjs/discord.js#ab82cafcde0ee259a32ef14303c1b4a64dea8fae",
+      "from": "github:discordjs/discord.js",
+      "requires": {
+        "@discordjs/collection": "^0.1.6",
+        "@discordjs/form-data": "^3.0.1",
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^2.6.1",
+        "prism-media": "^1.2.2",
+        "tweetnacl": "^1.0.3",
+        "ws": "^7.3.1"
+      }
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "mime-db": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
+    },
+    "mime-types": {
+      "version": "2.1.31",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+      "requires": {
+        "mime-db": "1.48.0"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "prism-media": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.9.tgz",
+      "integrity": "sha512-UHCYuqHipbTR1ZsXr5eg4JUmHER8Ss4YEb9Azn+9zzJ7/jlTtD1h0lc4g6tNx3eMlB8Mp6bfll0LPMAV4R6r3Q=="
+    },
+    "tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
+    "ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm6/ghpr_no_hash_pinning/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/ghpr_no_hash_pinning/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "dependencies": {
+    "discord.js": "github:discordjs/discord.js"
+  },
+  "engines": {
+    "node": "14.x"
+  }
+}


### PR DESCRIPTION
# Why is this needed?

To make sure that Dependabot does not pin to a specific git hash when the `package.json` has not pinned to one.

## What does this do?

It updates the npm helper to check for a pinned hash in git based version constraints.

Fixes https://github.com/dependabot/dependabot-core/issues/3813

### Screenshots

Before:

```bash
[dependabot-core-dev] ~/dependabot-core $ ./bin/dry-run.rb npm_and_yarn xlgmokha/hypixel-translators-bot --dep discord.js --branch core-3813
Resolving dependencies...
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.7-compliant syntax, but you are running 2.6.6.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> fetching dependency files
=> dumping fetched dependency files: ./dry-run/xlgmokha/hypixel-translators-bot/core-3813/
=> parsing dependency files
=> updating 1 dependencies: discord.js

=== discord.js (ab82cafcde0ee259a32ef14303c1b4a64dea8fae)
 => checking for updates 1/1
 => latest available version is 7b85a7259f563ab14ae6c0a665a3dd43c486fde4
 => latest allowed version is 7b85a7259f563ab14ae6c0a665a3dd43c486fde4
 => requirements to unlock: own
 => requirements update strategy: bump_versions
 => updating discord.js from ab82cafcde0ee259a32ef14303c1b4a64dea8fae to 7b85a7259f563ab14ae6c0a665a3dd43c486fde4

    ± package-lock.json
    ~~~
    37a38,42
    >     "@sapphire/async-queue": {
    >       "version": "1.1.2",
    >       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.2.tgz",
    >       "integrity": "sha512-NkR7AzC9uyb++tMIZgG4X0ci8JM1rnvNmKbLwY42RgotRV8JGUntZ7ZpR7MN7p5zPlVdKo/YmOqcCCsBJ6LNuw=="
    >     },
    88d92
    <       "dev": true,
    308,309c312
    <       "integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg==",
    <       "dev": true
    ---
    >       "integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg=="
    312,313c315,316
    <       "version": "github:discordjs/discord.js#ab82cafcde0ee259a32ef14303c1b4a64dea8fae",
    <       "from": "github:discordjs/discord.js",
    ---
    >       "version": "github:discordjs/discord.js#7b85a7259f563ab14ae6c0a665a3dd43c486fde4",
    >       "from": "github:discordjs/discord.js#7b85a7259f563ab14ae6c0a665a3dd43c486fde4",
    316a320,321
    >         "@sapphire/async-queue": "^1.1.2",
    >         "@types/ws": "^7.4.4",
    317a323
    >         "discord-api-types": "^0.18.1",
    319c325
    <         "prism-media": "^1.2.2",
    ---
    >         "prism-media": "^1.2.9",
    321c327,334
    <         "ws": "^7.3.1"
    ---
    >         "ws": "^7.4.6"
    >       },
    >       "dependencies": {
    >         "ws": {
    >           "version": "7.4.6",
    >           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
    >           "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
    >         }
    ~~~
```

After:

```bash
$ ./bin/dry-run.rb npm_and_yarn xlgmokha/hypixel-translators-bot --dep 'discord.js' --branch core-3813
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.7-compliant syntax, but you are running 2.6.6.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> fetching dependency files
=> dumping fetched dependency files: ./dry-run/xlgmokha/hypixel-translators-bot/core-3813/
=> parsing dependency files
=> updating 1 dependencies: discord.js

=== discord.js (ab82cafcde0ee259a32ef14303c1b4a64dea8fae)
 => checking for updates 1/1
 => latest available version is 51551f544b80d7d27ab0b315da01dfc560b2c115
 => latest allowed version is 51551f544b80d7d27ab0b315da01dfc560b2c115
 => requirements to unlock: own
 => requirements update strategy: bump_versions
 => updating discord.js from ab82cafcde0ee259a32ef14303c1b4a64dea8fae to 51551f544b80d7d27ab0b315da01dfc560b2c115

    ± package-lock.json
    ~~~
    37a38,42
    >     "@sapphire/async-queue": {
    >       "version": "1.1.2",
    >       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.2.tgz",
    >       "integrity": "sha512-NkR7AzC9uyb++tMIZgG4X0ci8JM1rnvNmKbLwY42RgotRV8JGUntZ7ZpR7MN7p5zPlVdKo/YmOqcCCsBJ6LNuw=="
    >     },
    88d92
    <       "dev": true,
    308,309c312
    <       "integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg==",
    <       "dev": true
    ---
    >       "integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg=="
    312c315
    <       "version": "github:discordjs/discord.js#ab82cafcde0ee259a32ef14303c1b4a64dea8fae",
    ---
    >       "version": "github:discordjs/discord.js#fdad14099779e61cb84dcd1cb2497e0e853a6144",
    316a320,321
    >         "@sapphire/async-queue": "^1.1.2",
    >         "@types/ws": "^7.4.4",
    317a323
    >         "discord-api-types": "^0.18.1",
    319c325
    <         "prism-media": "^1.2.2",
    ---
    >         "prism-media": "^1.2.9",
    321c327,334
    <         "ws": "^7.3.1"
    ---
    >         "ws": "^7.4.6"
    >       },
    >       "dependencies": {
    >         "ws": {
    >           "version": "7.4.6",
    >           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
    >           "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
    >         }
    ~~~
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)