### PR TITLE
Add `--no-install-recommends` to all `apt-get install` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ ENV BUNDLE_PATH=".bundle" \
 ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
 RUN apt-add-repository ppa:brightbox/ruby-ng \
   && apt-get update \
-  && apt-get install -y ruby2.7 ruby2.7-dev \
+  && apt-get install -y --no-install-recommends ruby2.7 ruby2.7-dev \
   && gem update --system 3.2.20 \
   && gem install bundler -v 1.17.3 --no-document \
   && gem install bundler -v 2.2.20 --no-document \
@@ -100,7 +100,7 @@ USER root
 
 # Install Node 14.0 and npm (updated after elm)
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
-  && apt-get install -y nodejs \
+  && apt-get install -y --no-install-recommends nodejs \
   && rm -rf /var/lib/apt/lists/*
 
 # NOTE: This was a hack to get around the fact that elm 18 failed to install with
@@ -127,7 +127,7 @@ COPY --from=composer:1.10.9 /usr/bin/composer /usr/local/bin/composer1
 COPY --from=composer:2.0.8 /usr/bin/composer /usr/local/bin/composer
 RUN add-apt-repository ppa:ondrej/php \
   && apt-get update \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
     php7.4 \
     php7.4-apcu \
     php7.4-bcmath \
@@ -197,7 +197,7 @@ ARG ERLANG_VERSION=1:23.3.1-1
 RUN wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
   && dpkg -i erlang-solutions_1.0_all.deb \
   && apt-get update \
-  && apt-get install -y esl-erlang=${ERLANG_VERSION} \
+  && apt-get install -y --no-install-recommends esl-erlang=${ERLANG_VERSION} \
   && wget https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip \
   && echo "$ELIXIR_CHECKSUM  Precompiled.zip" | sha512sum -c - \
   && unzip -d /usr/local/elixir -x Precompiled.zip \
@@ -225,7 +225,7 @@ ARG TERRAFORM_VERSION=1.0.0
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 RUN apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
   && apt-get update -y \
-  && apt-get install -y terraform=${TERRAFORM_VERSION} \
+  && apt-get install -y --no-install-recommends terraform=${TERRAFORM_VERSION} \
   && terraform -help \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This option will prevent not needed package being installed, make the
image smaller.

```
$ docker images
REPOSITORY                    TAG                 IMAGE ID       CREATED          SIZE
after                         latest              302fbe1d94dc   16 minutes ago   4.06GB
before                        latest              e59fb0274b02   17 minutes ago   4.17GB
```