### PR TITLE
Terraform: handle dependencies without a namespace

### DIFF
--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -170,13 +170,11 @@ module Dependabot
       end
 
       def provider_source_from(source_address, name)
-        return [DEFAULT_REGISTRY, DEFAULT_NAMESPACE, name] unless source_address
-
-        matches = source_address.match(PROVIDER_SOURCE_ADDRESS)
+        matches = source_address&.match(PROVIDER_SOURCE_ADDRESS)
         [
-          matches[:hostname] || DEFAULT_REGISTRY,
-          matches[:namespace],
-          matches[:name] || name
+          matches.try(:[], :hostname) || DEFAULT_REGISTRY,
+          matches.try(:[], :namespace) || DEFAULT_NAMESPACE,
+          matches.try(:[], :name) || name
         ]
       end
 

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -647,5 +647,16 @@ RSpec.describe Dependabot::Terraform::FileParser do
         expect(dependencies.count).to eq(0)
       end
     end
+
+    context "with a provider that doesn't have a namespace provider" do
+      let(:files) { project_dependency_files("provider_no_namespace") }
+
+      it "has the right details" do
+        dependency = dependencies.find { |d| d.name == "hashicorp/random" }
+
+        expect(dependency.version).to eq("2.2.1")
+        expect(dependency.requirements.first[:source][:module_identifier]).to eq("hashicorp/random")
+      end
+    end
   end
 end

--- a/terraform/spec/fixtures/projects/provider_no_namespace/main.tf
+++ b/terraform/spec/fixtures/projects/provider_no_namespace/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = ">= 0.14.2"
+    }
+    random = {
+      source  = "random"
+      version = "2.2.1"
+    }
+  }
+}


### PR DESCRIPTION
Default providers without a namespace to `hashicorp`.
