### PR TITLE
fix: remove fixed error message check

### DIFF
--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -58,8 +58,6 @@ module Dependabot
             # If pandoc isn't installed just return the rst
             pruned_text
           rescue RuntimeError => e
-            raise unless e.message.include?("Pandoc timed out")
-
             pruned_text
           end
         end

--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -57,7 +57,7 @@ module Dependabot
 
             # If pandoc isn't installed just return the rst
             pruned_text
-          rescue RuntimeError => e
+          rescue RuntimeError
             pruned_text
           end
         end


### PR DESCRIPTION
A new version of [pandoc-ruby](https://rubygems.org/gems/pandoc-ruby/versions/2.1.5) was recently released that changes the behaviour of how the `pandoc` executable is invoked. [source](https://github.com/xwmx/pandoc-ruby/compare/2.1.4...2.1.5). This caused one of the tests in the default branch to start failing.

The change introduced in this PR makes the minimal change necessary to fix the failing test while preserving the desired behaviour to unblock merging into the main branch.

/cc https://github.com/dependabot/dependabot-core/pull/2849
