### PR TITLE
Add issue template config with Dependabot contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions or comments about Dependabot Alerts or Security Updates
+    url: https://support.github.com/
+    about: You're looking at the repository for Dependabot's updating logic. For issues about Dependabot the service, please contact GitHub Support.


### PR DESCRIPTION
Help direct people to the correct place when they're looking for Dependabot Updates/Alerts support.