### PR TITLE
Run YarnUpdate only once for a version requirement

### DIFF
--- a/npm_and_yarn/helpers/lib/yarn/updater.js
+++ b/npm_and_yarn/helpers/lib/yarn/updater.js
@@ -107,8 +107,7 @@ async function updateDependencyFiles(directory, dependencies) {
   let requiredVersions = [];
   for (let dep of dependencies) {
     for (let reqs of dep.requirements) {
-      if(requiredVersions.indexOf(reqs.requirement) > -1)
-      {
+      if (requiredVersions.indexOf(reqs.requirement) > -1) {
           continue;
       }
       updateRunResults = Object.assign(

--- a/npm_and_yarn/helpers/lib/yarn/updater.js
+++ b/npm_and_yarn/helpers/lib/yarn/updater.js
@@ -104,16 +104,20 @@ async function updateDependencyFiles(directory, dependencies) {
   const readFile = (fileName) =>
     fs.readFileSync(path.join(directory, fileName)).toString();
   let updateRunResults = { "yarn.lock": readFile("yarn.lock") };
-
+  let requiredVersions = [];
   for (let dep of dependencies) {
     for (let reqs of dep.requirements) {
+      if(requiredVersions.indexOf(reqs.requirement) > -1)
+      {
+          continue;
+      }
       updateRunResults = Object.assign(
         updateRunResults,
         await updateDependencyFile(directory, dep.name, dep.version, reqs)
       );
+      requiredVersions.push(reqs.requirement);
     }
   }
-
   return updateRunResults;
 }
 


### PR DESCRIPTION
Issue: https://github.com/dependabot/dependabot-core/issues/4288

Currently, For a mono repo, when [UpdateDependencyFiles ](https://github.com/dependabot/dependabot-core/blob/d734dc6e4fe0f7903ee97e0079ac9f5362e408c1/npm_and_yarn/helpers/lib/yarn/updater.js#L103)is called for generating the lock file content, dependencies param is passed to it. Dependencies param contains the dep that needs to be updated in all required workspaces in the repo. 

As far as observed, the multiple package.json (multiple requirements) for a dependency are getting passed for a mono repo., where it does have only a single yarn.lock file. 
In this case, it's not necessary to run `yarn update` for each and every package.json or requirement if all are referring to same version.
For a single version, if run once, yarn.lock would be generated, and running the same version `yarn update` would result in repetition of the task.
In case if each package.json is referring to different versions of that dependency, this code would handle that by running `yarn update` accordingly.