### PR TITLE
Move composer-not-found fixture from decommissioned dependabot.com

### DIFF
--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
         expect { resolver.latest_resolvable_version }.
           to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
             expect(error.message).to start_with(
-              'The "https://dependabot.com/composer-not-found/packages.json"'\
+              'The "https://github.com/dependabot/composer-not-found/packages.json"'\
               " file could not be downloaded"
             )
           end

--- a/composer/spec/fixtures/projects/private_registry_not_found/composer.json
+++ b/composer/spec/fixtures/projects/private_registry_not_found/composer.json
@@ -2,7 +2,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "https://dependabot.com/composer-not-found"
+            "url": "https://github.com/dependabot/composer-not-found"
         }
     ],
     "require": {


### PR DESCRIPTION
dependabot.com now redirects to github.com which was causing our 404 test case to fail. I've chosen a new 404'ing url which is under the dependabot org on github to resist squatting attempts.