### PR TITLE
v0.151.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.151.1, 7 June 2021
+
+fix(npm): Prevent unnecessary hash pinning in lock file constraint
+
 ## v0.151.0, 7 June 2021
 
 - Pin erlang to OTP 23 until we can resolve OTP 24 warning issues

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.151.0"
+  VERSION = "0.151.1"
 end


### PR DESCRIPTION
## v0.151.1, 7 June 2021

fix(npm): Prevent unnecessary hash pinning in lock file constraint

https://github.com/dependabot/dependabot-core/compare/v0.151.0...9df3cda
