### PR TITLE
Revert order of filters in #fetch_lowest_security_fix_version across ecosystems

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -56,10 +56,10 @@ module Dependabot
 
           relevant_versions = dependency_source.versions
           relevant_versions = filter_prerelease_versions(relevant_versions)
-          relevant_versions = filter_ignored_versions(relevant_versions)
-          relevant_versions = filter_lower_versions(relevant_versions)
           relevant_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(relevant_versions,
                                                                                                     security_advisories)
+          relevant_versions = filter_ignored_versions(relevant_versions)
+          relevant_versions = filter_lower_versions(relevant_versions)
 
           relevant_versions.min
         end

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -42,10 +42,10 @@ module Dependabot
         def fetch_lowest_security_fix_version
           versions = available_versions
           versions = filter_prerelease_versions(versions)
-          versions = filter_ignored_versions(versions)
-          versions = filter_lower_versions(versions)
           versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions,
                                                                                            security_advisories)
+          versions = filter_ignored_versions(versions)
+          versions = filter_lower_versions(versions)
 
           versions.min
         end

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -46,10 +46,10 @@ module Dependabot
         def fetch_lowest_security_fix_version
           versions = available_versions
           versions = filter_prerelease_versions(versions)
-          versions = filter_ignored_versions(versions)
-          versions = filter_lower_versions(versions)
           versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions,
                                                                                            security_advisories)
+          versions = filter_ignored_versions(versions)
+          versions = filter_lower_versions(versions)
 
           versions.min
         end

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -47,10 +47,10 @@ module Dependabot
           possible_versions = filter_prereleases(possible_versions)
           possible_versions = filter_date_based_versions(possible_versions)
           possible_versions = filter_version_types(possible_versions)
-          possible_versions = filter_ignored_versions(possible_versions)
-          possible_versions = filter_lower_versions(possible_versions)
           possible_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(possible_versions,
                                                                                                     security_advisories)
+          possible_versions = filter_ignored_versions(possible_versions)
+          possible_versions = filter_lower_versions(possible_versions)
 
           possible_versions.first
         end

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -44,10 +44,10 @@ module Dependabot
           possible_versions = filter_prereleases(possible_versions)
           possible_versions = filter_date_based_versions(possible_versions)
           possible_versions = filter_version_types(possible_versions)
-          possible_versions = filter_ignored_versions(possible_versions)
-          possible_versions = filter_lower_versions(possible_versions)
           possible_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(possible_versions,
                                                                                                     security_advisories)
+          possible_versions = filter_ignored_versions(possible_versions)
+          possible_versions = filter_lower_versions(possible_versions)
 
           possible_versions.find { |v| released?(v.fetch(:version)) }
         end

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -43,11 +43,11 @@ module Dependabot
             begin
               possible_versions = versions
               possible_versions = filter_prereleases(possible_versions)
-              possible_versions = filter_ignored_versions(possible_versions)
-              possible_versions = filter_lower_versions(possible_versions)
               possible_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(
                 possible_versions, security_advisories
               )
+              possible_versions = filter_ignored_versions(possible_versions)
+              possible_versions = filter_lower_versions(possible_versions)
 
               possible_versions.min_by { |hash| hash.fetch(:version) }
             end

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -72,10 +72,11 @@ module Dependabot
           versions = filter_yanked_versions(versions)
           versions = filter_unsupported_versions(versions, python_version)
           versions = filter_prerelease_versions(versions)
-          versions = filter_ignored_versions(versions)
-          versions = filter_lower_versions(versions)
           versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(versions,
                                                                                            security_advisories)
+          versions = filter_ignored_versions(versions)
+          versions = filter_lower_versions(versions)
+
           versions.min
         end
 


### PR DESCRIPTION
Addresses https://github.com/dependabot/dependabot-core/pull/3905#discussion_r655682644 where the #filter_ignored_version executing before #filter_vulnerable_versions could cause tests to flake.
A refactor to remove the order-dependence of version filters is a WIP https://github.com/dependabot/dependabot-core/pull/3960
