### PR TITLE
Returns basename and relative path in CodeCommit file fetcher

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -330,8 +330,8 @@ module Dependabot
 
         response.files.map do |file|
           OpenStruct.new(
-            name: file.absolute_path,
-            path: file.absolute_path,
+            name: File.basename(file.relative_path),
+            path: file.relative_path,
             type: "file",
             size: 0 # file size would require new api call per file..
           )


### PR DESCRIPTION
Previously, the `name` and `path` attributes were both the absolute
path for all files retrieved from CodeCommit sources. This caused
problems in `fetch_file_from_host`, which joins the `directory`
from the config with the `filename`. When `filename` is the absolute
path, this essentially duplicated the directory in the result, e.g.
`directory/directory/relative path`.

This change returns the basename and relative path instead, matching
the implemenation for azure devops, and allowing the join in `fetch_file_from_host`
to return `directory/relative path.