### PR TITLE
Ruby: Fix 2.7 deprecation warnings in rubygems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,8 @@ RUN if ! getent group $USER_GID; then groupadd --gid $USER_GID dependabot ; \
 
 # Install Ruby 2.7, update RubyGems, and install Bundler
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
+# Disable the outdated rubygems installation from being loaded
+ENV DEBIAN_DISABLE_RUBYGEMS_INTEGRATION=true
 # Allow gem installs as the dependabot user
 ENV BUNDLE_PATH=".bundle" \
     BUNDLE_BIN=".bundle/bin"

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-require "json"
-require "tmpdir"
-require "excon"
-require "English"
 require "digest"
+require "English"
+require "excon"
+require "fileutils"
+require "json"
 require "open3"
 require "shellwords"
+require "tmpdir"
 
 require "dependabot/utils"
 require "dependabot/errors"

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
       end
 
       it "doesn't return to the excluded version" do
-        expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("1.0.1"))
+        expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("1.0.6"))
       end
     end
 


### PR DESCRIPTION
Disable the outdated system rubygems installation and use the updated
3.2.20 version.

The default brightbox ppa for ruby 2.7 installs rubygems 3.1.2 which
can't be updated with `gem update --system` and prints the following
deprecation warnings when loaded from bundler:

```
/usr/lib/ruby/vendor_ruby/rubygems/defaults/operating_system.rb:10: warning: constant Gem::ConfigMap is deprecated
```