### PR TITLE
Fix Terraform lockfile bug introduced in #3766

### DIFF
--- a/terraform/lib/dependabot/terraform/file_fetcher.rb
+++ b/terraform/lib/dependabot/terraform/file_fetcher.rb
@@ -23,7 +23,7 @@ module Dependabot
         fetched_files = []
         fetched_files += terraform_files
         fetched_files += terragrunt_files
-        fetched_files += lock_file if lock_file
+        fetched_files += [lock_file] if lock_file
 
         return fetched_files if fetched_files.any?
 

--- a/terraform/spec/dependabot/terraform/file_fetcher_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_fetcher_spec.rb
@@ -83,6 +83,31 @@ RSpec.describe Dependabot::Terraform::FileFetcher do
     end
   end
 
+  context "with a lockfile" do
+    before do
+      stub_request(:get, url + "?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "contents_lockfile_repo.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, ".terraform.lock.hcl?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "contents_terraform_file.json"),
+          headers: { "content-type" => "application/json" }
+        )
+    end
+
+    it "fetches the lockfile" do
+      expect(file_fetcher_instance.files.map(&:name)).
+        to match_array(%w(.terraform.lock.hcl))
+    end
+  end
+
   context "with a directory that doesn't exist" do
     let(:directory) { "/nonexistent" }
 

--- a/terraform/spec/fixtures/github/contents_lockfile_repo.json
+++ b/terraform/spec/fixtures/github/contents_lockfile_repo.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": ".terraform.lock.hcl",
+    "path": "prod/us-east-1/prod/webserver-cluster/.terraform.lock.hcl",
+    "sha": "e3cf573ae962cbfa23be5543e51b1bf3cd14c69c",
+    "size": 1464,
+    "url": "https://api.github.com/repos/seqsense/terraform-lock-fix-action/contents/test/.terraform.lock.hcl?ref=main",
+    "html_url": "https://github.com/seqsense/terraform-lock-fix-action/blob/main/.terraform.lock.hcl",
+    "git_url": "https://api.github.com/repos/seqsense/terraform-lock-fix-action/git/blobs/e3cf573ae962cbfa23be5543e51b1bf3cd14c69c",
+    "download_url": "https://raw.githubusercontent.com/seqsense/terraform-lock-fix-action/main/test/.terraform.lock.hcl",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/seqsense/terraform-lock-fix-action/contents/test/.terraform.lock.hcl?ref=main",
+      "git": "https://api.github.com/repos/seqsense/terraform-lock-fix-action/git/blobs/e3cf573ae962cbfa23be5543e51b1bf3cd14c69c",
+      "html": "https://github.com/seqsense/terraform-lock-fix-action/blob/main/test/.terraform.lock.hcl"
+    }
+  }
+]


### PR DESCRIPTION
Fixes a bug where `lock_file` would fail when appended `fetched_files` array. Introduced in https://github.com/dependabot/dependabot-core/pull/3766/commits/b3c774247f3ff1ec38e1dfbb8fd6851b51f02150

This fix wraps the `lock_file` in an array before appending it to `fetched_files`. It also adds a test to ensure the lockfile is correctly added in `FileFetcher`