### PR TITLE
v0.154.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.154.4, 22 June 2021
+
+- Terraform: handle nested module sources
+- Common: refactor filter_vulnerable_version into a separate module
+- Bundler: ignore invalid auth_uri
+
 ## v0.154.3, 21 June 2021
 
 - Terraform: handle missing source

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.154.3"
+  VERSION = "0.154.4"
 end


### PR DESCRIPTION
## v0.154.4, 22 June 2021

- Terraform: handle nested module sources
- Common: refactor filter_vulnerable_version into a separate module
- Bundler: ignore invalid auth_uri