### PR TITLE
Security advisories for Go

### DIFF
--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -42,7 +42,6 @@ module Dependabot
       end
 
       def lowest_resolvable_security_fix_version
-        raise "Dependency not vulnerable!" unless vulnerable?
 
         return latest_resolvable_version if git_dependency?
 

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -41,6 +41,16 @@ module Dependabot
         latest_resolvable_version
       end
 
+      def lowest_resolvable_security_fix_version
+        raise "Dependency not vulnerable!" unless vulnerable?
+
+        return latest_resolvable_version if git_dependency?
+
+        return unless lowest_security_fix_version
+
+        resolvable?(lowest_fix) ? lowest_fix : latest_resolvable_version
+      end
+
       def latest_resolvable_version_with_no_unlock
         # Irrelevant, since Go modules uses a single dependency file
         nil

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -24,11 +24,12 @@ module Dependabot
         PSEUDO_VERSION_REGEX = /\b\d{14}-[0-9a-f]{12}$/.freeze
 
         def initialize(dependency:, dependency_files:, credentials:,
-                       ignored_versions:, raise_on_ignored: false)
+                       ignored_versions:, security_advisories:, raise_on_ignored: false)
           @dependency          = dependency
           @dependency_files    = dependency_files
           @credentials         = credentials
           @ignored_versions    = ignored_versions
+          @security_advisories = security_advisories
           @raise_on_ignored    = raise_on_ignored
         end
 
@@ -43,7 +44,7 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :dependency_files, :credentials, :ignored_versions
+        attr_reader :dependency, :dependency_files, :credentials, :ignored_versions, :security_advisories
 
         def fetch_latest_version
           return dependency.version if dependency.version =~ PSEUDO_VERSION_REGEX
@@ -58,7 +59,7 @@ module Dependabot
         def fetch_lowest_security_fix_version
           return dependency.version if dependency.version =~ PSEUDO_VERSION_REGEX
 
-          relevant_versions = available_versions.versions
+          relevant_versions = available_versions
           relevant_versions = filter_prerelease_versions(relevant_versions)
           relevant_versions = filter_vulnerable_versions(relevant_versions)
           relevant_versions = filter_ignored_versions(relevant_versions)

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -41,7 +41,6 @@ module Dependabot
           @lowest_security_fix_version ||= fetch_lowest_security_fix_version
         end
 
-
         private
 
         attr_reader :dependency, :dependency_files, :credentials, :ignored_versions, :security_advisories

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -24,7 +24,7 @@ module Dependabot
         PSEUDO_VERSION_REGEX = /\b\d{14}-[0-9a-f]{12}$/.freeze
 
         def initialize(dependency:, dependency_files:, credentials:,
-                       ignored_versions:, security_advisories: [], raise_on_ignored: false)
+                       ignored_versions:, security_advisories:, raise_on_ignored: false)
           @dependency          = dependency
           @dependency_files    = dependency_files
           @credentials         = credentials

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -60,9 +60,9 @@ module Dependabot
 
           relevant_versions = available_versions
           relevant_versions = filter_prerelease_versions(relevant_versions)
-          relevant_versions = filter_vulnerable_versions(relevant_versions)
           relevant_versions = filter_ignored_versions(relevant_versions)
           relevant_versions = filter_lower_versions(relevant_versions)
+          Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(relevant_versions, security_advisories)
 
           relevant_versions.min
         end

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -62,7 +62,8 @@ module Dependabot
           relevant_versions = filter_prerelease_versions(relevant_versions)
           relevant_versions = filter_ignored_versions(relevant_versions)
           relevant_versions = filter_lower_versions(relevant_versions)
-          Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(relevant_versions, security_advisories)
+          relevant_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(relevant_versions,
+                                                                                                    security_advisories)
 
           relevant_versions.min
         end

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -60,10 +60,10 @@ module Dependabot
 
           relevant_versions = available_versions
           relevant_versions = filter_prerelease_versions(relevant_versions)
-          relevant_versions = filter_ignored_versions(relevant_versions)
-          relevant_versions = filter_lower_versions(relevant_versions)
           relevant_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(relevant_versions,
                                                                                                     security_advisories)
+          relevant_versions = filter_ignored_versions(relevant_versions)
+          relevant_versions = filter_lower_versions(relevant_versions)
 
           relevant_versions.min
         end

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -36,6 +36,11 @@ module Dependabot
           @latest_version ||= fetch_latest_version
         end
 
+        def lowest_security_fix_version
+          @lowest_security_fix_version ||= fetch_lowest_security_fix_version
+        end
+
+
         private
 
         attr_reader :dependency, :dependency_files, :credentials, :ignored_versions
@@ -48,6 +53,18 @@ module Dependabot
           candidate_versions = filter_ignored_versions(candidate_versions)
 
           candidate_versions.max
+        end
+
+        def fetch_lowest_security_fix_version
+          return dependency.version if dependency.version =~ PSEUDO_VERSION_REGEX
+
+          relevant_versions = available_versions.versions
+          relevant_versions = filter_prerelease_versions(relevant_versions)
+          relevant_versions = filter_vulnerable_versions(relevant_versions)
+          relevant_versions = filter_ignored_versions(relevant_versions)
+          relevant_versions = filter_lower_versions(relevant_versions)
+
+          relevant_versions.min
         end
 
         def available_versions

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -24,7 +24,7 @@ module Dependabot
         PSEUDO_VERSION_REGEX = /\b\d{14}-[0-9a-f]{12}$/.freeze
 
         def initialize(dependency:, dependency_files:, credentials:,
-                       ignored_versions:, security_advisories:, raise_on_ignored: false)
+                       ignored_versions:, security_advisories: [], raise_on_ignored: false)
           @dependency          = dependency
           @dependency_files    = dependency_files
           @credentials         = credentials

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
 
   let(:dependency_version) { "1.0.0" }
 
+  let(:security_advisories) { [] }
+
   let(:dependency) do
     Dependabot::Dependency.new(
       name: dependency_name,
@@ -291,13 +293,5 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
       end
     end
 
-    context "with a retracted update version" do
-      # latest release v1.0.1 is retracted
-      let(:dependency_name) { "github.com/dependabot-fixtures/go-modules-retracted" }
-
-      pending "doesn't return the retracted version" do
-        expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("1.0.2"))
-      end
-    end
   end
 end

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
   describe "#lowest_security_fix_version" do
     let(:dependency_name) { "github.com/dependabot-fixtures/go-modules-lib" }
 
-    let(:dependency_version) { "1.0.1" }
+    let(:dependency_version) { "1.0.0" }
 
     let(:dependency) do
       Dependabot::Dependency.new(
@@ -282,7 +282,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
       described_class.new(
         dependency: dependency,
         dependency_files: dependency_files,
-        security_advisories: [],
+        security_advisories: security_advisories,
         credentials: [{
           "type" => "git_source",
           "host" => "github.com",
@@ -307,13 +307,13 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
           Dependabot::SecurityAdvisory.new(
             dependency_name: dependency_name,
             package_manager: "go_modules",
-            vulnerable_versions: ["1.1.0"]
+            vulnerable_versions: ["<= 1.0.1"]
           )
         ]
       end
 
       it "doesn't return to the vulnerable version" do
-        expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("1.3.0"))
+        expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("1.1.0"))
       end
     end
 

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -7,60 +7,61 @@ require "dependabot/go_modules/native_helpers"
 require "dependabot/go_modules/update_checker/latest_version_finder"
 
 RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
+  let(:dependency_name) { "github.com/dependabot-fixtures/go-modules-lib" }
+
+  let(:dependency_version) { "1.0.0" }
+
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: dependency_name,
+      version: dependency_version,
+      package_manager: "go_modules",
+      requirements: [{
+        file: "go.mod",
+        requirement: dependency_version,
+        groups: [],
+        source: { type: "default", source: dependency_name }
+      }]
+    )
+  end
+
+  let(:go_mod_content) do
+    <<~GOMOD
+      module foobar
+      require #{dependency_name} v#{dependency_version}
+    GOMOD
+  end
+
+  let(:dependency_files) do
+    [
+      Dependabot::DependencyFile.new(
+        name: "go.mod",
+        content: go_mod_content
+      )
+    ]
+  end
+
+  let(:ignored_versions) { [] }
+
+  let(:raise_on_ignored) { false }
+
+  let(:finder) do
+    described_class.new(
+      dependency: dependency,
+      dependency_files: dependency_files,
+      credentials: [{
+        "type" => "git_source",
+        "host" => "github.com",
+        "username" => "x-access-token",
+        "password" => "token"
+      }],
+      ignored_versions: ignored_versions,
+      security_advisories: security_advisories,
+      raise_on_ignored: raise_on_ignored
+    )
+  end
+
   describe "#latest_version" do
-    let(:dependency_name) { "github.com/dependabot-fixtures/go-modules-lib" }
-
-    let(:dependency_version) { "1.0.0" }
-
-    let(:dependency) do
-      Dependabot::Dependency.new(
-        name: dependency_name,
-        version: dependency_version,
-        package_manager: "go_modules",
-        requirements: [{
-          file: "go.mod",
-          requirement: dependency_version,
-          groups: [],
-          source: { type: "default", source: dependency_name }
-        }]
-      )
-    end
-
-    let(:go_mod_content) do
-      <<~GOMOD
-        module foobar
-        require #{dependency_name} v#{dependency_version}
-      GOMOD
-    end
-
-    let(:dependency_files) do
-      [
-        Dependabot::DependencyFile.new(
-          name: "go.mod",
-          content: go_mod_content
-        )
-      ]
-    end
-
-    let(:ignored_versions) { [] }
-
-    let(:raise_on_ignored) { false }
-
-    let(:finder) do
-      described_class.new(
-        dependency: dependency,
-        dependency_files: dependency_files,
-        credentials: [{
-          "type" => "git_source",
-          "host" => "github.com",
-          "username" => "x-access-token",
-          "password" => "token"
-        }],
-        ignored_versions: ignored_versions,
-        raise_on_ignored: raise_on_ignored
-      )
-    end
-
     context "when there's a newer major version but not a new minor version" do
       it "returns the latest minor version for the dependency's current major version" do
         expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("1.1.0"))
@@ -240,80 +241,63 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
   end
 
   describe "#lowest_security_fix_version" do
-    let(:dependency_name) { "github.com/dependabot-fixtures/go-modules-lib" }
 
-    let(:dependency_version) { "1.0.0" }
+    subject { finder.lowest_security_fix_version }
+    
+    let(:current_version) { "1.0.0" }
 
-    let(:dependency) do
-      Dependabot::Dependency.new(
-        name: dependency_name,
-        version: dependency_version,
-        package_manager: "go_modules",
-        requirements: [{
-          file: "go.mod",
-          requirement: dependency_version,
-          groups: [],
-          source: { type: "default", source: dependency_name }
-        }]
-      )
+    context "when on a stable release and a newer versions are available" do
+      it "returns the lowest available new release" do
+        expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("1.0.1"))
+      end
     end
 
-    let(:go_mod_content) do
-      <<~GOMOD
-        module foobar
-        require #{dependency_name} v#{dependency_version}
-      GOMOD
-    end
+    context "with Dependabot-ignored versions" do
+      let(:ignored_versions) { ["= 1.0.1"] }
 
-    let(:dependency_files) do
-      [
-        Dependabot::DependencyFile.new(
-          name: "go.mod",
-          content: go_mod_content
-        )
-      ]
-    end
-
-    let(:ignored_versions) { [] }
-
-    let(:raise_on_ignored) { false }
-
-    subject(:finder) do
-      described_class.new(
-        dependency: dependency,
-        dependency_files: dependency_files,
-        security_advisories: security_advisories,
-        credentials: [{
-          "type" => "git_source",
-          "host" => "github.com",
-          "username" => "x-access-token",
-          "password" => "token"
-        }],
-        ignored_versions: ignored_versions,
-        raise_on_ignored: raise_on_ignored
-      )
+      it "doesn't return Dependabot-ignored versions" do
+        expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("1.0.5"))
+      end
     end
 
     context "with a go.mod vulnerable version" do
-      let(:go_mod_content) do
-        <<~GOMOD
-          module foobar
-          require #{dependency_name} v#{dependency_version}
-        GOMOD
-      end
-
       let(:security_advisories) do
         [
           Dependabot::SecurityAdvisory.new(
             dependency_name: dependency_name,
             package_manager: "go_modules",
-            vulnerable_versions: ["<= 1.0.1"]
+            vulnerable_versions: ["<= 1.0.5"]
           )
         ]
       end
 
       it "doesn't return to the vulnerable version" do
-        expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("1.0.5"))
+        expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("1.0.6"))
+      end
+    end
+
+    context "when on a pre-release" do
+      let(:dependency_version) { "1.2.0-pre1" }
+
+      it "returns newest pre-release" do
+        expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("1.2.0-pre2"))
+      end
+    end
+
+    context "when on a stable release and a newer prerelease is available" do
+      let(:current_version) { "1.1.0" }
+      
+      it "doesn't return pre-release" do
+        expect(finder.lowest_security_fix_version).to_not eq(Dependabot::GoModules::Version.new("1.2.0-pre2"))
+      end
+    end
+
+    context "with a retracted update version" do
+      # latest release v1.0.1 is retracted
+      let(:dependency_name) { "github.com/dependabot-fixtures/go-modules-retracted" }
+
+      pending "doesn't return the retracted version" do
+        expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("1.0.2"))
       end
     end
 

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
       end
 
       it "doesn't return to the vulnerable version" do
-        expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("1.1.0"))
+        expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("1.0.5"))
       end
     end
 

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -292,6 +292,5 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
         expect(finder.lowest_security_fix_version).to_not eq(Dependabot::GoModules::Version.new("1.2.0-pre2"))
       end
     end
-
   end
 end

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -241,9 +241,8 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
   end
 
   describe "#lowest_security_fix_version" do
-
     subject { finder.lowest_security_fix_version }
-    
+
     let(:current_version) { "1.0.0" }
 
     context "when on a stable release and a newer versions are available" do
@@ -286,7 +285,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
 
     context "when on a stable release and a newer prerelease is available" do
       let(:current_version) { "1.1.0" }
-      
+
       it "doesn't return pre-release" do
         expect(finder.lowest_security_fix_version).to_not eq(Dependabot::GoModules::Version.new("1.2.0-pre2"))
       end
@@ -300,6 +299,5 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
         expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("1.0.2"))
       end
     end
-
   end
 end

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -110,8 +110,8 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
     end
 
     context "when on a stable release and a newer prerelease is available" do
-      it "doesn't return pre-release" do
-        expect(finder.latest_version).to_not eq(Dependabot::GoModules::Version.new("1.2.0-pre2"))
+      it "returns the newest non-prerelease" do
+        expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("1.1.0"))
       end
     end
 

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -14,9 +14,13 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
       dependency: dependency,
       dependency_files: dependency_files,
       credentials: github_credentials,
+      security_advisories: security_advisories,
       ignored_versions: []
     )
   end
+
+  let(:security_advisories) { [] }
+
   let(:dependency) do
     Dependabot::Dependency.new(
       name: dependency_name,
@@ -76,26 +80,57 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
     it "doesn't update Git SHAs not on master to newer commits to master"
   end
 
-  describe "#lowest_resolvable_security_fix_version" do
-    subject(:lowest_resolvable_security_fix_version) { checker.lowest_resolvable_security_fix_version }
-    
-    let(:dependency_version) { "1.0.0" }
+  describe "#lowest_security_fix_version" do
+    subject(:lowest_security_fix_version) { checker.lowest_security_fix_version }
+
+    let(:dependency_version) { "1.0.1" }
 
     let(:security_advisories) do
       [
         Dependabot::SecurityAdvisory.new(
           dependency_name: dependency_name,
           package_manager: "go_modules",
-          vulnerable_versions: ["= 1.0.0"]
+          vulnerable_versions: ["= 1.0.1"]
         )
       ]
     end
-    
+
+    context "when a supported newer version is available" do
+      it "updates to the least new supported version" do
+        is_expected.to eq(Dependabot::GoModules::Version.new("1.0.5"))
+      end
+    end
+  end
+
+  describe "#lowest_resolvable_security_fix_version" do
+    subject(:lowest_resolvable_security_fix_version) { checker.lowest_resolvable_security_fix_version }
+
+    let(:dependency_version) { "1.0.1" }
+
+    let(:security_advisories) do
+      [
+        Dependabot::SecurityAdvisory.new(
+          dependency_name: dependency_name,
+          package_manager: "go_modules",
+          vulnerable_versions: ["= 1.0.1"]
+        )
+      ]
+    end
+
     context "when a supported newer version is available" do
       it "updates to the least new supported version" do
         is_expected.to eq(Dependabot::GoModules::Version.new("1.0.5"))
       end
     end
 
+    context "when the current version is not vulnerable" do
+      let(:dependency_version) { "1.0.0" }
+
+      it "raises an error " do
+        expect { lowest_resolvable_security_fix_version.to }.to raise_error(RuntimeError) do |error|
+          expect(error.message).to eq("Dependency not vulnerable!")
+        end
+      end
+    end
   end
 end

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -75,4 +75,27 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
     it "doesn't updates Git SHAs to releases that don't include them"
     it "doesn't update Git SHAs not on master to newer commits to master"
   end
+
+  describe "#lowest_resolvable_security_fix_version" do
+    subject(:lowest_resolvable_security_fix_version) { checker.lowest_resolvable_security_fix_version }
+    
+    let(:dependency_version) { "1.0.0" }
+
+    let(:security_advisories) do
+      [
+        Dependabot::SecurityAdvisory.new(
+          dependency_name: dependency_name,
+          package_manager: "go_modules",
+          vulnerable_versions: ["= 1.0.0"]
+        )
+      ]
+    end
+    
+    context "when a supported newer version is available" do
+      it "updates to the least new supported version" do
+        is_expected.to eq(Dependabot::GoModules::Version.new("1.0.5"))
+      end
+    end
+
+  end
 end

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -123,6 +123,15 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
       end
     end
 
+    context "doesn't update indirect dependencies (not supported)" do
+      let(:requirements) { [] }
+      it do
+        is_expected.to eq(
+          Dependabot::GoModules::Version.new(dependency.version)
+        )
+      end
+    end
+
     context "when the current version is not vulnerable" do
       let(:dependency_version) { "1.0.0" }
 


### PR DESCRIPTION
Currently tested against manual security advisories. 
Uses [github.com/dependabot-fixtures/go-modules-lib][test-fixture] as a test fixture and passes a dry-run.

Based off of https://github.com/dependabot/dependabot-core/pull/3905

TODO:
- [x] Add the lowest_security_fix_version and lowest_resolvable_security_fix_version methods to the `update checker` and the `version finder`
- [x] Add more releases to the [test fixture][test-fixture]
- [x] `LatestVersionFinderSpec#lowest_security_fix_version` tests
    - [x] supports/ignores pre-releases
    - [x] doesn't downgrade
    - [x] fixed versions
    - [x] not latest version
    - [x] not ignored
    - [x] Removed: not retracted release
- [x] `UpdateChecker#lowest_security_fix_version` tests

[test-fixture]: https://github.com/dependabot-fixtures/go-modules-lib