### PR TITLE
Bump to go 1.17.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,8 +167,8 @@ USER root
 ### GO
 
 # Install Go
-ARG GOLANG_VERSION=1.17.1
-ARG GOLANG_CHECKSUM=dab7d9c34361dc21ec237d584590d72500652e7c909bf082758fb63064fca0ef
+ARG GOLANG_VERSION=1.17.3
+ARG GOLANG_CHECKSUM=550f9845451c0c94be679faf116291e7807a8d78b43149f9506c1b15eb89008c
 ENV PATH=/opt/go/bin:$PATH
 RUN cd /tmp \
   && curl --http1.1 -o go.tar.gz https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz \


### PR DESCRIPTION
There were some minor fixes to the `go` command in `1.17.2`/`1.17.3`... 

I don't think any of them directly affect dependabot, but it
doesn't hurt to bump this and makes it so the next person has a smaller
diff to look at when they consider updating.

I also ran the `script/extract` in `gomodules-extracted` against `1.17.3` locally, and didn't see any changes other than a very minor build file change which I suspect is simply due to building on my Mac, so that should keep working as-is. It's important to keep the code in `gomodules-extracted`  in-sync with the version of `go` used here.