### PR TITLE
Bump bundler from 2.2.20 to 2.2.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN apt-add-repository ppa:brightbox/ruby-ng \
   && apt-get install -y --no-install-recommends ruby2.7 ruby2.7-dev \
   && gem update --system 3.2.20 \
   && gem install bundler -v 1.17.3 --no-document \
-  && gem install bundler -v 2.2.20 --no-document \
+  && gem install bundler -v 2.2.26 --no-document \
   && rm -rf /var/lib/gems/2.7.0/cache/* \
   && rm -rf /var/lib/apt/lists/*
 

--- a/bundler/helpers/v1/build
+++ b/bundler/helpers/v1/build
@@ -20,6 +20,6 @@ cd "$install_dir"
 
 # NOTE: Sets `BUNDLED WITH` to match the installed v1 version in Gemfile.lock
 # forcing native helpers to run with the same version
-BUNDLER_VERSION=1 bundle config set --local path ".bundle"
-BUNDLER_VERSION=1 bundle config set --local without "test"
-BUNDLER_VERSION=1 bundle install
+BUNDLER_VERSION=1.17.3 bundle config set --local path ".bundle"
+BUNDLER_VERSION=1.17.3 bundle config set --local without "test"
+BUNDLER_VERSION=1.17.3 bundle install

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -20,6 +20,6 @@ cd "$install_dir"
 
 # NOTE: Sets `BUNDLED WITH` to match the installed v2 version in Gemfile.lock
 # forcing specs and native helpers to run with the same version
-BUNDLER_VERSION=2 bundle config set --local path ".bundle"
-BUNDLER_VERSION=2 bundle config set --local without "test"
-BUNDLER_VERSION=2 bundle install
+BUNDLER_VERSION=2.2.26 bundle config set --local path ".bundle"
+BUNDLER_VERSION=2.2.26 bundle config set --local without "test"
+BUNDLER_VERSION=2.2.26 bundle install

--- a/bundler/helpers/v2/lib/functions/force_updater.rb
+++ b/bundler/helpers/v2/lib/functions/force_updater.rb
@@ -106,7 +106,7 @@ module Functions
         gemfile_name,
         lockfile_name,
         gems: gems_to_unlock + subdependencies,
-        lock_shared_dependencies: true
+        conservative: true
       )
 
       # Remove the Gemfile / gemspec requirements on the gems we're

--- a/bundler/helpers/v2/lib/functions/version_resolver.rb
+++ b/bundler/helpers/v2/lib/functions/version_resolver.rb
@@ -97,7 +97,7 @@ module Functions
         gemfile_name,
         lockfile_name,
         gems: dependencies_to_unlock,
-        lock_shared_dependencies: true
+        conservative: true
       )
     end
 

--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -3,8 +3,8 @@
 module Dependabot
   module Bundler
     module Helpers
-      V1 = "1"
-      V2 = "2"
+      V1 = "1.17.3"
+      V2 = "2.2.26"
       # If we are updating a project with no Gemfile.lock, we default to the
       # newest version we support
       DEFAULT = V2
@@ -31,7 +31,7 @@ module Dependabot
         if (matches = lockfile.content.match(BUNDLER_MAJOR_VERSION_REGEX))
           matches[:version]
         else
-          FAILOVER
+          "1"
         end
       end
     end

--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -8,17 +8,18 @@ module Dependabot
     module NativeHelpers
       def self.run_bundler_subprocess(function:, args:, bundler_version:)
         # Run helper suprocess with all bundler-related ENV variables removed
+        bundler_major_version = bundler_version.split(".").first
         ::Bundler.with_original_env do
           SharedHelpers.run_helper_subprocess(
-            command: helper_path(bundler_version: bundler_version),
+            command: helper_path(bundler_version: bundler_major_version),
             function: function,
             args: args,
             env: {
               # Bundler will pick the matching installed major version
               "BUNDLER_VERSION" => bundler_version,
-              "BUNDLE_GEMFILE" => File.join(versioned_helper_path(bundler_version: bundler_version), "Gemfile"),
+              "BUNDLE_GEMFILE" => File.join(versioned_helper_path(bundler_version: bundler_major_version), "Gemfile"),
               # Prevent the GEM_HOME from being set to a folder owned by root
-              "GEM_HOME" => File.join(versioned_helper_path(bundler_version: bundler_version), ".bundle")
+              "GEM_HOME" => File.join(versioned_helper_path(bundler_version: bundler_major_version), ".bundle")
             }
           )
         rescue SharedHelpers::HelperSubprocessFailed => e

--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -8,14 +8,14 @@ bundle exec rspec spec
 
 if [[ "$SUITE_NAME" == "bundler1" ]]; then
   cd helpers/v1 \
-    && BUNDLER_VERSION=1 bundle install \
-    && BUNDLER_VERSION=1 bundle exec rspec spec\
+    && BUNDLER_VERSION=1.17.3 bundle install \
+    && BUNDLER_VERSION=1.17.3 bundle exec rspec spec\
     && cd -
 fi
 
 if [[ "$SUITE_NAME" == "bundler2" ]]; then
   cd helpers/v2 \
-    && BUNDLER_VERSION=2 bundle install \
-    && BUNDLER_VERSION=2 bundle exec rspec spec \
+    && BUNDLER_VERSION=2.2.26 bundle install \
+    && BUNDLER_VERSION=2.2.26 bundle exec rspec spec \
     && cd -
 fi

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -759,7 +759,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
       parser.parse
 
       expect(events.last.payload).to eq(
-        { ecosystem: "bundler", package_managers: { "bundler" => PackageManagerHelper.bundler_version } }
+        { ecosystem: "bundler", package_managers: { "bundler" => PackageManagerHelper.bundler_major_version } }
       )
     end
   end

--- a/bundler/spec/dependabot/bundler/helper_spec.rb
+++ b/bundler/spec/dependabot/bundler/helper_spec.rb
@@ -40,29 +40,32 @@ RSpec.describe Dependabot::Bundler::Helpers do
     LOCKFILE
   end
 
+  let(:v1) { "1.17.3" }
+  let(:v2) { "2.2.26" }
+
   describe "#bundler_version" do
     def described_method(lockfile)
       described_class.bundler_version(lockfile)
     end
 
     it "is 2 if there is no lockfile" do
-      expect(described_method(no_lockfile)).to eql("2")
+      expect(described_method(no_lockfile)).to eql(v2)
     end
 
     it "is 1 if there is no bundled with string" do
-      expect(described_method(lockfile_bundled_with_missing)).to eql("1")
+      expect(described_method(lockfile_bundled_with_missing)).to eql(v1)
     end
 
     it "is 1 if it was bundled with a v1.x version" do
-      expect(described_method(lockfile_bundled_with_v1)).to eql("1")
+      expect(described_method(lockfile_bundled_with_v1)).to eql(v1)
     end
 
     it "is 2 if it was bundled with a v2.x version" do
-      expect(described_method(lockfile_bundled_with_v2)).to eql("2")
+      expect(described_method(lockfile_bundled_with_v2)).to eql(v2)
     end
 
     it "is 2 if it was bundled with a future version" do
-      expect(described_method(lockfile_bundled_with_future_version)).to eql("2")
+      expect(described_method(lockfile_bundled_with_future_version)).to eql(v2)
     end
   end
 

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -20,12 +20,16 @@ module PackageManagerHelper
   end
 
   def self.bundler_version
-    use_bundler_2? ? "2" : "1"
+    use_bundler_2? ? "2.2.26" : "1.17.3"
+  end
+
+  def self.bundler_major_version
+    bundler_version.split(".").first
   end
 end
 
 def bundler_project_dependency_files(project)
-  project_dependency_files(File.join("bundler#{PackageManagerHelper.bundler_version}", project))
+  project_dependency_files(File.join("bundler#{PackageManagerHelper.bundler_major_version}", project))
 end
 
 def bundler_project_dependency_file(project, filename:)


### PR DESCRIPTION
https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md#2225-july-30-2021

Something we _might_ get some support questions on is:
https://github.com/rubygems/rubygems/pull/4647 but overall I think
that's a very good change! The GEM sources not being split has bitten
our users in the past, so happy to see that change.

In a recent version of bundler, passing a major version like
`BUNDLER_VERSION=2 bundle --version` no longer works.

I suspect this may have happened here: https://github.com/rubygems/rubygems/pull/4750/files

We now need to pass the exact version of bundler we're using, which is a
bit cumbersome as you can see from the diff, and it also means we'll
have to change a few more lines every time we update a version of
bundler.

I don't think the current behavior we were relying on was documented, so
I'm not sure if we can open an issue with the Bundler team.

This seems like the most straight forward fix to me, but I am definitely
open to other suggestions