### PR TITLE
v0.165.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.165.0, 8 November 2021
+
+- Add timeout per operation [#4362](https://github.com/dependabot/dependabot-core/pull/4362)
+
 ## v0.164.1, 2 November 2021
 
 - Only check auth for github.com when running `bump-version` [#4347](https://github.com/dependabot/dependabot-core/pull/4347)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.164.1"
+  VERSION = "0.165.0"
 end


### PR DESCRIPTION
## v0.165.0, 8 November 2021

- Add timeout per operation [#4362](https://github.com/dependabot/dependabot-core/pull/4362)

https://github.com/dependabot/dependabot-core/compare/v0.164.1...3d386da
