### PR TITLE
Fix Poetry unreachable git deps error

### DIFF
--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -31,6 +31,7 @@ module Dependabot
             '\['git',
             \s+'clone',
             \s+'--recurse-submodules',
+            \s+'(--)?',
             \s+'(?<url>.+?)'.*
             \s+exit\s+status\s+128
           /mx.freeze


### PR DESCRIPTION
Since https://github.com/python-poetry/poetry-core/pull/202 poetry now
uses a slightly different (safer) git command, and this caused the
regex matching we do on the error output to now fail.

This fixes up the regex, and just to be safe ensures it'll keep working
with the old version as well.

The test that was failing was:
`python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb:179`