### PR TITLE
GemspecSanitizer: replace interpolated strings

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/gemspec_sanitizer.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/gemspec_sanitizer.rb
@@ -307,22 +307,11 @@ module Dependabot
           def replace_constant(node)
             case node.children.last&.type
             when :str, :int then nil # no-op
-            when :float, :const, :send, :lvar, :if
+            when :float, :const, :send, :lvar, :if, :dstr
               replace(
                 node.children.last.loc.expression,
                 %("#{replacement_version}")
               )
-            when :dstr
-              node.children.last.children.
-                select { |n| n.type == :begin }.
-                flat_map(&:children).
-                select { |n| node_is_version_constant?(n) }.
-                each do |n|
-                  replace(
-                    n.loc.expression,
-                    %("#{replacement_version}")
-                  )
-                end
             else
               raise "Unexpected node type #{node.children.last&.type}"
             end

--- a/bundler/spec/dependabot/bundler/file_updater/gemspec_sanitizer_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/gemspec_sanitizer_spec.rb
@@ -229,7 +229,12 @@ RSpec.describe Dependabot::Bundler::FileUpdater::GemspecSanitizer do
       # rubocop:disable Lint/InterpolationCheck
       context "with an assignment to a string-interpolated constant" do
         let(:content) { 'Spec.new { |s| s.version = "#{Example::Version}" }' }
-        it { is_expected.to eq('Spec.new { |s| s.version = "#{"1.5.0"}" }') }
+        it { is_expected.to eq('Spec.new { |s| s.version = "1.5.0" }') }
+      end
+
+      context "with an assignment to a string-interpolated constant with multiple values" do
+        let(:content) { 'Spec.new { |s| s.version = "#{Example::Version}-#{git_commit}" }' }
+        it { is_expected.to eq('Spec.new { |s| s.version = "1.5.0" }') }
       end
 
       context "with a version constant used elsewhere in the file" do


### PR DESCRIPTION
The previous impl only replaced the components of the interpolated
string that looked like versions.

When this is called with a `replacement_version` read from
`Gemfile.lock`, the replacement value is based on the interpolated string. That means replacing the entire string is more correct than swapping individual components.
