### PR TITLE
Clean up Go tmp directories

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -44,13 +44,15 @@ module Dependabot
 
           vendor_updater.updated_vendor_cache_files(base_directory: directory).
             each do |file|
-            updated_files << file
+              updated_files << file
           end
         end
 
         raise "No files changed!" if updated_files.none?
 
         updated_files
+      ensure
+        FileUtils.remove_entry(@repo_contents_path, force=true) if File.exists?(@repo_contents_path)
       end
 
       private

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -133,8 +133,6 @@ module Dependabot
             end
 
             { go_mod: updated_go_mod, go_sum: updated_go_sum }
-          ensure
-            FileUtils.remove_dir(repo_contents_path) if File.exists?(repo_contents_path)
           end
         end
 

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -133,6 +133,8 @@ module Dependabot
             end
 
             { go_mod: updated_go_mod, go_sum: updated_go_sum }
+          ensure
+            FileUtils.remove_dir(repo_contents_path) if File.exists?(repo_contents_path)
           end
         end
 

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -150,6 +150,8 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
         )
       end
 
+      subject(:updated_files) { updater.updated_dependency_files }
+
       it "includes an updated go.mod" do
         expect(updated_files.find { |f| f.name == "go.mod" }).to_not be_nil
       end
@@ -226,12 +228,12 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
         }]
       end
 
+      subject(:updated_files) { updater.updated_dependency_files }
+
       it "updates the go.mod" do
         expect(go_mod_body).to include("github.com/pkg/errors v0.8.0")
 
-        updater.updated_dependency_files
-
-        go_mod_file = updater.updated_dependency_files.find do |file|
+        go_mod_file = updated_files.find do |file|
           file.name == "go.mod"
         end
 
@@ -239,7 +241,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
       end
 
       it "includes the vendored files" do
-        expect(updater.updated_dependency_files.map(&:name)).to match_array(
+        expect(updated_files.map(&:name)).to match_array(
           %w(
             go.mod
             go.sum
@@ -316,7 +318,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
         end
 
         it "vendors in the right directory" do
-          expect(updater.updated_dependency_files.map(&:name)).to match_array(
+          expect(updated_files.map(&:name)).to match_array(
             %w(
               go.mod
               go.sum
@@ -330,7 +332,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
             )
           )
 
-          updater.updated_dependency_files.map(&:directory).each do |dir|
+          updated_files.map(&:directory).each do |dir|
             expect(dir).to eq("/nested")
           end
         end


### PR DESCRIPTION
Go_modules creates a few temporary directories as part of the FileUpdater process. Unfortunately, we do not clean up these temporary directories up after using them, which can lead to the issue of running out of disk space. This branch was a failed attempt at cleaning up the temporary directories.

There are two spots that we create temporary directories during a go_modules update: 
- At the start of the FileUpdater step if no repo_contents_path is provided https://github.com/dependabot/dependabot-core/blob/35032ea1459b48e93dea8c9d6b0c3f7417dce014/go_modules/lib/dependabot/go_modules/file_updater.rb#L66
- In the `go_module_updater` during the `update_files` step (`in_repo_path` is in SharedHelpers and yields a temporary directory) https://github.com/dependabot/dependabot-core/blob/35032ea1459b48e93dea8c9d6b0c3f7417dce014/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb#L84

Attempting to remove the temporary directories immediately after either of these steps will cause failures further down the line because when we finish updating the Go files, the `update_dependency_files` function utilizes the `vendor_updater` in common which `cd`s into each temporary directory https://github.com/dependabot/dependabot-core/blob/35032ea1459b48e93dea8c9d6b0c3f7417dce014/go_modules/lib/dependabot/go_modules/file_updater.rb#L45-L48

Unfortunately, as d6fd63543049266611bda764ec504158d0da6746 indicates, attempting to remove the temporary directories (even with `force=true`) at the end of the `update_dependency_files` function still fails to actually remove the directories, indicating there may be an open handle preventing the folders from being removed.

I have not tried overriding the `vendor_updater` class for go_modules, but that could help in resolving _when_ the temporary directories are no longer needed.

Another approach that's being tried to save on disk space during a go_modules updates is using a cache between all modules, instead of using `in_repo_path` and redownloading modules multiple times.