### PR TITLE
fix  `labels': Unsupported provider bitbucket

### DIFF
--- a/common/lib/dependabot/pull_request_creator/bitbucket.rb
+++ b/common/lib/dependabot/pull_request_creator/bitbucket.rb
@@ -82,7 +82,7 @@ module Dependabot
           branch_name,
           source.branch || default_branch,
           pr_description,
-          labeler&.labels_for_pr,
+          nil,
           work_item
         )
       end


### PR DESCRIPTION
Bitbucket doesn't yet supports PR labels.
dependabot throw this issue whenever I try to use it with bitbucket 
labeler.rb:241:in `labels': Unsupported provider bitbucket (RuntimeError)