### PR TITLE
Describe workaround for cloning with long file names on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ In addition to this library, you may be interested in:
   GitLab or Azure DevOps
 - The [API docs][api-docs] for Dependabot's hosted instance (dependabot.com)
 
+## Cloning the repository
+Clone the repository with Git using:
+
+```
+git clone https://github.com/dependabot/dependabot-core.git
+```
+
+On Windows this might fail with "Filename too long". To solve this, run the
+following commands in the cloned Git repository:
+
+1. `git config core.longpaths true`
+2. `git restore --source=HEAD :/`
+
+You can read more about this in the [Git for Windows wiki](https://github.com/git-for-windows/git/wiki/Git-cannot-create-a-file-or-directory-with-a-long-path).
+
 ## Setup
 
 To run all of Dependabot Core, you'll need Ruby, Python, PHP, Elixir, Node, Go,


### PR DESCRIPTION
Relates to #3676

On Windows cloning the repository might fail with "Filename too long". This pull request adds a section to the README explaining how to solve this.