### PR TITLE
Add a minimal test for go 1.17 module handling

### DIFF
--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -98,6 +98,10 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
           let(:project_name) { "go_1.13" }
 
           it { is_expected.to include("go 1.13") }
+
+          it "doesn't add additional go 1.17 requirement sections" do
+            is_expected.to include("require").once
+          end
         end
 
         context "for a go 1.17 go.mod" do

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -100,6 +100,16 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
           it { is_expected.to include("go 1.13") }
         end
 
+        context "for a go 1.17 go.mod" do
+          let(:project_name) { "go_1.17" }
+
+          it { is_expected.to include("go 1.17") }
+
+          it "preserves the two requirements sections" do
+            is_expected.to include("require").twice
+          end
+        end
+
         context "when a retract directive is present" do
           let(:project_name) { "go_retracted" }
 

--- a/go_modules/spec/fixtures/projects/go_1.17/go.mod
+++ b/go_modules/spec/fixtures/projects/go_1.17/go.mod
@@ -1,0 +1,13 @@
+module github.com/dependabot/vgotest
+
+go 1.17
+
+require (
+	github.com/dependabot-fixtures/go-modules-lib v1.0.0
+	rsc.io/quote v1.5.0
+)
+
+require (
+	golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c // indirect
+	rsc.io/sampler v1.3.0 // indirect
+)

--- a/go_modules/spec/fixtures/projects/go_1.17/go.sum
+++ b/go_modules/spec/fixtures/projects/go_1.17/go.sum
@@ -1,0 +1,8 @@
+github.com/dependabot-fixtures/go-modules-lib v1.0.0 h1:DsAam2sHRQNesAUZOQxf6Dtj2/2d//PV/1qYHji6yHA=
+github.com/dependabot-fixtures/go-modules-lib v1.0.0/go.mod h1:Hz94FAK+UAKQT1G6M6yb6W70BW0MvDO5GigfJH9dzXQ=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:qgOY6WgZOaTkIIMiVjBQcw93ERBE4m30iBm00nkL0i8=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+rsc.io/quote v1.5.0 h1:mVjf/WMWxfIw299sOl/O3EXn5qEaaJPMDHMsv7DBDlw=
+rsc.io/quote v1.5.0/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
+rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/go_modules/spec/fixtures/projects/go_1.17/main.go
+++ b/go_modules/spec/fixtures/projects/go_1.17/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	_ "github.com/dependabot-fixtures/go-modules-lib"
+	_ "rsc.io/quote"
+)
+
+func main() {
+}


### PR DESCRIPTION
This loosely covers the issue reported in https://github.com/dependabot/dependabot-core/issues/4148 where the new indirect requirement section of the `go.mod` file was removed.