### PR TITLE
Terraform: Handle 401 registry responses

### DIFF
--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -121,6 +121,7 @@ module Dependabot
       def http_get!(url)
         response = http_get(url)
 
+        raise Dependabot::PrivateSourceAuthenticationFailure, hostname if response.status == 401
         raise error("Response from registry was #{response.status}") unless response.status == 200
 
         response

--- a/terraform/spec/dependabot/terraform/registry_client_spec.rb
+++ b/terraform/spec/dependabot/terraform/registry_client_spec.rb
@@ -184,6 +184,19 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
     expect(source.url).to eq("https://github.com/hashicorp/terraform-provider-ciscoasa")
   end
 
+  context "with a custom hostname" do
+    let(:hostname) { "registry.example.org" }
+    subject(:client) { described_class.new(hostname: hostname) }
+
+    it "raises helpful error when request is not authenticated", :vcr do
+      stub_request(:get, "https://#{hostname}/.well-known/terraform.json").and_return(status: 401)
+
+      expect do
+        client.all_module_versions(identifier: "corp/package")
+      end.to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
+    end
+  end
+
   describe "#service_url_for" do
     let(:metadata) { "https://registry.terraform.io/.well-known/terraform.json" }
 


### PR DESCRIPTION
Raise a `PrivateSourceAuthenticationFailure` with the provided hostname
if the registry responds with a `401`.