### PR TITLE
Terraform: support updating local path modules

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -157,11 +157,12 @@ module Dependabot
         path = Pathname.new(File.join(dir)).cleanpath.to_path.gsub(%r{^/*}, "")
 
         @repo_contents ||= {}
-        @repo_contents[dir] ||= _fetch_repo_contents(
-          path,
-          raise_errors: raise_errors,
-          fetch_submodules: fetch_submodules
-        )
+        @repo_contents[dir] ||= if repo_contents_path
+                                  _cloned_repo_contents(path)
+                                else
+                                  _fetch_repo_contents(path, raise_errors: raise_errors,
+                                                             fetch_submodules: fetch_submodules)
+                                end
       end
 
       #################################################
@@ -223,6 +224,22 @@ module Dependabot
         end
 
         github_response.map { |f| _build_github_file_struct(f) }
+      end
+
+      def _cloned_repo_contents(relative_path)
+        repo_path = File.join(clone_repo_contents, relative_path)
+        return [] unless Dir.exist?(repo_path)
+
+        Dir.entries(repo_path).map do |name|
+          next if [".", ".."].include?(name)
+
+          OpenStruct.new(
+            name: name,
+            path: Pathname.new(File.join(relative_path, name)).cleanpath.to_path,
+            type: Dir.exist?(File.join(repo_path, name)) ? "dir" : "file",
+            size: 0 # NOTE: added for parity with github contents API
+          )
+        end.compact
       end
 
       def update_linked_paths(repo, path, commit, github_response)

--- a/terraform/lib/dependabot/terraform/file_fetcher.rb
+++ b/terraform/lib/dependabot/terraform/file_fetcher.rb
@@ -9,6 +9,9 @@ module Dependabot
     class FileFetcher < Dependabot::FileFetchers::Base
       include FileSelector
 
+      # https://www.terraform.io/docs/language/modules/sources.html#local-paths
+      LOCAL_PATH_SOURCE = %r{source\s*=\s*['"](?<path>..?\/[^'"]+)}.freeze
+
       def self.required_files_in?(filenames)
         filenames.any? { |f| f.end_with?(".tf", ".hcl") }
       end
@@ -23,6 +26,7 @@ module Dependabot
         fetched_files = []
         fetched_files += terraform_files
         fetched_files += terragrunt_files
+        fetched_files += local_path_module_files(terraform_files)
         fetched_files += [lock_file] if lock_file
 
         return fetched_files if fetched_files.any?
@@ -45,6 +49,35 @@ module Dependabot
           repo_contents(raise_errors: false).
           select { |f| f.type == "file" && terragrunt_file?(f.name) }.
           map { |f| fetch_file_from_host(f.name) }
+      end
+
+      def local_path_module_files(files, dir: ".")
+        terraform_files = []
+
+        files.each do |file|
+          terraform_file_local_module_details(file).each do |path|
+            base_path = Pathname.new(File.join(dir, path)).cleanpath.to_path
+            nested_terraform_files =
+              repo_contents(dir: base_path).
+              select { |f| f.type == "file" && f.name.end_with?(".tf") }.
+              map { |f| fetch_file_from_host(File.join(base_path, f.name)) }
+            terraform_files += nested_terraform_files
+            terraform_files += local_path_module_files(nested_terraform_files, dir: path)
+          end
+        end
+
+        # NOTE: The `support_file` attribute is not used but we set this to
+        # match what we do in other ecosystems
+        terraform_files.tap { |fs| fs.each { |f| f.support_file = true } }
+      end
+
+      def terraform_file_local_module_details(file)
+        return [] unless file.name.end_with?(".tf")
+        return [] unless file.content.match?(LOCAL_PATH_SOURCE)
+
+        file.content.scan(LOCAL_PATH_SOURCE).flatten.map do |path|
+          Pathname.new(path).cleanpath.to_path
+        end
       end
 
       def lock_file

--- a/terraform/spec/dependabot/terraform/file_fetcher_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_fetcher_spec.rb
@@ -14,68 +14,30 @@ RSpec.describe Dependabot::Terraform::FileFetcher do
       directory: directory
     )
   end
+
   let(:file_fetcher_instance) do
-    described_class.new(source: source, credentials: credentials)
+    described_class.new(source: source, credentials: [], repo_contents_path: repo_contents_path)
   end
+
+  let(:project_name) { "provider" }
   let(:directory) { "/" }
-  let(:github_url) { "https://api.github.com/" }
-  let(:url) { github_url + "repos/gocardless/bump/contents/" }
-  let(:credentials) do
-    [{
-      "type" => "git_source",
-      "host" => "github.com",
-      "username" => "x-access-token",
-      "password" => "token"
-    }]
+  let(:repo_contents_path) { build_tmp_repo(project_name) }
+
+  after do
+    FileUtils.rm_rf(repo_contents_path)
   end
 
-  before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
-
-  context "with a Terraform file" do
-    before do
-      stub_request(:get, url + "?ref=sha").
-        with(headers: { "Authorization" => "token token" }).
-        to_return(
-          status: 200,
-          body: fixture("github", "contents_terraform_repo.json"),
-          headers: { "content-type" => "application/json" }
-        )
-
-      %w(main.tf outputs.tf variables.tf).each do |nm|
-        stub_request(:get, File.join(url, "#{nm}?ref=sha")).
-          with(headers: { "Authorization" => "token token" }).
-          to_return(
-            status: 200,
-            body: fixture("github", "contents_terraform_file.json"),
-            headers: { "content-type" => "application/json" }
-          )
-      end
-    end
+  context "with Terraform files" do
+    let(:project_name) { "versions_file" }
 
     it "fetches the Terraform files" do
       expect(file_fetcher_instance.files.map(&:name)).
-        to match_array(%w(main.tf outputs.tf variables.tf))
+        to match_array(%w(main.tf versions.tf))
     end
   end
 
   context "with a HCL based terragrunt file" do
-    before do
-      stub_request(:get, url + "?ref=sha").
-        with(headers: { "Authorization" => "token token" }).
-        to_return(
-          status: 200,
-          body: fixture("github", "contents_terragrunt_hcl_repo.json"),
-          headers: { "content-type" => "application/json" }
-        )
-
-      stub_request(:get, File.join(url, "terragrunt.hcl?ref=sha")).
-        with(headers: { "Authorization" => "token token" }).
-        to_return(
-          status: 200,
-          body: fixture("github", "contents_terraform_file.json"),
-          headers: { "content-type" => "application/json" }
-        )
-    end
+    let(:project_name) { "terragrunt_hcl" }
 
     it "fetches the Terragrunt file" do
       expect(file_fetcher_instance.files.map(&:name)).
@@ -84,23 +46,7 @@ RSpec.describe Dependabot::Terraform::FileFetcher do
   end
 
   context "with a lockfile" do
-    before do
-      stub_request(:get, url + "?ref=sha").
-        with(headers: { "Authorization" => "token token" }).
-        to_return(
-          status: 200,
-          body: fixture("github", "contents_lockfile_repo.json"),
-          headers: { "content-type" => "application/json" }
-        )
-
-      stub_request(:get, File.join(url, ".terraform.lock.hcl?ref=sha")).
-        with(headers: { "Authorization" => "token token" }).
-        to_return(
-          status: 200,
-          body: fixture("github", "contents_terraform_file.json"),
-          headers: { "content-type" => "application/json" }
-        )
-    end
+    let(:project_name) { "terraform_lock_only" }
 
     it "fetches the lockfile" do
       expect(file_fetcher_instance.files.map(&:name)).
@@ -111,19 +57,22 @@ RSpec.describe Dependabot::Terraform::FileFetcher do
   context "with a directory that doesn't exist" do
     let(:directory) { "/nonexistent" }
 
-    before do
-      stub_request(:get, url + "nonexistent?ref=sha").
-        with(headers: { "Authorization" => "token token" }).
-        to_return(
-          status: 404,
-          body: fixture("github", "not_found.json"),
-          headers: { "content-type" => "application/json" }
-        )
-    end
-
     it "raises a helpful error" do
       expect { file_fetcher_instance.files }.
         to raise_error(Dependabot::DependencyFileNotFound)
+    end
+  end
+
+  context "when fetching nested local path modules" do
+    let(:project_name) { "provider_with_multiple_local_path_modules" }
+
+    it "fetches nested terraform files" do
+      expect(file_fetcher_instance.files.map(&:name)).
+        to match_array(
+          %w(.terraform.lock.hcl loader.tf providers.tf
+             loader/providers.tf loader/projects.tf
+             loader/project/providers.tf)
+        )
     end
   end
 end

--- a/terraform/spec/fixtures/projects/provider_with_multiple_local_path_modules/.terraform.lock.hcl
+++ b/terraform/spec/fixtures/projects/provider_with_multiple_local_path_modules/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/mongey/confluentcloud" {
+  version     = "0.0.6"
+  constraints = "0.0.6"
+  hashes = [
+    "h1:58+/tSkeRBILHm2Zjn+JGAKEAuORY4M/2CjxSjbNta0=",
+    "zh:1f5825ddd293be02517e2939e0063b00a460e0ccfb358263f366d47f4df4e283",
+    "zh:5213a30d49f466c4a60d3761a0a26f3b39bd27618c2ccda0ce8342d140747f3b",
+    "zh:647a0a2ca713b1151ce5a312dd6afa0ab1db0d98f077b3fecb3a52c4dd932b16",
+    "zh:71426dba630762ec5436335d218b45c7489ba626845c3889cf1a8a9e32ec8e5f",
+    "zh:7f023157190bdc2c0e095584fadc5d2f8b57b7f3e760be5408b91e4a6a9824c4",
+    "zh:b402470663e27d9f199ca57bd86b2a9db947f43efd703c770cd7829531c43ff5",
+    "zh:ce82a2580ddee49affdf56d488b456e73da8323586630c63c62b3d087f4ceb29",
+    "zh:d164ab6209b8a68e3fd03fe9d820b2a246b47ae42063efcb53194a157dc3f2cc",
+    "zh:f3e085b537c5842a7a88cb98c7985789a43bd8c349bb2ba1acf1110377640094",
+    "zh:f9ea5fcd51718d921753736bd0ff3816c3c1a36a74aa5093e347eae3d3c3ecd2",
+  ]
+}

--- a/terraform/spec/fixtures/projects/provider_with_multiple_local_path_modules/loader.tf
+++ b/terraform/spec/fixtures/projects/provider_with_multiple_local_path_modules/loader.tf
@@ -1,0 +1,3 @@
+module "loader" {
+  source = "./loader"
+}

--- a/terraform/spec/fixtures/projects/provider_with_multiple_local_path_modules/loader/project/providers.tf
+++ b/terraform/spec/fixtures/projects/provider_with_multiple_local_path_modules/loader/project/providers.tf
@@ -1,0 +1,1 @@
+../providers.tf

--- a/terraform/spec/fixtures/projects/provider_with_multiple_local_path_modules/loader/projects.tf
+++ b/terraform/spec/fixtures/projects/provider_with_multiple_local_path_modules/loader/projects.tf
@@ -1,0 +1,3 @@
+module "project" {
+  source = "./project"
+}

--- a/terraform/spec/fixtures/projects/provider_with_multiple_local_path_modules/loader/providers.tf
+++ b/terraform/spec/fixtures/projects/provider_with_multiple_local_path_modules/loader/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    confluentcloud = {
+      source  = "Mongey/confluentcloud"
+      version = "0.0.6"
+    }
+  }
+}

--- a/terraform/spec/fixtures/projects/provider_with_multiple_local_path_modules/providers.tf
+++ b/terraform/spec/fixtures/projects/provider_with_multiple_local_path_modules/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    confluentcloud = {
+      source  = "Mongey/confluentcloud"
+      version = "0.0.6"
+    }
+  }
+}


### PR DESCRIPTION
Add support for fetching and updating local path modules:

```
module "project" {
  source = "./project"
}
```

Terraform will resolve all local path modules when updating the
lockfile, so we need to make sure all requirements for the same
dependency have been updated, and written to the temporary directory
before we run `terraform providers lock _provider_`.

This also updates the file fetcher to not make an api request when
checking folder contents.

Fixes: https://github.com/dependabot/dependabot-core/issues/4043