### PR TITLE
[Azure] Add retries for Azure client POST

### DIFF
--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -234,20 +234,29 @@ module Dependabot
       end
 
       def post(url, json)
-        response = Excon.post(
-          url,
-          body: json,
-          user: credentials&.fetch("username", nil),
-          password: credentials&.fetch("password", nil),
-          idempotent: true,
-          **SharedHelpers.excon_defaults(
-            headers: auth_header.merge(
-              {
-                "Content-Type" => "application/json"
-              }
+        response = nil
+
+        retry_connection_failures do
+          response = Excon.post(
+            url,
+            body: json,
+            user: credentials&.fetch("username", nil),
+            password: credentials&.fetch("password", nil),
+            idempotent: true,
+            **SharedHelpers.excon_defaults(
+              headers: auth_header.merge(
+                {
+                  "Content-Type" => "application/json"
+                }
+              )
             )
           )
-        )
+
+          raise InternalServerError if response.status == 500
+          raise BadGateway if response.status == 502
+          raise ServiceNotAvailable if response.status == 503
+        end
+
         raise NotFound if response.status == 404
 
         response

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -258,23 +258,49 @@ RSpec.describe Dependabot::Clients::Azure do
     end
 
     context "Retries" do
-      it "with failure count <= max_retries" do
-        # Request succeeds (200) on second attempt.
-        stub_request(:get, base_url).
-          with(basic_auth: [username, password]).
-          to_return({ status: 502 }, { status: 200 })
+      context 'for GET' do
+        it "with failure count <= max_retries" do
+          # Request succeeds (200) on second attempt.
+          stub_request(:get, base_url).
+            with(basic_auth: [username, password]).
+            to_return({ status: 502 }, { status: 200 })
 
-        response = client.get(base_url)
-        expect(response.status).to eq(200)
+          response = client.get(base_url)
+          expect(response.status).to eq(200)
+        end
+
+        it "with failure count > max_retries raises error" do
+          #  Request fails (503) multiple times and exceeds max_retry limit
+          stub_request(:get, base_url).
+            with(basic_auth: [username, password]).
+            to_return({ status: 503 }, { status: 503 }, { status: 503 })
+
+          expect { client.get(base_url) }.to raise_error(Dependabot::Clients::Azure::ServiceNotAvailable)
+        end
       end
 
-      it "with failure count > max_retries raises error" do
-        #  Request fails (503) multiple times and exceeds max_retry limit
-        stub_request(:get, base_url).
-          with(basic_auth: [username, password]).
-          to_return({ status: 503 }, { status: 503 }, { status: 503 })
+      context "for POST" do
+        before :each do
+          @request_body = "request body"
+        end
+        it "with failure count <= max_retries" do
+          # Request succeeds on thrid attempt
+          stub_request(:post, base_url).
+            with(basic_auth: [username, password], body: @request_body).
+            to_return({ status: 503 }, { status: 503 }, { status: 200 })
 
-        expect { client.get(base_url) }.to raise_error(Dependabot::Clients::Azure::ServiceNotAvailable)
+          response = client.post(base_url, @request_body)
+          expect(response.status).to eq(200)
+        end
+
+        it "with failure count > max_retries raises an error" do
+          stub_request(:post, base_url).
+            with(basic_auth: [username, password], body: @request_body).
+            to_return({ status: 503 }, { status: 503 }, { status: 503 }, { status: 503 })
+
+          expect { client.post(base_url, @request_body) }.
+            to raise_error(Dependabot::Clients::Azure::ServiceNotAvailable)
+        end
       end
     end
   end


### PR DESCRIPTION
Azure client today doesn't implement any retries for POST requests. Azure GET has retry functionality for ServiceUnavailable errors.  When working with bigger repos, we see (transient) ServiceUnavailable more often for POST requests. This PR adds retries for the standard 500, 502, and 503 errors.