### PR TITLE
Terraform: fix module updates with a lockfile

### DIFF
--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -94,8 +94,10 @@ module Dependabot
         return if lock_file.nil?
 
         new_req = dependency.requirements.first
-        content = lock_file.content.dup
+        # NOTE: Only providers are inlcuded in the lockfile, modules are not
+        return unless new_req[:source][:type] == "provider"
 
+        content = lock_file.content.dup
         provider_source = new_req[:source][:registry_hostname] + "/" + new_req[:source][:module_identifier]
         declaration_regex = lockfile_declaration_regex(provider_source)
         lockfile_dependency_removed = content.sub(declaration_regex, "")

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -593,25 +593,25 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
-            name: ".terraform.lock.hcl",
-            version: "3.44.0",
+            name: "hashicorp/aws",
+            version: "3.45.0",
             previous_version: "3.37.0",
             requirements: [{
-              requirement: "3.45.0",
+              requirement: ">= 3.37.0, < 3.46.0",
               groups: [],
-              file: ".terraform.lock.hcl",
+              file: "versions.tf",
               source: {
-                type: "lockfile",
+                type: "provider",
                 registry_hostname: "registry.terraform.io",
                 module_identifier: "hashicorp/aws"
               }
             }],
             previous_requirements: [{
-              requirement: "3.37.0",
+              requirement: ">= 3.37.0, < 3.46.0",
               groups: [],
-              file: ".terraform.lock.hcl",
+              file: "versions.tf",
               source: {
-                type: "lockfile",
+                type: "provider",
                 registry_hostname: "registry.terraform.io",
                 module_identifier: "hashicorp/aws"
               }
@@ -633,15 +633,15 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
-            name: ".terraform.lock.hcl",
+            name: "hashicorp/aws",
             version: "3.42.0",
             previous_version: "3.37.0",
             requirements: [{
               requirement: "3.42.0",
               groups: [],
-              file: ".terraform.lock.hcl",
+              file: "versions.tf",
               source: {
-                type: "lockfile",
+                type: "provider",
                 registry_hostname: "registry.terraform.io",
                 module_identifier: "hashicorp/aws"
               }
@@ -649,9 +649,9 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
             previous_requirements: [{
               requirement: "3.37.0",
               groups: [],
-              file: ".terraform.lock.hcl",
+              file: "versions.tf",
               source: {
-                type: "lockfile",
+                type: "provider",
                 registry_hostname: "registry.terraform.io",
                 module_identifier: "hashicorp/aws"
               }
@@ -691,21 +691,6 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
             provider "registry.terraform.io/hashicorp/aws" {
               version     = "3.45.0"
               constraints = ">= 3.37.0, < 3.46.0"
-              hashes = [
-                "h1:LKU/xfna87/p+hl5yTTW3dvOqWJp5JEM+Dt3nnvSDvA=",
-                "zh:0fdbb3af75ff55807466533f97eb314556ec41a908a543d7cafb06546930f7c6",
-                "zh:20656895744fa0f4607096b9681c77b2385f450b1577f9151d3070818378a724",
-                "zh:390f316d00f25a5e45ef5410961fd05bf673068c1b701dc752d11df6d8e741d7",
-                "zh:3da70f9de241d5f66ea9994ef1e0beddfdb005fa2d2ef6712392f57c5d2e4844",
-                "zh:65de63cc0f97c85c28a19db560c546aa25f4f403dbf4783ac53c3918044cf180",
-                "zh:6fc52072e5a66a5d0510aaa2b373a2697895f51398613c68619d8c0c95fc75f5",
-                "zh:7c1da61092bd1206a020e3ee340ab11be8a4f9bb74e925ca1229ea5267fb3a62",
-                "zh:94e533d86ce3c08e7102dcabe34ba32ae7fd7819fd0aedef28f48d29e635eae2",
-                "zh:a3180d4826662e19e71cf20e925a2be8613a51f2f3f7b6d2643ac1418b976d58",
-                "zh:c783df364928c77fd4dec5419533b125bebe2d50212c4ad609f83b701c2d981a",
-                "zh:e1279bde388cb675d324584d965c6d22c3ec6890b13de76a50910a3bcd84ed64",
-              ]
-            }
           DEP
         )
       end
@@ -852,7 +837,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
               groups: [],
               file: "main.tf",
               source: {
-                type: "registry",
+                type: "provider",
                 registry_hostname: "registry.terraform.io",
                 module_identifier: "integrations/github"
               }
@@ -862,7 +847,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
               groups: [],
               file: "main.tf",
               source: {
-                type: "registry",
+                type: "provider",
                 registry_hostname: "registry.terraform.io",
                 module_identifier: "integrations/github"
               }
@@ -880,6 +865,53 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
             provider "registry.terraform.io/integrations/github" {
               version     = "4.12.0"
               constraints = "~> 4.4"
+          DEP
+        )
+      end
+    end
+
+    describe "when updating a module in a project with a provider lockfile" do
+      let(:files) { project_dependency_files("lockfile_with_modules") }
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "aztfmod/caf/azurerm",
+            version: "5.3.10",
+            previous_version: "5.1.0",
+            requirements: [{
+              requirement: "5.3.10",
+              groups: [],
+              file: "caf_module.tf",
+              source: {
+                type: "registry",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "aztfmod/caf/azurerm"
+              }
+            }],
+            previous_requirements: [{
+              requirement: "5.1.0",
+              groups: [],
+              file: "caf_module.tf",
+              source: {
+                type: "registry",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "aztfmod/caf/azurerm"
+              }
+            }],
+            package_manager: "terraform"
+          )
+        ]
+      end
+
+      it "updates the module version" do
+        module_file = subject.find { |file| file.name == "caf_module.tf" }
+
+        expect(module_file.content).to include(
+          <<~DEP
+            module "caf" {
+              source  = "aztfmod/caf/azurerm"
+              version = "5.3.10"
+            }
           DEP
         )
       end


### PR DESCRIPTION
This is the other side of https://github.com/dependabot/dependabot-core/pull/3968

This fixes module updates when there's a lockfile present. Modules are
not included in the lockfile so adding a guard to only attempt lockfile
updates for providers.

Fixed some test setup to match what the parsed files would look like.