### PR TITLE
v0.154.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.154.3, 19 June 2021
+
+- fix: Fetches upload-pack using git if http fails
+- fix(Terraform): handle dependencies without a namespace
+- chore: Replace wget with curl for minimized dependency
+- chore: add lint job to check shell scripts
+- build(deps): bump @npmcli/arborist in /npm_and_yarn/helpers
+- chore: Double quote variables in Dockerfile's shellscript, cc #3917
+
 ## v0.154.2, 17 June 2021
 
 - Terraform: Handle 401 registry responses

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.154.2"
+  VERSION = "0.154.3"
 end


### PR DESCRIPTION
## v0.154.3, 19 June 2021

- fix: Fetches upload-pack using git if http fails
- fix(Terraform): handle dependencies without a namespace
- chore: Replace wget with curl for minimized dependency
- chore: add lint job to check shell scripts
- build(deps): bump @npmcli/arborist in /npm_and_yarn/helpers
- chore: Double quote variables in Dockerfile's shellscript, cc #3917

https://github.com/dependabot/dependabot-core/compare/v0.154.2...1b17a40
