### PR TITLE
Tests: Allow profiling tests with stackprof when tagged

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,11 @@ and you'll get all you need.
 
 ## Profiling
 
-You can profile a dry-run by passing the `--profile` flag when running it. This
-will generate a `stackprof-<datetime>.dump` file in the `tmp/` folder, and you
-can generate a flamegraph from this by running:
-`stackprof --d3-flamegraph tmp/stackprof-<datetime>.dump > tmp/flamegraph.html`.
+You can profile a dry-run by passing the `--profile` flag when running it, or
+tag an rspec test with `:profile`. This will generate a
+`stackprof-<datetime>.dump` file in the `tmp/` folder, and you can generate a
+flamegraph from this by running:
+`stackprof --d3-flamegraph tmp/stackprof-<data or spec name>.dump > tmp/flamegraph.html`.
 
 ## Why is this public?
 


### PR DESCRIPTION
This adds the ability to tag a spec with `:profile`:

```ruby
it "profiles with rspec", :profile do
  # ..
end
```

And will then generate a stackprof dump in the `tmp` directory.

This is useful when debugging performance issues.