### PR TITLE
Explicitly ignore metadata detection for fuchsia.googlesource.com

### DIFF
--- a/common/lib/dependabot/source.rb
+++ b/common/lib/dependabot/source.rb
@@ -45,7 +45,7 @@ module Dependabot
       (?:#{AZURE_SOURCE})
     /x.freeze
 
-    IGNORED_PROVIDER_HOSTS = %w(gitbox.apache.org svn.apache.org).freeze
+    IGNORED_PROVIDER_HOSTS = %w(gitbox.apache.org svn.apache.org fuchsia.googlesource.com).freeze
 
     attr_accessor :provider, :repo, :directory, :branch, :commit,
                   :hostname, :api_endpoint


### PR DESCRIPTION
We've observed some failures when trying to establish if this might be
an GHES host, since we can be confident it's not, let's not bother
making a request to check.