### PR TITLE
Treat tokens after underscore as numeric if possible

### DIFF
--- a/gradle/lib/dependabot/gradle/version.rb
+++ b/gradle/lib/dependabot/gradle/version.rb
@@ -14,7 +14,8 @@ module Dependabot
       NULL_VALUES = %w(0 final ga).freeze
       PREFIXED_TOKEN_HIERARCHY = {
         "." => { qualifier: 1, number: 4 },
-        "-" => { qualifier: 2, number: 3 }
+        "-" => { qualifier: 2, number: 3 },
+        "_" => { qualifier: 2, number: 3 }
       }.freeze
       NAMED_QUALIFIERS_HIERARCHY = {
         "a" => 1, "alpha"     => 1,
@@ -132,7 +133,7 @@ module Dependabot
       end
 
       def split_into_prefixed_tokens(version)
-        ".#{version}".tr("_", "-").split(/(?=[\-\.])/)
+        ".#{version}".split(/(?=[_\-\.])/)
       end
 
       def pad_for_comparison(prefixed_tokens, other_prefixed_tokens)

--- a/gradle/lib/dependabot/gradle/version.rb
+++ b/gradle/lib/dependabot/gradle/version.rb
@@ -132,7 +132,7 @@ module Dependabot
       end
 
       def split_into_prefixed_tokens(version)
-        ".#{version}".split(/(?=[\-\.])/)
+        ".#{version}".tr("_", "-").split(/(?=[\-\.])/)
       end
 
       def pad_for_comparison(prefixed_tokens, other_prefixed_tokens)

--- a/gradle/spec/dependabot/gradle/version_spec.rb
+++ b/gradle/spec/dependabot/gradle/version_spec.rb
@@ -270,6 +270,12 @@ RSpec.describe Dependabot::Gradle::Version do
           it { is_expected.to eq(1) }
         end
 
+        context "numeric token after underscore" do
+          let(:version) { described_class.new("1.0.0_100") }
+          let(:other_version) { described_class.new("1.0.0_99") }
+          it { is_expected.to eq(1) }
+        end
+
         context "null values (again)" do
           let(:version) { described_class.new("1-sp-1") }
           let(:other_version) { described_class.new("1-ga-1") }


### PR DESCRIPTION
Fixes #1636

Treat `-` and `_` the same in Gradle version names. Since `1.0.0-10` > `1.0.0-9`, it makes sense to also have `1.0.0_10` > `1.0.0_9`.