### PR TITLE
Terraform: ignore symlinks in file fetcher

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -233,10 +233,19 @@ module Dependabot
         Dir.entries(repo_path).map do |name|
           next if [".", ".."].include?(name)
 
+          absolute_path = File.join(repo_path, name)
+          type = if File.symlink?(absolute_path)
+                   "symlink"
+                 elsif Dir.exist?(absolute_path)
+                   "dir"
+                 else
+                   "file"
+                 end
+
           OpenStruct.new(
             name: name,
             path: Pathname.new(File.join(relative_path, name)).cleanpath.to_path,
-            type: Dir.exist?(File.join(repo_path, name)) ? "dir" : "file",
+            type: type,
             size: 0 # NOTE: added for parity with github contents API
           )
         end.compact

--- a/terraform/spec/dependabot/terraform/file_fetcher_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_fetcher_spec.rb
@@ -66,12 +66,11 @@ RSpec.describe Dependabot::Terraform::FileFetcher do
   context "when fetching nested local path modules" do
     let(:project_name) { "provider_with_multiple_local_path_modules" }
 
-    it "fetches nested terraform files" do
+    it "fetches nested terraform files excluding symlinks" do
       expect(file_fetcher_instance.files.map(&:name)).
         to match_array(
           %w(.terraform.lock.hcl loader.tf providers.tf
-             loader/providers.tf loader/projects.tf
-             loader/project/providers.tf)
+             loader/providers.tf loader/projects.tf)
         )
     end
   end


### PR DESCRIPTION
Fix a bug with symlinks being fetched in the file fetcher, resulting in
attempted updates to these files, which fail when creating a pull
request.