### PR TITLE
Only check auth for github.com when running `bump-version`

### DIFF
--- a/bin/bump-version.rb
+++ b/bin/bump-version.rb
@@ -12,7 +12,7 @@ unless `which gh` && $?.success?
   exit 1
 end
 
-unless `gh auth status > /dev/null 2>&1` && $?.success?
+unless `gh auth status -h github.com > /dev/null 2>&1` && $?.success?
   puts "Please login to GitHub first: gh auth login"
   exit 1
 end


### PR DESCRIPTION
The script only needs to auth to github.com, not any GHES instances you have configuration for.