### PR TITLE
Add Forbidden error type to Azure client

### DIFF
--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -16,6 +16,8 @@ module Dependabot
 
       class Unauthorized < StandardError; end
 
+      class Forbidden < StandardError; end
+
       RETRYABLE_ERRORS = [InternalServerError, BadGateway, ServiceNotAvailable].freeze
 
       MAX_PR_DESCRIPTION_LENGTH = 3999
@@ -231,6 +233,7 @@ module Dependabot
         end
 
         raise Unauthorized if response.status == 401
+        raise Forbidden if response.status == 403
         raise NotFound if response.status == 404
 
         response
@@ -261,6 +264,7 @@ module Dependabot
         end
 
         raise Unauthorized if response.status == 401
+        raise Forbidden if response.status == 403
         raise NotFound if response.status == 404
 
         response

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -105,48 +105,50 @@ RSpec.describe Dependabot::Clients::Azure do
 
     let(:commit_url) { repo_url + "/pushes?api-version=5.0" }
 
-    before do
-      stub_request(:post, commit_url).
-        with(basic_auth: [username, password]).
-        to_return(status: 200)
-    end
-
-    context "when author_details is nil" do
-      let(:author_details) { nil }
-      it "pushes commit without author property" do
-        create_commit
-
-        expect(WebMock).
-          to(
-            have_requested(:post, "#{repo_url}/pushes?api-version=5.0").
-              with do |req|
-                json_body = JSON.parse(req.body)
-                expect(json_body.fetch("commits").count).to eq(1)
-                expect(json_body.fetch("commits").first.keys).
-                  to_not include("author")
-              end
-          )
+    context "when response is 200" do
+      before do
+        stub_request(:post, commit_url).
+          with(basic_auth: [username, password]).
+          to_return(status: 200)
       end
-    end
-
-    context "when author_details contains name and email" do
-      let(:author_details) do
-        { email: "support@dependabot.com", name: "dependabot" }
+  
+      context "when author_details is nil" do
+        let(:author_details) { nil }
+        it "pushes commit without author property" do
+          create_commit
+  
+          expect(WebMock).
+            to(
+              have_requested(:post, "#{repo_url}/pushes?api-version=5.0").
+                with do |req|
+                  json_body = JSON.parse(req.body)
+                  expect(json_body.fetch("commits").count).to eq(1)
+                  expect(json_body.fetch("commits").first.keys).
+                    to_not include("author")
+                end
+            )
+        end
       end
-
-      it "pushes commit with author property containing name and email" do
-        create_commit
-
-        expect(WebMock).
-          to(
-            have_requested(:post, "#{repo_url}/pushes?api-version=5.0").
-              with do |req|
-                json_body = JSON.parse(req.body)
-                expect(json_body.fetch("commits").count).to eq(1)
-                expect(json_body.fetch("commits").first.fetch("author")).
-                  to eq(author_details.transform_keys(&:to_s))
-              end
-          )
+  
+      context "when author_details contains name and email" do
+        let(:author_details) do
+          { email: "support@dependabot.com", name: "dependabot" }
+        end
+  
+        it "pushes commit with author property containing name and email" do
+          create_commit
+  
+          expect(WebMock).
+            to(
+              have_requested(:post, "#{repo_url}/pushes?api-version=5.0").
+                with do |req|
+                  json_body = JSON.parse(req.body)
+                  expect(json_body.fetch("commits").count).to eq(1)
+                  expect(json_body.fetch("commits").first.fetch("author")).
+                    to eq(author_details.transform_keys(&:to_s))
+                end
+            )
+        end
       end
     end
   end

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -105,13 +105,29 @@ RSpec.describe Dependabot::Clients::Azure do
 
     let(:commit_url) { repo_url + "/pushes?api-version=5.0" }
 
+    context "when response is 403" do
+      let(:author_details) do
+        { email: "support@dependabot.com", name: "dependabot" }
+      end
+
+      before do
+        stub_request(:post, commit_url).
+          with(basic_auth: [username, password]).
+          to_return(status: 403)
+      end
+
+      it "raises a helpful error" do
+        expect { subject }.to raise_error(Dependabot::Clients::Azure::Forbidden)
+      end
+    end
+
     context "when response is 200" do
       before do
         stub_request(:post, commit_url).
           with(basic_auth: [username, password]).
           to_return(status: 200)
       end
-  
+
       context "when author_details is nil" do
         let(:author_details) { nil }
         it "pushes commit without author property" do

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Dependabot::Clients::Azure do
         let(:author_details) { nil }
         it "pushes commit without author property" do
           create_commit
-  
+
           expect(WebMock).
             to(
               have_requested(:post, "#{repo_url}/pushes?api-version=5.0").
@@ -157,15 +157,15 @@ RSpec.describe Dependabot::Clients::Azure do
             )
         end
       end
-  
+
       context "when author_details contains name and email" do
         let(:author_details) do
           { email: "support@dependabot.com", name: "dependabot" }
         end
-  
+
         it "pushes commit with author property containing name and email" do
           create_commit
-  
+
           expect(WebMock).
             to(
               have_requested(:post, "#{repo_url}/pushes?api-version=5.0").

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -67,6 +67,18 @@ RSpec.describe Dependabot::Clients::Azure do
       end
     end
 
+    context "when response is 403" do
+      before do
+        stub_request(:get, branch_url).
+          with(basic_auth: [username, password]).
+          to_return(status: 403)
+      end
+
+      it "raises a helpful error" do
+        expect { subject }.to raise_error(Dependabot::Clients::Azure::Forbidden)
+      end
+    end
+
     context "when response is 401" do
       before do
         stub_request(:get, branch_url).


### PR DESCRIPTION
Adds a Forbidden error type to Dependabot:Clients:Azure to raise when a request returns 403

This fixes an issue where Dependabot:PullRequestCreator:Azure.create returns a 400 status to the caller when the root issue is a 403 being returned by Dependabot:PullRequestCreator:Azure.create_commit (since Azure.create creates both the commit and pull request it only ever returns the response code for the latter).