### PR TITLE
added php mcrypt extension 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,6 +156,7 @@ RUN add-apt-repository ppa:ondrej/php \
     php7.4-xml \
     php7.4-zip \
     php7.4-zmq \
+    php7.4-mcrypt \
   && rm -rf /var/lib/apt/lists/*
 USER dependabot
 # Perform a fake `composer update` to warm ~/dependabot/.cache/composer/repo


### PR DESCRIPTION
Before
```bash
dependabot@d0e8d7a84fce:~$ php -i | grep mcrypt
dependabot@d0e8d7a84fce:~$
```

After
```bash
dependabot@102a62523fb5:~# php -i | grep mcrypt
/etc/php/7.4/cli/conf.d/20-mcrypt.ini,
Registered Stream Filters => zlib.*, string.rot13, string.toupper, string.tolower, string.strip_tags, convert.*, consumed, dechunk, convert.iconv.*, mcrypt.*, mdecrypt.*
mcrypt
mcrypt support => enabled
mcrypt_filter support => enabled
mcrypt.algorithms_dir => no value => no value
mcrypt.modes_dir => no value => no value
```