### PR TITLE
Fix failing go modules tests

### DIFF
--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -659,20 +659,6 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
           end
         end
       end
-
-      context "with github credentials" do
-        let(:credentials) { github_credentials }
-
-        it "raises the correct error" do
-          error_class = Dependabot::GitDependenciesNotReachable
-          expect { updater.updated_go_sum_content }.
-            to raise_error(error_class) do |error|
-            expect(error.message).to include("dependabot-fixtures/go-modules-private")
-            expect(error.dependency_urls).
-              to eq(["github.com/dependabot-fixtures/go-modules-private"])
-          end
-        end
-      end
     end
 
     context "with an unreachable sub-dependency" do

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
   let(:updater) do
     described_class.new(
       dependencies: [dependency],
-      credentials: empty_credentials,
+      credentials: credentials,
       repo_contents_path: repo_contents_path,
       directory: directory,
       options: { tidy: tidy, vendor: false }
@@ -22,7 +22,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
   let(:tidy) { true }
   let(:directory) { "/" }
 
-  let(:empty_credentials) { [] }
+  let(:credentials) { [] }
 
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -638,6 +638,25 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
           expect(error.message).to include("dependabot-fixtures/go-modules-private")
           expect(error.dependency_urls).
             to eq(["github.com/dependabot-fixtures/go-modules-private"])
+        end
+      end
+
+      context "with bad credentials" do
+        let(:credentials) do
+          [{
+            "type" => "git_source",
+            "host" => "github.com",
+            "username" => "x-access-token",
+            "password" => ""
+          }]
+        end
+
+        it "raises the correct error" do
+          error_class = Dependabot::PrivateSourceAuthenticationFailure
+          expect { updater.updated_go_sum_content }.
+            to raise_error(error_class) do |error|
+            expect(error.message).to include("dependabot-fixtures/go-modules-private")
+          end
         end
       end
     end

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -659,6 +659,20 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
           end
         end
       end
+
+      context "with github credentials" do
+        let(:credentials) { github_credentials }
+
+        it "raises the correct error" do
+          error_class = Dependabot::GitDependenciesNotReachable
+          expect { updater.updated_go_sum_content }.
+            to raise_error(error_class) do |error|
+            expect(error.message).to include("dependabot-fixtures/go-modules-private")
+            expect(error.dependency_urls).
+              to eq(["github.com/dependabot-fixtures/go-modules-private"])
+          end
+        end
+      end
     end
 
     context "with an unreachable sub-dependency" do

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -134,13 +134,6 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
         }]
       end
 
-      it "raises a helpful error" do
-        expect { updated_files }.to raise_error(
-          Dependabot::PrivateSourceAuthenticationFailure,
-          %r{github\.com/mholt/caddy}
-        )
-      end
-
       context "with github credentials" do
         let(:credentials) { github_credentials }
 

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -112,37 +112,6 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
       end
     end
 
-    context "with an indirect dependency from an unreachable repo" do
-      let(:project_name) { "repo_not_found" }
-      let(:dependency_name) { "github.com/go-openapi/spec" }
-      let(:dependency_version) { "0.20.3" }
-      let(:dependency_previous_version) { "0.19.2" }
-      let(:requirements) do
-        [{
-          requirement: ::Gem::Version.new(dependency_version),
-          file: "go.mod",
-          source: { type: "default", source: dependency_name },
-          groups: []
-        }]
-      end
-      let(:previous_requirements) do
-        [{
-          requirement: "v#{dependency_previous_version}",
-          file: "go.mod",
-          source: { type: "default", source: dependency_name },
-          groups: []
-        }]
-      end
-
-      context "with github credentials" do
-        let(:credentials) { github_credentials }
-
-        it "raises a helpful error" do
-          expect { updated_files }.to raise_error(Dependabot::GitDependenciesNotReachable, %r{github\.com/mholt/caddy})
-        end
-      end
-    end
-
     context "without a go.sum" do
       let(:project_name) { "simple" }
       let(:files) { [go_mod] }

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -23,14 +23,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
   let(:project_name) { "go_sum" }
   let(:repo_contents_path) { build_tmp_repo(project_name) }
 
-  let(:credentials) do
-    [{
-      "type" => "git_source",
-      "host" => "github.com",
-      "username" => "x-access-token",
-      "password" => "token"
-    }]
-  end
+  let(:credentials) { [] }
 
   let(:go_mod) do
     Dependabot::DependencyFile.new(name: "go.mod", content: go_mod_body)


### PR DESCRIPTION
Recently GitHub changed its response to requests that appeared to be using user/pass authentication. Our use of `token`  in default credentials was triggering this new response and causing an unexpected [test failure](https://github.com/dependabot/dependabot-core/runs/3343021425):
https://github.com/dependabot/dependabot-core/blob/23049ea9d768bccbaf79da2b6d9a21822fdc10d1/go_modules/spec/dependabot/go_modules/file_updater_spec.rb#L26-L33

```
go: k8s.io/kubernetes@v1.15.9 requires
        github.com/mholt/caddy@v0.0.0-20180213163048-2de495001514: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /home/dependabot/go/pkg/mod/cache/vcs/4d13fcc7852c2edc10fd0bb49b723561904719db812ccb21ab70a690362645eb: exit status 128:
        remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
        remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
        fatal: unable to access 'https://github.com/mholt/caddy/': The requested URL returned error: 403
```

Previously we'd see an error like this for a bad credentials case:
```
go: github.com/dependabot-fixtures/go-modules-private@v0.0.2-0.20210810060509-69d966798b9c: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /home/dependabot/go/pkg/mod/cache/vcs/51c9292b9f45a35312c3863da5428630dd2a800586fd865c7065132199b41694: exit status 128:
        remote: Invalid username or password.
        fatal: Authentication failed for 'https://github.com/dependabot-fixtures/go-modules-private/'
```

I found we could still reproduce the expected error by either using a revoked PAT as the token or by using a blank token. I chose using a blank token and also migrated the failing test to `go_mod_updater_spec.rb` where other similar tests were: https://github.com/dependabot/dependabot-core/pull/4141/commits/f0513e2861bf16966a1b345ff0ada767f26afca5

I also ran into issues locally with a test relying on `github_credentials` being set. Those require setting up a PAT to be able to run the tests locally. I migrated that test to `go_mod_updater_spec.rb` as well in https://github.com/dependabot/dependabot-core/pull/4141/commits/712059359a3b922a181d2de0a50ddeefc38820ae but then decided to remove it in https://github.com/dependabot/dependabot-core/pull/4141/commits/d26bffa88ab9761296b91037caa3828e086224f3 since it wasn't adding much value compared to the local dev friction it causes (it's very similar to the empty credentials case).

Finally, I've updated `file_updater_spec.rb` to use empty credentials by default which is a more realistic use case: https://github.com/dependabot/dependabot-core/pull/4141/commits/44df6cb378138f0d4c1606bc2d9a81fadb91a3e1

I didn't add any tests for the new password auth sunsetting message as it shouldn't be very common and results in a `GitDependenciesNotReachable` error which is still appropriate.