### PR TITLE
Handle unreachable go module dependencies in LatestVersionFinder

### DIFF
--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -19,7 +19,9 @@ module Dependabot
           # Package url 404s
           /404 Not Found/,
           /Repository not found/,
-          /unrecognized import path/
+          /unrecognized import path/,
+          # (Private) module could not be fetched
+          /module .*: git ls-remote .*: exit status 128/m.freeze
         ].freeze
         PSEUDO_VERSION_REGEX = /\b\d{14}-[0-9a-f]{12}$/.freeze
 

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -51,12 +51,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
     described_class.new(
       dependency: dependency,
       dependency_files: dependency_files,
-      credentials: [{
-        "type" => "git_source",
-        "host" => "github.com",
-        "username" => "x-access-token",
-        "password" => "token"
-      }],
+      credentials: [],
       ignored_versions: ignored_versions,
       security_advisories: security_advisories,
       raise_on_ignored: raise_on_ignored

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -186,6 +186,28 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
       end
     end
 
+    context "when the module is unreachable" do
+      let(:dependency_files) { [go_mod] }
+      let(:dependency_name) { "github.com/dependabot-fixtures/go-modules-private" }
+      let(:dependency_version) { "1.0.0" }
+      let(:go_mod) do
+        Dependabot::DependencyFile.new(
+          name: "go.mod",
+          content: fixture("projects", "unreachable_dependency", "go.mod")
+        )
+      end
+
+      it "raises a GitDependenciesNotReachable error" do
+        error_class = Dependabot::GitDependenciesNotReachable
+        expect { finder.latest_version }.
+          to raise_error(error_class) do |error|
+          expect(error.message).to include("github.com/dependabot-fixtures/go-modules-private")
+          expect(error.dependency_urls).
+            to eq(["github.com/dependabot-fixtures/go-modules-private"])
+        end
+      end
+    end
+
     context "with a retracted update version" do
       # latest release v1.0.1 is retracted
       let(:dependency_name) { "github.com/dependabot-fixtures/go-modules-retracted" }


### PR DESCRIPTION
Previously we improved handling of unreachable go module dependencies when performing an update in https://github.com/dependabot/dependabot-core/pull/4130

This updates the `LatestVersionFinder` to detect unreachable dependency errors as well. Previously we'd return an `UnknownError` in this case where Dependabot checks if an unreachable dependency needs an update.

I've also continued replacing the default credentials used in the test with empty credentials. This is a more realistic use case since using made up credentials can result in other unexpected errors: https://github.com/dependabot/dependabot-core/pull/4141