### PR TITLE
Upgrade elixir to v1.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,8 +187,8 @@ RUN cd /tmp \
 # Install Erlang, Elixir and Hex
 ENV PATH="$PATH:/usr/local/elixir/bin"
 # https://github.com/elixir-lang/elixir/releases
-ARG ELIXIR_VERSION=v1.11.4
-ARG ELIXIR_CHECKSUM=4d8ead533a7bd35b41669be0d4548b612d5cc17723da67cfdf996ab36522fd0163215915a970675c6ebcba4dbfc7a46e644cb144b16087bc9417b385955a1e79
+ARG ELIXIR_VERSION=v1.12.2
+ARG ELIXIR_CHECKSUM=38eb2281032b0cb096ef5e61f048c5374d6fb9bf4078ab8f9526a42e16e7c661732a632b55d6072328eedf87a47e6eeb3f0e3f90bba1086239c71350f90c75e5
 ARG ERLANG_VERSION=1:23.3.1-1
 RUN curl -sSLfO https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
   && dpkg -i erlang-solutions_1.0_all.deb \


### PR DESCRIPTION
This was previously done here: https://github.com/dependabot/dependabot-core/pull/4089

But that was reverted after being released due to an issue with the
erlang upgrade in that PR. This bumps only the elixir version, which
should be safe.