### PR TITLE
test: place upper bound on version constraint

### DIFF
--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -912,7 +912,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
           <<~DEP
             provider "registry.terraform.io/integrations/github" {
               version     = "4.12.0"
-              constraints = "~> 4.4"
+              constraints = "~> 4.4, <= 4.12.0"
           DEP
         )
       end

--- a/terraform/spec/fixtures/projects/lockfile_with_modules/versions.tf
+++ b/terraform/spec/fixtures/projects/lockfile_with_modules/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 4.4"
+      version = "~> 4.4, <= 4.12.0"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
This fixes a test that started to fail because a new version of a Terraform
dependency was released.

Before:

```bash
Failures:

  1) Dependabot::Terraform::FileUpdater#updated_dependency_files with a lockfile and modules that need to be installed updates the version in the lockfile
     Failure/Error:
       expect(lockfile.content).to include(
         <<~DEP
           provider "registry.terraform.io/integrations/github" {
             version     = "4.12.0"
             constraints = "~> 4.4"
         DEP
       )

       expected "# This file is maintained automatically by \"terraform init\".\n# Manual edits may be lost in future...64511702\",\n    \"zh:e2b1f5133d53e640fc7048c70f813530204e2c6d4941a7433c60cac5a3354778\",\n  ]\n}\n" to include "provider \"registry.terraform.io/integrations/github\" {\n  version     = \"4.12.0\"\n  constraints = \"~> 4.4\"\n"
       Diff:
       @@ -1,23 +1,45 @@
       -provider "registry.terraform.io/integrations/github" {\n  version     = "4.12.0"\n  constraints = "~> 4.4"\n
       +# This file is maintained automatically by "terraform init".
       +# Manual edits may be lost in future updates.
       +
       +provider "registry.terraform.io/integrations/github" {
       +  version     = "4.12.1"
       +  constraints = "~> 4.4"
       +  hashes = [
       +    "h1:QpcHj8PVfd336f71aaSW4LhxoVRdkGBfqHNHbevGfjU=",
       +    "zh:00d79526ce1e2e6eca41610f626223c1f5ca2923e26813639160ad4d1c808171",
       +    "zh:3d623090280e36c55297d9a03e06b9a68c54b60a313223cbc075d788beba02f0",
       +    "zh:443df557537e6ba45abad452e78b6de596d18bb0e188be77f96aee4bf3ff8710",
       +    "zh:5329b855068e317908bf25f225c2ff1dfe8f42ec6985cc528a0ca56b70c15244",
       +    "zh:5eecc807c1d7843260d45e0c6922f4c8f999a77c4b5b7271d17c4fc28973caed",
       +    "zh:647f4bd5d05ea81e039336637b57e8e593b9b3fc0d407f26195d0b95cf91534e",
       +    "zh:64a25c352c8227a31e274645ebcc5ab3c08814c8d9101c11ed8e858e05dcb9d9",
       +    "zh:aae528e5f723aa4419c2c30eac4a4f6b0e4af8f239ef9da101501ad03a7ecc7c",
       +    "zh:ac095cd178e3691777543aaa9c0cb7a3084adda3046110fa90525e3a7b5b4707",
       +    "zh:b846bfceae0c9dd7961211c6964729826c0505e144a049dbd612a0a514797ec4",
       +    "zh:c0f3f603d224aae872ab30cb5bd4c87ec4a4467b216d5d702050aee182c68bdf",
       +    "zh:c6b1e75cb50456dcf95dee2d8fe660ce3f16c770516261c406bb3e6d64511702",
       +    "zh:e2b1f5133d53e640fc7048c70f813530204e2c6d4941a7433c60cac5a3354778",
       +  ]
       +}

     # ./spec/dependabot/terraform/file_updater_spec.rb:911:in `block (4 levels) in <top (required)>'
     # /home/dependabot/dependabot-core/common/spec/spec_helper.rb:49:in `block (2 levels) in <top (required)>'
     # ./.bundle/ruby/2.7.0/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

Finished in 15.65 seconds (files took 2.88 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/dependabot/terraform/file_updater_spec.rb:908 # Dependabot::Terraform::FileUpdater#updated_dependency_files with a lockfile and modules that need to be installed updates the version in the lockfile
```


https://github.com/integrations/terraform-provider-github/releases/tag/v4.12.1
