### PR TITLE
chore: install shellcheck in the dev container

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -3,7 +3,7 @@ FROM dependabot/dependabot-core
 # Temporarily switch to root user in order to install packages
 USER root
 RUN apt-get update \
-  && apt-get install -y vim strace ltrace gdb \
+  && apt-get install -y vim strace ltrace gdb shellcheck \
   && rm -rf /var/lib/apt/lists/*
 USER dependabot
 


### PR DESCRIPTION
# Why is this needed?

To ensure that the dev container has `shellcheck` installed so that the
`./bin/lint` script can be used.

## What does this do?

It installs the `shellcheck` package in the dev docker image.

/xref: https://github.com/dependabot/dependabot-core/pull/3932#discussion_r654200778
