### PR TITLE
bundler: optimize gemfile parsing

### DIFF
--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -60,17 +60,17 @@ module Dependabot
         return dependencies unless gemfile
 
         [gemfile, *evaled_gemfiles].each do |file|
+          gemfile_declaration_finder = GemfileDeclarationFinder.new(gemfile: file)
+
           parsed_gemfile.each do |dep|
-            gemfile_declaration_finder =
-              GemfileDeclarationFinder.new(dependency: dep, gemfile: file)
-            next unless gemfile_declaration_finder.gemfile_includes_dependency?
+            next unless gemfile_declaration_finder.gemfile_includes_dependency?(dep)
 
             dependencies <<
               Dependency.new(
                 name: dep.fetch("name"),
                 version: dependency_version(dep.fetch("name"))&.to_s,
                 requirements: [{
-                  requirement: gemfile_declaration_finder.enhanced_req_string,
+                  requirement: gemfile_declaration_finder.enhanced_req_string(dep),
                   groups: dep.fetch("groups").map(&:to_sym),
                   source: dep.fetch("source")&.transform_keys(&:to_sym),
                   file: file.name

--- a/bundler/lib/dependabot/bundler/file_parser/gemfile_declaration_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_parser/gemfile_declaration_finder.rb
@@ -8,20 +8,20 @@ module Dependabot
     class FileParser
       # Checks whether a dependency is declared in a Gemfile
       class GemfileDeclarationFinder
-        def initialize(dependency:, gemfile:)
-          @dependency = dependency
+        def initialize(gemfile:)
           @gemfile = gemfile
+          @declaration_nodes = {}
         end
 
-        def gemfile_includes_dependency?
-          !declaration_node.nil?
+        def gemfile_includes_dependency?(dependency)
+          !declaration_node(dependency).nil?
         end
 
-        def enhanced_req_string
-          return unless gemfile_includes_dependency?
+        def enhanced_req_string(dependency)
+          return unless gemfile_includes_dependency?(dependency)
 
           fallback_string = dependency.fetch("requirement")
-          req_nodes = declaration_node.children[3..-1]
+          req_nodes = declaration_node(dependency).children[3..-1]
           req_nodes = req_nodes.reject { |child| child.type == :hash }
 
           return fallback_string if req_nodes.none?
@@ -39,31 +39,35 @@ module Dependabot
 
         private
 
-        attr_reader :dependency, :gemfile
+        attr_reader :gemfile
 
-        def declaration_node
-          return @declaration_node if defined?(@declaration_node)
-          return unless Parser::CurrentRuby.parse(gemfile.content)
-
-          @declaration_node = nil
-          Parser::CurrentRuby.parse(gemfile.content).children.any? do |node|
-            @declaration_node = deep_search_for_gem(node)
-          end
-          @declaration_node
+        def parsed_gemfile
+          @parsed_gemfile ||= Parser::CurrentRuby.parse(gemfile.content)
         end
 
-        def deep_search_for_gem(node)
-          return node if declares_targeted_gem?(node)
+        def declaration_node(dependency)
+          return @declaration_nodes[dependency] if @declaration_nodes.key?(dependency)
+          return unless parsed_gemfile
+
+          @declaration_nodes[dependency] = nil
+          parsed_gemfile.children.any? do |node|
+            @declaration_nodes[dependency] = deep_search_for_gem(node, dependency)
+          end
+          @declaration_nodes[dependency]
+        end
+
+        def deep_search_for_gem(node, dependency)
+          return node if declares_targeted_gem?(node, dependency)
           return unless node.is_a?(Parser::AST::Node)
 
           declaration_node = nil
           node.children.find do |child_node|
-            declaration_node = deep_search_for_gem(child_node)
+            declaration_node = deep_search_for_gem(child_node, dependency)
           end
           declaration_node
         end
 
-        def declares_targeted_gem?(node)
+        def declares_targeted_gem?(node, dependency)
           return false unless node.is_a?(Parser::AST::Node)
           return false unless node.children[1] == :gem
 

--- a/bundler/spec/dependabot/bundler/file_parser/gemfile_declaration_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser/gemfile_declaration_finder_spec.rb
@@ -7,7 +7,7 @@ require "dependabot/bundler/file_parser/gemfile_declaration_finder"
 
 RSpec.describe Dependabot::Bundler::FileParser::GemfileDeclarationFinder do
   let(:checker) do
-    described_class.new(dependency: dependency, gemfile: gemfile)
+    described_class.new(gemfile: gemfile)
   end
 
   let(:dependency) do
@@ -25,7 +25,7 @@ RSpec.describe Dependabot::Bundler::FileParser::GemfileDeclarationFinder do
 
   describe "#gemfile_includes_dependency?" do
     subject(:gemfile_includes_dependency) do
-      checker.gemfile_includes_dependency?
+      checker.gemfile_includes_dependency?(dependency)
     end
 
     context "when the file does not include the dependency" do
@@ -61,7 +61,7 @@ RSpec.describe Dependabot::Bundler::FileParser::GemfileDeclarationFinder do
   end
 
   describe "#enhanced_req_string" do
-    subject(:enhanced_req_string) { checker.enhanced_req_string }
+    subject(:enhanced_req_string) { checker.enhanced_req_string(dependency) }
 
     context "when the file does not include the dependency" do
       let(:dependency_name) { "dependabot-core" }


### PR DESCRIPTION
# Summary
After profiling `FileParser#parse` for bundler, I found that the ruby
Parser was extremely hot. The same Gemfile was being parsed twice for
each dependency, when it only needed to be parsed a single time per
file.

The performance improvement depends on the size of the Gemfile being
parsed, but the following example shows the speedup for the
[discourse/discourse](https://github.com/discourse/discourse) repo.

Before:
```
Warming up --------------------------------------
               parse     1.000  i/100ms
Calculating -------------------------------------
               parse      0.121  (± 0.0%) i/s -   1.000  in   8.262804s
```

After:
```
Warming up --------------------------------------
               parse     1.000  i/100ms
Calculating -------------------------------------
               parse      6.319  (±15.8%) i/s -  32.000  in   5.099269s
```

# Other Information

I wasn't sure what the policy around breaking API changes was, especially for a relatively internal class like `GemfileDeclarationFinder`. Any feedback would be appreciated, I believe I can accomplish something similar without breaking the method signatures if necessary.

## Benchmark Script
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "dependabot-common", path: "./common"
  gem "dependabot-bundler", path: "./bundler"
  gem "benchmark-ips"
  # This was helping some DNS issues I was having but is optional
  gem "resolv-replace"
end

package_manager = "bundler"
repo_name = "discourse/discourse"

credentials = [
  {
    "type" => "git_source",
    "host" => "github.com",
    "username" => "x-access-token",
    "password" => ENV["GITHUB_ACCESS_TOKEN"] # A GitHub access token with read access to public repos
  }
]

source = Dependabot::Source.new(
  provider: "github",
  repo: repo_name,
  directory: "/",
)

puts "Fetching #{package_manager} dependency files for #{repo_name}"
fetcher = Dependabot::FileFetchers.for_package_manager(package_manager).new(
  source: source,
  credentials: credentials,
)

puts "Parsing dependencies information"
parser = Dependabot::FileParsers.for_package_manager(package_manager).new(
  dependency_files: fetcher.files,
  source: source,
  credentials: credentials,
)

Benchmark.ips do |x|
  x.report("parse") { parser.parse }
  x.compare!
end
```
