### PR TITLE
Ignore errors from Source enterprise check and ignore known failures

### DIFF
--- a/common/lib/dependabot/source.rb
+++ b/common/lib/dependabot/source.rb
@@ -45,6 +45,8 @@ module Dependabot
       (?:#{AZURE_SOURCE})
     /x.freeze
 
+    IGNORED_PROVIDER_HOSTS = %w(gitbox.apache.org svn.apache.org).freeze
+
     attr_accessor :provider, :repo, :directory, :branch, :commit,
                   :hostname, :api_endpoint
 
@@ -64,6 +66,7 @@ module Dependabot
     def self.github_enterprise_from_url(url_string)
       captures = url_string&.match(GITHUB_ENTERPRISE_SOURCE)&.named_captures
       return unless captures
+      return if IGNORED_PROVIDER_HOSTS.include?(captures.fetch("host"))
 
       base_url = "https://#{captures.fetch('host')}"
 
@@ -86,6 +89,8 @@ module Dependabot
         # currently doesn't work with development environments
         resp.headers["X-GitHub-Request-Id"] &&
         !resp.headers["X-GitHub-Request-Id"].empty?
+    rescue Excon::Error
+      false
     end
 
     def initialize(provider:, repo:, directory: nil, branch: nil, commit: nil,

--- a/common/spec/dependabot/source_spec.rb
+++ b/common/spec/dependabot/source_spec.rb
@@ -235,6 +235,11 @@ RSpec.describe Dependabot::Source do
       end
     end
 
+    context "with an explicitly ignored URL" do
+      let(:url) { "https://gitbox.apache.org/repos/asf?p=commons-lang.git" }
+      it { is_expected.to be_nil }
+    end
+
     context "with a Bitbucket URL" do
       let(:url) do
         "https://bitbucket.org/org/abc/src/master/dir/readme.md?at=default"


### PR DESCRIPTION
We check if a potential Source is GitHub enterprise by making a request
to a `/status` endpoint against the root URL and checking some headers.

We've observed this check failing in some cases when the source is not
enterprise, and we get rate limited, or otherwise the request fails with
an error.

In this case we do not want to block creating a PR, but instead we
should assume the source is not Enterprise.

This also adds a list of known hosts that we come across often that
definitely are not GitHub Enterprise instances, and we ignore those and
don't bother making a request to them.