### PR TITLE
Version finder filters refactor

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -14,7 +14,6 @@ module Dependabot
   module Bundler
     class UpdateChecker
       class LatestVersionFinder
-        include Dependabot::UpdateCheckers::VersionFilters
 
         def initialize(dependency:, dependency_files:, repo_contents_path: nil,
                        credentials:, ignored_versions:, raise_on_ignored: false,

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -14,7 +14,6 @@ module Dependabot
   module Bundler
     class UpdateChecker
       class LatestVersionFinder
-
         def initialize(dependency:, dependency_files:, repo_contents_path: nil,
                        credentials:, ignored_versions:, raise_on_ignored: false,
                        security_advisories:, options:)

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -60,7 +60,8 @@ module Dependabot
           relevant_versions = filter_prerelease_versions(relevant_versions)
           relevant_versions = filter_ignored_versions(relevant_versions)
           relevant_versions = filter_lower_versions(relevant_versions)
-          relevant_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(relevant_versions, security_advisories)
+          relevant_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(relevant_versions,
+                                                                                                    security_advisories)
 
           relevant_versions.min
         end

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -58,9 +58,9 @@ module Dependabot
 
           relevant_versions = dependency_source.versions
           relevant_versions = filter_prerelease_versions(relevant_versions)
-          relevant_versions = filter_vulnerable_versions(relevant_versions)
           relevant_versions = filter_ignored_versions(relevant_versions)
           relevant_versions = filter_lower_versions(relevant_versions)
+          relevant_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(relevant_versions, security_advisories)
 
           relevant_versions.min
         end

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -3,6 +3,7 @@
 require "excon"
 
 require "dependabot/bundler/update_checker"
+require "dependabot/update_checkers/version_filters"
 require "dependabot/bundler/requirement"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
@@ -13,6 +14,8 @@ module Dependabot
   module Bundler
     class UpdateChecker
       class LatestVersionFinder
+        include Dependabot::UpdateCheckers::VersionFilters
+
         def initialize(dependency:, dependency_files:, repo_contents_path: nil,
                        credentials:, ignored_versions:, raise_on_ignored: false,
                        security_advisories:, options:)
@@ -76,11 +79,6 @@ module Dependabot
           end
 
           filtered
-        end
-
-        def filter_vulnerable_versions(versions_array)
-          versions_array.
-            reject { |v| security_advisories.any? { |a| a.vulnerable?(v) } }
         end
 
         def filter_lower_versions(versions_array)

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -2,11 +2,14 @@
 
 require "excon"
 require "dependabot/cargo/update_checker"
+require "dependabot/update_checkers/version_filters"
 
 module Dependabot
   module Cargo
     class UpdateChecker
       class LatestVersionFinder
+        include Dependabot::UpdateCheckers::VersionFilters
+
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, raise_on_ignored: false,
                        security_advisories:)
@@ -61,11 +64,6 @@ module Dependabot
           end
 
           filtered
-        end
-
-        def filter_vulnerable_versions(versions_array)
-          versions_array.
-            reject { |v| security_advisories.any? { |a| a.vulnerable?(v) } }
         end
 
         def filter_lower_versions(versions_array)

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -8,7 +8,6 @@ module Dependabot
   module Cargo
     class UpdateChecker
       class LatestVersionFinder
-
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, raise_on_ignored: false,
                        security_advisories:)

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -44,9 +44,10 @@ module Dependabot
         def fetch_lowest_security_fix_version
           versions = available_versions
           versions = filter_prerelease_versions(versions)
-          versions = filter_vulnerable_versions(versions)
           versions = filter_ignored_versions(versions)
           versions = filter_lower_versions(versions)
+          versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions, security_advisories)
+
           versions.min
         end
 

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -46,7 +46,8 @@ module Dependabot
           versions = filter_prerelease_versions(versions)
           versions = filter_ignored_versions(versions)
           versions = filter_lower_versions(versions)
-          versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions, security_advisories)
+          versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions,
+                                                                                           security_advisories)
 
           versions.min
         end

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -8,7 +8,6 @@ module Dependabot
   module Cargo
     class UpdateChecker
       class LatestVersionFinder
-        include Dependabot::UpdateCheckers::VersionFilters
 
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, raise_on_ignored: false,

--- a/common/lib/dependabot/update_checkers/version_filters.rb
+++ b/common/lib/dependabot/update_checkers/version_filters.rb
@@ -4,7 +4,7 @@ module Dependabot
       def filter_vulnerable_versions(versions_array)
         versions_array.reject do |v|
           security_advisories.any? do |a|
-            if a.is_a?(Gem::Version)
+            if v.is_a?(Gem::Version)
               a.vulnerable?(v)
             else
               a.vulnerable?(v.fetch(:version))

--- a/common/lib/dependabot/update_checkers/version_filters.rb
+++ b/common/lib/dependabot/update_checkers/version_filters.rb
@@ -1,0 +1,17 @@
+module Dependabot
+  module UpdateCheckers
+    module VersionFilters
+      def filter_vulnerable_versions(versions_array)
+        versions_array.reject do |v|
+          security_advisories.any? do |a|
+            if a.is_a?(Gem::Version)
+              a.vulnerable?(v)
+            else
+              a.vulnerable?(v.fetch(:version))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/common/lib/dependabot/update_checkers/version_filters.rb
+++ b/common/lib/dependabot/update_checkers/version_filters.rb
@@ -3,7 +3,7 @@
 module Dependabot
   module UpdateCheckers
     module VersionFilters
-      def filter_vulnerable_versions(versions_array)
+      def self.filter_vulnerable_versions(versions_array, security_advisories)
         versions_array.reject do |v|
           security_advisories.any? do |a|
             if v.is_a?(Gem::Version)

--- a/common/lib/dependabot/update_checkers/version_filters.rb
+++ b/common/lib/dependabot/update_checkers/version_filters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Dependabot
   module UpdateCheckers
     module VersionFilters

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -48,9 +48,10 @@ module Dependabot
         def fetch_lowest_security_fix_version
           versions = available_versions
           versions = filter_prerelease_versions(versions)
-          versions = filter_vulnerable_versions(versions)
           versions = filter_ignored_versions(versions)
           versions = filter_lower_versions(versions)
+          versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions, security_advisories)
+
           versions.min
         end
 

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -12,7 +12,6 @@ module Dependabot
   module Composer
     class UpdateChecker
       class LatestVersionFinder
-        include Dependabot::UpdateCheckers::VersionFilters
 
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, raise_on_ignored: false,

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -4,6 +4,7 @@ require "excon"
 require "json"
 
 require "dependabot/composer/update_checker"
+require "dependabot/update_checkers/version_filters"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
 
@@ -11,6 +12,8 @@ module Dependabot
   module Composer
     class UpdateChecker
       class LatestVersionFinder
+        include Dependabot::UpdateCheckers::VersionFilters
+
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, raise_on_ignored: false,
                        security_advisories:)
@@ -67,11 +70,6 @@ module Dependabot
           end
 
           filtered
-        end
-
-        def filter_vulnerable_versions(versions_array)
-          versions_array.
-            reject { |v| security_advisories.any? { |a| a.vulnerable?(v) } }
         end
 
         def filter_lower_versions(versions_array)

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -50,7 +50,8 @@ module Dependabot
           versions = filter_prerelease_versions(versions)
           versions = filter_ignored_versions(versions)
           versions = filter_lower_versions(versions)
-          versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions, security_advisories)
+          versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions,
+                                                                                           security_advisories)
 
           versions.min
         end

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -12,7 +12,6 @@ module Dependabot
   module Composer
     class UpdateChecker
       class LatestVersionFinder
-
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, raise_on_ignored: false,
                        security_advisories:)

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -3,6 +3,7 @@
 require "excon"
 
 require "dependabot/go_modules/update_checker"
+require "dependabot/update_checkers/version_filters"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/go_modules/requirement"
@@ -12,6 +13,8 @@ module Dependabot
   module GoModules
     class UpdateChecker
       class LatestVersionFinder
+        include Dependabot::UpdateCheckers::VersionFilters
+
         RESOLVABILITY_ERROR_REGEXES = [
           # Package url/proxy doesn't include any redirect meta tags
           /no go-import meta tags/,

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -13,7 +13,6 @@ module Dependabot
   module GoModules
     class UpdateChecker
       class LatestVersionFinder
-        include Dependabot::UpdateCheckers::VersionFilters
 
         RESOLVABILITY_ERROR_REGEXES = [
           # Package url/proxy doesn't include any redirect meta tags

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -13,7 +13,6 @@ module Dependabot
   module GoModules
     class UpdateChecker
       class LatestVersionFinder
-
         RESOLVABILITY_ERROR_REGEXES = [
           # Package url/proxy doesn't include any redirect meta tags
           /no go-import meta tags/,

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -2,6 +2,7 @@
 
 require "nokogiri"
 require "dependabot/shared_helpers"
+require "dependabot/update_checkers/version_filters"
 require "dependabot/gradle/file_parser/repositories_finder"
 require "dependabot/gradle/update_checker"
 require "dependabot/gradle/version"
@@ -12,6 +13,8 @@ module Dependabot
   module Gradle
     class UpdateChecker
       class VersionFinder
+        include Dependabot::UpdateCheckers::VersionFilters
+
         GOOGLE_MAVEN_REPO = "https://maven.google.com"
         GRADLE_PLUGINS_REPO = "https://plugins.gradle.org/m2"
         KOTLIN_PLUGIN_REPO_PREFIX = "org.jetbrains.kotlin"
@@ -109,18 +112,6 @@ module Dependabot
           end
 
           filtered
-        end
-
-        def filter_vulnerable_versions(possible_versions)
-          versions_array = possible_versions
-
-          security_advisories.each do |advisory|
-            versions_array =
-              versions_array.
-              reject { |v| advisory.vulnerable?(v.fetch(:version)) }
-          end
-
-          versions_array
         end
 
         def filter_lower_versions(possible_versions)

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -13,7 +13,6 @@ module Dependabot
   module Gradle
     class UpdateChecker
       class VersionFinder
-        include Dependabot::UpdateCheckers::VersionFilters
 
         GOOGLE_MAVEN_REPO = "https://maven.google.com"
         GRADLE_PLUGINS_REPO = "https://plugins.gradle.org/m2"

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -49,9 +49,9 @@ module Dependabot
           possible_versions = filter_prereleases(possible_versions)
           possible_versions = filter_date_based_versions(possible_versions)
           possible_versions = filter_version_types(possible_versions)
-          possible_versions = filter_vulnerable_versions(possible_versions)
           possible_versions = filter_ignored_versions(possible_versions)
           possible_versions = filter_lower_versions(possible_versions)
+          possible_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(possible_versions, security_advisories)
 
           possible_versions.first
         end

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -13,7 +13,6 @@ module Dependabot
   module Gradle
     class UpdateChecker
       class VersionFinder
-
         GOOGLE_MAVEN_REPO = "https://maven.google.com"
         GRADLE_PLUGINS_REPO = "https://plugins.gradle.org/m2"
         KOTLIN_PLUGIN_REPO_PREFIX = "org.jetbrains.kotlin"

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -51,7 +51,8 @@ module Dependabot
           possible_versions = filter_version_types(possible_versions)
           possible_versions = filter_ignored_versions(possible_versions)
           possible_versions = filter_lower_versions(possible_versions)
-          possible_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(possible_versions, security_advisories)
+          possible_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(possible_versions,
+                                                                                                    security_advisories)
 
           possible_versions.first
         end

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -13,7 +13,6 @@ module Dependabot
   module Maven
     class UpdateChecker
       class VersionFinder
-
         TYPE_SUFFICES = %w(jre android java).freeze
 
         def initialize(dependency:, dependency_files:, credentials:,

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -46,9 +46,9 @@ module Dependabot
           possible_versions = filter_prereleases(possible_versions)
           possible_versions = filter_date_based_versions(possible_versions)
           possible_versions = filter_version_types(possible_versions)
-          possible_versions = filter_vulnerable_versions(possible_versions)
           possible_versions = filter_ignored_versions(possible_versions)
           possible_versions = filter_lower_versions(possible_versions)
+          possible_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(possible_versions, security_advisories)
 
           possible_versions.find { |v| released?(v.fetch(:version)) }
         end

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -2,6 +2,7 @@
 
 require "nokogiri"
 require "dependabot/shared_helpers"
+require "dependabot/update_checkers/version_filters"
 require "dependabot/maven/file_parser/repositories_finder"
 require "dependabot/maven/update_checker"
 require "dependabot/maven/version"
@@ -12,6 +13,8 @@ module Dependabot
   module Maven
     class UpdateChecker
       class VersionFinder
+        include Dependabot::UpdateCheckers::VersionFilters
+
         TYPE_SUFFICES = %w(jre android java).freeze
 
         def initialize(dependency:, dependency_files:, credentials:,
@@ -105,18 +108,6 @@ module Dependabot
           end
 
           filtered
-        end
-
-        def filter_vulnerable_versions(possible_versions)
-          versions_array = possible_versions
-
-          security_advisories.each do |advisory|
-            versions_array =
-              versions_array.
-              reject { |v| advisory.vulnerable?(v.fetch(:version)) }
-          end
-
-          versions_array
         end
 
         def filter_lower_versions(possible_versions)

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -48,7 +48,8 @@ module Dependabot
           possible_versions = filter_version_types(possible_versions)
           possible_versions = filter_ignored_versions(possible_versions)
           possible_versions = filter_lower_versions(possible_versions)
-          possible_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(possible_versions, security_advisories)
+          possible_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(possible_versions,
+                                                                                                    security_advisories)
 
           possible_versions.find { |v| released?(v.fetch(:version)) }
         end

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -13,7 +13,6 @@ module Dependabot
   module Maven
     class UpdateChecker
       class VersionFinder
-        include Dependabot::UpdateCheckers::VersionFilters
 
         TYPE_SUFFICES = %w(jre android java).freeze
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -12,9 +12,9 @@ module Dependabot
   module NpmAndYarn
     class UpdateChecker
       class LatestVersionFinder
-        class RegistryError < StandardError
-          include Dependabot::UpdateCheckers::VersionFilters
+        include Dependabot::UpdateCheckers::VersionFilters
 
+        class RegistryError < StandardError
           attr_reader :status
 
           def initialize(status, msg)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -12,7 +12,6 @@ module Dependabot
   module NpmAndYarn
     class UpdateChecker
       class LatestVersionFinder
-
         class RegistryError < StandardError
           attr_reader :status
 
@@ -37,10 +36,11 @@ module Dependabot
           return unless valid_npm_details?
           return version_from_dist_tags if version_from_dist_tags
           return if specified_dist_tag_requirement?
-          
+
           versions = possible_versions
           versions = filter_lower_versions(versions)
-          versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions, security_advisories)
+          versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions,
+                                                                                           security_advisories)
 
           ensure_secure_version_available!(versions)
           possible_versions.find { |v| !yanked?(v) }
@@ -87,9 +87,7 @@ module Dependabot
         end
 
         def ensure_secure_version_available!(secure_versions)
-          if @raise_on_ignored && !secure_versions.nil? && secure_versions.empty?
-            raise AllVersionsIgnored
-          end
+          raise AllVersionsIgnored if @raise_on_ignored && !secure_versions.nil? && secure_versions.empty?
         end
 
         def possible_previous_versions_with_details
@@ -102,7 +100,7 @@ module Dependabot
         def possible_versions_with_details(filter_ignored: true)
           versions = possible_previous_versions_with_details.
                      reject { |_, details| details["deprecated"] }
-          
+
           versions = filter_ignored_versions(versions) if filter_ignored
 
           versions

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -12,7 +12,6 @@ module Dependabot
   module NpmAndYarn
     class UpdateChecker
       class LatestVersionFinder
-        include Dependabot::UpdateCheckers::VersionFilters
 
         class RegistryError < StandardError
           attr_reader :status

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -13,7 +13,7 @@ module Dependabot
     class UpdateChecker
       class LatestVersionFinder
         class RegistryError < StandardError
-        include Dependabot::UpdateCheckers::VersionFilters
+          include Dependabot::UpdateCheckers::VersionFilters
 
           attr_reader :status
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -2,6 +2,7 @@
 
 require "excon"
 require "dependabot/npm_and_yarn/update_checker"
+require "dependabot/update_checkers/version_filters"
 require "dependabot/npm_and_yarn/update_checker/registry_finder"
 require "dependabot/npm_and_yarn/version"
 require "dependabot/npm_and_yarn/requirement"
@@ -12,6 +13,8 @@ module Dependabot
     class UpdateChecker
       class LatestVersionFinder
         class RegistryError < StandardError
+        include Dependabot::UpdateCheckers::VersionFilters
+
           attr_reader :status
 
           def initialize(status, msg)
@@ -123,18 +126,6 @@ module Dependabot
 
           versions_array.
             select { |v| reqs.all? { |r| r.any? { |o| o.satisfied_by?(v) } } }
-        end
-
-        def filter_vulnerable_versions(versions_array)
-          updated_versions_array = versions_array
-
-          security_advisories.each do |advisory|
-            updated_versions_array =
-              updated_versions_array.
-              reject { |v| advisory.vulnerable?(v) }
-          end
-
-          updated_versions_array
         end
 
         def filter_lower_versions(versions_array)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -67,9 +67,10 @@ module Dependabot
             else possible_versions(filter_ignored: false)
             end
 
-          secure_versions = filter_vulnerable_versions(versions_array)
           secure_versions = filter_ignored_versions(secure_versions)
           secure_versions = filter_lower_versions(secure_versions)
+          secure_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(secure_versions, security_advisories)
+
           secure_versions.reverse.find { |version| !yanked?(version) }
         rescue Excon::Error::Socket, Excon::Error::Timeout
           raise if dependency_registry == "registry.npmjs.org"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -67,9 +67,10 @@ module Dependabot
             else possible_versions(filter_ignored: false)
             end
 
-          secure_versions = filter_ignored_versions(secure_versions)
+          secure_versions = filter_ignored_versions(versions_array)
           secure_versions = filter_lower_versions(secure_versions)
-          secure_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(secure_versions, security_advisories)
+          secure_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(secure_versions,
+                                                                                                  security_advisories)
 
           secure_versions.reverse.find { |version| !yanked?(version) }
         rescue Excon::Error::Socket, Excon::Error::Timeout

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -47,7 +47,9 @@ module Dependabot
               possible_versions = filter_prereleases(possible_versions)
               possible_versions = filter_ignored_versions(possible_versions)
               possible_versions = filter_lower_versions(possible_versions)
-              possible_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(possible_versions, security_advisories)
+              possible_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(
+                possible_versions, security_advisories
+              )
 
               possible_versions.min_by { |hash| hash.fetch(:version) }
             end

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -15,7 +15,6 @@ module Dependabot
       class VersionFinder
         require_relative "repository_finder"
 
-
         NUGET_RANGE_REGEX = /[\(\[].*,.*[\)\]]/.freeze
 
         def initialize(dependency:, dependency_files:, credentials:,

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -15,7 +15,6 @@ module Dependabot
       class VersionFinder
         require_relative "repository_finder"
 
-        include Dependabot::UpdateCheckers::VersionFilters
 
         NUGET_RANGE_REGEX = /[\(\[].*,.*[\)\]]/.freeze
 

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -5,6 +5,7 @@ require "nokogiri"
 
 require "dependabot/nuget/version"
 require "dependabot/nuget/requirement"
+require "dependabot/update_checkers/version_filters"
 require "dependabot/nuget/update_checker"
 require "dependabot/shared_helpers"
 
@@ -13,6 +14,8 @@ module Dependabot
     class UpdateChecker
       class VersionFinder
         require_relative "repository_finder"
+
+        include Dependabot::UpdateCheckers::VersionFilters
 
         NUGET_RANGE_REGEX = /[\(\[].*,.*[\)\]]/.freeze
 
@@ -81,18 +84,6 @@ module Dependabot
           end
 
           filtered
-        end
-
-        def filter_vulnerable_versions(possible_versions)
-          versions_array = possible_versions
-
-          security_advisories.each do |advisory|
-            versions_array =
-              versions_array.
-              reject { |v| advisory.vulnerable?(v.fetch(:version)) }
-          end
-
-          versions_array
         end
 
         def filter_lower_versions(possible_versions)

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -45,9 +45,10 @@ module Dependabot
             begin
               possible_versions = versions
               possible_versions = filter_prereleases(possible_versions)
-              possible_versions = filter_vulnerable_versions(possible_versions)
               possible_versions = filter_ignored_versions(possible_versions)
               possible_versions = filter_lower_versions(possible_versions)
+              possible_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(possible_versions, security_advisories)
+
               possible_versions.min_by { |hash| hash.fetch(:version) }
             end
         end

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -74,9 +74,9 @@ module Dependabot
           versions = filter_yanked_versions(versions)
           versions = filter_unsupported_versions(versions, python_version)
           versions = filter_prerelease_versions(versions)
-          versions = filter_vulnerable_versions(versions)
           versions = filter_ignored_versions(versions)
           versions = filter_lower_versions(versions)
+          versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions, security_advisories)
           versions.min
         end
 

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -6,6 +6,7 @@ require "nokogiri"
 
 require "dependabot/dependency"
 require "dependabot/python/update_checker"
+require "dependabot/update_checkers/version_filters"
 require "dependabot/shared_helpers"
 require "dependabot/python/authed_url_builder"
 require "dependabot/python/name_normaliser"
@@ -14,6 +15,8 @@ module Dependabot
   module Python
     class UpdateChecker
       class LatestVersionFinder
+        include Dependabot::UpdateCheckers::VersionFilters
+
         require_relative "index_finder"
 
         def initialize(dependency:, dependency_files:, credentials:,
@@ -106,11 +109,6 @@ module Dependabot
           end
 
           filtered
-        end
-
-        def filter_vulnerable_versions(versions_array)
-          versions_array.
-            reject { |v| security_advisories.any? { |a| a.vulnerable?(v) } }
         end
 
         def filter_lower_versions(versions_array)

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -15,7 +15,6 @@ module Dependabot
   module Python
     class UpdateChecker
       class LatestVersionFinder
-
         require_relative "index_finder"
 
         def initialize(dependency:, dependency_files:, credentials:,

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -15,7 +15,6 @@ module Dependabot
   module Python
     class UpdateChecker
       class LatestVersionFinder
-        include Dependabot::UpdateCheckers::VersionFilters
 
         require_relative "index_finder"
 

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -76,7 +76,8 @@ module Dependabot
           versions = filter_prerelease_versions(versions)
           versions = filter_ignored_versions(versions)
           versions = filter_lower_versions(versions)
-          versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions, security_advisories)
+          versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions,
+                                                                                           security_advisories)
           versions.min
         end
 


### PR DESCRIPTION
This PR follows up on https://github.com/dependabot/dependabot-core/pull/3905#discussion_r655568901 where it was found that the order of version filters can affect when errors occur in ecosystems' `LatestVersionFinder` class.

For example:
```
secure_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(secure_versions,
                                                                                security_advisories)
secure_versions = filter_ignored_versions(secure_versions)
secure_versions = filter_lower_versions(secure_versions)
```
will correctly raise a `Dependabot::AllVersionsIgnored` error in `npm_and_yarn`, but moving the first line to the bottom will not raise an error at all.

This is because the error is raised in `#filter_ignored_versions`. This PR extracts that error into its own method which is then called appropriately. (WIP)