### PR TITLE
Terraform: Configure git for `terraform init` and capture errors

### DIFF
--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -730,6 +730,46 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       end
     end
 
+    context "when using a lockfile that requires access to an unreachable module" do
+      let(:project_name) { "lockfile_unreachable_module" }
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "hashicorp/aws",
+            version: "3.42.0",
+            previous_version: "3.37.0",
+            requirements: [{
+              requirement: "3.42.0",
+              groups: [],
+              file: "versions.tf",
+              source: {
+                type: "provider",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "hashicorp/aws"
+              }
+            }],
+            previous_requirements: [{
+              requirement: "3.37.0",
+              groups: [],
+              file: "versions.tf",
+              source: {
+                type: "provider",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "hashicorp/aws"
+              }
+            }],
+            package_manager: "terraform"
+          )
+        ]
+      end
+
+      it "raises a helpful error" do
+        expect { subject }.to raise_error(Dependabot::PrivateSourceAuthenticationFailure) do |error|
+          expect(error.source).to eq("github.com/dependabot-fixtures/private-terraform-module")
+        end
+      end
+    end
+
     describe "for a provider with an implicit source" do
       let(:project_name) { "provider_implicit_source" }
       let(:dependencies) do

--- a/terraform/spec/fixtures/projects/lockfile_unreachable_module/.terraform.lock.hcl
+++ b/terraform/spec/fixtures/projects/lockfile_unreachable_module/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "4.4.0"
+  constraints = "~> 4.4"
+  hashes = [
+    "h1:dgn+oL1cC8kz3ODIuT/PyHqgso00SpItPN089ZuUGt4=",
+    "h1:eKArqtLcYoYUFf4dgNzVemqu2GsoEf7K0ZLEXjSoPBo=",
+    "zh:0ebb07c4971ca7d60fce8614270d056328a121fd4ffbda4b29a06d4a1e90e939",
+    "zh:178b333f2f285c1a59b9335320f584bd01304179c2d6a1919366945b55cfb293",
+    "zh:2c9087e987a5e1af2aad803a79fa5bd847ac060d4c766b5a187b9aabb3f734a4",
+    "zh:419597d8d284616ed93a2c13b3833b129aaba7af7a057d2f48aeb7bc3610cefc",
+    "zh:61686d578880ad76cb8e9c2cc72ad14ef2896fde973cca18b8f7c8848781c71d",
+    "zh:662e125ac42a0c113d811afd2e7a0f81ba061f00cc62ba7435bd685f889290b9",
+    "zh:87fb3d97070cae7f0b623d1a9b59e8cfad0dfece4a27ee964c4c77f228592a80",
+    "zh:e9dcc85ef2f2e09d298f3bbbb9b0d673596d62c1d7d480b2999b4badb2f4aeff",
+    "zh:f052c377a0630a6881c183ac5de0dbef4e5627638a23434a6aa7fce8977b43de",
+    "zh:f7456ec2a6a31caa5d2c85f4da660689f8bac5541c70324803de0c26a14586e1",
+    "zh:fbf6bfddde6f209dc65052ca27e0c83e96bae5fde6940edf029ca42e7e4f1110",
+  ]
+}

--- a/terraform/spec/fixtures/projects/lockfile_unreachable_module/main.tf
+++ b/terraform/spec/fixtures/projects/lockfile_unreachable_module/main.tf
@@ -1,0 +1,3 @@
+module "caf" {
+  source  = "github.com/dependabot-fixtures/private-terraform-module"
+}


### PR DESCRIPTION
When attempting to `terraform init` when there are private module
sources present, currently we raise a `HelperSubprocessFailed`.

Terraform will attempt to use any git credentials that are configured,
so passing these along should help in some cases when Dependabot is
configured to access these, and when it isn't we should raise a
PrivateSourceAuthenticationFailure to communicate more clearly that we
cannot reach a certain source.

It's a little unfortunate that we even need to do this, because this
happens when we attempt to update a lockfile, and these don't support
modules. However, `terraform providers lock` will still complain about
modules needing to be installed, and this should do a better job of
that.