### PR TITLE
Terraform: Prevent `terraform init` from initializing backends

### DIFF
--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -133,7 +133,10 @@ module Dependabot
 
       def run_terraform_init
         SharedHelpers.with_git_configured(credentials: credentials) do
-          SharedHelpers.run_shell_command("terraform init")
+          # -backend=false option used to ignore any backend configuration, as these won't be accessible
+          # -input=false option used to immediately fail if it needs user input
+          # -no-color option used to prevent any color characters being printed in the output 
+          SharedHelpers.run_shell_command("terraform init -backend=false -input=false -no-color")
         rescue SharedHelpers::HelperSubprocessFailed => e
           output = strip_terminal_colors(e.message)
 

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -135,19 +135,15 @@ module Dependabot
         SharedHelpers.with_git_configured(credentials: credentials) do
           # -backend=false option used to ignore any backend configuration, as these won't be accessible
           # -input=false option used to immediately fail if it needs user input
-          # -no-color option used to prevent any color characters being printed in the output 
+          # -no-color option used to prevent any color characters being printed in the output
           SharedHelpers.run_shell_command("terraform init -backend=false -input=false -no-color")
         rescue SharedHelpers::HelperSubprocessFailed => e
-          output = strip_terminal_colors(e.message)
+          output = e.message
 
           if output.match?(PRIVATE_MODULE_ERROR)
             raise PrivateSourceAuthenticationFailure, output.match(PRIVATE_MODULE_ERROR).named_captures.fetch("repo")
           end
         end
-      end
-
-      def strip_terminal_colors(output)
-        output.gsub(/\e\[(\d+)m/, "")
       end
 
       def dependency

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -1009,5 +1009,50 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
         )
       end
     end
+
+    describe "when updating provider with backend in configuration" do
+      let(:project_name) { "provider_with_backend" }
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "hashicorp/azurerm",
+            version: "2.64.0",
+            previous_version: "2.63.0",
+            requirements: [{
+              requirement: ">= 2.48.0",
+              groups: [],
+              file: "providers.tf",
+              source: {
+                type: "provider",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "hashicorp/azurerm"
+              }
+            }],
+            previous_requirements: [{
+              requirement: ">= 2.48.0",
+              groups: [],
+              file: "providers.tf",
+              source: {
+                type: "provider",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "hashicorp/azurerm"
+              }
+            }],
+            package_manager: "terraform"
+          )
+        ]
+      end
+
+      it "updates the module version" do
+        lockfile = subject.find { |file| file.name == ".terraform.lock.hcl" }
+
+        expect(lockfile.content).to include(
+          <<~DEP
+            provider "registry.terraform.io/hashicorp/azurerm" {
+              version     = "2.64.0"
+          DEP
+        )
+      end
+    end
   end
 end

--- a/terraform/spec/fixtures/projects/provider_with_backend/.terraform.lock.hcl
+++ b/terraform/spec/fixtures/projects/provider_with_backend/.terraform.lock.hcl
@@ -4,7 +4,7 @@
 
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "2.63.0"
-  constraints = ">= 2.48.0"
+  constraints = ">= 2.48.0, < 2.65.0"
   hashes = [
     "h1:MIBLWidFqvbwUIW94QS+/Y1tNJYfSwFr4t28I84Okvs=",
     "zh:050254861e4481c905945dc1ba0aa222373ae92d549a0168b7a271260497ca5b",

--- a/terraform/spec/fixtures/projects/provider_with_backend/.terraform.lock.hcl
+++ b/terraform/spec/fixtures/projects/provider_with_backend/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "2.63.0"
+  constraints = ">= 2.48.0"
+  hashes = [
+    "h1:MIBLWidFqvbwUIW94QS+/Y1tNJYfSwFr4t28I84Okvs=",
+    "zh:050254861e4481c905945dc1ba0aa222373ae92d549a0168b7a271260497ca5b",
+    "zh:053f7de4ff0c6f3878e70c31258b5e23fc63905ef9f31d49440746b4a43a1971",
+    "zh:1afe053ff2807e5c78e8c95d79a9a1fda809836ec85c68533b109ce49eeb55ae",
+    "zh:2cad35e7bbbd02a4aefa369235ef4a5a563ff3dee05b6bf78b40aece205a8902",
+    "zh:3749ab4bad6108b6b0718c3cab05ff72b61e3eebaf37b5b4017ae938499f2b45",
+    "zh:4b6370d88fff833a33104b1c70df1992f7fdf2cdb21ae0719dbd9d0a3388ee55",
+    "zh:9e0f1f0432b61fa89d8358f869b405b539ffe63951b384b5d36456213a881e98",
+    "zh:b1de4dc52af843a265a7f7f5190a529bc70e77a684b10c855b9cf39b2c1bdcf2",
+    "zh:d9b6ac7b6a27c367a12bf86ce09bc4d1661de796f371c2da2c31e20ac0dce4a9",
+    "zh:f95256d93f41d1e6252bc090b2a2ababcb9ea7be9fe45706bccb21b859c3c04f",
+    "zh:fae8bb6f824f38088ce06f64dd0bbf506f70cc8ffdffd6b8a6ba6a678efcc596",
+  ]
+}

--- a/terraform/spec/fixtures/projects/provider_with_backend/providers.tf
+++ b/terraform/spec/fixtures/projects/provider_with_backend/providers.tf
@@ -1,0 +1,16 @@
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+}
+
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 2.48.0"
+    }
+  }
+  backend "azurerm" {
+  }
+}

--- a/terraform/spec/fixtures/projects/provider_with_backend/providers.tf
+++ b/terraform/spec/fixtures/projects/provider_with_backend/providers.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.48.0"
+      version = ">= 2.48.0, < 2.65.0"
     }
   }
   backend "azurerm" {

--- a/terraform/spec/fixtures/projects/provider_with_local_path_moudules/.terraform.lock.hcl
+++ b/terraform/spec/fixtures/projects/provider_with_local_path_moudules/.terraform.lock.hcl
@@ -4,7 +4,7 @@
 
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "2.63.0"
-  constraints = ">= 2.48.0"
+  constraints = ">= 2.48.0, < 2.65.0"
   hashes = [
     "h1:MIBLWidFqvbwUIW94QS+/Y1tNJYfSwFr4t28I84Okvs=",
     "zh:050254861e4481c905945dc1ba0aa222373ae92d549a0168b7a271260497ca5b",

--- a/terraform/spec/fixtures/projects/provider_with_local_path_moudules/providers.tf
+++ b/terraform/spec/fixtures/projects/provider_with_local_path_moudules/providers.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.48.0"
+      version = ">= 2.48.0, < 2.65.0"
     }
   }
 }


### PR DESCRIPTION
Some terraform setups have backend (where the state is stored) configurations present in the code. When this is the case the `terraform init` command will fail trying to initialize the backend. Most backend types can't be initialized by dependabot as where they are pointing should be well protected or require user input to continue. Example of error message: https://github.com/dependabot/dependabot-core/issues/3909#issuecomment-866239727

I have added the following options to the `terraform init` command:

- `-backend=false` to ignore any backend configuration
- `-input=false` to immediately fail if it needs user input
- `-no-color` to prevent color characters from printing, which means `strip_terminal_colors` could be removed

Hopefully I have gotten things correct set up here. First time I'm writing in Ruby 😄