### PR TITLE
dry-run: earlier next when dependency up to date

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -613,6 +613,11 @@ dependencies.each do |dep|
   puts " => checking for updates #{checker_count}/#{dependencies.count}"
   puts " => latest available version is #{checker.latest_version}"
 
+  if checker.up_to_date?
+    puts "    (no update needed as it's already up-to-date)"
+    next
+  end
+
   if $options[:security_updates_only] && !checker.vulnerable?
     if checker.version_class.correct?(checker.dependency.version)
       puts "    (no security update needed as it's not vulnerable)"
@@ -648,11 +653,6 @@ dependencies.each do |dep|
     conflicting_dependencies.each do |conflicting_dep|
       puts "   #{conflicting_dep['explanation']}"
     end
-  end
-
-  if checker.up_to_date?
-    puts "    (no update needed as it's already up-to-date)"
-    next
   end
 
   requirements_to_unlock =


### PR DESCRIPTION
# Summary

The dry run script currently does a lot of unnecessary work checking
vulnerability status and checking sub dependencies when a dependency is
already on the latest version. This commit moves the check for a
dependency being up to date immediately after fetching the latest
version so that the unnecessary work is skipped.

This also aligns the behavior with dependabot-script:
https://github.com/dependabot/dependabot-script/blob/4330ff7043b6fe2bb009005e2f5b0ca9985f32f2/generic-update-script.rb#L179

Before:
```
$ time bin/dry-run.rb bundler discourse/discourse
real    43m9.203s
user    41m10.464s
sys     1m47.502s
```

After:
```
$ time bin/dry-run.rb bundler discourse/discourse
real    22m48.066s
user    21m36.573s
sys     0m52.919s
```