### PR TITLE
Terraform: handle nested module sources

### DIFF
--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -157,7 +157,11 @@ module Dependabot
         %r{
           (?<=\{)
           (?:(?!^\}).)*
-          source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)?#{Regexp.escape(dependency.name)}["']
+          source\s*=\s*["']
+            (#{Regexp.escape(registry_host_for(dependency))}/)?
+            #{Regexp.escape(dependency.name)}
+            (//modules/\S+)?
+            ["']
           (?:(?!^\}).)*
         }mx
       end

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -791,5 +791,52 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
         )
       end
     end
+
+    describe "for a nested module" do
+      let(:files) { project_dependency_files("nested_modules") }
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "terraform-aws-modules/iam/aws",
+            version: "4.1.0",
+            previous_version: "4.0.0",
+            requirements: [{
+              requirement: "4.1.0",
+              groups: [],
+              file: "main.tf",
+              source: {
+                type: "registry",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "iam/aws"
+              }
+            }],
+            previous_requirements: [{
+              requirement: "4.0.0",
+              groups: [],
+              file: "main.tf",
+              source: {
+                type: "registry",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "iam/aws"
+              }
+            }],
+            package_manager: "terraform"
+          )
+        ]
+      end
+
+      it "updates the requirement" do
+        updated_file = subject.find { |file| file.name == "main.tf" }
+
+        expect(updated_file.content).to include(
+          <<~DEP
+            module "github_terraform" {
+              source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+              version = "4.1.0"
+            }
+          DEP
+        )
+      end
+    end
   end
 end

--- a/terraform/spec/fixtures/projects/nested_modules/main.tf
+++ b/terraform/spec/fixtures/projects/nested_modules/main.tf
@@ -1,0 +1,4 @@
+module "github_terraform" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "4.0.0"
+}


### PR DESCRIPTION
Relax the regex that matches module sources to include nested modules.

Nested modules mentioned in docs here: https://www.terraform.io/docs/language/modules/develop/structure.html

