### PR TITLE
Ensure we cleanup tmp directories after use

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -40,10 +40,14 @@ module Dependabot
 
     def self.in_a_temporary_directory(directory = "/")
       Dir.mkdir(Utils::BUMP_TMP_DIR_PATH) unless Dir.exist?(Utils::BUMP_TMP_DIR_PATH)
-      Dir.mktmpdir(Utils::BUMP_TMP_FILE_PREFIX, Utils::BUMP_TMP_DIR_PATH) do |dir|
-        path = Pathname.new(File.join(dir, directory)).expand_path
+      tmp_dir = Dir.mktmpdir(Utils::BUMP_TMP_FILE_PREFIX, Utils::BUMP_TMP_DIR_PATH)
+
+      begin
+        path = Pathname.new(File.join(tmp_dir, directory)).expand_path
         FileUtils.mkpath(path)
         Dir.chdir(path) { yield(path) }
+      ensure
+        FileUtils.rm_rf(tmp_dir)
       end
     end
 

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Dependabot::SharedHelpers do
   let(:spec_root) { File.join(File.dirname(__FILE__), "..") }
 
   describe ".in_a_temporary_directory" do
+    def existing_tmp_folders
+      Dir.glob(File.join(Dependabot::Utils::BUMP_TMP_DIR_PATH, "*"))
+    end
+
     subject(:in_a_temporary_directory) do
       Dependabot::SharedHelpers.in_a_temporary_directory { output_dir.call }
     end
@@ -19,6 +23,10 @@ RSpec.describe Dependabot::SharedHelpers do
     it "yields the path to the temporary directory created" do
       expect { |b| described_class.in_a_temporary_directory(&b) }.
         to yield_with_args(Pathname)
+    end
+
+    it "removes the temporary directory after use" do
+      expect { in_a_temporary_directory }.not_to(change { existing_tmp_folders })
     end
   end
 


### PR DESCRIPTION
In very long-running jobs with a lot of dependencies, it is feasible we can loop through the `in_a_temporary_directory` step hundreds of times.

This change ensures we clean up these directories after use in an effort to reclaim disk space in all cases and to avoid problems in persistent run environments such as the `bin/docker-dev-shell` environment.