### PR TITLE
Enable available rubocops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,205 +1,143 @@
+---
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.5
   Exclude:
-    - '*/vendor/**/*'
-    - '*/bin/**/*'
-    - '**/tmp/**/*'
-    - '*/spec/fixtures/**/*'
-
+  - "*/vendor/**/*"
+  - "*/bin/**/*"
+  - "**/tmp/**/*"
+  - "*/spec/fixtures/**/*"
+  TargetRubyVersion: 2.5
 Layout/DotPosition:
   EnforcedStyle: trailing
-
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: false
-
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
-
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
-
 Layout/LineLength:
   Max: 120
-
 Layout/RescueEnsureAlignment:
   Enabled: false
-
 Layout/SpaceAroundMethodCallOperator:
   Enabled: false
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: false
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: false
-
-Lint/RaiseException:
-  Enabled: false
-
-Lint/StructNewOverride:
-  Enabled: false
-
 Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
-
-Lint/DuplicateRequire:
-  Enabled: true
-
-Lint/DuplicateRescueException:
-  Enabled: true
-
-Lint/EmptyConditionalBody:
-  Enabled: true
-
-Lint/EmptyFile:
-  Enabled: true
-
-Lint/FloatComparison:
-  Enabled: true
-
-Lint/MissingSuper:
+Lint/DeprecatedOpenSSLConstant:
   Enabled: false
-
-Lint/OutOfRangeRegexpRef:
-  Enabled: true
-
-Lint/SelfAssignment:
-  Enabled: true
-
-Lint/TopLevelReturnWithArgument:
-  Enabled: true
-
-Lint/TrailingCommaInAttributeDeclaration:
-  Enabled: true
-
-Lint/UnreachableLoop:
-  Enabled: true
-
-Lint/UselessMethodDefinition:
-  Enabled: true
-
-Metrics/ClassLength:
-  Max: 350
-
-Metrics/ModuleLength:
-  Max: 350
-
-Metrics/CyclomaticComplexity:
-  Max: 15
-
-Metrics/PerceivedComplexity:
-  Max: 10 # default: 8
-
-Metrics/AbcSize:
-  Max: 35
-
-Metrics/MethodLength:
-  Max: 35
-
-Metrics/BlockLength:
-  Max: 35
-  Exclude:
-    - '*/Rakefile'
-    - '**/spec/**/*'
-    - '*/dependabot-*.gemspec'
-
-Metrics/ParameterLists:
-  CountKeywordArgs: false
-
-Naming/FileName:
-  Enabled: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-
-Style/SignalException:
-  EnforcedStyle: only_raise
-
-Style/Documentation:
-  Enabled: false
-
-Style/HashEachMethods:
-  Enabled: false
-
-Style/HashTransformKeys:
-  Enabled: false
-
-Style/HashTransformValues:
-  Enabled: false
-
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    '%i': ()
-    '%I': ()
-    '%w': ()
-    '%W': ()
-
-Style/ExponentialNotation:
-  Enabled: false
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: false
-
-Style/RedundantRegexpEscape:
-  Enabled: false
-
-Style/SlicingWithRange:
-  Enabled: false
-
-Style/RedundantFetchBlock:
-  Enabled: false
-
 Lint/DuplicateElsifCondition:
   Enabled: false
-
+Lint/DuplicateRequire:
+  Enabled: true
+Lint/DuplicateRescueException:
+  Enabled: true
+Lint/EmptyConditionalBody:
+  Enabled: true
+Lint/EmptyFile:
+  Enabled: true
+Lint/FloatComparison:
+  Enabled: true
+Lint/MissingSuper:
+  Enabled: false
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+Lint/RaiseException:
+  Enabled: false
+Lint/SelfAssignment:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: false
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: true
+Lint/UnreachableLoop:
+  Enabled: true
+Lint/UselessMethodDefinition:
+  Enabled: true
+Metrics/AbcSize:
+  Max: 35
+Metrics/BlockLength:
+  Exclude:
+  - "*/Rakefile"
+  - "**/spec/**/*"
+  - "*/dependabot-*.gemspec"
+  Max: 35
+Metrics/ClassLength:
+  Max: 350
+Metrics/CyclomaticComplexity:
+  Max: 15
+Metrics/MethodLength:
+  Max: 35
+Metrics/ModuleLength:
+  Max: 350
+Metrics/ParameterLists:
+  CountKeywordArgs: false
+Metrics/PerceivedComplexity:
+  Max: 10
+Naming/FileName:
+  Enabled: false
 Style/AccessorGrouping:
   Enabled: false
-
 Style/ArrayCoercion:
   Enabled: false
-
 Style/BisectedAttrAccessor:
   Enabled: false
-
 Style/CaseLikeIf:
   Enabled: false
-
-Style/HashAsLastArrayItem:
-  Enabled: false
-
-Style/HashLikeCase:
-  Enabled: false
-
-Style/RedundantAssignment:
-  Enabled: false
-
-Style/RedundantFileExtensionInRequire:
-  Enabled: false
-
 Style/CombinableLoops:
   Enabled: true
-
+Style/Documentation:
+  Enabled: false
 Style/ExplicitBlockArgument:
   Enabled: true
-
+Style/ExponentialNotation:
+  Enabled: false
 Style/GlobalStdStream:
   Enabled: true
-
+Style/HashAsLastArrayItem:
+  Enabled: false
+Style/HashEachMethods:
+  Enabled: false
+Style/HashLikeCase:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: false
+Style/HashTransformValues:
+  Enabled: false
 Style/KeywordParametersOrder:
   Enabled: false
-
 Style/OptionalBooleanParameter:
   Enabled: false
-
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    "%I": "()"
+    "%W": "()"
+    "%i": "()"
+    "%w": "()"
+Style/RedundantAssignment:
+  Enabled: false
+Style/RedundantFetchBlock:
+  Enabled: false
+Style/RedundantFileExtensionInRequire:
+  Enabled: false
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+Style/RedundantRegexpEscape:
+  Enabled: false
 Style/RedundantSelfAssignment:
   Enabled: true
-
+Style/SignalException:
+  EnforcedStyle: only_raise
 Style/SingleArgumentDig:
   Enabled: true
-
+Style/SlicingWithRange:
+  Enabled: false
 Style/SoleNestedConditional:
   Enabled: true
-
 Style/StringConcatenation:
   Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,37 +21,71 @@ Layout/RescueEnsureAlignment:
   Enabled: false
 Layout/SpaceAroundMethodCallOperator:
   Enabled: false
+Lint/AmbiguousAssignment:
+  Enabled: true
 Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+Lint/DeprecatedConstants:
   Enabled: true
 Lint/DeprecatedOpenSSLConstant:
   Enabled: false
+Lint/DuplicateBranch:
+  Enabled: false
 Lint/DuplicateElsifCondition:
   Enabled: false
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: true
 Lint/DuplicateRequire:
   Enabled: true
 Lint/DuplicateRescueException:
+  Enabled: true
+Lint/EmptyBlock:
+  Enabled: true
+Lint/EmptyClass:
   Enabled: true
 Lint/EmptyConditionalBody:
   Enabled: true
 Lint/EmptyFile:
   Enabled: true
+Lint/EmptyInPattern:
+  Enabled: true
 Lint/FloatComparison:
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock:
   Enabled: true
 Lint/MissingSuper:
   Enabled: false
 Lint/MixedRegexpCaptureTypes:
   Enabled: false
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: false
+Lint/NumberedParameterAssignment:
+  Enabled: true
+Lint/OrAssignmentToConstant:
+  Enabled: true
 Lint/OutOfRangeRegexpRef:
   Enabled: true
 Lint/RaiseException:
   Enabled: false
+Lint/RedundantDirGlobSort:
+  Enabled: true
 Lint/SelfAssignment:
   Enabled: true
 Lint/StructNewOverride:
   Enabled: false
+Lint/SymbolConversion:
+  Enabled: true
+Lint/ToEnumArguments:
+  Enabled: true
 Lint/TopLevelReturnWithArgument:
   Enabled: true
 Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: true
+Lint/TripleQuotes:
+  Enabled: true
+Lint/UnexpectedBlockArity:
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator:
   Enabled: true
 Lint/UnreachableLoop:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,16 +81,24 @@ Naming/FileName:
   Enabled: false
 Style/AccessorGrouping:
   Enabled: false
+Style/ArgumentsForwarding:
+  Enabled: true
 Style/ArrayCoercion:
   Enabled: false
 Style/BisectedAttrAccessor:
   Enabled: false
 Style/CaseLikeIf:
   Enabled: false
+Style/CollectionCompact:
+  Enabled: true
 Style/CombinableLoops:
+  Enabled: true
+Style/DocumentDynamicEvalDefinition:
   Enabled: true
 Style/Documentation:
   Enabled: false
+Style/EndlessMethod:
+  Enabled: true
 Style/ExplicitBlockArgument:
   Enabled: true
 Style/ExponentialNotation:
@@ -99,16 +107,30 @@ Style/GlobalStdStream:
   Enabled: true
 Style/HashAsLastArrayItem:
   Enabled: false
+Style/HashConversion:
+  Enabled: true
 Style/HashEachMethods:
   Enabled: false
+Style/HashExcept:
+  Enabled: true
 Style/HashLikeCase:
   Enabled: false
 Style/HashTransformKeys:
   Enabled: false
 Style/HashTransformValues:
   Enabled: false
+Style/IfWithBooleanLiteralBranches:
+  Enabled: true
+Style/InPatternThen:
+  Enabled: true
 Style/KeywordParametersOrder:
   Enabled: false
+Style/MultilineInPatternThen:
+  Enabled: true
+Style/NegatedIfElseCondition:
+  Enabled: true
+Style/NilLambda:
+  Enabled: true
 Style/OptionalBooleanParameter:
   Enabled: false
 Style/PercentLiteralDelimiters:
@@ -117,6 +139,10 @@ Style/PercentLiteralDelimiters:
     "%W": "()"
     "%i": "()"
     "%w": "()"
+Style/QuotedSymbols:
+  Enabled: true
+Style/RedundantArgument:
+  Enabled: true
 Style/RedundantAssignment:
   Enabled: false
 Style/RedundantFetchBlock:
@@ -137,7 +163,11 @@ Style/SlicingWithRange:
   Enabled: false
 Style/SoleNestedConditional:
   Enabled: true
+Style/StringChars:
+  Enabled: true
 Style/StringConcatenation:
   Enabled: false
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/SwapValues:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
   - "**/tmp/**/*"
   - "*/spec/fixtures/**/*"
   TargetRubyVersion: 2.5
+  SuggestExtensions: false
+Gemspec/DateAssignment:
+  Enabled: true
 Layout/DotPosition:
   EnforcedStyle: trailing
 Layout/EmptyLinesAroundAttributeAccessor:
@@ -21,6 +24,8 @@ Layout/RescueEnsureAlignment:
   Enabled: false
 Layout/SpaceAroundMethodCallOperator:
   Enabled: false
+Layout/SpaceBeforeBrackets:
+  Enabled: true
 Lint/AmbiguousAssignment:
   Enabled: true
 Lint/BinaryOperatorWithIdenticalOperands:

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ require "shellwords"
 require "rubygems/package"
 require "bundler"
 require "./common/lib/dependabot/version"
+require "yaml"
 
 GEMSPECS = %w(
   common/dependabot-common.gemspec
@@ -83,6 +84,25 @@ namespace :gems do
 
   task :clean do
     FileUtils.rm(Dir["pkg/*.gem"])
+  end
+end
+
+class Hash
+  def sort_by_key(recursive = false, &block)
+    keys.sort(&block).each_with_object({}) do |key, seed|
+      seed[key] = self[key]
+      seed[key] = seed[key].sort_by_key(true, &block) if recursive && seed[key].is_a?(Hash)
+      seed
+    end
+  end
+end
+
+namespace :rubocop do
+  task :sort do
+    File.write(
+      ".rubocop.yml",
+      YAML.load_file(".rubocop.yml").sort_by_key(true).to_yaml
+    )
   end
 end
 

--- a/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
@@ -50,10 +50,10 @@ module Dependabot
         end
 
         def ruby_version
-          requirement = if !ruby_requirement.is_a?(Gem::Requirement)
-                          Dependabot::Bundler::Requirement.new(ruby_requirement)
-                        else
+          requirement = if ruby_requirement.is_a?(Gem::Requirement)
                           ruby_requirement
+                        else
+                          Dependabot::Bundler::Requirement.new(ruby_requirement)
                         end
 
           ruby_version =

--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -154,7 +154,7 @@ module Dependabot
     end
 
     def symbolize_keys(hash)
-      Hash[hash.keys.map { |k| [k.to_sym, hash[k]] }]
+      hash.keys.map { |k| [k.to_sym, hash[k]] }.to_h
     end
   end
 end

--- a/common/lib/dependabot/file_updaters/vendor_updater.rb
+++ b/common/lib/dependabot/file_updaters/vendor_updater.rb
@@ -25,7 +25,7 @@ module Dependabot
           status = SharedHelpers.run_shell_command(
             "git status --untracked-files all --porcelain v1 #{relative_dir}"
           )
-          changed_paths = status.split("\n").map { |l| l.split(" ") }
+          changed_paths = status.split("\n").map(&:split)
           changed_paths.map do |type, path|
             # The following types are possible to be returned:
             # M = Modified = Default for DependencyFile

--- a/common/lib/dependabot/git_metadata_fetcher.rb
+++ b/common/lib/dependabot/git_metadata_fetcher.rb
@@ -106,7 +106,7 @@ module Dependabot
       peeled_lines = []
 
       result = upload_pack.lines.each_with_object({}) do |line, res|
-        full_ref_name = line.split(" ").last
+        full_ref_name = line.split.last
         next unless full_ref_name.start_with?("refs/tags", "refs/heads")
 
         peeled_lines << line && next if line.strip.end_with?("^{}")
@@ -174,7 +174,7 @@ module Dependabot
     end
 
     def sha_for_update_pack_line(line)
-      line.split(" ").first.chars.last(40).join
+      line.split.first.chars.last(40).join
     end
 
     def excon_defaults

--- a/common/lib/dependabot/metadata_finders/base/release_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/release_finder.rb
@@ -167,7 +167,7 @@ module Dependabot
 
         def serialize_release(release)
           rel = release
-          title = "## #{rel.name.to_s != '' ? rel.name : rel.tag_name}\n"
+          title = "## #{rel.name.to_s == '' ? rel.tag_name : rel.name}\n"
           body = if rel.body.to_s.gsub(/\n*\z/m, "") == ""
                    "No release notes provided."
                  else
@@ -178,7 +178,7 @@ module Dependabot
         end
 
         def release_body_includes_title?(release)
-          title = release.name.to_s != "" ? release.name : release.tag_name
+          title = release.name.to_s == "" ? release.tag_name : release.name
           release.body.to_s.match?(/\A\s*\#*\s*#{Regexp.quote(title)}/m)
         end
 

--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -267,7 +267,7 @@ module Dependabot
 
       def add_reviewers_to_pull_request(pull_request)
         reviewers_hash =
-          Hash[reviewers.keys.map { |k| [k.to_sym, reviewers[k]] }]
+          reviewers.keys.map { |k| [k.to_sym, reviewers[k]] }.to_h
 
         github_client_for_source.request_pull_request_review(
           source.repo,
@@ -297,7 +297,7 @@ module Dependabot
 
       def comment_with_invalid_reviewer(pull_request, message)
         reviewers_hash =
-          Hash[reviewers.keys.map { |k| [k.to_sym, reviewers[k]] }]
+          reviewers.keys.map { |k| [k.to_sym, reviewers[k]] }.to_h
         reviewers = []
         reviewers += reviewers_hash[:reviewers] || []
         reviewers += (reviewers_hash[:team_reviewers] || []).

--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -153,7 +153,7 @@ module Dependabot
 
       def add_approvers_to_merge_request(merge_request)
         approvers_hash =
-          Hash[approvers.keys.map { |k| [k.to_sym, approvers[k]] }]
+          approvers.keys.map { |k| [k.to_sym, approvers[k]] }.to_h
 
         gitlab_client_for_source.edit_merge_request_approvers(
           source.repo,

--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -51,10 +51,10 @@ module Dependabot
           doc.walk do |node|
             if node.type == :text &&
                node.string_content.match?(MENTION_REGEX)
-              nodes = if !parent_node_link?(node)
-                        build_mention_nodes(node.string_content)
-                      else
+              nodes = if parent_node_link?(node)
                         build_mention_link_text_nodes(node.string_content)
+                      else
+                        build_mention_nodes(node.string_content)
                       end
 
               nodes.each do |n|

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -65,7 +65,7 @@ module Dependabot
 
     # Escapes all special characters, e.g. = & | <>
     def self.escape_command(command)
-      command_parts = command.split(" ").map(&:strip).reject(&:empty?)
+      command_parts = command.split.map(&:strip).reject(&:empty?)
       Shellwords.join(command_parts)
     end
 

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -1332,7 +1332,7 @@ RSpec.describe Dependabot::FileFetchers::Base do
       # `git clone` against a file:// URL that is filled by the test
       let(:repo_path) { Dir.mktmpdir }
       after { FileUtils.rm_rf(repo_path) }
-      let(:fill_repo) {}
+      let(:fill_repo) { nil }
       before do
         Dir.chdir(repo_path) do
           `git init .`

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with a security vulnerability fixed" do
-          let(:vulnerabilities_fixed) { { "business": [{}] } }
+          let(:vulnerabilities_fixed) { { business: [{}] } }
           it { is_expected.to start_with("[Security] Bump business") }
         end
 
@@ -446,7 +446,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with a security vulnerability fixed" do
-          let(:vulnerabilities_fixed) { { "business": [{}] } }
+          let(:vulnerabilities_fixed) { { business: [{}] } }
           it { is_expected.to start_with("chore(deps): [security] bump") }
         end
 
@@ -489,7 +489,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with a security vulnerability fixed" do
-          let(:vulnerabilities_fixed) { { "business": [{}] } }
+          let(:vulnerabilities_fixed) { { business: [{}] } }
           it { is_expected.to start_with("Upgrade: [Security] Bump") }
         end
       end
@@ -505,7 +505,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         it { is_expected.to start_with("⬆️ Bump business") }
 
         context "with a security vulnerability fixed" do
-          let(:vulnerabilities_fixed) { { "business": [{}] } }
+          let(:vulnerabilities_fixed) { { business: [{}] } }
           it { is_expected.to start_with("⬆️🔒 Bump business") }
         end
       end
@@ -613,7 +613,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with a security vulnerability fixed" do
-          let(:vulnerabilities_fixed) { { "business": [{}] } }
+          let(:vulnerabilities_fixed) { { business: [{}] } }
           it { is_expected.to start_with("[Security] Update business") }
         end
 
@@ -667,7 +667,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with a security vulnerability fixed" do
-          let(:vulnerabilities_fixed) { { "business": [{}] } }
+          let(:vulnerabilities_fixed) { { business: [{}] } }
           it { is_expected.to start_with("chore(deps): [security] update") }
         end
       end
@@ -687,7 +687,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with a security vulnerability fixed" do
-          let(:vulnerabilities_fixed) { { "business": [{}] } }
+          let(:vulnerabilities_fixed) { { business: [{}] } }
           it { is_expected.to start_with("Upgrade: [Security] Update") }
         end
       end
@@ -1807,7 +1807,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       it { is_expected.to start_with(":arrow_up: Bump ") }
 
       context "with a security vulnerability fixed" do
-        let(:vulnerabilities_fixed) { { "business": [{}] } }
+        let(:vulnerabilities_fixed) { { business: [{}] } }
         it { is_expected.to start_with(":arrow_up::lock: Bump ") }
       end
     end

--- a/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
@@ -321,7 +321,7 @@ module Dependabot
                            fetch(keys[:lockfile], []).
                            find { |d| d["name"] == name }&.
                            dig("source", "reference")
-              updated_req_parts = req.split(" ")
+              updated_req_parts = req.split
               updated_req_parts[0] = updated_req_parts[0] + "##{commit_sha}"
               json[keys[:manifest]][name] = updated_req_parts.join(" ")
             end

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -186,7 +186,7 @@ module Dependabot
                            fetch(keys[:lockfile], []).
                            find { |d| d["name"] == name }&.
                            dig("source", "reference")
-              updated_req_parts = req.split(" ")
+              updated_req_parts = req.split
               updated_req_parts[0] = updated_req_parts[0] + "##{commit_sha}"
               json[keys[:manifest]][name] = updated_req_parts.join(" ")
             end

--- a/gradle/spec/dependabot/gradle/version_spec.rb
+++ b/gradle/spec/dependabot/gradle/version_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Dependabot::Gradle::Version do
   end
 
   describe "#<=>" do
-    subject { version.send(:"<=>", other_version) }
+    subject { version.send(:<=>, other_version) }
 
     context "compared to a Gem::Version" do
       context "that is lower" do

--- a/hex/lib/dependabot/hex/file_parser.rb
+++ b/hex/lib/dependabot/hex/file_parser.rb
@@ -112,7 +112,7 @@ module Dependabot
       end
 
       def symbolize_keys(hash)
-        Hash[hash.keys.map { |k| [k.to_sym, hash[k]] }]
+        hash.keys.map { |k| [k.to_sym, hash[k]] }.to_h
       end
 
       def mixfiles

--- a/maven/spec/dependabot/maven/version_spec.rb
+++ b/maven/spec/dependabot/maven/version_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Dependabot::Maven::Version do
   end
 
   describe "#<=>" do
-    subject { version.send(:"<=>", other_version) }
+    subject { version.send(:<=>, other_version) }
 
     context "compared to a Gem::Version" do
       context "that is lower" do

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -131,7 +131,7 @@ module Dependabot
                   reject { |file| updated_filenames.include?(file.name) }
 
           args = dependency.to_h
-          args = Hash[args.keys.map { |k| [k.to_sym, args[k]] }]
+          args = args.keys.map { |k| [k.to_sym, args[k]] }.to_h
           args[:requirements] = new_reqs
           args[:previous_requirements] = old_reqs
 

--- a/terraform/spec/dependabot/terraform/registry_client_spec.rb
+++ b/terraform/spec/dependabot/terraform/registry_client_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
         "modules": [
           {
             "source": "hashicorp/consul/aws",
-            "versions": [{ 'version': "0.1.0" }, { 'version': "0.2.0" }]
+            "versions": [{ "version": "0.1.0" }, { "version": "0.2.0" }]
           }
         ]
       }.to_json)

--- a/terraform/spec/dependabot/terraform/registry_client_spec.rb
+++ b/terraform/spec/dependabot/terraform/registry_client_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
     stub_request(:get, "https://#{hostname}/v1/providers/hashicorp/aws/versions").and_return(
       status: 200,
       body: {
-        "id": "hashicorp/aws",
-        "versions": [{ "version": "3.42.0" }, { "version": "3.41.0" }]
+        id: "hashicorp/aws",
+        versions: [{ version: "3.42.0" }, { version: "3.41.0" }]
       }.to_json
     )
     client = described_class.new(hostname: hostname)
@@ -97,7 +97,7 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
       "providers.v1": "/v1/providers/"
     }.to_json)
     stub_request(:get, "https://#{hostname}/v1/providers/x/y/versions").
-      and_return(body: { "id": "x/y", "versions": [{ "version": "0.1.0" }] }.to_json)
+      and_return(body: { id: "x/y", versions: [{ version: "0.1.0" }] }.to_json)
     client = described_class.new(hostname: hostname, credentials: credentials)
 
     expect(client.all_provider_versions(identifier: "x/y")).to match_array([
@@ -126,10 +126,10 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
       }.to_json)
     stub_request(:get, "https://#{hostname}/api/registry/v1/modules/hashicorp/consul/aws/versions").
       and_return(status: 200, body: {
-        "modules": [
+        modules: [
           {
-            "source": "hashicorp/consul/aws",
-            "versions": [{ "version": "0.1.0" }, { "version": "0.2.0" }]
+            source: "hashicorp/consul/aws",
+            versions: [{ version: "0.1.0" }, { version: "0.2.0" }]
           }
         ]
       }.to_json)


### PR DESCRIPTION
This is an idle hands PR: I upgraded my system and wanted to verify this toolchain wasn't broken.

The changeset begins by adding a `rake rubocop:sort` task, which does a recursive sort of `.rubocop.yml` for 💄 .
From there, new but not enabled cops are enabled in 3 phases with autofix+sort applied at each round.

When an autofix wasn't available, the rule was disabled (I didn't write any code):
* [`Lint/NoReturnInBeginEndBlocks`](https://rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/NoReturnInBeginEndBlocks)
* [`Lint/DuplicateBranch`](https://rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/DuplicateBranch)
