### PR TITLE
Terraform: handle missing source

### DIFF
--- a/terraform/spec/dependabot/terraform/registry_client_spec.rb
+++ b/terraform/spec/dependabot/terraform/registry_client_spec.rb
@@ -161,6 +161,38 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
     expect(source.url).to eq("https://github.com/hashicorp/terraform-aws-consul")
   end
 
+  it "handles sources that can't be found", :vcr do
+    provider_dependency = Dependabot::Dependency.new(
+      name: "dependabot/package",
+      version: "0.9.3",
+      package_manager: "terraform",
+      previous_version: "0.1.0",
+      requirements: [{
+        requirement: "0.3.8",
+        groups: [],
+        file: "main.tf",
+        source: {
+          type: "registry",
+          registry_hostname: "registry.dependabot.com",
+          module_identifier: "dependabot/package"
+        }
+      }],
+      previous_requirements: [{
+        requirement: "0.1.0",
+        groups: [],
+        file: "main.tf",
+        source: {
+          type: "registry",
+          registry_hostname: "registry.dependabot.com",
+          module_identifier: "dependabot/package"
+        }
+      }]
+    )
+
+    source = client.source(dependency: provider_dependency)
+    expect(source).to eq(nil)
+  end
+
   it "fetches the source for a provider from a custom registry", :vcr do
     hostname = "terraform.example.org"
     client = described_class.new(hostname: hostname)

--- a/terraform/spec/fixtures/vcr_cassettes/Dependabot_Terraform_RegistryClient/fetches_the_source_for_a_provider_dependency.yml
+++ b/terraform/spec/fixtures/vcr_cassettes/Dependabot_Terraform_RegistryClient/fetches_the_source_for_a_provider_dependency.yml
@@ -2,27 +2,17 @@
 http_interactions:
 - request:
     method: get
-    uri: https://registry.terraform.io/.well-known/terraform.json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      string: '{"modules.v1":"/v1/modules/","providers.v1":"/v1/providers/"}'
-  recorded_at: Fri, 28 May 2021 22:51:01 GMT
-- request:
-    method: get
     uri: https://registry.terraform.io/v1/modules/hashicorp/consul/aws/0.9.3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
   response:
     status:
       code: 200
       message: OK
     headers:
-      Content-Type:
+      content-type:
       - application/json
     body:
       encoding: UTF-8
@@ -668,6 +658,126 @@ http_interactions:
         name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this
         cluster. Set to an empty string to not associate a Key Pair.","default":"","required":true}],"outputs":[{"name":"iam_role_id_clients","description":""},{"name":"num_clients","description":""},{"name":"num_servers","description":""},{"name":"consul_servers_cluster_tag_value","description":""},{"name":"aws_region","description":""},{"name":"iam_role_id_servers","description":""},{"name":"iam_role_arn_servers","description":""},{"name":"asg_name_servers","description":""},{"name":"security_group_id_clients","description":""},{"name":"iam_role_arn_clients","description":""},{"name":"asg_name_clients","description":""},{"name":"security_group_id_servers","description":""},{"name":"launch_config_name_servers","description":""},{"name":"consul_servers_cluster_tag_key","description":""},{"name":"launch_config_name_clients","description":""}],"dependencies":[],"provider_dependencies":[{"name":"aws","namespace":"","source":"","version":""},{"name":"template","namespace":"","source":"","version":""}],"resources":[]}],"providers":["aws","azurerm","google"],"versions":["0.0.1","0.0.2","0.0.3","0.0.4","0.0.5","0.1.0","0.1.1","0.1.2","0.2.0","0.2.1","0.2.2","0.3.0","0.3.1","0.3.2","0.3.3","0.3.4","0.3.5","0.3.6","0.3.7","0.3.8","0.3.9","0.3.10","0.4.0","0.4.1","0.4.2","0.4.3","0.4.4","0.4.5","0.5.0","0.6.0","0.6.1","0.7.0","0.7.1","0.7.2","0.7.3","0.7.4","0.7.5","0.7.6","0.7.7","0.7.8","0.7.9","0.7.10","0.7.11","0.8.0","0.8.1","0.8.2","0.8.3","0.8.4","0.8.5","0.8.6","0.9.0","0.9.1","0.9.2","0.9.3","0.10.0","0.10.1"]}
 
-'
+        '
   recorded_at: Fri, 28 May 2021 22:51:01 GMT
+- request:
+    method: get
+    uri: https://registry.terraform.io/.well-known/terraform.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      user-agent:
+      - dependabot-core/0.154.2 excon/0.82.0 ruby/2.7.3 (x86_64-darwin19) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '65'
+      server:
+      - Cowboy
+      cache-control:
+      - public, max-age=3600, stale-if-error=31536000
+      content-encoding:
+      - ''
+      content-security-policy:
+      - 'default-src ''self''; script-src ''self'' ''unsafe-inline'' https://www.google-analytics.com
+        https://cdn.segment.com https://www.googletagmanager.com https://a.optnmstr.com;
+        style-src ''self'' ''unsafe-inline'' https://maxcdn.bootstrapcdn.com https://fonts.googleapis.com
+        https://p.typekit.net https://use.typekit.net; img-src ''self'' data: https:
+        https://www.google-analytics.com; font-src ''self'' https://maxcdn.bootstrapcdn.com
+        https://fonts.googleapis.com https://fonts.gstatic.com https://use.typekit.net;
+        connect-src ''self'' https://www.google-analytics.com https://api.segment.io
+        https://sentry.io https://api.omappapi.com https://api.opmnstr.com https://api.optmnstr.com
+        https://*.algolia.net https://*.algolianet.com'
+      content-type:
+      - application/json
+      feature-policy:
+      - ''
+      last-modified:
+      - Fri, 18 Jun 2021 14:48:43 GMT
+      referrer-policy:
+      - no-referrer-when-downgrade
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-registry-fastboot:
+      - 'false'
+      x-xss-protection:
+      - 1; mode=block
+      via:
+      - 1.1 vegur, 1.1 varnish, 1.1 varnish
+      accept-ranges:
+      - bytes
+      date:
+      - Mon, 21 Jun 2021 12:44:33 GMT
+      age:
+      - '1376'
+      x-served-by:
+      - cache-dca17760-DCA, cache-lhr7375-LHR
+      x-cache:
+      - HIT, HIT
+      x-cache-hits:
+      - 1, 16
+      vary:
+      - Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: '{"modules.v1":"/v1/modules/","providers.v1":"/v1/providers/"}
+
+        '
+  recorded_at: Mon, 21 Jun 2021 12:44:33 GMT
+- request:
+    method: get
+    uri: https://registry.terraform.io/v1/modules/terraform-providers/opsgenie/0.9.3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      user-agent:
+      - dependabot-core/0.154.2 excon/0.82.0 ruby/2.7.3 (x86_64-darwin19) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '49'
+      server:
+      - Cowboy
+      content-encoding:
+      - ''
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 vegur, 1.1 varnish, 1.1 varnish
+      accept-ranges:
+      - bytes
+      date:
+      - Mon, 21 Jun 2021 12:44:33 GMT
+      x-served-by:
+      - cache-dca17739-DCA, cache-lhr7343-LHR
+      x-cache:
+      - MISS, MISS
+      x-cache-hits:
+      - 0, 0
+      vary:
+      - Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: '{"errors":["Not Found"]}
+
+        '
+  recorded_at: Mon, 21 Jun 2021 12:44:33 GMT
 recorded_with: VCR 6.0.0

--- a/terraform/spec/fixtures/vcr_cassettes/Dependabot_Terraform_RegistryClient/handles_sources_that_can_t_be_found.yml
+++ b/terraform/spec/fixtures/vcr_cassettes/Dependabot_Terraform_RegistryClient/handles_sources_that_can_t_be_found.yml
@@ -1,0 +1,123 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://registry.terraform.io/.well-known/terraform.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      user-agent:
+      - dependabot-core/0.154.2 excon/0.82.0 ruby/2.7.3 (x86_64-darwin19) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '65'
+      server:
+      - Cowboy
+      cache-control:
+      - public, max-age=3600, stale-if-error=31536000
+      content-encoding:
+      - ''
+      content-security-policy:
+      - 'default-src ''self''; script-src ''self'' ''unsafe-inline'' https://www.google-analytics.com
+        https://cdn.segment.com https://www.googletagmanager.com https://a.optnmstr.com;
+        style-src ''self'' ''unsafe-inline'' https://maxcdn.bootstrapcdn.com https://fonts.googleapis.com
+        https://p.typekit.net https://use.typekit.net; img-src ''self'' data: https:
+        https://www.google-analytics.com; font-src ''self'' https://maxcdn.bootstrapcdn.com
+        https://fonts.googleapis.com https://fonts.gstatic.com https://use.typekit.net;
+        connect-src ''self'' https://www.google-analytics.com https://api.segment.io
+        https://sentry.io https://api.omappapi.com https://api.opmnstr.com https://api.optmnstr.com
+        https://*.algolia.net https://*.algolianet.com'
+      content-type:
+      - application/json
+      feature-policy:
+      - ''
+      last-modified:
+      - Fri, 18 Jun 2021 14:48:43 GMT
+      referrer-policy:
+      - no-referrer-when-downgrade
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-registry-fastboot:
+      - 'false'
+      x-xss-protection:
+      - 1; mode=block
+      via:
+      - 1.1 vegur, 1.1 varnish, 1.1 varnish
+      accept-ranges:
+      - bytes
+      date:
+      - Mon, 21 Jun 2021 12:46:30 GMT
+      age:
+      - '1494'
+      x-served-by:
+      - cache-dca17760-DCA, cache-lhr7346-LHR
+      x-cache:
+      - HIT, HIT
+      x-cache-hits:
+      - 1, 31
+      vary:
+      - Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: '{"modules.v1":"/v1/modules/","providers.v1":"/v1/providers/"}
+
+        '
+  recorded_at: Mon, 21 Jun 2021 12:46:30 GMT
+- request:
+    method: get
+    uri: https://registry.terraform.io/v1/modules/dependabot/package/0.9.3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      user-agent:
+      - dependabot-core/0.154.2 excon/0.82.0 ruby/2.7.3 (x86_64-darwin19) (+https://github.com/dependabot/dependabot-core)
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '49'
+      server:
+      - Cowboy
+      content-encoding:
+      - ''
+      content-type:
+      - application/json
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 vegur, 1.1 varnish, 1.1 varnish
+      accept-ranges:
+      - bytes
+      date:
+      - Mon, 21 Jun 2021 12:46:30 GMT
+      x-served-by:
+      - cache-dca17779-DCA, cache-lhr7358-LHR
+      x-cache:
+      - MISS, MISS
+      x-cache-hits:
+      - 0, 0
+      vary:
+      - Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: '{"errors":["Not Found"]}
+
+        '
+  recorded_at: Mon, 21 Jun 2021 12:46:30 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
Silently ignore failing source requests to not block PR creation.
Returning nil here will cause the PR creator to not include any
changelogs/release notes.