### PR TITLE
[WIP] Nodesource cert verification issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
     libxml2-dev \
     libxmlsec1-dev \
     libgeos-dev \
+    libgnutls30 \
     python3-enchant \
   && locale-gen en_US.UTF-8 \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
As per https://github.com/nodesource/distributions/issues/1266 the
LetsEncrypt DST Root CA X3 has expired last week, and this prevents us
from building the docker image.

Installing `libgnutls30` as suggested in that thread seems to fix it,
but to be entirely honest I am not sure why.

Until the nodesource maintainers suggest a solution, this at least
unblocks container builds, but I'd recommend that we only use this in
local development and not publish it.