### PR TITLE
Pin erlang to OTP 23 until we can resolve OTP 24 warning issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,10 +186,11 @@ ENV PATH="$PATH:/usr/local/elixir/bin"
 # https://github.com/elixir-lang/elixir/releases
 ARG ELIXIR_VERSION=v1.11.4
 ARG ELIXIR_CHECKSUM=4d8ead533a7bd35b41669be0d4548b612d5cc17723da67cfdf996ab36522fd0163215915a970675c6ebcba4dbfc7a46e644cb144b16087bc9417b385955a1e79
+ARG ERLANG_VERSION=1:23.3.1-1
 RUN wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
   && dpkg -i erlang-solutions_1.0_all.deb \
   && apt-get update \
-  && apt-get install -y esl-erlang \
+  && apt-get install -y esl-erlang=${ERLANG_VERSION} \
   && wget https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip \
   && echo "$ELIXIR_CHECKSUM  Precompiled.zip" | sha512sum -c - \
   && unzip -d /usr/local/elixir -x Precompiled.zip \


### PR DESCRIPTION
This pins the `esl-erlang` package to a version that uses OTP 23 instead of the latest which is using OTP 24. OTP 24 introduced some new warning output which is causing mix updates to fail.

https://elixirforum.com/t/mix-local-hex-warning/39665

I took this version from the last core release which was successfully processing mix updates:
```
% docker run -it dependabot/dependabot-core:0.147.0
dependabot@95d004bd8c6d:~$ apt list esl-erlang
Listing... Done
esl-erlang/now 1:23.3.1-1 amd64 [installed,local]
```

The next version contained the update causing the failures:
```
% docker run -it dependabot/dependabot-core:0.147.1
dependabot@a084b38baba1:~$ apt list esl-erlang
Listing... Done
esl-erlang/now 1:24.0-1 amd64 [installed,local]
```

Fixes: https://github.com/dependabot/dependabot-core/issues/3773

