### PR TITLE
poetry: ignore path dependencies in UpdateChecker

### DIFF
--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -252,6 +252,8 @@ module Dependabot
       end
 
       def fetch_latest_version
+        return nil if PoetryVersionResolver.path_dependency?(pyproject.content, dependency)
+
         latest_version_finder.latest_version
       end
 

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -252,7 +252,8 @@ module Dependabot
       end
 
       def fetch_latest_version
-        return nil if PoetryVersionResolver.path_dependency?(pyproject.content, dependency)
+        # NOTE: Prevent leaking potentially private path dependency names to PyPi
+        return nil if pyproject && PoetryVersionResolver.path_dependency?(pyproject.content, dependency)
 
         latest_version_finder.latest_version
       end

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -44,6 +44,8 @@ module Dependabot
         end
 
         def latest_resolvable_version(requirement: nil)
+          return nil if PoetryVersionResolver.path_dependency?(pyproject.content, dependency)
+
           version_string =
             fetch_latest_resolvable_version_string(requirement: requirement)
 
@@ -63,6 +65,21 @@ module Dependabot
           raise unless e.message.include?("SolverProblemError")
 
           @resolvable[version] = false
+        end
+
+        def self.path_dependency?(pyproject_content, dependency)
+          pyproject_object = TomlRB.parse(pyproject_content)
+          poetry_object = pyproject_object.dig("tool", "poetry")
+
+          %w(dependencies dev-dependencies).each do |type|
+            names = poetry_object[type]&.keys || []
+            pkg_name = names.find { |nm| NameNormaliser.normalise(nm) == dependency.name }
+            next unless pkg_name
+            next unless poetry_object.dig(type, pkg_name).is_a?(Hash)
+
+            return true if poetry_object[type][pkg_name].fetch("path", false)
+          end
+          false
         end
 
         private

--- a/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
@@ -42,13 +42,6 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
     )
   end
   let(:pipfile_fixture_name) { "exact_version" }
-  let(:pyproject) do
-    Dependabot::DependencyFile.new(
-      name: "pyproject.toml",
-      content: fixture("pyproject_files", pyproject_fixture_name)
-    )
-  end
-  let(:pyproject_fixture_name) { "exact_version.toml" }
   let(:requirements_file) do
     Dependabot::DependencyFile.new(
       name: "requirements.txt",

--- a/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
@@ -222,6 +222,21 @@ RSpec.describe namespace::PoetryVersionResolver do
       it { is_expected.to be >= Gem::Version.new("1.4.3") }
     end
 
+    context "with a path dependency" do
+      let(:pyproject_fixture_name) { "path_dependency.toml" }
+      let(:dependency_name) { "toml" }
+      let(:dependency_requirements) do
+        [{
+          file: "pyproject.toml",
+          requirement: nil,
+          groups: ["dependencies"],
+          source: nil
+        }]
+      end
+
+      it { is_expected.to be_nil }
+    end
+
     context "not resolvable" do
       let(:dependency_files) { [pyproject] }
       let(:pyproject_fixture_name) { "solver_problem.toml" }

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -113,6 +113,20 @@ RSpec.describe Dependabot::Python::UpdateChecker do
         ).and_call_original
       expect(checker.latest_version).to eq(Gem::Version.new("2.6.0"))
     end
+
+    context "with a pyproject path dependency" do
+      let(:pyproject_fixture_name) { "path_dependency.toml" }
+      let(:dependency_name) { "toml" }
+      let(:dependency_files) { [pyproject] }
+
+      it "does not query index" do
+        allow(described_class::LatestVersionFinder).to receive(:new)
+
+        expect(checker.latest_version).to be_nil
+
+        expect(described_class::LatestVersionFinder).not_to have_received(:new)
+      end
+    end
   end
 
   describe "#lowest_security_fix_version" do


### PR DESCRIPTION
This PR updates the python `UpdateChecker` to ignore dependencies specified as a poetry [path dependency](https://python-poetry.org/docs/dependency-specification/#path-dependencies).

There are two points of concern:
* When querying for the latest versions, available indexes were queried. This is a privacy concern: customers with monorepos will leak every submodule's name to PyPI. (In my test setup, my internal module that I named  `nested` was compared to https://pypi.org/project/Nested/ 😨 ).
* When invoking `poetry` to query for resolvable versions, dependabot [injects a `version` string to dependencies](https://github.com/dependabot/dependabot-core/blob/dce1b23793935cc0080729e90d8f3ba0bd52b5c3/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb#L271-L275).

The latter causes a manifest like:
```toml
[tool.poetry.dependencies]
python = "^3.9"
nested = { path = "nested" }
```

To be re-written by Dependabot and fed to poetry as:
```toml
[tool.poetry.dependencies]
python = "^3.9"
nested = { path = "nested", version = ">= 0.1.0, <= 1.0.1" }
```

Which results in:
```
rsion_resolver.rb:88:in `block (2 levels) in fetch_latest_resolvable_version_string'
/home/dependabot/dependabot-core/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb:338:in `run_poetry_command': RuntimeError (Dependabot::SharedHelpers::HelperSubprocessFailed)

  The Poetry configuration is invalid:
    - [dependencies.nested] {'path': 'nested', 'version': '>= 0.1.0, <= 1.0.1'} is not valid under any of the given schemas
  

  at /usr/local/.pyenv/versions/3.9.5/lib/python3.9/site-packages/poetry/core/factory.py:43 in create_poetry
       39│             message = ""
       40│             for error in check_result["errors"]:
       41│                 message += "  - {}\\n".format(error)
       42│ 
    →  43│             raise RuntimeError("The Poetry configuration is invalid:\\n" + message)
       44│ 
       45│         # Load package
       46│         name = local_config["name"]
       47│         version = local_config["version"]
```

Splitting between the `PoetryVersionResolver` and `UpdateChecker` is an unintentional byproduct of implementation order - I'd intended to only change the `PoetryVersionResolver`, but I didn't like seeing the PyPI results in the dry-run script output.