### PR TITLE
Terraform: Improve file updater and registry request error handling

### DIFF
--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -12,6 +12,7 @@ module Dependabot
       include FileSelector
 
       PRIVATE_MODULE_ERROR = /Could not download module.*code from\n.*\"(?<repo>\S+)\":/.freeze
+      MODULE_NOT_INSTALLED_ERROR =  /Module not installed.*module\s*\"(?<mod>\S+)\"/m.freeze
 
       def self.updated_files_regex
         [/\.tf$/, /\.hcl$/]
@@ -110,7 +111,7 @@ module Dependabot
           updated_manifest_files.each { |f| File.write(f.name, f.content) }
 
           File.write(".terraform.lock.hcl", lockfile_dependency_removed)
-          SharedHelpers.run_shell_command("terraform providers lock #{provider_source}")
+          SharedHelpers.run_shell_command("terraform providers lock #{provider_source} -no-color")
 
           updated_lockfile = File.read(".terraform.lock.hcl")
           updated_dependency = updated_lockfile.scan(declaration_regex).first
@@ -122,6 +123,10 @@ module Dependabot
             content.sub!(declaration_regex, updated_dependency)
           end
         rescue SharedHelpers::HelperSubprocessFailed => e
+          if @retrying_lock && e.message.match?(MODULE_NOT_INSTALLED_ERROR)
+            mod = e.message.match(MODULE_NOT_INSTALLED_ERROR).named_captures.fetch("mod")
+            raise Dependabot::DependencyFileNotResolvable, "Attempt to install module #{mod} failed"
+          end
           raise if @retrying_lock || !e.message.include?("terraform init")
 
           # NOTE: Modules need to be installed before terraform can update the
@@ -146,6 +151,8 @@ module Dependabot
           if output.match?(PRIVATE_MODULE_ERROR)
             raise PrivateSourceAuthenticationFailure, output.match(PRIVATE_MODULE_ERROR).named_captures.fetch("repo")
           end
+
+          raise Dependabot::DependencyFileNotResolvable, "Error running `terraform init`: #{output}"
         end
       end
 

--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -33,6 +33,8 @@ module Dependabot
         JSON.parse(response.body).
           fetch("versions").
           map { |release| version_class.new(release.fetch("version")) }
+      rescue Excon::Error
+        raise error("Could not fetch provider versions")
       end
 
       # Fetch all the versions of a module, and return a Version


### PR DESCRIPTION
This PR addresses two issues:

Dependabot sometimes comes across terraform modules that need to be installed, where terraform will hint at this with a message like: `This module is not yet installed. Run "terraform init" to install all modules`. We will then dutifully run that command and retry, and typically the `terraform providers lock` command will succeed at that point.

However, when that command fails we would previously try to run `terraform providers lock` again, and spit out the full error to users, which on our end would be handled as an unknown error.

The change introduced here is to report any failures for `terraform init` as resolvability failures, and the same goes if the command exits successfully, but the next run of `terraform providers lock` gives us the same `This module is not yet installed` error.

The other error we address is networking failures when attempting to reach a dependencies provider (terraform registry), we rescue these and raise an appropriate message.