### PR TITLE
Bump Ubuntu to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
`18.04` is getting a bit long in the tooth... `20.04` is the most recent LTS, and `22.04` isn't too far in the future.

I'm sure this will break a bunch of things, so let's try it and see what the tests say...