### PR TITLE
v0.154.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.154.1, 16 June 2021
+
+- Ruby: Fix 2.7 deprecation warnings in rubygems
+- Bundler: Run native helper specs
+
 ## v0.154.0, 15 June 2021
 
 - Update ruby from 2.6 to 2.7

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.154.0"
+  VERSION = "0.154.1"
 end


### PR DESCRIPTION
## v0.154.1, 16 June 2021

- Ruby: Fix 2.7 deprecation warnings in rubygems
- Bundler: Run native helper specs