### PR TITLE
Add missing `-y` for apt-get install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -218,7 +218,7 @@ ARG TERRAFORM_VERSION=1.0.0
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 RUN apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
   && apt-get update -y \
-  && apt-get install terraform=${TERRAFORM_VERSION} \
+  && apt-get install -y terraform=${TERRAFORM_VERSION} \
   && terraform -help \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Should always use `-y` with `apt-get install` in Dockerfile to prevent manual input interrupt the image build. (This is the only on missing in the Dockerfile)