### PR TITLE
Bump golang from 1.17 to 1.17.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,8 +167,8 @@ USER root
 ### GO
 
 # Install Go
-ARG GOLANG_VERSION=1.17
-ARG GOLANG_CHECKSUM=6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d
+ARG GOLANG_VERSION=1.17.1
+ARG GOLANG_CHECKSUM=dab7d9c34361dc21ec237d584590d72500652e7c909bf082758fb63064fca0ef
 ENV PATH=/opt/go/bin:$PATH
 RUN cd /tmp \
   && curl --http1.1 -o go.tar.gz https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz \


### PR DESCRIPTION
From https://golang.org/dl/

go1.17.1.linux-amd64.tar.gz | Archive | Linux | x86-64 | 129MB | dab7d9c34361dc21ec237d584590d72500652e7c909bf082758fb63064fca0ef
-- | -- | -- | -- | -- | --

Also related: https://github.com/dependabot/gomodules-extracted/pull/14