### PR TITLE
v0.155.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.155.0, 22 June 2021
+
+- Go: add security advisories
+- Devcontainer: do not rename gemspec
+- docker-dev-shell: do not rename gemspec
+
 ## v0.154.5, 22 June 2021
 
 - Terraform: install modules when updating lockfile

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.154.5"
+  VERSION = "0.155.0"
 end


### PR DESCRIPTION
- Go: add security advisories
- Devcontainer: do not rename gemspec
- docker-dev-shell: do not rename gemspec﻿
