### PR TITLE
Cargo: pass permit_copy_rename environment variable

### DIFF
--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -19,6 +19,7 @@ module Dependabot
         OBJECT_PATTERN = /object not found - no match for id \(.*\)/.freeze
         REF_NOT_FOUND_REGEX =
           /#{UNABLE_TO_UPDATE}.*(#{REVSPEC_PATTERN}|#{OBJECT_PATTERN})/m.freeze
+        CARGO_DEFAULT_ENV = { "RUSTUP_PERMIT_COPY_RENAME" => "1" }.freeze
 
         def initialize(dependency:, credentials:,
                        original_dependency_files:, prepared_dependency_files:)
@@ -133,7 +134,7 @@ module Dependabot
         def run_cargo_command(command)
           start = Time.now
           command = SharedHelpers.escape_command(command)
-          stdout, process = Open3.capture2e(command)
+          stdout, process = Open3.capture2e(CARGO_DEFAULT_ENV, command)
           time_taken = Time.now - start
 
           # Raise an error with the output from the shell session if Cargo


### PR DESCRIPTION
Resolves an issue with rustup copying files during updates.

https://rust-lang.github.io/rustup/environment-variables.html:

When set, allows rustup to fall-back to copying files if attempts to rename
result in an cross-device link errors. These errors occur on OverlayFS,
which is used by Docker.