### PR TITLE
Ignore replaced dependencies

### DIFF
--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Dependabot::GoModules::FileParser do
         parser.parse.select(&:top_level?)
       end
 
-      its(:length) { is_expected.to eq(3) }
+      its(:length) { is_expected.to eq(2) }
 
       it "sets the package manager" do
         expect(dependencies.first.package_manager).to eq("go_modules")
@@ -127,6 +127,19 @@ RSpec.describe Dependabot::GoModules::FileParser do
             )
           end
         end
+      end
+    end
+
+    describe "a dependency that is replaced" do
+      subject(:dependency) do
+        dependencies.find { |d| d.name == "rsc.io/qr" }
+      end
+
+      it "has the right details" do
+        expect(dependency).to be_a(Dependabot::Dependency)
+        expect(dependency.name).to eq("rsc.io/qr")
+        expect(dependency.version).to eq("0.1.0")
+        expect(dependency.requirements).to eq([])
       end
     end
 


### PR DESCRIPTION
This pull request makes sure that replaced modules are not being updated. I saw this behavior with one of my own projects where Dependabot updated the original import directive, but since the dependency itself was replaced by another directive, the actual update had no effect. 

Basically the go.mod looked like this:

```
require (
	github.com/dghubble/oauth1 v0.6.0
)

replace github.com/dghubble/oauth1 => github.com/klippa-app/oauth1 v0.0.0-20190731095211-0d6b37cb52ba
```

And the PR that Dependabot created resulted in this:
```
-	github.com/dghubble/oauth1 v0.6.0
+	github.com/dghubble/oauth1 v0.7.0
```	

While technically correct, since that is the latest version of `github.com/dghubble/oauth1`, this PR doesn't do anything, since the import is replaced. I updated the `FileParser` to be aware of these situations, and it now mimics the behaviour of `go get -u`.