### PR TITLE
v0.152.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.152.1, 11 June 2021
+
+- Tests: Allow profiling tests with stackprof when tagged
+- Throw an error when using the deprecated terraform provider syntax, include upgrade instructions
+- Update `bump-version` with instructions to checkout the new branch
+
 ## v0.152.0, 10 June 2021
 
 - Python: Upgrade pip to 21.1.2

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.152.0"
+  VERSION = "0.152.1"
 end


### PR DESCRIPTION
- Tests: Allow profiling tests with stackprof when tagged
- Throw an error when using the deprecated terraform provider syntax, include upgrade instructions
- Update `bump-version` with instructions to checkout the new branch﻿
