### PR TITLE
Update Ruby from 2.6 to 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,15 +64,19 @@ RUN if ! getent group $USER_GID; then groupadd --gid $USER_GID dependabot ; \
 
 ### RUBY
 
-# Install Ruby 2.6.6, update RubyGems, and install Bundler
+# Install Ruby 2.7, update RubyGems, and install Bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
+# Allow gem installs as the dependabot user
+ENV BUNDLE_PATH=".bundle" \
+    BUNDLE_BIN=".bundle/bin"
+ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
 RUN apt-add-repository ppa:brightbox/ruby-ng \
   && apt-get update \
-  && apt-get install -y ruby2.6 ruby2.6-dev \
+  && apt-get install -y ruby2.7 ruby2.7-dev \
   && gem update --system 3.2.20 \
   && gem install bundler -v 1.17.3 --no-document \
   && gem install bundler -v 2.2.20 --no-document \
-  && rm -rf /var/lib/gems/2.6.0/cache/* \
+  && rm -rf /var/lib/gems/2.7.0/cache/* \
   && rm -rf /var/lib/apt/lists/*
 
 
@@ -253,10 +257,6 @@ RUN bash /opt/terraform/helpers/build /opt/terraform
 RUN bash /opt/composer/helpers/v1/build /opt/composer/v1
 RUN bash /opt/composer/helpers/v2/build /opt/composer/v2
 
-# Allow further gem installs as the dependabot user
 ENV HOME="/home/dependabot"
-ENV BUNDLE_PATH="$HOME/.bundle" \
-    BUNDLE_BIN=".bundle/bin"
-ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
 
 WORKDIR ${HOME}

--- a/bundler/helpers/v1/build
+++ b/bundler/helpers/v1/build
@@ -20,6 +20,6 @@ cd "$install_dir"
 
 # NOTE: Sets `BUNDLED WITH` to match the installed v1 version in Gemfile.lock
 # forcing native helpers to run with the same version
-BUNDLER_VERSION=2 bundle config set --local path ".bundle"
+BUNDLER_VERSION=1 bundle config set --local path ".bundle"
 BUNDLER_VERSION=1 bundle config set --local without "test"
 BUNDLER_VERSION=1 bundle install

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -18,7 +18,7 @@ cp -r \
 
 cd "$install_dir"
 
-# NOTE: Sets `BUNDLED WITH` to match the installed v1 version in Gemfile.lock
+# NOTE: Sets `BUNDLED WITH` to match the installed v2 version in Gemfile.lock
 # forcing specs and native helpers to run with the same version
 BUNDLER_VERSION=2 bundle config set --local path ".bundle"
 BUNDLER_VERSION=2 bundle config set --local without "test"

--- a/bundler/helpers/v2/lib/functions/lockfile_updater.rb
+++ b/bundler/helpers/v2/lib/functions/lockfile_updater.rb
@@ -9,6 +9,7 @@ module Functions
         not\sfind\s(?<name>[^\s]+)-\d|
         has\s(?<name>[^\s]+)\slocked\sat
       /x.freeze
+      DEPENDENCY_DROPPED = "_dependency_dropped_"
 
     def initialize(gemfile_name:, lockfile_name:, dependencies:)
       @gemfile_name = gemfile_name
@@ -36,7 +37,7 @@ module Functions
 
         old_reqs.each do |dep_name, old_req|
           d_dep = definition.dependencies.find { |d| d.name == dep_name }
-          if old_req == :none then definition.dependencies.delete(d_dep)
+          if old_req.to_s == DEPENDENCY_DROPPED then definition.dependencies.delete(d_dep)
           else
             d_dep.instance_variable_set(:@requirement, old_req)
           end
@@ -200,7 +201,7 @@ module Functions
         if defn_dep.nil?
           definition.dependencies <<
             Bundler::Dependency.new(dep.fetch("name"), dep.fetch("version"))
-          old_reqs[dep.fetch("name")] = :none
+          old_reqs[dep.fetch("name")] = DEPENDENCY_DROPPED
         elsif git_dependency?(dep) &&
               defn_dep.source.is_a?(Bundler::Source::Git)
           defn_dep.source.unlock!

--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -17,7 +17,6 @@ module Dependabot
               # Bundler will pick the matching installed major version
               "BUNDLER_VERSION" => bundler_version,
               "BUNDLE_GEMFILE" => File.join(versioned_helper_path(bundler_version: bundler_version), "Gemfile"),
-              "BUNDLE_PATH" => File.join(versioned_helper_path(bundler_version: bundler_version), ".bundle"),
               # Prevent the GEM_HOME from being set to a folder owned by root
               "GEM_HOME" => File.join(versioned_helper_path(bundler_version: bundler_version), ".bundle")
             }
@@ -36,7 +35,7 @@ module Dependabot
       end
 
       def self.helper_path(bundler_version:)
-        "ruby #{File.join(versioned_helper_path(bundler_version: bundler_version), 'run.rb')}"
+        "bundle exec ruby #{File.join(versioned_helper_path(bundler_version: bundler_version), 'run.rb')}"
       end
 
       def self.native_helpers_root

--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -142,6 +142,11 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
           let(:dependency_files) { bundler_project_dependency_files("bundler_specified") }
 
+          before do
+            stub_request(:get, rubygems_url + "versions/bundler.json").
+              to_return(status: 200, body: fixture("rubygems_responses", "versions-bundler.json"))
+          end
+
           it "returns nil as resolution returns the bundler version installed by core" do
             expect(subject).to be_nil
           end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -170,7 +170,7 @@ module Dependabot
                   [{ production: !details["dev"] }]
               end
 
-              dependency_set << Dependency.new(dependency_args)
+              dependency_set << Dependency.new(**dependency_args)
               dependency_set += recursively_fetch_npm_lock_dependencies(details)
             end
 

--- a/python/spec/dependabot/python/requirement_spec.rb
+++ b/python/spec/dependabot/python/requirement_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Dependabot::Python::Requirement do
     context "with an array" do
       let(:requirement_string) { ["== 1.3.*", ">= 1.3.1"] }
       its(:to_s) do
-        is_expected.to eq(Gem::Requirement.new([">= 1.3.1", "~> 1.3.0.a"]).to_s)
+        is_expected.to eq(Gem::Requirement.new(["~> 1.3.0.a", ">= 1.3.1"]).to_s)
       end
     end
 


### PR DESCRIPTION
Updates Ruby from 2.6 to 2.7.

Ruby 2.7 ships a version of rubygems where the `Gem::Requirement` class is sorted. I don't think we rely on sort order in dependabot-core, we loop over requirements in turn to check if they match.

I had to change how we run the native helpers, to use `bundle exec` to make it pick up the `BUNDLER_VERSION` env var. Ruby 2.7 started falling back to bundler 2.1.4 for both bundler v1 and v2 without `bundle exec`.

## TODO
- [x] Test on staging