### PR TITLE
Python: Upgrade pyenv to 2.0.1 to add support for Python 3.9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,9 +82,9 @@ ENV PYENV_ROOT=/usr/local/.pyenv \
   PATH="/usr/local/.pyenv/bin:$PATH"
 RUN mkdir -p "$PYENV_ROOT" && chown dependabot:dependabot "$PYENV_ROOT"
 USER dependabot
-RUN git clone https://github.com/pyenv/pyenv.git --branch 1.2.26 --single-branch --depth=1 /usr/local/.pyenv \
-  && pyenv install 3.9.4 \
-  && pyenv global 3.9.4 \
+RUN git clone https://github.com/pyenv/pyenv.git --branch v2.0.1 --single-branch --depth=1 /usr/local/.pyenv \
+  && pyenv install 3.9.5 \
+  && pyenv global 3.9.5 \
   && rm -Rf /tmp/python-build*
 USER root
 

--- a/python/helpers/build
+++ b/python/helpers/build
@@ -16,9 +16,9 @@ cp -r \
   "$install_dir"
 
 cd "$install_dir"
-PYENV_VERSION=3.9.4  pyenv exec pip install -r "requirements.txt"
+PYENV_VERSION=3.9.5  pyenv exec pip install -r "requirements.txt"
 
 # Workaround of https://github.com/python-poetry/poetry/issues/3010
 # By default poetry config file is stored under ~/.config/pypoetry
 # and is not bound to any specific Python version
-PYENV_VERSION=3.9.4 pyenv exec poetry config experimental.new-installer false
+PYENV_VERSION=3.9.5 pyenv exec poetry config experimental.new-installer false

--- a/python/lib/dependabot/python/python_versions.rb
+++ b/python/lib/dependabot/python/python_versions.rb
@@ -4,14 +4,14 @@ module Dependabot
   module Python
     module PythonVersions
       PRE_INSTALLED_PYTHON_VERSIONS = %w(
-        3.9.4
+        3.9.5
       ).freeze
 
       # Due to an OpenSSL issue we can only install the following versions in
       # the Dependabot container.
       SUPPORTED_VERSIONS = %w(
-        3.9.4 3.9.3 3.9.2 3.9.1 3.9.0
-        3.8.9 3.8.8 3.8.7 3.8.6 3.8.5 3.8.4 3.8.3 3.8.2 3.8.1 3.8.0
+        3.9.5 3.9.4 3.9.3 3.9.2 3.9.1 3.9.0
+        3.8.10 3.8.9 3.8.8 3.8.7 3.8.6 3.8.5 3.8.4 3.8.3 3.8.2 3.8.1 3.8.0
         3.7.10 3.7.9 3.7.8 3.7.7 3.7.6 3.7.5 3.7.4 3.7.3 3.7.2 3.7.1 3.7.0
         3.6.13 3.6.12 3.6.11 3.6.10 3.6.9 3.6.8 3.6.7 3.6.6 3.6.5 3.6.4 3.6.3
         3.6.2 3.6.1 3.6.0 3.5.10 3.5.8 3.5.7 3.5.6 3.5.5 3.5.4 3.5.3

--- a/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipenvVersionResolver do
                 to start_with("Dependabot detected the following Python")
               expect(error.message).to include("3.4.*")
               expect(error.message).
-                to include("supported in Dependabot: 3.9.4, 3.9.3, 3.9.2")
+                to include("supported in Dependabot: 3.9.5, 3.9.4, 3.9.3")
             end
         end
       end


### PR DESCRIPTION
- Also adds support for 3.8.10

Fixes https://github.com/dependabot/dependabot-core/issues/3889