### PR TITLE
fix(terraform): exclude path source types in update check

### DIFF
--- a/terraform/lib/dependabot/terraform/update_checker.rb
+++ b/terraform/lib/dependabot/terraform/update_checker.rb
@@ -11,6 +11,8 @@ require "dependabot/terraform/registry_client"
 module Dependabot
   module Terraform
     class UpdateChecker < Dependabot::UpdateCheckers::Base
+      ELIGIBLE_SOURCE_TYPES = %w(git provider registry).freeze
+
       def latest_version
         return latest_version_for_git_dependency if git_dependency?
         return latest_version_for_registry_dependency if registry_dependency?
@@ -175,8 +177,7 @@ module Dependabot
       end
 
       def dependency_source_details
-        sources =
-          dependency.requirements.map { |r| r.fetch(:source) }.uniq.compact
+        sources = eligible_sources_from(dependency.requirements)
 
         raise "Multiple sources! #{sources.join(', ')}" if sources.count > 1
 
@@ -197,6 +198,13 @@ module Dependabot
             requirement_class: Requirement,
             version_class: Version
           )
+      end
+
+      def eligible_sources_from(requirements)
+        requirements.
+          map { |r| r.fetch(:source) }.
+          find_all { |x| ELIGIBLE_SOURCE_TYPES.include?(x[:type].to_s) }.
+          uniq.compact
       end
     end
   end

--- a/terraform/lib/dependabot/terraform/update_checker.rb
+++ b/terraform/lib/dependabot/terraform/update_checker.rb
@@ -203,7 +203,7 @@ module Dependabot
       def eligible_sources_from(requirements)
         requirements.
           map { |r| r.fetch(:source) }.
-          find_all { |x| ELIGIBLE_SOURCE_TYPES.include?(x[:type].to_s) }.
+          select { |source| ELIGIBLE_SOURCE_TYPES.include?(source[:type].to_s) }.
           uniq.compact
       end
     end

--- a/terraform/spec/dependabot/terraform/update_checker_spec.rb
+++ b/terraform/spec/dependabot/terraform/update_checker_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe Dependabot::Terraform::UpdateChecker do
   describe "#latest_version" do
     subject { checker.latest_version }
 
+    context "with multiple file sources" do
+      let(:requirements) do
+        [
+          { file: "./modules/main.tf", source: { type: "path", url: "./modules" }, requirement: nil, groups: [] },
+          { file: "main.tf", source: { type: "path", url: "./" }, requirement: nil, groups: [] }
+        ]
+      end
+
+      it "ignores the dependencies with file sources" do
+        expect(subject).to be_nil
+      end
+    end
+
     context "with a git dependency" do
       let(:source) do
         {


### PR DESCRIPTION
# Why is this needed?

To skip performing update checks on Terraform dependencies that have a source
type of 'path'.

## What does this do?

This adds an allow list of eligible source types that can be used for update
checks.

xref: https://github.com/github/dependabot-updates/issues/1668

Before:

```bash
[dependabot-core-dev] ~/dependabot-core $ bin/dry-run.rb terraform "plus3it/terraform-aws-ldap-maintainer" --dir="/." --commit=151a9b745a7e0eec3888e26886e214e174e71f68 --cache=files
warning: parser/current is loading parser/ruby27, which recognizes
warning: 2.7.4-compliant syntax, but you are running 2.7.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> reading cloned repo from /home/dependabot/dependabot-core/tmp/plus3it/terraform-aws-ldap-maintainer
=> checking out commit 151a9b745a7e0eec3888e26886e214e174e71f68
=> parsing dependency files
=> updating 8 dependencies: api_gateway, dynamodb_cleanup, lambda, lambda_layer, ldap_query_lambda, slack_bot, slack_event_listener, slack_notifier

=== api_gateway ()
 => checking for updates 1/8
Traceback (most recent call last):
        5: from bin/dry-run.rb:606:in `<main>'
        4: from bin/dry-run.rb:606:in `each'
        3: from bin/dry-run.rb:614:in `block in <main>'
        2: from /home/dependabot/dependabot-core/terraform/lib/dependabot/terraform/update_checker.rb:18:in `latest_version'
        1: from /home/dependabot/dependabot-core/terraform/lib/dependabot/terraform/update_checker.rb:168:in `registry_dependency?'
/home/dependabot/dependabot-core/terraform/lib/dependabot/terraform/update_checker.rb:182:in `dependency_source_details': Multiple sources! {:type=>"path", :url=>"./modules/api_gateway"}, {:type=>"path", :url=>"./api_gateway"} (RuntimeError)
```

After:

```bash
[dependabot-core-dev] ~/dependabot-core $ bin/dry-run.rb terraform "plus3it/terraform-aws-ldap-maintainer" --dir="/." --commit=151a9b745a7e0eec3888e26886e214e174e71f68 --cache=files
warning: parser/current is loading parser/ruby27, which recognizes
warning: 2.7.4-compliant syntax, but you are running 2.7.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> reading cloned repo from /home/dependabot/dependabot-core/tmp/plus3it/terraform-aws-ldap-maintainer
=> checking out commit 151a9b745a7e0eec3888e26886e214e174e71f68
=> parsing dependency files
=> updating 8 dependencies: api_gateway, dynamodb_cleanup, lambda, lambda_layer, ldap_query_lambda, slack_bot, slack_event_listener, slack_notifier

=== api_gateway ()
 => checking for updates 1/8
 => latest available version is
 => latest allowed version is
    (no update needed as it's already up-to-date)

=== dynamodb_cleanup ()
 => checking for updates 2/8
 => latest available version is
 => latest allowed version is
    (no update needed as it's already up-to-date)

=== lambda ()
 => checking for updates 3/8
 => latest available version is c86bc201caff0d45c7963a002a7a0c5b49f720d6
 => latest allowed version is c86bc201caff0d45c7963a002a7a0c5b49f720d6
    (no update needed as it's already up-to-date)

=== lambda_layer (2.7.0)
 => checking for updates 4/8
 => latest available version is 2.7.0
 => latest allowed version is 2.7.0
    (no update needed as it's already up-to-date)

=== ldap_query_lambda ()
 => checking for updates 5/8
 => latest available version is
 => latest allowed version is
    (no update needed as it's already up-to-date)

=== slack_bot ()
 => checking for updates 6/8
 => latest available version is
 => latest allowed version is
    (no update needed as it's already up-to-date)

=== slack_event_listener ()
 => checking for updates 7/8
 => latest available version is
 => latest allowed version is
    (no update needed as it's already up-to-date)

=== slack_notifier ()
 => checking for updates 8/8
 => latest available version is
 => latest allowed version is
    (no update needed as it's already up-to-date)
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
