### PR TITLE
Terraform: handle unreachable private module proxy

### DIFF
--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -231,20 +231,22 @@ module Dependabot
       # rubocop:disable Metrics/PerceivedComplexity
       # See https://www.terraform.io/docs/modules/sources.html#http-urls for
       # details of how Terraform handle HTTP(S) sources for modules
-      def get_proxied_source(raw_source)
+      def get_proxied_source(raw_source) # rubocop:disable Metrics/AbcSize
         return raw_source unless raw_source.start_with?("http")
 
         uri = URI.parse(raw_source.split(%r{(?<!:)//}).first)
         return raw_source if uri.path.end_with?(*ARCHIVE_EXTENSIONS)
-        return raw_source if URI.parse(raw_source).query.include?("archive=")
+        return raw_source if URI.parse(raw_source).query&.include?("archive=")
 
         url = raw_source.split(%r{(?<!:)//}).first + "?terraform-get=1"
+        host = URI.parse(raw_source).host
 
         response = Excon.get(
           url,
           idempotent: true,
           **SharedHelpers.excon_defaults
         )
+        raise PrivateSourceAuthenticationFailure, host if response.status == 401
 
         return response.headers["X-Terraform-Get"] if response.headers["X-Terraform-Get"]
 
@@ -252,6 +254,10 @@ module Dependabot
         doc.css("meta").find do |tag|
           tag.attributes&.fetch("name", nil)&.value == "terraform-get"
         end&.attributes&.fetch("content", nil)&.value
+      rescue Excon::Error::Socket, Excon::Error::Timeout => e
+        raise PrivateSourceAuthenticationFailure, host if e.message.include?("no address for")
+
+        raw_source
       end
       # rubocop:enable Metrics/PerceivedComplexity
 
@@ -271,7 +277,7 @@ module Dependabot
         path_uri = URI.parse(source_string.split(%r{(?<!:)//}).first)
         query_uri = URI.parse(source_string)
         return :http_archive if path_uri.path.end_with?(*ARCHIVE_EXTENSIONS)
-        return :http_archive if query_uri.query.include?("archive=")
+        return :http_archive if query_uri.query&.include?("archive=")
 
         raise "HTTP source, but not an archive!"
       end

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -658,5 +658,15 @@ RSpec.describe Dependabot::Terraform::FileParser do
         expect(dependency.requirements.first[:source][:module_identifier]).to eq("hashicorp/random")
       end
     end
+
+    context "with a private module proxy that can't be reached", vcr: true do
+      let(:files) { project_dependency_files("private_module_proxy") }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Dependabot::PrivateSourceAuthenticationFailure) do |boom|
+          expect(boom.source).to eq("artifactory.dependabot.com")
+        end
+      end
+    end
   end
 end

--- a/terraform/spec/fixtures/projects/private_module_proxy/main.tf
+++ b/terraform/spec/fixtures/projects/private_module_proxy/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.14"
+}
+
+module "nsg_rules" {
+  source = "http://artifactory.dependabot.com/artifactory/tf-modules/azurerm/terraform-azurerm-nsg-rules.v1.1.0.tar.gz"
+}


### PR DESCRIPTION
Raise a `PrivateSourceAuthenticationFailure` when a private module proxy
can't be reached.