### PR TITLE
Terraform: Pin fixture to range to prevent tests failing

### DIFF
--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -1064,7 +1064,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
             version: "0.0.11",
             previous_version: "0.0.6",
             requirements: [{
-              requirement: ">= 0.0.11",
+              requirement: ">= 0.0.11, < 0.0.12",
               groups: [],
               file: "providers.tf",
               source: {
@@ -1074,7 +1074,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
               }
             }],
             previous_requirements: [{
-              requirement: ">= 0.0.6",
+              requirement: ">= 0.0.6, < 0.0.12",
               groups: [],
               file: "providers.tf",
               source: {

--- a/terraform/spec/fixtures/projects/provider_with_mixed_case/providers.tf
+++ b/terraform/spec/fixtures/projects/provider_with_mixed_case/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     confluentcloud = {
       source  = "Mongey/confluentcloud"
-      version = ">= 0.0.6"
+      version = ">= 0.0.6, < 0.0.12"
     }
   }
 }


### PR DESCRIPTION
This test was currently set up in a way that caused new releases of
Mongey/confluentcloud to make our tests fail. Now we pin it to a range,
in line with other tests