### PR TITLE
Bundler: Run native helper specs

### DIFF
--- a/bundler/helpers/v1/lib/functions/lockfile_updater.rb
+++ b/bundler/helpers/v1/lib/functions/lockfile_updater.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "fileutils"
+
 module Functions
   class LockfileUpdater
     RETRYABLE_ERRORS = [Bundler::HTTPError].freeze

--- a/bundler/helpers/v1/spec/functions/file_parser_spec.rb
+++ b/bundler/helpers/v1/spec/functions/file_parser_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Functions::FileParser do
     )
   end
 
-  let(:project_name) { "gemfile" }
-
   describe "#parsed_gemfile" do
+    let(:project_name) { "gemfile" }
+
     subject(:parsed_gemfile) do
       in_tmp_folder do
         dependency_source.parsed_gemfile(gemfile_name: "Gemfile")
@@ -43,14 +43,11 @@ RSpec.describe Functions::FileParser do
   end
 
   describe "#parsed_gemspec" do
-    let!(:gemspec_fixture) do
-      fixture("ruby", "gemspecs", "exact")
-    end
+    let(:project_name) { "gemfile_exact" }
 
     subject(:parsed_gemspec) do
-      in_tmp_folder do |tmp_path|
-        File.write(File.join(tmp_path, "test.gemspec"), gemspec_fixture)
-        dependency_source.parsed_gemspec(gemspec_name: "test.gemspec")
+      in_tmp_folder do |_tmp_path|
+        dependency_source.parsed_gemspec(gemspec_name: "example.gemspec")
       end
     end
 

--- a/bundler/helpers/v2/lib/functions/lockfile_updater.rb
+++ b/bundler/helpers/v2/lib/functions/lockfile_updater.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "fileutils"
+
 module Functions
   class LockfileUpdater
     RETRYABLE_ERRORS = [Bundler::HTTPError].freeze

--- a/bundler/helpers/v2/spec/functions/file_parser_spec.rb
+++ b/bundler/helpers/v2/spec/functions/file_parser_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Functions::FileParser do
     )
   end
 
-  let(:project_name) { "gemfile" }
-
   describe "#parsed_gemfile" do
+    let(:project_name) { "gemfile" }
+
     subject(:parsed_gemfile) do
       in_tmp_folder do
         dependency_source.parsed_gemfile(gemfile_name: "Gemfile")
@@ -108,14 +108,11 @@ RSpec.describe Functions::FileParser do
   end
 
   describe "#parsed_gemspec" do
-    let!(:gemspec_fixture) do
-      fixture("ruby", "gemspecs", "exact")
-    end
+    let(:project_name) { "gemfile_exact" }
 
     subject(:parsed_gemspec) do
-      in_tmp_folder do |tmp_path|
-        File.write(File.join(tmp_path, "test.gemspec"), gemspec_fixture)
-        dependency_source.parsed_gemspec(gemspec_name: "test.gemspec")
+      in_tmp_folder do |_tmp_path|
+        dependency_source.parsed_gemspec(gemspec_name: "example.gemspec")
       end
     end
 

--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -1,19 +1,21 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .
 bundle exec rspec spec
 
-if [ "$SUITE_NAME" == "bundler1" ]; then
-  cd helpers/v1 && \
-  BUNDLER_VERSION=1 bundle install && \
-  BUNDLER_VERSION=1 bundle exec rspec spec &&\
-  cd -
+if [[ "$SUITE_NAME" == "bundler1" ]]; then
+  cd helpers/v1 \
+    && BUNDLER_VERSION=1 bundle install \
+    && BUNDLER_VERSION=1 bundle exec rspec spec\
+    && cd -
 fi
 
-if [ "$SUITE_NAME" == "bundler2" ]; then
-  cd helpers/v2 && \
-  BUNDLER_VERSION=2 bundle install && \
-  BUNDLER_VERSION=2 bundle exec rspec spec &&\
-  cd -
+if [[ "$SUITE_NAME" == "bundler2" ]]; then
+  cd helpers/v2 \
+    && BUNDLER_VERSION=2 bundle install \
+    && BUNDLER_VERSION=2 bundle exec rspec spec \
+    && cd -
 fi

--- a/cargo/script/ci-test
+++ b/cargo/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/common/script/ci-test
+++ b/common/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/common/spec/helpers/test/error_bash
+++ b/common/spec/helpers/test/error_bash
@@ -1,3 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+
+set -e
 
 exit 1

--- a/common/spec/helpers/test/run_bash
+++ b/common/spec/helpers/test/run_bash
@@ -1,3 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+
+set -e
 
 echo "$@"

--- a/composer/script/ci-test
+++ b/composer/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/dep/script/ci-test
+++ b/dep/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/docker/script/ci-test
+++ b/docker/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/elm/script/ci-test
+++ b/elm/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/git_submodules/script/ci-test
+++ b/git_submodules/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/github_actions/script/ci-test
+++ b/github_actions/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/go_modules/script/ci-test
+++ b/go_modules/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/gradle/script/ci-test
+++ b/gradle/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/hex/script/ci-test
+++ b/hex/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/maven/script/ci-test
+++ b/maven/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/npm_and_yarn/script/ci-test
+++ b/npm_and_yarn/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/nuget/script/ci-test
+++ b/nuget/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/omnibus/script/ci-test
+++ b/omnibus/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .

--- a/python/script/ci-test
+++ b/python/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 pyenv exec flake8 helpers/. --count --exclude=./.*,./python/spec/fixtures --show-source --statistics

--- a/terraform/script/ci-test
+++ b/terraform/script/ci-test
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 bundle install
 bundle exec rubocop .


### PR DESCRIPTION
Fix bundler `script/ci-test` bash codes and conform scripts to use
`bin/bash`.

Native helper specs are not being run as the script/ci-test currently
bails out with:

```
./script/ci-test: 7: [: bundler1: unexpected operator
./script/ci-test: 14: [: bundler1: unexpected operator
```