### PR TITLE
v0.156.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.156.2, 25 June 2021
+
+- poetry: skip path and url dependencies [#3991](https://github.com/dependabot/dependabot-core/pull/3991)
+- Terraform: Prevent `terraform init` from initializing backends (@hfurubotten) [#3986](https://github.com/dependabot/dependabot-core/pull/3986)
+
 ## v0.156.1, 24 June 2021
 
 - Terraform: Configure git for `terraform init` and capture errors [#3983](https://github.com/dependabot/dependabot-core/pull/3983)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.156.1"
+  VERSION = "0.156.2"
 end


### PR DESCRIPTION
- poetry: skip path and url dependencies [#3991](https://github.com/dependabot/dependabot-core/pull/3991)
- Terraform: Prevent `terraform init` from initializing backends (_hfurubotten) [#3986](https://github.com/dependabot/dependabot-core/pull/3986)

I skipped https://github.com/dependabot/dependabot-core/pull/3990 as internal cleanup.