### PR TITLE
enable rubocop on bundler/helpers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,9 +4,7 @@ AllCops:
   Exclude:
     - '*/vendor/**/*'
     - '*/bin/**/*'
-    - '*/tmp/**/*'
-    - 'tmp/**/*'
-    - '*/helpers/**/*'
+    - '**/tmp/**/*'
     - '*/spec/fixtures/**/*'
 
 Layout/DotPosition:

--- a/bundler/helpers/v1/lib/functions.rb
+++ b/bundler/helpers/v1/lib/functions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "functions/file_parser"
 require "functions/force_updater"
 require "functions/lockfile_updater"
@@ -123,8 +125,6 @@ module Functions
       lockfile_name: args.fetch(:lockfile_name)
     ).conflicting_dependencies
   end
-
-  private
 
   def self.set_bundler_flags_and_credentials(dir:, credentials:)
     dir = dir ? Pathname.new(dir) : dir

--- a/bundler/helpers/v1/lib/functions/dependency_source.rb
+++ b/bundler/helpers/v1/lib/functions/dependency_source.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Functions
   class DependencySource
     attr_reader :gemfile_name, :dependency_name
@@ -66,7 +68,7 @@ module Functions
       return @specified_source if defined? @specified_source
 
       @specified_source = definition.dependencies.
-        find { |dep| dep.name == dependency_name }&.source
+                          find { |dep| dep.name == dependency_name }&.source
     end
 
     def default_source

--- a/bundler/helpers/v1/lib/functions/file_parser.rb
+++ b/bundler/helpers/v1/lib/functions/file_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Functions
   class FileParser
     def initialize(lockfile_name:)
@@ -54,12 +56,8 @@ module Functions
       return nil if default_rubygems?(source)
 
       details = { type: source.class.name.split("::").last.downcase }
-      if source.is_a?(Bundler::Source::Git)
-        details.merge!(git_source_details(source))
-      end
-      if source.is_a?(Bundler::Source::Rubygems)
-        details[:url] = source.remotes.first.to_s
-      end
+      details.merge!(git_source_details(source)) if source.is_a?(Bundler::Source::Git)
+      details[:url] = source.remotes.first.to_s if source.is_a?(Bundler::Source::Rubygems)
       details
     end
 

--- a/bundler/helpers/v1/lib/functions/file_parser.rb
+++ b/bundler/helpers/v1/lib/functions/file_parser.rb
@@ -41,7 +41,7 @@ module Functions
     end
 
     def source_from_lockfile(dependency_name)
-      parsed_lockfile&.specs.find { |s| s.name == dependency_name }&.source
+      parsed_lockfile&.specs&.find { |s| s.name == dependency_name }&.source
     end
 
     def source_for(dependency)

--- a/bundler/helpers/v1/lib/functions/force_updater.rb
+++ b/bundler/helpers/v1/lib/functions/force_updater.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Functions
   class ForceUpdater
     class TransitiveDependencyError < StandardError; end

--- a/bundler/helpers/v1/lib/functions/lockfile_updater.rb
+++ b/bundler/helpers/v1/lib/functions/lockfile_updater.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 module Functions
   class LockfileUpdater
     RETRYABLE_ERRORS = [Bundler::HTTPError].freeze
     GEM_NOT_FOUND_ERROR_REGEX =
-    /
-      locked\sto\s(?<name>[^\s]+)\s\(|
-      not\sfind\s(?<name>[^\s]+)-\d|
-      has\s(?<name>[^\s]+)\slocked\sat
-    /x.freeze
+      /
+        locked\sto\s(?<name>[^\s]+)\s\(|
+        not\sfind\s(?<name>[^\s]+)-\d|
+        has\s(?<name>[^\s]+)\slocked\sat
+      /x.freeze
 
     def initialize(gemfile_name:, lockfile_name:, dependencies:)
       @gemfile_name = gemfile_name
@@ -135,7 +137,7 @@ module Functions
       raise unless error.message.match?(GEM_NOT_FOUND_ERROR_REGEX)
 
       gem_name = error.message.match(GEM_NOT_FOUND_ERROR_REGEX).
-                named_captures["name"]
+                 named_captures["name"]
       raise if dependencies_to_unlock.include?(gem_name)
 
       dependencies_to_unlock << gem_name
@@ -161,9 +163,7 @@ module Functions
         end.compact.map(&:name)
 
       # If there are specific dependencies we can unlock, unlock them
-      if potentials_deps.any?
-        return dependencies_to_unlock.append(*potentials_deps)
-      end
+      return dependencies_to_unlock.append(*potentials_deps) if potentials_deps.any?
 
       # Fall back to unlocking *all* sub-dependencies. This is required
       # because Bundler's VersionConflict objects don't include enough
@@ -205,7 +205,7 @@ module Functions
               defn_dep.source.is_a?(Bundler::Source::Git)
           defn_dep.source.unlock!
         elsif Gem::Version.correct?(dep.fetch("version"))
-          new_req = Gem::Requirement.create("= #{dep.fetch("version")}")
+          new_req = Gem::Requirement.create("= #{dep.fetch('version')}")
           old_reqs[dep.fetch("name")] = defn_dep.requirement
           defn_dep.instance_variable_set(:@requirement, new_req)
         end

--- a/bundler/helpers/v1/lib/functions/lockfile_updater.rb
+++ b/bundler/helpers/v1/lib/functions/lockfile_updater.rb
@@ -24,7 +24,7 @@ module Functions
 
     attr_reader :gemfile_name, :lockfile_name, :dependencies
 
-    def generate_lockfile
+    def generate_lockfile # rubocop:disable Metrics/PerceivedComplexity
       dependencies_to_unlock = dependencies.map { |d| d.fetch("name") }
 
       begin

--- a/bundler/helpers/v1/lib/functions/version_resolver.rb
+++ b/bundler/helpers/v1/lib/functions/version_resolver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Functions
   class VersionResolver
     GEM_NOT_FOUND_ERROR_REGEX = /locked to (?<name>[^\s]+) \(/.freeze
@@ -20,9 +22,7 @@ module Functions
       # included in a gemspec, it's because the Gemfile didn't import
       # the gemspec. This is unusual, but the correct behaviour if/when
       # it happens is to behave as if the repo was gemspec-only.
-      if dep.nil? && dependency_requirements.any?
-        return "latest"
-      end
+      return "latest" if dep.nil? && dependency_requirements.any?
 
       # Otherwise, if the dependency wasn't found it's because it is a
       # subdependency that was removed when attempting to update it.
@@ -38,9 +38,7 @@ module Functions
         ruby_version: ruby_version,
         fetcher: fetcher_class(dep)
       }
-      if dep.source.instance_of?(::Bundler::Source::Git)
-        details[:commit_sha] = dep.source.revision
-      end
+      details[:commit_sha] = dep.source.revision if dep.source.instance_of?(::Bundler::Source::Git)
       details
     end
 
@@ -92,7 +90,7 @@ module Functions
     end
 
     def build_definition(dependencies_to_unlock)
-      # Note: we lock shared dependencies to avoid any top-level
+      # NOTE: we lock shared dependencies to avoid any top-level
       # dependencies getting unlocked (which would happen if they were
       # also subdependencies of the dependency being unlocked)
       ::Bundler::Definition.build(

--- a/bundler/helpers/v1/monkey_patches/git_source_patch.rb
+++ b/bundler/helpers/v1/monkey_patches/git_source_patch.rb
@@ -41,9 +41,7 @@ module Bundler
         $LOAD_PATH.shift until $LOAD_PATH.empty?
         reduced_load_paths.each { |p| $LOAD_PATH << p }
 
-        if destination.relative?
-          destination = destination.expand_path(Bundler.root)
-        end
+        destination = destination.expand_path(Bundler.root) if destination.relative?
         Dir["#{destination}/#{@glob}"].each do |spec_path|
           # Evaluate gemspecs and cache the result. Gemspecs
           # in git might require git or other dependencies.

--- a/bundler/helpers/v1/run.rb
+++ b/bundler/helpers/v1/run.rb
@@ -13,7 +13,7 @@ require "git_source_patch"
 
 require "functions"
 
-MAX_BUNDLER_VERSION="2.0.0"
+MAX_BUNDLER_VERSION = "2.0.0"
 
 def validate_bundler_version!
   return true if correct_bundler_version?
@@ -38,9 +38,9 @@ begin
   args = request["args"].transform_keys(&:to_sym)
 
   output({ result: Functions.send(function, **args) })
-rescue => error
+rescue StandardError => e
   output(
-    { error: error.message, error_class: error.class, trace: error.backtrace }
+    { error: e.message, error_class: e.class, trace: e.backtrace }
   )
   exit(1)
 end

--- a/bundler/helpers/v1/spec/functions/dependency_source_spec.rb
+++ b/bundler/helpers/v1/spec/functions/dependency_source_spec.rb
@@ -40,10 +40,10 @@ RSpec.describe Functions::DependencySource do
 
     it "returns all versions from the private source" do
       is_expected.to eq([
-                          Gem::Version.new("1.5.0"),
-                          Gem::Version.new("1.9.0"),
-                          Gem::Version.new("1.10.0.beta")
-                        ])
+        Gem::Version.new("1.5.0"),
+        Gem::Version.new("1.9.0"),
+        Gem::Version.new("1.10.0.beta")
+      ])
     end
 
     context "specified as the default source" do
@@ -51,10 +51,10 @@ RSpec.describe Functions::DependencySource do
 
       it "returns all versions from the private source" do
         is_expected.to eq([
-                            Gem::Version.new("1.5.0"),
-                            Gem::Version.new("1.9.0"),
-                            Gem::Version.new("1.10.0.beta")
-                          ])
+          Gem::Version.new("1.5.0"),
+          Gem::Version.new("1.9.0"),
+          Gem::Version.new("1.10.0.beta")
+        ])
       end
     end
 

--- a/bundler/helpers/v1/spec/native_spec_helper.rb
+++ b/bundler/helpers/v1/spec/native_spec_helper.rb
@@ -36,9 +36,7 @@ def project_dependency_files(project)
     files = files.select { |f| File.file?(f) }
     files.map do |filename|
       content = File.read(filename)
-      if filename == "Gemfile.lock"
-        content = content.gsub(LOCKFILE_ENDING, "")
-      end
+      content = content.gsub(LOCKFILE_ENDING, "") if filename == "Gemfile.lock"
       {
         name: filename,
         content: content

--- a/bundler/helpers/v2/lib/functions.rb
+++ b/bundler/helpers/v2/lib/functions.rb
@@ -128,8 +128,6 @@ module Functions
     ).conflicting_dependencies
   end
 
-  private
-
   def self.set_bundler_flags_and_credentials(dir:, credentials:)
     dir = dir ? Pathname.new(dir) : dir
     Bundler.instance_variable_set(:@root, dir)

--- a/bundler/helpers/v2/lib/functions/dependency_source.rb
+++ b/bundler/helpers/v2/lib/functions/dependency_source.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Functions
   class DependencySource
     attr_reader :gemfile_name, :dependency_name
@@ -66,7 +68,7 @@ module Functions
       return @specified_source if defined? @specified_source
 
       @specified_source = definition.dependencies.
-        find { |dep| dep.name == dependency_name }&.source
+                          find { |dep| dep.name == dependency_name }&.source
     end
 
     def default_source

--- a/bundler/helpers/v2/lib/functions/file_parser.rb
+++ b/bundler/helpers/v2/lib/functions/file_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Functions
   class FileParser
     def initialize(lockfile_name:)
@@ -54,12 +56,8 @@ module Functions
       return nil if default_rubygems?(source)
 
       details = { type: source.class.name.split("::").last.downcase }
-      if source.is_a?(Bundler::Source::Git)
-        details.merge!(git_source_details(source))
-      end
-      if source.is_a?(Bundler::Source::Rubygems)
-        details[:url] = source.remotes.first.to_s
-      end
+      details.merge!(git_source_details(source)) if source.is_a?(Bundler::Source::Git)
+      details[:url] = source.remotes.first.to_s if source.is_a?(Bundler::Source::Rubygems)
       details
     end
 

--- a/bundler/helpers/v2/lib/functions/file_parser.rb
+++ b/bundler/helpers/v2/lib/functions/file_parser.rb
@@ -41,7 +41,7 @@ module Functions
     end
 
     def source_from_lockfile(dependency_name)
-      parsed_lockfile&.specs.find { |s| s.name == dependency_name }&.source
+      parsed_lockfile&.specs&.find { |s| s.name == dependency_name }&.source
     end
 
     def source_for(dependency)

--- a/bundler/helpers/v2/lib/functions/force_updater.rb
+++ b/bundler/helpers/v2/lib/functions/force_updater.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Functions
   class ForceUpdater
     class TransitiveDependencyError < StandardError; end

--- a/bundler/helpers/v2/lib/functions/lockfile_updater.rb
+++ b/bundler/helpers/v2/lib/functions/lockfile_updater.rb
@@ -24,7 +24,7 @@ module Functions
 
     attr_reader :gemfile_name, :lockfile_name, :dependencies
 
-    def generate_lockfile
+    def generate_lockfile # rubocop:disable Metrics/PerceivedComplexity
       dependencies_to_unlock = dependencies.map { |d| d.fetch("name") }
 
       begin

--- a/bundler/helpers/v2/lib/functions/version_resolver.rb
+++ b/bundler/helpers/v2/lib/functions/version_resolver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Functions
   class VersionResolver
     GEM_NOT_FOUND_ERROR_REGEX = /locked to (?<name>[^\s]+) \(/.freeze
@@ -20,9 +22,7 @@ module Functions
       # included in a gemspec, it's because the Gemfile didn't import
       # the gemspec. This is unusual, but the correct behaviour if/when
       # it happens is to behave as if the repo was gemspec-only.
-      if dep.nil? && dependency_requirements.any?
-        return "latest"
-      end
+      return "latest" if dep.nil? && dependency_requirements.any?
 
       # Otherwise, if the dependency wasn't found it's because it is a
       # subdependency that was removed when attempting to update it.
@@ -38,9 +38,7 @@ module Functions
         ruby_version: ruby_version,
         fetcher: fetcher_class(dep)
       }
-      if dep.source.instance_of?(::Bundler::Source::Git)
-        details[:commit_sha] = dep.source.revision
-      end
+      details[:commit_sha] = dep.source.revision if dep.source.instance_of?(::Bundler::Source::Git)
       details
     end
 
@@ -92,7 +90,7 @@ module Functions
     end
 
     def build_definition(dependencies_to_unlock)
-      # Note: we lock shared dependencies to avoid any top-level
+      # NOTE: we lock shared dependencies to avoid any top-level
       # dependencies getting unlocked (which would happen if they were
       # also subdependencies of the dependency being unlocked)
       ::Bundler::Definition.build(

--- a/bundler/helpers/v2/monkey_patches/git_source_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/git_source_patch.rb
@@ -40,9 +40,7 @@ module Bundler
         $LOAD_PATH.shift until $LOAD_PATH.empty?
         reduced_load_paths.each { |p| $LOAD_PATH << p }
 
-        if destination.relative?
-          destination = destination.expand_path(Bundler.root)
-        end
+        destination = destination.expand_path(Bundler.root) if destination.relative?
         Dir["#{destination}/#{@glob}"].each do |spec_path|
           # Evaluate gemspecs and cache the result. Gemspecs
           # in git might require git or other dependencies.

--- a/bundler/helpers/v2/run.rb
+++ b/bundler/helpers/v2/run.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler"
 require "json"
 
@@ -36,9 +38,9 @@ begin
   args = request["args"].transform_keys(&:to_sym)
 
   output({ result: Functions.send(function, **args) })
-rescue => error
+rescue StandardError => e
   output(
-    { error: error.message, error_class: error.class, trace: error.backtrace }
+    { error: e.message, error_class: e.class, trace: e.backtrace }
   )
   exit(1)
 end

--- a/bundler/helpers/v2/spec/functions/dependency_source_spec.rb
+++ b/bundler/helpers/v2/spec/functions/dependency_source_spec.rb
@@ -40,10 +40,10 @@ RSpec.describe Functions::DependencySource do
 
     it "returns all versions from the private source" do
       is_expected.to eq([
-                          Gem::Version.new("1.5.0"),
-                          Gem::Version.new("1.9.0"),
-                          Gem::Version.new("1.10.0.beta")
-                        ])
+        Gem::Version.new("1.5.0"),
+        Gem::Version.new("1.9.0"),
+        Gem::Version.new("1.10.0.beta")
+      ])
     end
 
     context "specified as the default source" do
@@ -51,10 +51,10 @@ RSpec.describe Functions::DependencySource do
 
       it "returns all versions from the private source" do
         is_expected.to eq([
-                            Gem::Version.new("1.5.0"),
-                            Gem::Version.new("1.9.0"),
-                            Gem::Version.new("1.10.0.beta")
-                          ])
+          Gem::Version.new("1.5.0"),
+          Gem::Version.new("1.9.0"),
+          Gem::Version.new("1.10.0.beta")
+        ])
       end
     end
 

--- a/bundler/helpers/v2/spec/functions/file_parser_spec.rb
+++ b/bundler/helpers/v2/spec/functions/file_parser_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Functions::FileParser do
           {
             groups: [:default],
             name: "prius",
-            requirement:  Gem::Requirement.new(">= 0"),
+            requirement: Gem::Requirement.new(">= 0"),
             source: {
               branch: "master",
               ref: "master",
@@ -80,7 +80,7 @@ RSpec.describe Functions::FileParser do
           {
             groups: [:default],
             name: "que",
-            requirement:  Gem::Requirement.new(">= 0"),
+            requirement: Gem::Requirement.new(">= 0"),
             source: {
               branch: "master",
               ref: "v0.11.6",
@@ -92,7 +92,7 @@ RSpec.describe Functions::FileParser do
           {
             groups: [:default],
             name: "uk_phone_numbers",
-            requirement:  Gem::Requirement.new(">= 0"),
+            requirement: Gem::Requirement.new(">= 0"),
             source: {
               branch: "master",
               ref: "master",

--- a/bundler/helpers/v2/spec/functions_spec.rb
+++ b/bundler/helpers/v2/spec/functions_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Functions do
         jfrog_source = Functions.jfrog_source(
           dir: tmp_path,
           gemfile_name: "Gemfile",
-          credentials: {},
+          credentials: {}
         )
 
         expect(jfrog_source).to eq("test.jfrog.io")

--- a/bundler/helpers/v2/spec/native_spec_helper.rb
+++ b/bundler/helpers/v2/spec/native_spec_helper.rb
@@ -36,9 +36,7 @@ def project_dependency_files(project)
     files = files.select { |f| File.file?(f) }
     files.map do |filename|
       content = File.read(filename)
-      if filename == "Gemfile.lock"
-        content = content.gsub(LOCKFILE_ENDING, "")
-      end
+      content = content.gsub(LOCKFILE_ENDING, "") if filename == "Gemfile.lock"
       {
         name: filename,
         content: content


### PR DESCRIPTION
Dependabot's logic for the bundler ecosystem is split between "normal" dependabot-core, and helpers specific to bundler1 and bundler2.

I'm not sure why the ruby code in the helpers was being excluded from rubocop, so this PR enables it and fixes all outstanding issues that have accumulated. This maintains styling across dependabot-core's ruby codebase.