### PR TITLE
Fix for Azure client trying to parse 401 responses

### DIFF
--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -14,6 +14,8 @@ module Dependabot
 
       class BadGateway < StandardError; end
 
+      class Unauthorized < StandardError; end
+
       RETRYABLE_ERRORS = [InternalServerError, BadGateway, ServiceNotAvailable].freeze
 
       MAX_PR_DESCRIPTION_LENGTH = 3999
@@ -228,6 +230,7 @@ module Dependabot
           raise ServiceNotAvailable if response.status == 503
         end
 
+        raise Unauthorized if response.status == 401
         raise NotFound if response.status == 404
 
         response
@@ -257,6 +260,7 @@ module Dependabot
           raise ServiceNotAvailable if response.status == 503
         end
 
+        raise Unauthorized if response.status == 401
         raise NotFound if response.status == 404
 
         response

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -67,6 +67,18 @@ RSpec.describe Dependabot::Clients::Azure do
       end
     end
 
+    context "when response is 401" do
+      before do
+        stub_request(:get, branch_url).
+          with(basic_auth: [username, password]).
+          to_return(status: 401)
+      end
+
+      it "raises a helpful error" do
+        expect { subject }.to raise_error(Dependabot::Clients::Azure::Unauthorized)
+      end
+    end
+
     context "when response is 400" do
       before do
         stub_request(:get, branch_url).
@@ -157,6 +169,18 @@ RSpec.describe Dependabot::Clients::Azure do
       specify { expect { subject }.to_not raise_error }
 
       it { is_expected.to eq(JSON.parse(response_body)) }
+    end
+
+    context "when response is 401" do
+      before do
+        stub_request(:get, pull_request_url).
+          with(basic_auth: [username, password]).
+          to_return(status: 401)
+      end
+
+      it "raises a helpful error" do
+        expect { subject }.to raise_error(Dependabot::Clients::Azure::Unauthorized)
+      end
     end
 
     context "when response is 404" do


### PR DESCRIPTION
Currently azure.rb does not have any logic to catch 401 error codes and will attempt to parse the response if one is encountered, causing auth exceptions for this client to be surfaced to the user as a JSON::ParserError.

This fix adds an Unauthorized exception to azure.rb and raises it when calls to Excon.get and Excon.post return a 401 status.