### PR TITLE
PR Updater: Handle required status checks

### DIFF
--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -173,7 +173,8 @@ module Dependabot
 
         if e.message.match?(/protected branch/i) ||
            e.message.match?(/not authorized to push/i) ||
-           e.message.match?(/must not contain merge commits/)
+           e.message.match?(/must not contain merge commits/) ||
+           e.message.match?(/required status check/i)
           raise BranchProtected
         end
 

--- a/common/spec/dependabot/pull_request_updater/github_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/github_spec.rb
@@ -638,5 +638,23 @@ RSpec.describe Dependabot::PullRequestUpdater::Github do
           to raise_error(Dependabot::PullRequestUpdater::BranchProtected)
       end
     end
+
+    context "when pushing to a protected branch enforcing required status checks" do
+      before do
+        stub_request(
+          :patch,
+          "#{watched_repo_url}/git/refs/heads/#{branch_name}"
+        ).to_return(
+          status: 422,
+          body: fixture("github", "required_status_checks_protected_branch.json"),
+          headers: json_header
+        )
+      end
+
+      it "raises a helpful error" do
+        expect { updater.update }.
+          to raise_error(Dependabot::PullRequestUpdater::BranchProtected)
+      end
+    end
   end
 end

--- a/common/spec/fixtures/github/required_status_checks_protected_branch.json
+++ b/common/spec/fixtures/github/required_status_checks_protected_branch.json
@@ -1,0 +1,4 @@
+{
+  "message": "Required status check \"ci/jenkins/pr-merge\" is expected. At least 1 approving review is required by reviewers with write access.",
+  "documentation_url": "https://help.github.com/articles/about-protected-branches"
+}


### PR DESCRIPTION
As per [the docs][docs] when branch protection rules are enabled, force
pushing to them is disabled.

This handles errors when this happens and raises a `BranchProtected`
error, which will allow us to handle this gracefully and inform the user
of this.

[docs]: https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#about-branch-protection-rules