### PR TITLE
bin/ci-test

### DIFF
--- a/bin/ci-test
+++ b/bin/ci-test
@@ -1,0 +1,56 @@
+#!/bin/bash -e
+#/ usage: ci-test SUITE
+#/ simulate the process followed by ~/.github/workflows/ci.yml
+
+function print_usage() {
+  grep ^#/ "$0" | cut -c4-
+}
+
+function handle_args() {
+  export SUITE=$1
+  case $SUITE in
+    bundler1 | bundler2)
+      export MODULE=bundler
+      ;;
+    "")
+      print_usage
+      exit 1
+      ;;
+    *)
+      export MODULE=$SUITE
+  esac
+
+  if ! [ -d "$MODULE" ]; then
+    print_usage
+    echo "module not found, try:"
+    for m in $(ls */*.gemspec | grep -v omni); do
+      echo -n "  "; dirname $m
+    done
+    exit 1
+  fi
+}
+
+function build() {
+  export DOCKER_BUILDKIT=1
+  export DOCKER_SCAN_SUGGEST=false
+  export CORE=dependabot/dependabot-core
+  export CI=dependabot/dependabot-core-ci
+
+  set -x
+  docker build -qt $CORE .
+  docker build -qt $CI -f Dockerfile.ci .
+  docker run --rm \
+    -e "CI=true" \
+    -e "SUITE_NAME=$SUITE" \
+    -e "DEPENDABOT_TEST_ACCESS_TOKEN=${LOCAL_GITHUB_ACCESS_TOKEN}" \
+    -it $CI \
+    bash -c \
+    "cd /home/dependabot/dependabot-core/$MODULE && ./script/ci-test"
+}
+
+function main() {
+  handle_args "$@"
+  build
+}
+
+main "$@"

--- a/bin/ci-test
+++ b/bin/ci-test
@@ -23,8 +23,9 @@ function handle_args() {
   if ! [ -d "$MODULE" ]; then
     print_usage
     echo "module not found, try:"
-    for m in $(ls */*.gemspec | grep -v omni); do
-      echo -n "  "; dirname $m
+    for m in */*.gemspec; do
+      [[ "$m" == "omnibus" ]] && continue
+      echo -n "  "; dirname "$m"
     done
     exit 1
   fi

--- a/bin/lint
+++ b/bin/lint
@@ -3,6 +3,7 @@
 set -e
 
 shellcheck \
+  ./bin/ci-test \
   ./bin/docker-dev-shell \
   ./bin/lint \
   ./*/helpers/build \


### PR DESCRIPTION
This brings back the helper added in https://github.com/dependabot/dependabot-core/pull/3398 . I'd re-written it for https://github.com/dependabot/dependabot-core/pull/3911 , then @Nishnha asked about the same thing.

The goal of this script is to replicate the build performed by Actions in CI, https://github.com/dependabot/dependabot-core/blob/main/.github/workflows/ci.yml by bypass remote Docker caching.

It's still not a good idea to have this build logic defined in two places; I just wanted feedback looks from Actions environment (which isn't _quite_ the same as the development shell) without pushing.