### PR TITLE
v0.154.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.154.5, 22 June 2021
+
+- Terraform: install modules when updating lockfile
+
 ## v0.154.4, 22 June 2021
 
 - Terraform: handle nested module sources

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.154.4"
+  VERSION = "0.154.5"
 end


### PR DESCRIPTION
## v0.154.5, 22 June 2021

- Terraform: install modules when updating lockfile
