### PR TITLE
Add license to image and gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,9 +43,6 @@ namespace :gems do
     pkg_path = File.join(root_path, "pkg")
     Dir.mkdir(pkg_path) unless File.directory?(pkg_path)
 
-    license_path = File.join(root_path, "LICENSE")
-    FileUtils.cp(license_path, pkg_path) if File.file?(license_path)
-
     GEMSPECS.each do |gemspec_path|
       puts "> Building #{gemspec_path}"
       Dir.chdir(File.dirname(gemspec_path)) do


### PR DESCRIPTION
This adds the LICENSE to the home directory of the Docker image.

![Screen Shot 2021-10-14 at 11 30 09 AM](https://user-images.githubusercontent.com/12107187/137349472-5f428177-7299-42c2-a428-877f5465702e.png)

The [dependabot-* gems on rubygems](https://rubygems.org/gems/dependabot-omnibus) currently have the license set as 'nonstandard' and do not include a license file.
~~TBD:~~ `rake gems:release` will **not** include the LICENSE in the `dependabot-*` gems in this PR.