### PR TITLE
Add support for gradlePluginPortal()

### DIFF
--- a/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
@@ -12,6 +12,8 @@ module Dependabot
         # we're confident we're selecting repos correctly it's wise to include
         # it as a default.
         CENTRAL_REPO_URL = "https://repo.maven.apache.org/maven2"
+        GOOGLE_MAVEN_REPO = "https://maven.google.com"
+        GRADLE_PLUGINS_REPO = "https://plugins.gradle.org/m2"
 
         REPOSITORIES_BLOCK_START = /(?:^|\s)repositories\s*\{/.freeze
 
@@ -96,11 +98,13 @@ module Dependabot
           end
 
           repository_blocks.each do |block|
-            repository_urls << "https://maven.google.com/" if block.match?(/\sgoogle\(/)
+            repository_urls << GOOGLE_MAVEN_REPO if block.match?(/\sgoogle\(/)
 
-            repository_urls << "https://repo.maven.apache.org/maven2/" if block.match?(/\smavenCentral\(/)
+            repository_urls << CENTRAL_REPO_URL if block.match?(/\smavenCentral\(/)
 
             repository_urls << "https://jcenter.bintray.com/" if block.match?(/\sjcenter\(/)
+
+            repository_urls << GRADLE_PLUGINS_REPO if block.match?(/\sgradlePluginPortal\(/)
 
             block.scan(MAVEN_REPO_REGEX) do
               repository_urls << Regexp.last_match.named_captures.fetch("url")

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -13,8 +13,6 @@ module Dependabot
   module Gradle
     class UpdateChecker
       class VersionFinder
-        GOOGLE_MAVEN_REPO = "https://maven.google.com"
-        GRADLE_PLUGINS_REPO = "https://plugins.gradle.org/m2"
         KOTLIN_PLUGIN_REPO_PREFIX = "org.jetbrains.kotlin"
         TYPE_SUFFICES = %w(jre android java native_mt agp).freeze
 
@@ -59,7 +57,7 @@ module Dependabot
           version_details =
             repositories.map do |repository_details|
               url = repository_details.fetch("url")
-              next google_version_details if url == GOOGLE_MAVEN_REPO
+              next google_version_details if url == Gradle::FileParser::RepositoriesFinder::GOOGLE_MAVEN_REPO
 
               dependency_metadata(repository_details).css("versions > version").
                 select { |node| version_class.correct?(node.content) }.
@@ -136,10 +134,10 @@ module Dependabot
         end
 
         def google_version_details
-          url = GOOGLE_MAVEN_REPO
+          url = Gradle::FileParser::RepositoriesFinder::GOOGLE_MAVEN_REPO
           group_id, artifact_id = group_and_artifact_ids
 
-          dependency_metadata_url = "#{GOOGLE_MAVEN_REPO}/"\
+          dependency_metadata_url = "#{Gradle::FileParser::RepositoriesFinder::GOOGLE_MAVEN_REPO}/"\
                                     "#{group_id.tr('.', '/')}/"\
                                     "group-index.xml"
 
@@ -250,7 +248,7 @@ module Dependabot
 
         def plugin_repository_details
           [{
-            "url" => GRADLE_PLUGINS_REPO,
+            "url" => Gradle::FileParser::RepositoriesFinder::GRADLE_PLUGINS_REPO,
             "auth_headers" => {}
           }] + dependency_repository_details
         end

--- a/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
                 https://jcenter.bintray.com
                 https://dl.bintray.com/magnusja/maven
                 https://maven.google.com
+                https://plugins.gradle.org/m2
               )
             )
           end

--- a/gradle/spec/fixtures/buildfiles/subproject_repos.gradle
+++ b/gradle/spec/fixtures/buildfiles/subproject_repos.gradle
@@ -11,5 +11,6 @@ subprojects {
         jcenter()
         maven { url 'https://dl.bintray.com/magnusja/maven' }
         google()
+        gradlePluginPortal()
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dependabot/dependabot-core/issues/4069

Also extracts the URLs into constants, note that trailing slashes are stripped in `repositories_finder.rb` line 115, so excluding trailing slashes from the constants does not change the result.

No constant introduced for jcenter because it's deprecated (both the method and the service).