### PR TITLE
nuget: allow registries without PackageBaseAddress

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -106,17 +106,16 @@ module Dependabot
             listing.
               fetch("versions", []).
               map do |v|
-                nuspec_url =
-                  listing.fetch("listing_details").
-                  fetch(:versions_url).
+                listing_details = listing.fetch("listing_details")
+                nuspec_url = listing_details.
+                             fetch(:versions_url, nil)&.
                   gsub(/index\.json$/, "#{v}/#{sanitized_name}.nuspec")
 
                 {
                   version: version_class.new(v),
                   nuspec_url: nuspec_url,
                   source_url: nil,
-                  repo_url:
-                    listing.fetch("listing_details").fetch(:repository_url)
+                  repo_url: listing_details.fetch(:repository_url)
                 }
               end
           end

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -97,6 +97,29 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RepositoryFinder do
         )
       end
 
+      context "that does not return PackageBaseAddress" do
+        let(:custom_repo_url) { "http://localhost:8082/artifactory/api/nuget/v3/nuget-local" }
+        before do
+          stub_request(:get, custom_repo_url).
+            to_return(
+              status: 200,
+              body: fixture("nuget_responses", "artifactory_base.json")
+            )
+        end
+
+        it "gets the right URL" do
+          expect(dependency_urls).to eq(
+            [{
+              repository_url: custom_repo_url,
+              search_url: "http://localhost:8082/artifactory/api/nuget/v3/"\
+                             "nuget-local/query?q=microsoft.extensions.dependencymodel&prerelease=true",
+              auth_header: { "Authorization" => "Basic bXk6cGFzc3cwcmQ=" },
+              repository_type: "v3"
+            }]
+          )
+        end
+      end
+
       context "that 404s" do
         before { stub_request(:get, custom_repo_url).to_return(status: 404) }
 

--- a/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
@@ -309,6 +309,10 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
       let(:custom_repo_url) do
         "https://www.myget.org/F/exceptionless/api/v3/index.json"
       end
+      let(:custom_nuget_search_url) do
+        "https://www.myget.org/F/exceptionless/api/v3/"\
+        "query?q=microsoft.extensions.dependencymodel&prerelease=true"
+      end
       before do
         stub_request(:get, nuget_versions_url).to_return(status: 404)
         stub_request(:get, nuget_search_url).to_return(status: 404)
@@ -323,9 +327,6 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
         custom_nuget_versions_url =
           "https://www.myget.org/F/exceptionless/api/v3/flatcontainer/"\
           "microsoft.extensions.dependencymodel/index.json"
-        custom_nuget_search_url =
-          "https://www.myget.org/F/exceptionless/api/v3/"\
-          "query?q=microsoft.extensions.dependencymodel&prerelease=true"
         stub_request(:get, custom_nuget_versions_url).to_return(status: 404)
         stub_request(:get, custom_nuget_versions_url).
           with(basic_auth: %w(my passw0rd)).
@@ -337,6 +338,23 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
       end
 
       its([:version]) { is_expected.to eq(version_class.new("2.1.0")) }
+
+      context "that does not return PackageBaseAddress" do
+        let(:custom_repo_url) { "http://localhost:8082/artifactory/api/nuget/v3/nuget-local" }
+        let(:custom_nuget_search_url) do
+          "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/"\
+          "query?prerelease=true&q=microsoft.extensions.dependencymodel"
+        end
+        before do
+          stub_request(:get, custom_repo_url).
+            to_return(
+              status: 200,
+              body: fixture("nuget_responses", "artifactory_base.json")
+            )
+        end
+
+        its([:version]) { is_expected.to eq(version_class.new("2.1.0")) }
+      end
     end
 
     context "with a version range specified" do

--- a/nuget/spec/fixtures/nuget_responses/artifactory_base.json
+++ b/nuget/spec/fixtures/nuget_responses/artifactory_base.json
@@ -1,0 +1,74 @@
+{
+    "version": "3.0.0",
+    "resources": [
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/query",
+        "@type": "SearchQueryService",
+        "comment": "Query endpoint of NuGet Search service (primary)"
+      },
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/",
+        "@type": "RegistrationsBaseUrl",
+        "comment": "Base URL of Azure storage where NuGet package registration info is stored"
+      },
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/nuget-local",
+        "@type": "LegacyGallery"
+      },
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/nuget-local",
+        "@type": "LegacyGallery/2.0.0"
+      },
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/nuget-local",
+        "@type": "PackagePublish/2.0.0"
+      },
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/query",
+        "@type": "SearchQueryService/3.0.0-rc",
+        "comment": "Query endpoint of NuGet Search service (primary) used by RC clients"
+      },
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/",
+        "@type": "RegistrationsBaseUrl/3.0.0-rc",
+        "comment": "Base URL of Azure storage where NuGet package registration info is stored used by RC clients. This base URL does not include SemVer 2.0.0 packages."
+      },
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/{id-lower}/index.json",
+        "@type": "PackageDisplayMetadataUriTemplate/3.0.0-rc",
+        "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID"
+      },
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/{id-lower}/{version-lower}.json",
+        "@type": "PackageVersionDisplayMetadataUriTemplate/3.0.0-rc",
+        "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID, Version"
+      },
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/query",
+        "@type": "SearchQueryService/3.0.0-beta",
+        "comment": "Query endpoint of NuGet Search service (primary) used by beta clients"
+      },
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/",
+        "@type": "RegistrationsBaseUrl/3.0.0-beta",
+        "comment": "Base URL of Azure storage where NuGet package registration info is stored used by Beta clients. This base URL does not include SemVer 2.0.0 packages."
+      },
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/",
+        "@type": "RegistrationsBaseUrl/3.4.0",
+        "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL does not include SemVer 2.0.0 packages."
+      },
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration-semver2/",
+        "@type": "RegistrationsBaseUrl/3.6.0",
+        "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
+      },
+      {
+        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration-semver2/",
+        "@type": "RegistrationsBaseUrl/Versioned",
+        "clientVersion": "4.3.0-alpha",
+        "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
+      }
+    ]
+  }
+  

--- a/nuget/spec/fixtures/nuget_responses/artifactory_base.json
+++ b/nuget/spec/fixtures/nuget_responses/artifactory_base.json
@@ -1,74 +1,73 @@
 {
-    "version": "3.0.0",
-    "resources": [
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/query",
-        "@type": "SearchQueryService",
-        "comment": "Query endpoint of NuGet Search service (primary)"
-      },
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/",
-        "@type": "RegistrationsBaseUrl",
-        "comment": "Base URL of Azure storage where NuGet package registration info is stored"
-      },
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/nuget-local",
-        "@type": "LegacyGallery"
-      },
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/nuget-local",
-        "@type": "LegacyGallery/2.0.0"
-      },
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/nuget-local",
-        "@type": "PackagePublish/2.0.0"
-      },
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/query",
-        "@type": "SearchQueryService/3.0.0-rc",
-        "comment": "Query endpoint of NuGet Search service (primary) used by RC clients"
-      },
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/",
-        "@type": "RegistrationsBaseUrl/3.0.0-rc",
-        "comment": "Base URL of Azure storage where NuGet package registration info is stored used by RC clients. This base URL does not include SemVer 2.0.0 packages."
-      },
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/{id-lower}/index.json",
-        "@type": "PackageDisplayMetadataUriTemplate/3.0.0-rc",
-        "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID"
-      },
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/{id-lower}/{version-lower}.json",
-        "@type": "PackageVersionDisplayMetadataUriTemplate/3.0.0-rc",
-        "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID, Version"
-      },
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/query",
-        "@type": "SearchQueryService/3.0.0-beta",
-        "comment": "Query endpoint of NuGet Search service (primary) used by beta clients"
-      },
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/",
-        "@type": "RegistrationsBaseUrl/3.0.0-beta",
-        "comment": "Base URL of Azure storage where NuGet package registration info is stored used by Beta clients. This base URL does not include SemVer 2.0.0 packages."
-      },
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/",
-        "@type": "RegistrationsBaseUrl/3.4.0",
-        "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL does not include SemVer 2.0.0 packages."
-      },
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration-semver2/",
-        "@type": "RegistrationsBaseUrl/3.6.0",
-        "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
-      },
-      {
-        "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration-semver2/",
-        "@type": "RegistrationsBaseUrl/Versioned",
-        "clientVersion": "4.3.0-alpha",
-        "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
-      }
-    ]
-  }
-  
+  "version": "3.0.0",
+  "resources": [
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/query",
+      "@type": "SearchQueryService",
+      "comment": "Query endpoint of NuGet Search service (primary)"
+    },
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/",
+      "@type": "RegistrationsBaseUrl",
+      "comment": "Base URL of Azure storage where NuGet package registration info is stored"
+    },
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/nuget-local",
+      "@type": "LegacyGallery"
+    },
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/nuget-local",
+      "@type": "LegacyGallery/2.0.0"
+    },
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/nuget-local",
+      "@type": "PackagePublish/2.0.0"
+    },
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/query",
+      "@type": "SearchQueryService/3.0.0-rc",
+      "comment": "Query endpoint of NuGet Search service (primary) used by RC clients"
+    },
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/",
+      "@type": "RegistrationsBaseUrl/3.0.0-rc",
+      "comment": "Base URL of Azure storage where NuGet package registration info is stored used by RC clients. This base URL does not include SemVer 2.0.0 packages."
+    },
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/{id-lower}/index.json",
+      "@type": "PackageDisplayMetadataUriTemplate/3.0.0-rc",
+      "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID"
+    },
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/{id-lower}/{version-lower}.json",
+      "@type": "PackageVersionDisplayMetadataUriTemplate/3.0.0-rc",
+      "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID, Version"
+    },
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/query",
+      "@type": "SearchQueryService/3.0.0-beta",
+      "comment": "Query endpoint of NuGet Search service (primary) used by beta clients"
+    },
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/",
+      "@type": "RegistrationsBaseUrl/3.0.0-beta",
+      "comment": "Base URL of Azure storage where NuGet package registration info is stored used by Beta clients. This base URL does not include SemVer 2.0.0 packages."
+    },
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration/",
+      "@type": "RegistrationsBaseUrl/3.4.0",
+      "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL does not include SemVer 2.0.0 packages."
+    },
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration-semver2/",
+      "@type": "RegistrationsBaseUrl/3.6.0",
+      "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
+    },
+    {
+      "@id": "http://localhost:8082/artifactory/api/nuget/v3/nuget-local/registration-semver2/",
+      "@type": "RegistrationsBaseUrl/Versioned",
+      "clientVersion": "4.3.0-alpha",
+      "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
+    }
+  ]
+}


### PR DESCRIPTION
When interacting with Nuget repositories, Dependabot will look for a [Package Content](https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource) resource, specifically [`PackageBaseVersion/3.0.0`](https://github.com/dependabot/dependabot-core/blob/2f0db3e851ba2cc43d0b6dcd70da5e69d5b63eb6/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb#L84). Unfortunately not every server supports this feature, Artifactory Pro does not seem to.

This PR captures the repository details from a test instance of Artifactory Pro, and verifies the registries lacking `PackageBaseVersion/3.0.0` are supported. Previously the `.fetch(:versions_url)` step would raise a `KeyError`.

The downstream concern from this change: what happens now that `nuspec_url` might be nil? The only usage I could spot was in the [MetadataFinder](https://github.com/dependabot/dependabot-core/blob/2f0db3e851ba2cc43d0b6dcd70da5e69d5b63eb6/nuget/lib/dependabot/nuget/metadata_finder.rb#L62-L76), which careful to inject a default if `nuspec_url` is not found.

⚠️ that behaviour of falling back to `api.nuget.org` if `nuspec_url` isn't available is scary - it has the potential to leak the existence of private packages to `nuget.org`. That's outside of this PR's scope, it just made me do a double take.