### PR TITLE
Skip classifier when checking for internal dep

### DIFF
--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -88,6 +88,9 @@ module Dependabot
         return unless (name = dependency_name(dependency_node, pom))
         return if internal_dependency_names.include?(name)
 
+        classifier = dependency_classifier(dependency_node, pom)
+        name = classifier ? "#{name}:#{classifier}" : name
+
         build_dependency(pom, dependency_node, name)
       end
 
@@ -125,7 +128,7 @@ module Dependabot
         return unless dependency_node.at_xpath("./groupId")
         return unless dependency_node.at_xpath("./artifactId")
 
-        name = [
+        [
           evaluated_value(
             dependency_node.at_xpath("./groupId").content.strip,
             pom
@@ -135,15 +138,15 @@ module Dependabot
             pom
           )
         ].join(":")
+      end
 
-        if dependency_node.at_xpath("./classifier")
-          name += ":#{evaluated_value(
-            dependency_node.at_xpath('./classifier').content.strip,
-            pom
-          )}"
-        end
+      def dependency_classifier(dependency_node, pom)
+        return unless dependency_node.at_xpath("./classifier")
 
-        name
+        evaluated_value(
+          dependency_node.at_xpath("./classifier").content.strip,
+          pom
+        )
       end
 
       def plugin_name(dependency_node, pom)

--- a/maven/spec/fixtures/poms/multimodule_pom.xml
+++ b/maven/spec/fixtures/poms/multimodule_pom.xml
@@ -49,6 +49,12 @@
                 <artifactId>util</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>net.evenh.multimodule</groupId>
+                <artifactId>util</artifactId>
+                <version>${project.version}</version>
+                <classifier>sources</classifier>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
When building up the list of internal dependencies, it is not possible
to know the classifiers, so we skip appending classifier to a dependency
name when checking whether it is an internal dependency or not.

The details of this proposed change is described by https://github.com/dependabot/dependabot-core/pull/1924#issuecomment-891981747https://github.com/dependabot/dependabot-core/pull/1924#issuecomment-891981747