### PR TITLE
Bump go from 1.16.3 to 1.16.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,8 +167,8 @@ USER root
 ### GO
 
 # Install Go
-ARG GOLANG_VERSION=1.16.3
-ARG GOLANG_CHECKSUM=951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2
+ARG GOLANG_VERSION=1.16.7
+ARG GOLANG_CHECKSUM=7fe7a73f55ba3e2285da36f8b085e5c0159e9564ef5f63ee0ed6b818ade8ef04
 ENV PATH=/opt/go/bin:$PATH
 RUN cd /tmp \
   && curl --http1.1 -o go.tar.gz https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz \


### PR DESCRIPTION
Go 1.17.0 is [out](https://blog.golang.org/go1.17)! This gets us to the [latest 1.16.x release](https://golang.org/dl/) first.