### PR TITLE
Add instruction to checkout new branch

### DIFF
--- a/bin/bump-version.rb
+++ b/bin/bump-version.rb
@@ -51,6 +51,7 @@ puts
 puts "git add CHANGELOG.md common/lib/dependabot/version.rb"
 puts "git commit -m 'v#{new_version}'"
 puts "git push origin HEAD:v#{new_version}-release-notes"
+puts "git checkout v#{new_version}-release-notes"
 puts "# ... create PR, verify, merge, for example:"
 puts "gh pr create"
 puts "# tag the approved release notes:"


### PR DESCRIPTION
This PR adds a `git checkout` instruction before creating a PR in `bin/bump-version`.