### PR TITLE
Double quote variables in shellscript

### DIFF
--- a/dep/helpers/build
+++ b/dep/helpers/build
@@ -18,7 +18,7 @@ if [ ! -d "$install_dir/bin" ]; then
 fi
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
-cd $helpers_dir
+cd "$helpers_dir"
 
 os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 echo "building $install_dir/bin/helper"

--- a/go_modules/helpers/build
+++ b/go_modules/helpers/build
@@ -18,7 +18,7 @@ if [ ! -d "$install_dir/bin" ]; then
 fi
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
-cd $helpers_dir
+cd "$helpers_dir"
 
 os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 echo "building $install_dir/bin/helper"

--- a/hex/helpers/build
+++ b/hex/helpers/build
@@ -8,7 +8,7 @@ if [ -z "$install_dir" ]; then
   exit 1
 fi
 
-mkdir -p $install_dir
+mkdir -p "$install_dir"
 
 mix local.hex --force
 mix archive.install hex nerves_bootstrap --force
@@ -20,9 +20,9 @@ case `uname` in
   *) CP_OPTS='-r' ;;
 esac
 
-cp $CP_OPTS "$helpers_dir/lib" $install_dir
-cp $CP_OPTS "$helpers_dir/mix.exs" $install_dir
-cp $CP_OPTS "$helpers_dir/mix.lock" $install_dir
+cp $CP_OPTS "$helpers_dir/lib" "$install_dir"
+cp $CP_OPTS "$helpers_dir/mix.exs" "$install_dir"
+cp $CP_OPTS "$helpers_dir/mix.lock" "$install_dir"
 
 cd "$install_dir"
 mix deps.get


### PR DESCRIPTION
This will help prevent globbing and word splitting. Most of them are
already quoted, just few of them are missed.