### PR TITLE
v0.156.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.156.6, 13 July 2021
+
+- Terraform: handle mixed case providers [#4044](https://github.com/dependabot/dependabot-core/pull/4044)
+
 ## v0.156.5, 12 July 2021
 
 - fix(poetry): Detect relative project paths [#4018](https://github.com/dependabot/dependabot-core/pull/4018)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.156.5"
+  VERSION = "0.156.6"
 end


### PR DESCRIPTION
## v0.156.6, 13 July 2021

- Terraform: handle mixed case providers [#4044](https://github.com/dependabot/dependabot-core/pull/4044)

