### PR TITLE
Improve argument sanitation

### DIFF
--- a/common/lib/dependabot/git_metadata_fetcher.rb
+++ b/common/lib/dependabot/git_metadata_fetcher.rb
@@ -94,8 +94,9 @@ module Dependabot
       service_pack_uri = uri
       service_pack_uri += ".git" unless service_pack_uri.end_with?(".git")
 
-      command = "git ls-remote #{service_pack_uri}"
       env = { "PATH" => ENV["PATH"] }
+      command = "git ls-remote #{service_pack_uri}"
+      command = SharedHelpers.escape_command(command)
 
       stdout, stderr, process = Open3.capture3(env, command)
       # package the command response like a HTTP response so error handling

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -172,6 +172,8 @@ module Dependabot
             version = "v" + dep.version.sub(/^v/i, "")
             command << " #{dep.name}@#{version}"
           end
+          command = SharedHelpers.escape_command(command)
+
           _, stderr, status = Open3.capture3(ENVIRONMENT, command)
           handle_subprocess_error(stderr) unless status.success?
         ensure


### PR DESCRIPTION
More consistent use of `SharedHelpers.escape_command` on args.