### PR TITLE
bin/dry-run.rb requires a development container to run

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -2,7 +2,6 @@ FROM dependabot/dependabot-core
 
 # Temporarily switch to root user in order to install packages
 USER root
-RUN touch /etc/dependabot-core-dev
 RUN apt-get update \
   && apt-get install -y vim strace ltrace gdb shellcheck \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -2,6 +2,7 @@ FROM dependabot/dependabot-core
 
 # Temporarily switch to root user in order to install packages
 USER root
+RUN touch /etc/dependabot-core-dev
 RUN apt-get update \
   && apt-get install -y vim strace ltrace gdb shellcheck \
   && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -101,16 +101,13 @@ $ bin/docker-dev-shell
 
 ### Dry run script
 
-*Note: you must have run `bundle install` in the `omnibus` directory before
-running this script.*
-
 You can use the "dry-run" script to simulate a dependency update job, printing
 the diff that would be generated to the terminal. It takes two positional
 arguments: the package manager and the GitHub repo name (including the
 account):
 
 ```bash
-$ cd omnibus && bundle install && cd -
+$ bin/docker-dev-shell
 $ bin/dry-run.rb go_modules rsc/quote
 => fetching dependency files
 => parsing dependency files

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -35,6 +35,15 @@
 
 # rubocop:disable Style/GlobalVars
 
+unless File.exist?("/etc/dependabot-core-dev")
+  puts <<~INFO
+    bin/dry-run.rb is only supported in a developerment container.
+
+    Please use bin/docker-dev-shell first.
+  INFO
+  exit 1
+end
+
 $LOAD_PATH << "./bundler/lib"
 $LOAD_PATH << "./cargo/lib"
 $LOAD_PATH << "./common/lib"

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -35,7 +35,8 @@
 
 # rubocop:disable Style/GlobalVars
 
-unless File.exist?("/etc/dependabot-core-dev")
+require "etc"
+unless Etc.getpwuid(Process.uid).name == "dependabot"
   puts <<~INFO
     bin/dry-run.rb is only supported in a developerment container.
 


### PR DESCRIPTION
While it is possible to run `bin/dry-run.rb` on a native machine, it requires the user to correctly install native dependencies, such as the right versions of package managers and so on to be guaranteed to match a 'real' Dependabot run.

Since we use this tool as a first line debugging step, it often adds friction to the process of reproducing builds if a native environment is used.

In order to reduce context and make this process more confident, let's make it a requirement the script is ran using the developer shell so we default to reproducible outcomes.