### PR TITLE
Escape paths passed to VendorUpdater

### DIFF
--- a/common/lib/dependabot/file_updaters/vendor_updater.rb
+++ b/common/lib/dependabot/file_updaters/vendor_updater.rb
@@ -68,7 +68,8 @@ module Dependabot
       def binary_file?(path)
         return false unless File.exist?(path)
 
-        encoding = `file -b --mime-encoding #{path}`.strip
+        command = SharedHelpers.escape_command("file -b --mime-encoding #{path}")
+        encoding = `#{command}`.strip
 
         !TEXT_ENCODINGS.include?(encoding)
       end


### PR DESCRIPTION
Paths in packages could be constructed to perform command, when not
properly escaped those could be executed.

```
(byebug) `file -b --mime-encoding t&&curl$IFS@0.0.0.0&&.go`
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (7) Failed to connect to 0.0.0.0 port 80: Connection refused
"cannot open `t' (No such file or directory)\n"
```

```
(byebug) `#{Dependabot::SharedHelpers.escape_command("file -b --mime-encoding t&&curl$IFS@0.0.0.0&&.go")}`
"cannot open `t&&curl$IFS@0.0.0.0&&.go' (No such file or directory)\n"
```