### PR TITLE
Terraform: always clone repository contents

### DIFF
--- a/terraform/lib/dependabot/terraform.rb
+++ b/terraform/lib/dependabot/terraform.rb
@@ -17,3 +17,6 @@ Dependabot::PullRequestCreator::Labeler.
 require "dependabot/dependency"
 Dependabot::Dependency.
   register_production_check("terraform", ->(_) { true })
+
+require "dependabot/utils"
+Dependabot::Utils.register_always_clone("terraform")

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -104,8 +104,6 @@ module Dependabot
 
         base_dir = dependency_files.first.directory
         SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
-          write_dependency_files
-
           File.write(".terraform.lock.hcl", lockfile_dependency_removed)
           SharedHelpers.run_shell_command("terraform providers lock #{provider_source}")
 
@@ -129,15 +127,6 @@ module Dependabot
         end
 
         content
-      end
-
-      def write_dependency_files
-        dependency_files.each do |file|
-          # Do not include the .terraform directory or .terraform.lock.hcl
-          next if file.name.include?(".terraform")
-
-          File.write(file.name, file.content)
-        end
       end
 
       def dependency

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -102,7 +102,8 @@ module Dependabot
         declaration_regex = lockfile_declaration_regex(provider_source)
         lockfile_dependency_removed = content.sub(declaration_regex, "")
 
-        SharedHelpers.in_a_temporary_directory do
+        base_dir = dependency_files.first.directory
+        SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
           write_dependency_files
 
           File.write(".terraform.lock.hcl", lockfile_dependency_removed)

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -10,10 +10,18 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
   it_behaves_like "a dependency file updater"
 
   subject(:updater) do
-    described_class.new(dependency_files: files, dependencies: dependencies, credentials: credentials)
+    described_class.new(
+      dependency_files: files,
+      dependencies: dependencies,
+      credentials: credentials,
+      repo_contents_path: repo_contents_path
+    )
   end
 
-  let(:files) { [] }
+  let(:project_name) { "" }
+  let(:repo_contents_path) { build_tmp_repo(project_name) }
+
+  let(:files) { project_dependency_files(project_name) }
   let(:dependencies) { [] }
   let(:credentials) do
     [{ "type" => "git_source", "host" => "github.com", "username" => "x-access-token", "password" => "token" }]
@@ -23,7 +31,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     subject { updater.updated_dependency_files }
 
     context "with a private module" do
-      let(:files) { project_dependency_files("private_module") }
+      let(:project_name) { "private_module" }
 
       let(:dependencies) do
         [
@@ -69,7 +77,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     end
 
     context "with a private provider" do
-      let(:files) { project_dependency_files("private_provider") }
+      let(:project_name) { "private_provider" }
 
       let(:dependencies) do
         [
@@ -119,7 +127,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     end
 
     context "with a valid legacy dependency file" do
-      let(:files) { project_dependency_files("git_tags_011") }
+      let(:project_name) { "git_tags_011" }
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -158,7 +166,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     end
 
     context "with a valid HCL2 dependency file" do
-      let(:files) { project_dependency_files("git_tags_012") }
+      let(:project_name) { "git_tags_012" }
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -231,7 +239,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       end
 
       context "with a legacy git dependency" do
-        let(:files) { project_dependency_files("git_tags_011") }
+        let(:project_name) { "git_tags_011" }
 
         it "updates the requirement" do
           updated_file = subject.find { |file| file.name == "main.tf" }
@@ -257,7 +265,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       end
 
       context "with an hcl2-based git dependency" do
-        let(:files) { project_dependency_files("git_tags_012") }
+        let(:project_name) { "git_tags_012" }
 
         it "updates the requirement" do
           updated_file = subject.find { |file| file.name == "main.tf" }
@@ -283,7 +291,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       end
 
       context "with an up-to-date hcl2-based git dependency" do
-        let(:files) { project_dependency_files("hcl2") }
+        let(:project_name) { "hcl2" }
 
         it "shows no updates" do
           expect { subject }.to raise_error do |error|
@@ -293,7 +301,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       end
 
       context "with a legacy registry dependency" do
-        let(:files) { project_dependency_files("registry") }
+        let(:project_name) { "registry" }
         let(:dependencies) do
           [
             Dependabot::Dependency.new(
@@ -339,7 +347,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       end
 
       context "with an hcl2-based registry dependency" do
-        let(:files) { project_dependency_files("registry_012") }
+        let(:project_name) { "registry_012" }
         let(:dependencies) do
           [
             Dependabot::Dependency.new(
@@ -386,7 +394,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     end
 
     context "with an hcl-based terragrunt file" do
-      let(:files) { project_dependency_files("terragrunt_hcl") }
+      let(:project_name) { "terragrunt_hcl" }
 
       let(:dependencies) do
         [
@@ -433,7 +441,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     end
 
     context "with a required provider" do
-      let(:files) { project_dependency_files("registry_provider") }
+      let(:project_name) { "registry_provider" }
 
       let(:dependencies) do
         [
@@ -489,7 +497,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     end
 
     context "with a required provider block with multiple versions" do
-      let(:files) { project_dependency_files("registry_provider_compound_local_name") }
+      let(:project_name) { "registry_provider_compound_local_name" }
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -541,7 +549,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     end
 
     context "with a versions file" do
-      let(:files) { project_dependency_files("versions_file") }
+      let(:project_name) { "versions_file" }
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -589,7 +597,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     end
 
     context "updating an up-to-date terraform project with a lockfile" do
-      let(:files) { project_dependency_files("up-to-date_lockfile") }
+      let(:project_name) { "up-to-date_lockfile" }
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -629,7 +637,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     end
 
     context "using versions.tf with a lockfile present" do
-      let(:files) { project_dependency_files("lockfile") }
+      let(:project_name) { "lockfile" }
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -723,7 +731,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     end
 
     describe "for a provider with an implicit source" do
-      let(:files) { project_dependency_files("provider_implicit_source") }
+      let(:project_name) { "provider_implicit_source" }
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -778,7 +786,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     end
 
     describe "for a nested module" do
-      let(:files) { project_dependency_files("nested_modules") }
+      let(:project_name) { "nested_modules" }
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -825,7 +833,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     end
 
     describe "with a lockfile and modules that need to be installed" do
-      let(:files) { project_dependency_files("lockfile_with_modules") }
+      let(:project_name) { "lockfile_with_modules" }
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -871,7 +879,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
     end
 
     describe "when updating a module in a project with a provider lockfile" do
-      let(:files) { project_dependency_files("lockfile_with_modules") }
+      let(:project_name) { "lockfile_with_modules" }
       let(:dependencies) do
         [
           Dependabot::Dependency.new(
@@ -912,6 +920,51 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
               source  = "aztfmod/caf/azurerm"
               version = "5.3.10"
             }
+          DEP
+        )
+      end
+    end
+
+    describe "when updating a provider with local path modules" do
+      let(:project_name) { "provider_with_local_path_moudules" }
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "hashicorp/azurerm",
+            version: "2.64.0",
+            previous_version: "2.63.0",
+            requirements: [{
+              requirement: ">= 2.48.0",
+              groups: [],
+              file: "providers.tf",
+              source: {
+                type: "provider",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "hashicorp/azurerm"
+              }
+            }],
+            previous_requirements: [{
+              requirement: ">= 2.48.0",
+              groups: [],
+              file: "providers.tf",
+              source: {
+                type: "provider",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "hashicorp/azurerm"
+              }
+            }],
+            package_manager: "terraform"
+          )
+        ]
+      end
+
+      it "updates the module version" do
+        lockfile = subject.find { |file| file.name == ".terraform.lock.hcl" }
+
+        expect(lockfile.content).to include(
+          <<~DEP
+            provider "registry.terraform.io/hashicorp/azurerm" {
+              version     = "2.64.0"
           DEP
         )
       end

--- a/terraform/spec/fixtures/projects/provider_with_local_path_moudules/.terraform.lock.hcl
+++ b/terraform/spec/fixtures/projects/provider_with_local_path_moudules/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "2.63.0"
+  constraints = ">= 2.48.0"
+  hashes = [
+    "h1:MIBLWidFqvbwUIW94QS+/Y1tNJYfSwFr4t28I84Okvs=",
+    "zh:050254861e4481c905945dc1ba0aa222373ae92d549a0168b7a271260497ca5b",
+    "zh:053f7de4ff0c6f3878e70c31258b5e23fc63905ef9f31d49440746b4a43a1971",
+    "zh:1afe053ff2807e5c78e8c95d79a9a1fda809836ec85c68533b109ce49eeb55ae",
+    "zh:2cad35e7bbbd02a4aefa369235ef4a5a563ff3dee05b6bf78b40aece205a8902",
+    "zh:3749ab4bad6108b6b0718c3cab05ff72b61e3eebaf37b5b4017ae938499f2b45",
+    "zh:4b6370d88fff833a33104b1c70df1992f7fdf2cdb21ae0719dbd9d0a3388ee55",
+    "zh:9e0f1f0432b61fa89d8358f869b405b539ffe63951b384b5d36456213a881e98",
+    "zh:b1de4dc52af843a265a7f7f5190a529bc70e77a684b10c855b9cf39b2c1bdcf2",
+    "zh:d9b6ac7b6a27c367a12bf86ce09bc4d1661de796f371c2da2c31e20ac0dce4a9",
+    "zh:f95256d93f41d1e6252bc090b2a2ababcb9ea7be9fe45706bccb21b859c3c04f",
+    "zh:fae8bb6f824f38088ce06f64dd0bbf506f70cc8ffdffd6b8a6ba6a678efcc596",
+  ]
+}

--- a/terraform/spec/fixtures/projects/provider_with_local_path_moudules/main.tf
+++ b/terraform/spec/fixtures/projects/provider_with_local_path_moudules/main.tf
@@ -1,0 +1,7 @@
+module "this" {
+  source = "./modules/repeat_this"
+}
+
+module "that" {
+  source = "./modules/repeat_that"
+}

--- a/terraform/spec/fixtures/projects/provider_with_local_path_moudules/modules/repeat_that/main.tf
+++ b/terraform/spec/fixtures/projects/provider_with_local_path_moudules/modules/repeat_that/main.tf
@@ -1,0 +1,8 @@
+resource "azurerm_resource_group" "that" {
+  name     = "that-is-a-resource-group"
+  location = "westeurope"
+
+  tags = {
+    "environment" = "lab"
+  }
+}

--- a/terraform/spec/fixtures/projects/provider_with_local_path_moudules/modules/repeat_this/main.tf
+++ b/terraform/spec/fixtures/projects/provider_with_local_path_moudules/modules/repeat_this/main.tf
@@ -1,0 +1,8 @@
+resource "azurerm_resource_group" "this" {
+  name     = "this-is-a-resource-group"
+  location = "northeurope"
+
+  tags = {
+    "environment" = "lab"
+  }
+}

--- a/terraform/spec/fixtures/projects/provider_with_local_path_moudules/providers.tf
+++ b/terraform/spec/fixtures/projects/provider_with_local_path_moudules/providers.tf
@@ -1,0 +1,14 @@
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+}
+
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 2.48.0"
+    }
+  }
+}


### PR DESCRIPTION
Terraform projects can include local path modules that are currently not
fetched in the file fetching step so any lockfile update will fail
because these files are missing.

The easiest fix seemed to be to always start cloning terraform projects
as this is what we want to end up doing for all ecosystems.

The file fetcher will still hit the gh api when getting the [repo contents](https://github.com/dependabot/dependabot-core/blob/40baefd1e812feca9712daa1e359583a29b5fdc1/common/lib/dependabot/file_fetchers/base.rb#L171-L178)
but this would require changes in common so keen to make that change
separately as it currently works.