### PR TITLE
v0.157.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.157.1, 27 July 2021
+
+- Upgrade elixir to v1.12.2 [#4093](https://github.com/dependabot/dependabot-core/pull/4093)
+- Revert "Elixir version upgrades" [#4091](https://github.com/dependabot/dependabot-core/pull/4091)
+
 ## v0.157.0, 26 July 2021
 
 - Elixir version upgrades (@baseballlover723) [#4089](https://github.com/dependabot/dependabot-core/pull/4089)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.157.0"
+  VERSION = "0.157.1"
 end


### PR DESCRIPTION
- Upgrade elixir to v1.12.2 [#4093](https://github.com/dependabot/dependabot-core/pull/4093)
- Revert "Elixir version upgrades" [#4091](https://github.com/dependabot/dependabot-core/pull/4091)

Functionally this only reverts the erlang/otp upgrade from 0.157.0