### PR TITLE
Support updating dependencies on settings file

### DIFF
--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -29,6 +29,7 @@ module Dependabot
       def fetch_files
         fetched_files = []
         fetched_files << buildfile if buildfile
+        fetched_files << settings_file if settings_file
         fetched_files += subproject_buildfiles
         fetched_files += dependency_script_plugins
         check_required_files_present

--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -18,7 +18,7 @@ module Dependabot
       require "dependabot/file_parsers/base/dependency_set"
       require_relative "file_parser/property_value_finder"
 
-      SUPPORTED_BUILD_FILE_NAMES = %w(build.gradle build.gradle.kts settings.gradle.kts settings.gradle.kts).freeze
+      SUPPORTED_BUILD_FILE_NAMES = %w(build.gradle build.gradle.kts settings.gradle settings.gradle.kts).freeze
 
       PROPERTY_REGEX =
         /

--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -18,7 +18,7 @@ module Dependabot
       require "dependabot/file_parsers/base/dependency_set"
       require_relative "file_parser/property_value_finder"
 
-      SUPPORTED_BUILD_FILE_NAMES = %w(build.gradle build.gradle.kts).freeze
+      SUPPORTED_BUILD_FILE_NAMES = %w(build.gradle build.gradle.kts settings.gradle.kts settings.gradle.kts).freeze
 
       PROPERTY_REGEX =
         /

--- a/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
       end
 
       it "fetches the main buildfile and subproject buildfile" do
-        expect(file_fetcher_instance.files.count).to eq(2)
+        expect(file_fetcher_instance.files.count).to eq(3)
         expect(file_fetcher_instance.files.map(&:name)).
-          to match_array(%w(build.gradle app/build.gradle))
+          to match_array(%w(build.gradle settings.gradle app/build.gradle))
       end
 
       context "when the subproject can't fe found" do
@@ -73,9 +73,9 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
         end
 
         it "fetches the main buildfile" do
-          expect(file_fetcher_instance.files.count).to eq(1)
+          expect(file_fetcher_instance.files.count).to eq(2)
           expect(file_fetcher_instance.files.map(&:name)).
-            to match_array(%w(build.gradle))
+            to match_array(%w(build.gradle settings.gradle))
         end
       end
     end
@@ -89,9 +89,9 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
       end
 
       it "fetches the main buildfile and subproject buildfile" do
-        expect(file_fetcher_instance.files.count).to eq(1)
+        expect(file_fetcher_instance.files.count).to eq(2)
         expect(file_fetcher_instance.files.map(&:name)).
-          to match_array(%w(app/build.gradle))
+          to match_array(%w(settings.gradle app/build.gradle))
       end
     end
 
@@ -118,9 +118,9 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
         end
 
         it "fetches the main buildfile and subproject buildfile" do
-          expect(file_fetcher_instance.files.count).to eq(2)
+          expect(file_fetcher_instance.files.count).to eq(3)
           expect(file_fetcher_instance.files.map(&:name)).
-            to match_array(%w(build.gradle.kts app/build.gradle.kts))
+            to match_array(%w(build.gradle.kts settings.gradle.kts app/build.gradle.kts))
         end
       end
     end

--- a/gradle/spec/dependabot/gradle/file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser_spec.rb
@@ -424,6 +424,21 @@ RSpec.describe Dependabot::Gradle::FileParser do
       end
     end
 
+    describe "settings script" do
+      let(:files) { [buildfile, settings_file] }
+      let(:settings_file) do
+        Dependabot::DependencyFile.new(
+          name: "settings.gradle",
+          content: fixture("settings_files", settings_file_fixture_name)
+        )
+      end
+      let(:settings_file_fixture_name) { "buildscript_dependencies_settings.gradle" }
+
+      subject(:dependencies) { parser.parse }
+
+      its(:length) { is_expected.to eq(20) }
+    end
+
     context "with kotlin" do
       let(:buildfile) do
         Dependabot::DependencyFile.new(
@@ -750,6 +765,21 @@ RSpec.describe Dependabot::Gradle::FileParser do
             )
           end
         end
+      end
+
+      describe "kotlin settings script" do
+        let(:files) { [buildfile, settings_file] }
+        let(:settings_file) do
+          Dependabot::DependencyFile.new(
+            name: "settings.gradle.kts",
+            content: fixture("settings_files", settings_file_fixture_name)
+          )
+        end
+        let(:settings_file_fixture_name) { "buildscript_dependencies_settings.gradle.kts" }
+
+        subject(:dependencies) { parser.parse }
+
+        its(:length) { is_expected.to eq(20) }
       end
     end
   end

--- a/gradle/spec/fixtures/settings_files/buildscript_dependencies_settings.gradle
+++ b/gradle/spec/fixtures/settings_files/buildscript_dependencies_settings.gradle
@@ -1,0 +1,8 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.ow2.asm:asm:9.2'
+    }
+}

--- a/gradle/spec/fixtures/settings_files/buildscript_dependencies_settings.gradle.kts
+++ b/gradle/spec/fixtures/settings_files/buildscript_dependencies_settings.gradle.kts
@@ -1,0 +1,8 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath("org.ow2.asm:asm:9.2")
+    }
+}


### PR DESCRIPTION
Implements & Closes #4299

The syntax of settings files about dependencies is mostly same as build files.
settings files support plugins block, `classpath "group:name:version"` syntax in `buildscript { dependencies { here } }`, and `group: 'group', name: 'name', version: 'name'`.
