### PR TITLE
Terraform: handle mixed case providers

### DIFF
--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -206,7 +206,7 @@ module Dependabot
           (?:(?!^\}).)*
           provider\s*["']#{Regexp.escape(provider_source)}["']\s*\{
           (?:(?!^\}).)*}
-        /mx
+        /mix
       end
     end
   end

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -1054,5 +1054,50 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
         )
       end
     end
+
+    describe "when updating a provider with local path modules" do
+      let(:project_name) { "provider_with_mixed_case" }
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "Mongey/confluentcloud",
+            version: "0.0.11",
+            previous_version: "0.0.6",
+            requirements: [{
+              requirement: ">= 0.0.11",
+              groups: [],
+              file: "providers.tf",
+              source: {
+                type: "provider",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "Mongey/confluentcloud"
+              }
+            }],
+            previous_requirements: [{
+              requirement: ">= 0.0.6",
+              groups: [],
+              file: "providers.tf",
+              source: {
+                type: "provider",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "Mongey/confluentcloud"
+              }
+            }],
+            package_manager: "terraform"
+          )
+        ]
+      end
+
+      it "updates the module version" do
+        lockfile = subject.find { |file| file.name == ".terraform.lock.hcl" }
+
+        expect(lockfile.content).to include(
+          <<~DEP
+            provider "registry.terraform.io/mongey/confluentcloud" {
+              version     = "0.0.11"
+          DEP
+        )
+      end
+    end
   end
 end

--- a/terraform/spec/fixtures/projects/provider_with_mixed_case/.terraform.lock.hcl
+++ b/terraform/spec/fixtures/projects/provider_with_mixed_case/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/mongey/confluentcloud" {
+  version     = "0.0.6"
+  constraints = "0.0.6"
+  hashes = [
+    "h1:58+/tSkeRBILHm2Zjn+JGAKEAuORY4M/2CjxSjbNta0=",
+    "zh:1f5825ddd293be02517e2939e0063b00a460e0ccfb358263f366d47f4df4e283",
+    "zh:5213a30d49f466c4a60d3761a0a26f3b39bd27618c2ccda0ce8342d140747f3b",
+    "zh:647a0a2ca713b1151ce5a312dd6afa0ab1db0d98f077b3fecb3a52c4dd932b16",
+    "zh:71426dba630762ec5436335d218b45c7489ba626845c3889cf1a8a9e32ec8e5f",
+    "zh:7f023157190bdc2c0e095584fadc5d2f8b57b7f3e760be5408b91e4a6a9824c4",
+    "zh:b402470663e27d9f199ca57bd86b2a9db947f43efd703c770cd7829531c43ff5",
+    "zh:ce82a2580ddee49affdf56d488b456e73da8323586630c63c62b3d087f4ceb29",
+    "zh:d164ab6209b8a68e3fd03fe9d820b2a246b47ae42063efcb53194a157dc3f2cc",
+    "zh:f3e085b537c5842a7a88cb98c7985789a43bd8c349bb2ba1acf1110377640094",
+    "zh:f9ea5fcd51718d921753736bd0ff3816c3c1a36a74aa5093e347eae3d3c3ecd2",
+  ]
+}

--- a/terraform/spec/fixtures/projects/provider_with_mixed_case/providers.tf
+++ b/terraform/spec/fixtures/projects/provider_with_mixed_case/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~>0.14"
+
+  required_providers {
+    confluentcloud = {
+      source  = "Mongey/confluentcloud"
+      version = ">= 0.0.6"
+    }
+  }
+}


### PR DESCRIPTION
Provider names can include uppercase characters but the resulting
lockfile downcases the name in the provider url.