### PR TITLE
v0.151.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.151.0, 7 June 2021
+
+- Pin erlang to OTP 23 until we can resolve OTP 24 warning issues
+- build(deps-dev): bump friendsofphp/php-cs-fixer in /composer/helpers/v2
+
 ## v0.150.0, 7 June 2021
 
 - build(deps): bump composer/composer from 2.0.14 to 2.1.1 in /composer/helpers/v2

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.150.0"
+  VERSION = "0.151.0"
 end


### PR DESCRIPTION
## v0.151.0, 7 June 2021

- Pin erlang to OTP 23 until we can resolve OTP 24 warning issues
- build(deps-dev): bump friendsofphp/php-cs-fixer in /composer/helpers/v2

https://github.com/dependabot/dependabot-core/compare/v0.150.0...v0.151.0-release-notes