### PR TITLE
Remove wrong GitLab handling

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -289,9 +289,7 @@ module Dependabot
           elsif resolved_url.include?("/#{name}/-/#{name}")
             # MyGet / Bintray format
             resolved_url.split("/#{name}/-/#{name}").first.
-              gsub("dl.bintray.com//", "api.bintray.com/npm/").
-              # GitLab format
-              gsub(%r{\/projects\/\d+}, "")
+              gsub("dl.bintray.com//", "api.bintray.com/npm/")
           elsif resolved_url.include?("/#{name}/-/#{name.split('/').last}")
             # Sonatype Nexus / Artifactory JFrog format
             resolved_url.split("/#{name}/-/#{name.split('/').last}").first

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -267,8 +267,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
                   groups: ["devDependencies"],
                   source: {
                     type: "registry",
-                    url: "https://gitlab.mydomain.com/api/v4/"\
-                         "packages/npm"
+                    url: "https://gitlab.mydomain.com/api/v4/projects/229/packages/npm"
                   }
                 }]
               )


### PR DESCRIPTION
Fixes #4318 

Dont know the reason for this lines.

This line removes the package id from the dependency url, which is required when limiting your packages to a private GitLab group.

After the fix, dependabot is able to fetch the right private group registry, which is the same as the resolved dependency url.