### PR TITLE
Terraform: Handle "terraform-providers" namespace

### DIFF
--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -91,12 +91,16 @@ module Dependabot
 
         source_address = details.fetch("source", nil)
         version_req = details["version"]&.strip
-        hostname, namespace, name = provider_source_from(source_address, name)
-        dependency_name = source_address ? "#{namespace}/#{name}" : name
+        hostname, file_namespace, name = provider_source_from(source_address, name)
+        # NOTE: terraform-providers/name is a shorthard for the provider name
+        # matching the namespace, we separate this from the file namespace
+        # needed to find the provider in the parsed file
+        dependency_namespace = file_namespace == "terraform-providers" ? name : file_namespace
+        dependency_name = source_address ? "#{dependency_namespace}/#{name}" : name
 
         Dependency.new(
           name: dependency_name,
-          version: determine_version_for(hostname, namespace, name, version_req),
+          version: determine_version_for(hostname, file_namespace, name, version_req),
           package_manager: "terraform",
           requirements: [
             requirement: version_req,
@@ -105,7 +109,7 @@ module Dependabot
             source: {
               type: "provider",
               registry_hostname: hostname,
-              module_identifier: "#{namespace}/#{name}"
+              module_identifier: "#{file_namespace}/#{name}"
             }
           ]
         )

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -668,5 +668,16 @@ RSpec.describe Dependabot::Terraform::FileParser do
         end
       end
     end
+
+    context "with a provider that uses the terraform-providers namespace" do
+      let(:files) { project_dependency_files("terraform_providers_namespace") }
+
+      it "has the right details" do
+        dependency = dependencies.find { |d| d.name == "fastly/fastly" }
+
+        expect(dependency.version).to eq("0.29.0")
+        expect(dependency.requirements.first[:source][:module_identifier]).to eq("terraform-providers/fastly")
+      end
+    end
   end
 end

--- a/terraform/spec/fixtures/projects/terraform_providers_namespace/main.tf
+++ b/terraform/spec/fixtures/projects/terraform_providers_namespace/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    fastly = {
+      source = "terraform-providers/fastly"
+      version = "0.29.0"
+    }
+  }
+  required_version = ">= 0.29"
+}


### PR DESCRIPTION
Handle dependencies that have been declared with the
`terraform-providers` namespace, .e.g "terraform-providers/fastly".

This seems to always map to packages where the namespace matches the
name and there's also a package with the same name. Not all providers
where a package matches the namespace supports this but they also can't
be installed with `terraform-providers` as the namespace. e.g. 
`terraform-providers/checkly` doesn't work but `checkly/checkly` works.

Only changing the dependency name as this is used to later fetch the
dependency source.