### PR TITLE
chore: run builds on a regular basis to detect anomolies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - "**"
+  schedule:
+    - cron: '0 0 * * *'
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
A recent release of a [project dependency was released](https://github.com/lostisland/faraday/releases/tag/v1.7.1) that caused most of our
builds to fail. We didn't detect this until the [first unrelated PR](https://github.com/dependabot/dependabot-core/pull/4179) was submitted
to fix a different defect. That PR was held up because the default builds were
failing.

This change introduces a cron job to run the builds on a daily basis to try to
detect these types of errors sooner.
