### PR TITLE
Fetches metadata upload-pack using git if http/s fails

### DIFF
--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -190,7 +190,16 @@ RSpec.describe Dependabot::GitCommitChecker do
         end
 
         context "but GitHub returns a 404" do
-          before { stub_request(:get, service_pack_url).to_return(status: 404) }
+          let(:url) { "https://github.com/gocardless/business.git" }
+
+          before do
+            stub_request(:get, service_pack_url).to_return(status: 404)
+
+            exit_status = double(success?: false)
+            allow(Open3).to receive(:capture3).and_call_original
+            allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{url}").and_return(["", "", exit_status])
+          end
+
           it { is_expected.to eq(false) }
         end
 
@@ -433,6 +442,12 @@ RSpec.describe Dependabot::GitCommitChecker do
             git_url = "https://github.com/gocardless/business.git"
             stub_request(:get, git_url + "/info/refs?service=git-upload-pack").
               to_return(status: 404)
+
+            exit_status = double(success?: false)
+            allow(Open3).to receive(:capture3).and_call_original
+            allow(Open3).to receive(:capture3).
+              with(anything, "git ls-remote #{git_url}").
+              and_return(["", "", exit_status])
           end
           let(:ref) { "my_ref" }
 
@@ -629,10 +644,16 @@ RSpec.describe Dependabot::GitCommitChecker do
       end
 
       context "that results in a 403" do
+        let(:url) { "https://github.com/gocardless/business.git" }
+
         before do
           stub_request(:get, git_url).
             with(headers: { "Authorization" => auth_header }).
             to_return(status: 403)
+
+          exit_status = double(success?: false)
+          allow(Open3).to receive(:capture3).and_call_original
+          allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{url}").and_return(["", "", exit_status])
         end
 
         it "raises a helpful error" do
@@ -884,7 +905,15 @@ RSpec.describe Dependabot::GitCommitChecker do
     end
 
     context "but GitHub returns a 404" do
-      before { stub_request(:get, service_pack_url).to_return(status: 404) }
+      let(:url) { "https://github.com/gocardless/business.git" }
+
+      before do
+        stub_request(:get, service_pack_url).to_return(status: 404)
+
+        exit_status = double(success?: false)
+        allow(Open3).to receive(:capture3).and_call_original
+        allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{url}").and_return(["", "", exit_status])
+      end
 
       it "raises a helpful error" do
         expect { checker.local_tag_for_latest_version }.
@@ -1108,10 +1137,16 @@ RSpec.describe Dependabot::GitCommitChecker do
     end
 
     context "that results in a 403" do
+      let(:url) { "https://github.com/gocardless/business.git" }
+
       before do
         stub_request(:get, git_url).
           with(headers: { "Authorization" => auth_header }).
           to_return(status: 403)
+
+        exit_status = double(success?: false)
+        allow(Open3).to receive(:capture3).and_call_original
+        allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{url}").and_return(["", "", exit_status])
       end
 
       it { is_expected.to eq(false) }

--- a/common/spec/dependabot/git_metadata_fetcher_spec.rb
+++ b/common/spec/dependabot/git_metadata_fetcher_spec.rb
@@ -125,6 +125,21 @@ RSpec.describe Dependabot::GitMetadataFetcher do
           )
         end
 
+        context "when HTTP returns a 500 but git ls-remote succeeds" do
+          let(:uri) { "https://github.com/gocardless/business.git" }
+          let(:stdout) { fixture("git", "upload_packs", upload_pack_fixture) }
+
+          before do
+            stub_request(:get, service_pack_url).to_return(status: 500)
+
+            exit_status = double(success?: true)
+            allow(Open3).to receive(:capture3).and_call_original
+            allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{uri}").and_return([stdout, "", exit_status])
+          end
+
+          its(:count) { is_expected.to eq(14) }
+        end
+
         context "when there is no github.com credential" do
           let(:credentials) do
             [{
@@ -210,6 +225,21 @@ RSpec.describe Dependabot::GitMetadataFetcher do
       end
       let(:upload_pack_fixture) { "no_tags" }
 
+      context "when HTTP returns a 500 but git ls-remote succeeds" do
+        let(:uri) { "https://github.com/gocardless/business.git" }
+        let(:stdout) { fixture("git", "upload_packs", upload_pack_fixture) }
+
+        before do
+          stub_request(:get, service_pack_url).to_return(status: 500)
+
+          exit_status = double(success?: true)
+          allow(Open3).to receive(:capture3).and_call_original
+          allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{uri}").and_return([stdout, "", exit_status])
+        end
+
+        it { is_expected.to eq(%w(master rails5)) }
+      end
+
       context "with tags on GitHub" do
         let(:upload_pack_fixture) { "no_versions" }
         it { is_expected.to eq(%w(master imported release)) }
@@ -264,6 +294,24 @@ RSpec.describe Dependabot::GitMetadataFetcher do
     it "gets the correct commit SHA (not the tag SHA)" do
       expect(head_commit_for_ref).
         to eq("df9f605d7111b6814fe493cf8f41de3f9f0978b2")
+    end
+
+    context "when HTTP returns a 500 but git ls-remote succeeds" do
+      let(:uri) { "https://github.com/gocardless/business.git" }
+      let(:stdout) { fixture("git", "upload_packs", upload_pack_fixture) }
+
+      before do
+        stub_request(:get, service_pack_url).to_return(status: 500)
+
+        exit_status = double(success?: true)
+        allow(Open3).to receive(:capture3).and_call_original
+        allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{uri}").and_return([stdout, "", exit_status])
+      end
+
+      it "gets the correct commit SHA (not the tag SHA)" do
+        expect(head_commit_for_ref).
+          to eq("df9f605d7111b6814fe493cf8f41de3f9f0978b2")
+      end
     end
 
     context "with a branch" do

--- a/common/spec/dependabot/git_metadata_fetcher_spec.rb
+++ b/common/spec/dependabot/git_metadata_fetcher_spec.rb
@@ -134,7 +134,9 @@ RSpec.describe Dependabot::GitMetadataFetcher do
 
             exit_status = double(success?: true)
             allow(Open3).to receive(:capture3).and_call_original
-            allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{uri}").and_return([stdout, "", exit_status])
+            allow(Open3).to receive(:capture3).
+              with(anything, "git ls-remote #{uri}").
+              and_return([stdout, "", exit_status])
           end
 
           its(:count) { is_expected.to eq(14) }
@@ -234,7 +236,9 @@ RSpec.describe Dependabot::GitMetadataFetcher do
 
           exit_status = double(success?: true)
           allow(Open3).to receive(:capture3).and_call_original
-          allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{uri}").and_return([stdout, "", exit_status])
+          allow(Open3).to receive(:capture3).
+            with(anything, "git ls-remote #{uri}").
+            and_return([stdout, "", exit_status])
         end
 
         it { is_expected.to eq(%w(master rails5)) }

--- a/common/spec/dependabot/git_metadata_fetcher_spec.rb
+++ b/common/spec/dependabot/git_metadata_fetcher_spec.rb
@@ -61,7 +61,15 @@ RSpec.describe Dependabot::GitMetadataFetcher do
       end
 
       context "but GitHub returns a 404" do
-        before { stub_request(:get, service_pack_url).to_return(status: 404) }
+        let(:uri) { "https://github.com/gocardless/business.git" }
+
+        before do
+          stub_request(:get, service_pack_url).to_return(status: 404)
+
+          exit_status = double(success?: false)
+          allow(Open3).to receive(:capture3).and_call_original
+          allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{uri}").and_return(["", "", exit_status])
+        end
 
         it "raises a helpful error" do
           expect { tags }.
@@ -70,7 +78,15 @@ RSpec.describe Dependabot::GitMetadataFetcher do
       end
 
       context "but GitHub returns a 401" do
-        before { stub_request(:get, service_pack_url).to_return(status: 401) }
+        let(:uri) { "https://github.com/gocardless/business.git" }
+
+        before do
+          stub_request(:get, service_pack_url).to_return(status: 401)
+
+          exit_status = double(success?: false)
+          allow(Open3).to receive(:capture3).and_call_original
+          allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{uri}").and_return(["", "", exit_status])
+        end
 
         it "raises a helpful error" do
           expect { tags }.
@@ -79,7 +95,15 @@ RSpec.describe Dependabot::GitMetadataFetcher do
       end
 
       context "but GitHub returns a 500" do
-        before { stub_request(:get, service_pack_url).to_return(status: 500) }
+        let(:uri) { "https://github.com/gocardless/business.git" }
+
+        before do
+          stub_request(:get, service_pack_url).to_return(status: 500)
+
+          exit_status = double(success?: false)
+          allow(Open3).to receive(:capture3).and_call_original
+          allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{uri}").and_return(["", "", exit_status])
+        end
 
         it "raises a helpful error" do
           expect { tags }.to raise_error(Octokit::InternalServerError)
@@ -197,7 +221,15 @@ RSpec.describe Dependabot::GitMetadataFetcher do
       end
 
       context "but GitHub returns a 404" do
-        before { stub_request(:get, service_pack_url).to_return(status: 404) }
+        let(:uri) { "https://github.com/gocardless/business.git" }
+
+        before do
+          stub_request(:get, service_pack_url).to_return(status: 404)
+
+          exit_status = double(success?: false)
+          allow(Open3).to receive(:capture3).and_call_original
+          allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{uri}").and_return(["", "", exit_status])
+        end
 
         it "raises a helpful error" do
           expect { ref_names }.

--- a/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
@@ -259,6 +259,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
     end
 
     context "with a github repo that has a DMCA takedown notice" do
+      let(:url) { "https://github.com/gocardless/business.git" }
       before do
         stub_request(:get, service_pack_url).
           to_return(
@@ -268,6 +269,10 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
               "content-type" => "application/x-git-upload-pack-advertisement"
             }
           )
+
+        exit_status = double(success?: false)
+        allow(Open3).to receive(:capture3).and_call_original
+        allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{url}").and_return(["", "", exit_status])
       end
 
       it { is_expected.to eq("https://github.com/gocardless/business/commits") }
@@ -511,6 +516,13 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
           context "when authentication fails" do
             before do
               stub_request(:get, service_pack_url).to_return(status: 404)
+
+              url = "https://github.com/gocardless/business.git"
+              exit_status = double(success?: false)
+              allow(Open3).to receive(:capture3).and_call_original
+              allow(Open3).to receive(:capture3).
+                with(anything, "git ls-remote #{url}").
+                and_return(["", "", exit_status])
             end
 
             it do

--- a/common/spec/dependabot/pull_request_creator/github_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/github_spec.rb
@@ -338,10 +338,14 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
 
     context "when we got a 401" do
       before do
-        service_pack_url =
-          "https://github.com/gocardless/bump.git/info/refs"\
-          "?service=git-upload-pack"
+        url = "https://github.com/gocardless/bump.git"
+        service_pack_url = "#{url}/info/refs?service=git-upload-pack"
+
         stub_request(:get, service_pack_url).to_return(status: 401)
+
+        exit_status = double(success?: false)
+        allow(Open3).to receive(:capture3).and_call_original
+        allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{url}").and_return(["", "", exit_status])
       end
 
       it "raises a normal error" do
@@ -356,10 +360,14 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
                     body: fixture("github", "bump_repo.json"),
                     headers: json_header)
 
-        service_pack_url =
-          "https://github.com/gocardless/bump.git/info/refs"\
-          "?service=git-upload-pack"
+        url = "https://github.com/gocardless/bump.git"
+        service_pack_url = "#{url}/info/refs?service=git-upload-pack"
+
         stub_request(:get, service_pack_url).to_return(status: 404)
+
+        exit_status = double(success?: false)
+        allow(Open3).to receive(:capture3).and_call_original
+        allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{url}").and_return(["", "", exit_status])
       end
 
       it "raises a normal error" do
@@ -369,15 +377,19 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
 
     context "when the repo exists but is disabled" do
       before do
-        service_pack_url =
-          "https://github.com/gocardless/bump.git/info/refs"\
-          "?service=git-upload-pack"
+        url = "https://github.com/gocardless/bump.git"
+        service_pack_url = "#{url}/info/refs?service=git-upload-pack"
+
         stub_request(:get, service_pack_url).
           to_return(
             status: 403,
             body: "Account `gocardless' is disabled. Please ask the owner to "\
                   "check their account."
           )
+
+        exit_status = double(success?: false)
+        allow(Open3).to receive(:capture3).and_call_original
+        allow(Open3).to receive(:capture3).with(anything, "git ls-remote #{url}").and_return(["", "", exit_status])
       end
 
       it "raises a helpful error" do


### PR DESCRIPTION
Some formats for git remotes require extra git configuration to be able to authenticate to the remote. Falling back to `git ls-remote` allows the metadata fetcher to use any authentication mechanism implemented in the user's gitconfig. Particularly troublesome are codecommit formats using the [awscli credential helper](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-unixes.html) or the [git-remote-codecommit plugin](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-git-remote-codecommit.html).