### PR TITLE
Bump minor for change to cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.155.2, 23 June 2021
+## v0.156.0, 23 June 2021
 
 - Create changelog from merge commits [#3642](https://github.com/dependabot/dependabot-core/pull/3642)
 - Terraform: always clone repository contents [#3978](https://github.com/dependabot/dependabot-core/pull/3978)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.155.2"
+  VERSION = "0.156.0"
 end


### PR DESCRIPTION
Merged too quickly https://github.com/dependabot/dependabot-core/pull/3979
Makes sense to bump minor for the terraform cloning change.