### PR TITLE
Add timeout per operation

### DIFF
--- a/bundler/helpers/v1/run.rb
+++ b/bundler/helpers/v1/run.rb
@@ -6,6 +6,11 @@ require "json"
 $LOAD_PATH.unshift(File.expand_path("./lib", __dir__))
 $LOAD_PATH.unshift(File.expand_path("./monkey_patches", __dir__))
 
+trap "HUP" do
+  puts JSON.generate(error: "timeout", error_class: "Timeout::Error", trace: [])
+  exit 2
+end
+
 # Bundler monkey patches
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"

--- a/bundler/helpers/v2/run.rb
+++ b/bundler/helpers/v2/run.rb
@@ -6,6 +6,11 @@ require "json"
 $LOAD_PATH.unshift(File.expand_path("./lib", __dir__))
 $LOAD_PATH.unshift(File.expand_path("./monkey_patches", __dir__))
 
+trap "HUP" do
+  puts JSON.generate(error: "timeout", error_class: "Timeout::Error", trace: [])
+  exit 2
+end
+
 # Bundler monkey patches
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"

--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -145,6 +145,7 @@ module Dependabot
             NativeHelpers.run_bundler_subprocess(
               bundler_version: bundler_version,
               function: "parsed_gemfile",
+              options: options,
               args: {
                 gemfile_name: gemfile.name,
                 lockfile_name: lockfile&.name,
@@ -175,6 +176,7 @@ module Dependabot
             NativeHelpers.run_bundler_subprocess(
               bundler_version: bundler_version,
               function: "parsed_gemspec",
+              options: options,
               args: {
                 gemspec_name: file.name,
                 lockfile_name: lockfile&.name,

--- a/bundler/lib/dependabot/bundler/file_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater.rb
@@ -79,6 +79,7 @@ module Dependabot
           NativeHelpers.run_bundler_subprocess(
             bundler_version: bundler_version,
             function: "vendor_cache_dir",
+            options: options,
             args: {
               dir: repo_contents_path
             }

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -69,6 +69,7 @@ module Dependabot
               NativeHelpers.run_bundler_subprocess(
                 bundler_version: bundler_version,
                 function: "update_lockfile",
+                options: options,
                 args: {
                   gemfile_name: gemfile.name,
                   lockfile_name: lockfile.name,

--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -12,14 +12,14 @@ module Dependabot
         ::Bundler.with_original_env do
           timeout_seconds = options[:timeout_per_operation_seconds]
           command = if timeout_seconds
-            [
-              "timeout -s HUP",
-              timeout_seconds,
-              helper_path(bundler_version: bundler_major_version)
-            ].join(" ")
-          else
-            helper_path(bundler_version: bundler_major_version)
-          end
+                      [
+                        "timeout -s HUP",
+                        timeout_seconds,
+                        helper_path(bundler_version: bundler_major_version)
+                      ].join(" ")
+                    else
+                      helper_path(bundler_version: bundler_major_version)
+                    end
           SharedHelpers.run_helper_subprocess(
             command: command,
             function: function,

--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -11,7 +11,8 @@ module Dependabot
         bundler_major_version = bundler_version.split(".").first
         ::Bundler.with_original_env do
           SharedHelpers.run_helper_subprocess(
-            command: helper_path(bundler_version: bundler_major_version, timeout_seconds: options[:timeout_per_operation_seconds]),
+            command: helper_path(bundler_version: bundler_major_version,
+                                 timeout_seconds: options[:timeout_per_operation_seconds]),
             function: function,
             args: args,
             env: {

--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -7,10 +7,13 @@ module Dependabot
   module Bundler
     module NativeHelpers
       class BundleCommand
+        MAX_SECONDS = 1800
+        MIN_SECONDS = 60
+
         attr_reader :timeout_seconds
 
         def initialize(timeout_seconds)
-          @timeout_seconds = timeout_seconds
+          @timeout_seconds = adjust(timeout_seconds)
         end
 
         def build(script_path)
@@ -24,7 +27,17 @@ module Dependabot
         private
 
         def timeout_command
-          "timeout -s HUP #{timeout_seconds}" if timeout_seconds
+          "timeout -s HUP #{timeout_seconds}" unless timeout_seconds.zero?
+        end
+
+        def adjust(seconds)
+          return 0 unless seconds
+
+          seconds = seconds.to_i
+          return MAX_SECONDS if seconds > MAX_SECONDS
+          return MIN_SECONDS if seconds < MIN_SECONDS
+
+          seconds
         end
       end
 

--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -11,7 +11,7 @@ module Dependabot
         MIN_SECONDS = 60
 
         def initialize(timeout_seconds)
-          @timeout_seconds = adjust(timeout_seconds)
+          @timeout_seconds = clamp(timeout_seconds)
         end
 
         def build(script)
@@ -26,14 +26,10 @@ module Dependabot
           "timeout -s HUP #{timeout_seconds}" unless timeout_seconds.zero?
         end
 
-        def adjust(seconds)
+        def clamp(seconds)
           return 0 unless seconds
 
-          seconds = seconds.to_i
-          return MAX_SECONDS if seconds > MAX_SECONDS
-          return MIN_SECONDS if seconds < MIN_SECONDS
-
-          seconds
+          seconds.to_i.clamp(MIN_SECONDS, MAX_SECONDS)
         end
       end
 

--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -10,21 +10,17 @@ module Dependabot
         MAX_SECONDS = 1800
         MIN_SECONDS = 60
 
-        attr_reader :timeout_seconds
-
         def initialize(timeout_seconds)
           @timeout_seconds = adjust(timeout_seconds)
         end
 
-        def build(script_path)
-          [
-            timeout_command,
-            :bundle, :exec, :ruby,
-            script_path
-          ].compact.join(" ")
+        def build(script)
+          [timeout_command, :bundle, :exec, :ruby, script].compact.join(" ")
         end
 
         private
+
+        attr_reader :timeout_seconds
 
         def timeout_command
           "timeout -s HUP #{timeout_seconds}" unless timeout_seconds.zero?

--- a/bundler/lib/dependabot/bundler/update_checker/conflicting_dependency_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/conflicting_dependency_resolver.rb
@@ -35,6 +35,7 @@ module Dependabot
             NativeHelpers.run_bundler_subprocess(
               bundler_version: bundler_version,
               function: "conflicting_dependencies",
+              options: options,
               args: {
                 dir: tmp_dir,
                 dependency_name: dependency.name,

--- a/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
@@ -50,6 +50,7 @@ module Dependabot
             updated_deps, specs = NativeHelpers.run_bundler_subprocess(
               bundler_version: bundler_version,
               function: "force_update",
+              options: options,
               args: {
                 dir: tmp_dir,
                 dependency_name: dependency.name,

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
@@ -61,6 +61,7 @@ module Dependabot
                 NativeHelpers.run_bundler_subprocess(
                   bundler_version: bundler_version,
                   function: "depencency_source_latest_git_version",
+                  options: options,
                   args: {
                     dir: tmp_dir,
                     gemfile_name: gemfile.name,
@@ -106,6 +107,7 @@ module Dependabot
                 NativeHelpers.run_bundler_subprocess(
                   bundler_version: bundler_version,
                   function: "private_registry_versions",
+                  options: options,
                   args: {
                     dir: tmp_dir,
                     gemfile_name: gemfile.name,
@@ -126,6 +128,7 @@ module Dependabot
               NativeHelpers.run_bundler_subprocess(
                 bundler_version: bundler_version,
                 function: "dependency_source_type",
+                options: options,
                 args: {
                   dir: tmp_dir,
                   gemfile_name: gemfile.name,

--- a/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
@@ -167,6 +167,7 @@ module Dependabot
             git_specs = NativeHelpers.run_bundler_subprocess(
               bundler_version: bundler_version,
               function: "git_specs",
+              options: options,
               args: {
                 dir: tmp_dir,
                 gemfile_name: gemfile.name,
@@ -195,6 +196,7 @@ module Dependabot
             NativeHelpers.run_bundler_subprocess(
               bundler_version: bundler_version,
               function: "jfrog_source",
+              options: options,
               args: {
                 dir: dir,
                 gemfile_name: gemfile.name,

--- a/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
@@ -82,6 +82,7 @@ module Dependabot
               details = NativeHelpers.run_bundler_subprocess(
                 bundler_version: bundler_version,
                 function: "resolve_version",
+                options: options,
                 args: {
                   dependency_name: dependency.name,
                   dependency_requirements: dependency.requirements,
@@ -167,7 +168,7 @@ module Dependabot
               ignored_versions: ignored_versions,
               raise_on_ignored: @raise_on_ignored,
               security_advisories: [],
-              options: options
+              options: options,
             ).latest_version_details
         end
 

--- a/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
@@ -168,7 +168,7 @@ module Dependabot
               ignored_versions: ignored_versions,
               raise_on_ignored: @raise_on_ignored,
               security_advisories: [],
-              options: options,
+              options: options
             ).latest_version_details
         end
 

--- a/bundler/spec/dependabot/bundler/native_helpers_spec.rb
+++ b/bundler/spec/dependabot/bundler/native_helpers_spec.rb
@@ -30,5 +30,27 @@ RSpec.describe Dependabot::Bundler::NativeHelpers do
           )
       end
     end
+
+    context "without a timeout" do
+      it "does not apply a timeout" do
+        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+
+        subject.run_bundler_subprocess(
+          function: "noop",
+          args: [],
+          bundler_version: "2.0.0",
+          options: { }
+        )
+
+        expect(Dependabot::SharedHelpers).
+          to have_received(:run_helper_subprocess).
+          with(
+            command: "bundle exec ruby /opt/bundler/v2/run.rb",
+            function: "noop",
+            args: [],
+            env: anything
+          )
+      end
+    end
   end
 end

--- a/bundler/spec/dependabot/bundler/native_helpers_spec.rb
+++ b/bundler/spec/dependabot/bundler/native_helpers_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/bundler/native_helpers"
+
+RSpec.describe Dependabot::Bundler::NativeHelpers do
+  subject { described_class }
+
+  describe ".run_bundler_subprocess" do
+    context "with a timeout provided" do
+      it "terminates the spawned process when the timeout is exceeded" do
+        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+
+        subject.run_bundler_subprocess(
+          function: "noop",
+          args: [],
+          bundler_version: "2.0.0",
+          options: {
+            timeout_per_operation_seconds: 1
+          }
+        )
+
+        expect(Dependabot::SharedHelpers).
+          to have_received(:run_helper_subprocess).
+          with(
+            command: "timeout -s HUP 1 bundle exec ruby /opt/bundler/v2/run.rb",
+            function: "noop",
+            args: [],
+            env: anything
+          )
+      end
+    end
+  end
+end

--- a/bundler/spec/dependabot/bundler/native_helpers_spec.rb
+++ b/bundler/spec/dependabot/bundler/native_helpers_spec.rb
@@ -7,23 +7,67 @@ RSpec.describe Dependabot::Bundler::NativeHelpers do
   subject { described_class }
 
   describe ".run_bundler_subprocess" do
+    let(:options) { {} }
+
+    before do
+      allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+
+      subject.run_bundler_subprocess(
+        function: "noop",
+        args: [],
+        bundler_version: "2.0.0",
+        options: options
+      )
+    end
+
     context "with a timeout provided" do
+      let(:options) { { timeout_per_operation_seconds: 120 } }
+
       it "terminates the spawned process when the timeout is exceeded" do
-        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-
-        subject.run_bundler_subprocess(
-          function: "noop",
-          args: [],
-          bundler_version: "2.0.0",
-          options: {
-            timeout_per_operation_seconds: 1
-          }
-        )
-
         expect(Dependabot::SharedHelpers).
           to have_received(:run_helper_subprocess).
           with(
-            command: "timeout -s HUP 1 bundle exec ruby /opt/bundler/v2/run.rb",
+            command: "timeout -s HUP 120 bundle exec ruby /opt/bundler/v2/run.rb",
+            function: "noop",
+            args: [],
+            env: anything
+          )
+      end
+    end
+
+    context "with a timeout that is too high" do
+      let(:thirty_minutes_plus_one_second) { 1801 }
+      let(:options) do
+        {
+          timeout_per_operation_seconds: thirty_minutes_plus_one_second
+        }
+      end
+
+      it "applies the maximum timeout" do
+        expect(Dependabot::SharedHelpers).
+          to have_received(:run_helper_subprocess).
+          with(
+            command: "timeout -s HUP 1800 bundle exec ruby /opt/bundler/v2/run.rb",
+            function: "noop",
+            args: [],
+            env: anything
+          )
+      end
+    end
+
+    context "with a timeout that is too low" do
+      let(:fifty_nine_seconds) { 59 }
+      let(:options) do
+        {
+          timeout_per_operation_seconds: fifty_nine_seconds
+        }
+      end
+
+      it "applies the minimum timeout" do
+        expect(Dependabot::SharedHelpers).
+          to have_received(:run_helper_subprocess).
+          with(
+            command: "timeout -s HUP 60 bundle exec ruby /opt/bundler/v2/run.rb",
             function: "noop",
             args: [],
             env: anything
@@ -32,16 +76,9 @@ RSpec.describe Dependabot::Bundler::NativeHelpers do
     end
 
     context "without a timeout" do
+      let(:options) { {} }
+
       it "does not apply a timeout" do
-        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-
-        subject.run_bundler_subprocess(
-          function: "noop",
-          args: [],
-          bundler_version: "2.0.0",
-          options: {}
-        )
-
         expect(Dependabot::SharedHelpers).
           to have_received(:run_helper_subprocess).
           with(

--- a/bundler/spec/dependabot/bundler/native_helpers_spec.rb
+++ b/bundler/spec/dependabot/bundler/native_helpers_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Dependabot::Bundler::NativeHelpers do
           function: "noop",
           args: [],
           bundler_version: "2.0.0",
-          options: { }
+          options: {}
         )
 
         expect(Dependabot::SharedHelpers).

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -253,6 +253,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
           with({
             bundler_version: bundler_version,
             function: "dependency_source_type",
+            options: anything,
             args: anything
           }).and_call_original
 
@@ -261,6 +262,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
           with({
             bundler_version: bundler_version,
             function: "private_registry_versions",
+            options: anything,
             args: anything
           }).
           and_return(
@@ -308,6 +310,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
             with({
               bundler_version: bundler_version,
               function: "private_registry_versions",
+              options: anything,
               args: anything
             }).
             and_raise(subprocess_error)
@@ -341,6 +344,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
             with({
               bundler_version: bundler_version,
               function: "private_registry_versions",
+              options: anything,
               args: anything
             }).
             and_raise(subprocess_error)
@@ -374,6 +378,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
             with({
               bundler_version: bundler_version,
               function: "private_registry_versions",
+              options: anything,
               args: anything
             }).
             and_raise(subprocess_error)
@@ -407,6 +412,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
             with({
               bundler_version: bundler_version,
               function: "private_registry_versions",
+              options: anything,
               args: anything
             }).
             and_raise(subprocess_error)
@@ -429,6 +435,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
             with({
               bundler_version: bundler_version,
               function: "private_registry_versions",
+              options: anything,
               args: anything
             }).
             and_return(
@@ -570,6 +577,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
           with({
             bundler_version: bundler_version,
             function: "dependency_source_type",
+            options: anything,
             args: anything
           }).and_call_original
 
@@ -578,6 +586,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
           with({
             bundler_version: bundler_version,
             function: "private_registry_versions",
+            options: anything,
             args: anything
           }).
           and_return(

--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -262,6 +262,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
             with({
               bundler_version: PackageManagerHelper.bundler_version,
               function: "resolve_version",
+              options: anything,
               args: anything
             }).
             and_return(

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           with({
             bundler_version: bundler_version,
             function: "dependency_source_type",
+            options: anything,
             args: anything
           }).and_call_original
 
@@ -166,6 +167,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
           with({
             bundler_version: bundler_version,
             function: "private_registry_versions",
+            options: anything,
             args: anything
           }).
           and_return(


### PR DESCRIPTION
This change introduces an experiment that allows configuring a timeout per
operation to prevent spawned processes from running indefinitely.
