### PR TITLE
Gomod: Handle unrecognized import path error

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -35,7 +35,9 @@ module Dependabot
           /go: .*: invalid pseudo-version/m.freeze,
           # Package does not exist, has been pulled or cannot be reached due to
           # auth problems with either git or the go proxy
-          /go: .*: unknown revision/m.freeze
+          /go: .*: unknown revision/m.freeze,
+          # Package pointing to a proxy that 404s
+          /go: .*: unrecognized import path/m.freeze
         ].freeze
 
         MODULE_PATH_MISMATCH_REGEXES = [

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -437,6 +437,33 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
       end
     end
 
+    context "for a project that references a non-existing proxy" do
+      let(:project_name) { "nonexisting_proxy" }
+      let(:dependency_name) { "rsc.io/quote" }
+      let(:dependency_version) { "v1.5.2" }
+      let(:dependency_previous_version) { "v1.4.0" }
+      let(:requirements) do
+        [{
+          file: "go.mod",
+          requirement: "v1.5.2",
+          groups: [],
+          source: {
+            type: "default",
+            source: "rsc.io/quote"
+          }
+        }]
+      end
+      let(:previous_requirements) { [] }
+
+      it "raises the correct error" do
+        error_class = Dependabot::DependencyFileNotResolvable
+        expect { updater.updated_go_sum_content }.
+          to raise_error(error_class) do |error|
+          expect(error.message).to include("unrecognized import path")
+        end
+      end
+    end
+
     context "when module major version doesn't match (v1)" do
       let(:project_name) { "module_major_version_mismatch_v1" }
       let(:dependency_name) do

--- a/go_modules/spec/fixtures/projects/nonexisting_proxy/go.mod
+++ b/go_modules/spec/fixtures/projects/nonexisting_proxy/go.mod
@@ -1,0 +1,8 @@
+module github.com/dependabot/vgotest
+
+go 1.18
+
+require (
+  dependabot.com/nonexistingdep v1.0.0
+  rsc.io/quote v1.4.0
+)

--- a/go_modules/spec/fixtures/projects/nonexisting_proxy/main.go
+++ b/go_modules/spec/fixtures/projects/nonexisting_proxy/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	_ "dependabot.com/nonexistingdep"
+	_ "rsc.io/quote"
+)
+
+func main() {
+}


### PR DESCRIPTION
When referencing a go proxy that 404s, we see this error. Previously
this would not be handled, but it should result in a
DependencyFileNotResolvable error, so users have a sense of what's
wrong.