### PR TITLE
fix: allow up to 120 seconds to complete an update for a single dependency

### DIFF
--- a/bundler/helpers/v2/run.rb
+++ b/bundler/helpers/v2/run.rb
@@ -2,6 +2,7 @@
 
 require "bundler"
 require "json"
+require "timeout"
 
 $LOAD_PATH.unshift(File.expand_path("./lib", __dir__))
 $LOAD_PATH.unshift(File.expand_path("./monkey_patches", __dir__))
@@ -37,7 +38,9 @@ begin
   function = request["function"]
   args = request["args"].transform_keys(&:to_sym)
 
-  output({ result: Functions.send(function, **args) })
+  Timeout.timeout(120) do
+    output({ result: Functions.send(function, **args) })
+  end
 rescue StandardError => e
   output(
     { error: e.message, error_class: e.class, trace: e.backtrace }


### PR DESCRIPTION
# Why is this needed?

To prevent spending too much time trying to update a single dependency during a
scheduled update.


## What does this do?

It sets a timeout of 120 seconds to ensure that the sequential dependency
updates aren't blocked by a single dependency that is having difficulty being
updated.
