### PR TITLE
Run linter against shell scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,10 @@ jobs:
             --env "SUITE_NAME=${{ matrix.suite.name }}" \
             --rm "$CORE_CI_IMAGE" bash -c \
             "cd /home/dependabot/dependabot-core/${{ matrix.suite.path }} && ./script/ci-test"
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: apt-get update -y && apt-get install --no-install-recommends shellcheck
+      - run: ./bin/lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,5 +98,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: apt-get update -y && apt-get install --no-install-recommends shellcheck
+      - run: sudo apt-get update -y && sudo apt-get install --no-install-recommends shellcheck
       - run: ./bin/lint

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -11,7 +11,7 @@ REBUILD=false
 # Enable docker buildkit with inline cache builds
 export DOCKER_BUILDKIT=1
 
-OPTS=`getopt -o hr --long help,rebuild -n 'parse-options' -- "$@"`
+OPTS=$(getopt -o hr --long help,rebuild -n 'parse-options' -- "$@")
 if [ $? != 0 ]; then
   echo "failed parsing options" >&2
   exit 1

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -58,7 +58,7 @@ fi
 set +e
 RUNNING=$(docker ps --format '{{.Names}}' | grep "$CONTAINER_NAME")
 set -e
-echo $RUNNING
+echo "$RUNNING"
 if [ -n "$RUNNING" ]; then
   if [ -z "$BUILT_IMAGE" ]; then
     # image was not rebuilt - can we reuse existing?

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -11,7 +11,9 @@ REBUILD=false
 # Enable docker buildkit with inline cache builds
 export DOCKER_BUILDKIT=1
 
+# shellcheck disable=SC2034
 OPTS=$(getopt -o hr --long help,rebuild -n 'parse-options' -- "$@")
+# shellcheck disable=SC2181
 if [ $? != 0 ]; then
   echo "failed parsing options" >&2
   exit 1

--- a/bin/lint
+++ b/bin/lint
@@ -6,4 +6,5 @@ shellcheck \
   ./bin/docker-dev-shell \
   ./bin/lint \
   ./*/helpers/build \
+  ./*/script/* \
   "$@"

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+shellcheck */helpers/build bin/*

--- a/bin/lint
+++ b/bin/lint
@@ -5,4 +5,5 @@ set -e
 shellcheck \
   ./bin/docker-dev-shell \
   ./bin/lint \
-  ./*/helpers/build
+  ./*/helpers/build \
+  "$@"

--- a/bin/lint
+++ b/bin/lint
@@ -2,4 +2,7 @@
 
 set -e
 
-shellcheck ./bin/* ./*/helpers/build
+shellcheck \
+  ./bin/docker-dev-shell \
+  ./bin/lint \
+  ./*/helpers/build

--- a/bin/lint
+++ b/bin/lint
@@ -2,4 +2,4 @@
 
 set -e
 
-shellcheck */helpers/build bin/*
+shellcheck ./bin/* ./*/helpers/build

--- a/hex/helpers/build
+++ b/hex/helpers/build
@@ -15,7 +15,7 @@ mix archive.install hex nerves_bootstrap --force
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 
-case `uname` in
+case $(uname) in
   'Darwin') CP_OPTS='-R' ;;
   *) CP_OPTS='-r' ;;
 esac


### PR DESCRIPTION
# Why is this needed?

To ensure that we follow the best practices for shell scripting described in
the Shellcheck wiki. e.g. [SC2006](https://github.com/koalaman/shellcheck/wiki/SC2006).

## What does this do?

It adds a `./bin/lint` script that can be used to run the shellcheck linter
on your machine. It also adds a job to the CI workflow to ensure that the
linter checks are passing.

xref: https://github.com/dependabot/dependabot-core/pull/3917#issuecomment-862823068

### Screenshots

Before:

```bash
モ ./bin/lint

In ./bin/docker-dev-shell line 14:
OPTS=`getopt -o hr --long help,rebuild -n 'parse-options' -- "$@"`
^--^ SC2034: OPTS appears unused. Verify use (or export if used externally).
     ^-- SC2006: Use $(...) notation instead of legacy backticked `...`.

Did you mean:
OPTS=$(getopt -o hr --long help,rebuild -n 'parse-options' -- "$@")


In ./bin/docker-dev-shell line 15:
if [ $? != 0 ]; then
     ^-- SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In ./bin/docker-dev-shell line 61:
echo $RUNNING
     ^------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
echo "$RUNNING"


In ./hex/helpers/build line 18:
case `uname` in
     ^-----^ SC2006: Use $(...) notation instead of legacy backticked `...`.

Did you mean:
case $(uname) in

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- OPTS appears unused. Verify use (...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2006 -- Use $(...) notation instead of le...
```

After:

```bash
モ ./bin/lint
~/src/github.com/xlgmokha/dependabot-core [turtles-in-a-half-shellcheck]
モ echo $?
0
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
