### PR TITLE
Clarify support policies in README and Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,16 +1,14 @@
 ---
 name: "\U0001F41B Bug report"
-about: Report a bug in Dependabot to help us fix it
+about: Report a bug in dependabot-core to help us fix it
 title: ''
 labels: 'T: bug 🐞'
 assignees: ''
 
 ---
 
-<!-- Please search existing issues to avoid creating duplicates. -->
-
-<!-- The Dependabot team is currently at reduced capacity, because of this our
-response times on issues will be slower than we'd like. -->
+<!-- For support on the GitHub-integrated Dependabot service, please contact [GitHub support](https://support.github.com/) -->
+<!-- This issue-tracker is meant for issues related to Dependabot's updating logic, a good rule of thumb is that if you have questions about the _diff_ in a PR, it belongs here, otherwise the GitHub support team is best equipped to help you -->
 
 <!-- The more information you can provide, the easier it will be to reproduce the issue and find a fix -->
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Welcome to the public home of Dependabot. This repository serves 2 purposes:
 
 1. It houses the source code for Dependabot Core, which is the heart of [Dependabot][dependabot]. Dependabot Core handles the logic for updating dependencies on GitHub (including GitHub Enterprise), GitLab, and Azure DevOps. If you want to host your own automated dependency update bot then this repo should give you the tools you need. A reference implementation is available [here][dependabot-script].
-2. It is the public issue tracker for all things Dependabot, replacing the now-archived [feedback](https://github.com/dependabot/feedback/) repository.
+2. It is the public issue tracker for issues related to Dependabot's updating logic. For issues about Dependabot the service, please contact [GitHub support][support]. While the distinction between Dependabot Core and the service can be fuzzy, a good rule of thumb is if your issue is with the _diff_ that Dependabot created, it belongs here and for most other things the GitHub support team is best equipped to help you.
 
 ## Got feedback?
 
@@ -235,3 +235,4 @@ recurring payments from Europe, check them out.
 [bump]: https://github.com/gocardless/bump
 [bump-core]: https://github.com/gocardless/bump-core
 [gocardless]: https://gocardless.com
+[support]: https://support.github.com/


### PR DESCRIPTION
We tend to get a lot of questions here about the Dependabot service that
we operate at GitHub. Many of those questions are much easier to resolve
when going through Support, as they have much better tooling and
processes to follow up on those sorts of questions.

This attempts to clarify that in the README and issue template.