### PR TITLE
Clarify that Remote Containers Clone Repository commands are not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ Once that's finished, start the `Debug Dry Run` configuration `(F5)` and you'll 
 to select a package manager and a repository to perform a dry run on.
 Feel free to place breakpoints on the code.
 
+⚠️ The `Clone Repository ...` commands of the Remote Containers extension are currently
+missing some functionality and are therefore not supported. You have to clone the
+repository manually and use the `Reopen in Container` or `Open Folder in Container...`
+command.
+
 ## Releasing
 
 Triggering the jobs that will push the new gems is done by following the steps below.


### PR DESCRIPTION
[`devcontainer.json`](https://github.com/dependabot/dependabot-core/blob/main/.devcontainer/devcontainer.json) currently uses `${localWorkspaceFolder}` which is not available when using the "Clone Repository" commands, see
https://code.visualstudio.com/docs/remote/devcontainerjson-reference#_variables-in-devcontainerjson

When using "Clone Repository" the extension fails with rather cryptic Docker errors, see https://github.com/microsoft/vscode-remote-release/issues/5547.