### PR TITLE
Maven: Correctly handle nested declarations

### DIFF
--- a/maven/lib/dependabot/maven/file_updater/declaration_finder.rb
+++ b/maven/lib/dependabot/maven/file_updater/declaration_finder.rb
@@ -9,9 +9,7 @@ module Dependabot
   module Maven
     class FileUpdater
       class DeclarationFinder
-        DECLARATION_REGEX =
-          %r{<parent>.*?</parent>|<dependency>.*?</dependency>|
-             <plugin>.*?</plugin>|<extension>.*?</extension>}mx.freeze
+        DECLARATION_TYPES = %w(parent dependency plugin extension).freeze
 
         attr_reader :dependency, :declaring_requirement, :dependency_files
 
@@ -78,9 +76,14 @@ module Dependabot
         end
 
         def deep_find_declarations(string)
-          string.scan(DECLARATION_REGEX).flat_map do |matching_node|
-            [matching_node, *deep_find_declarations(matching_node[1..-1])]
+          pom = Nokogiri::XML(string)
+          nodes = []
+          pom.traverse do |node|
+            next unless DECLARATION_TYPES.include?(node.node_name)
+
+            nodes << node.to_s
           end
+          nodes
         end
 
         def declaring_requirement_matches?(node)

--- a/maven/lib/dependabot/maven/update_checker/property_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/property_updater.rb
@@ -105,7 +105,7 @@ module Dependabot
             dependency: dep,
             declaring_requirement: declaring_requirement,
             dependency_files: dependency_files
-          ).declaration_nodes.first.at_css("version")&.content
+          ).declaration_nodes.first.at_xpath("./*/version")&.content
         end
 
         def pom

--- a/maven/spec/dependabot/maven/file_updater/declaration_finder_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater/declaration_finder_spec.rb
@@ -420,5 +420,32 @@ RSpec.describe Dependabot::Maven::FileUpdater::DeclarationFinder do
           to eq("org.springframework")
       end
     end
+
+    context "with a plugin that contains a nested plugin configuration declaration" do
+      let(:pom) do
+        Dependabot::DependencyFile.new(name: "pom.xml", content: fixture("poms", "nested_plugin.xml"))
+      end
+      let(:dependency_name) { "org.jetbrains.kotlin:kotlin-maven-plugin" }
+      let(:dependency_version) { "1.4.30" }
+      let(:declaring_requirement) do
+        {
+          requirement: dependency_version,
+          file: "pom.xml",
+          groups: [],
+          source: nil,
+          metadata: { packaging_type: "jar", property_name: "kotlin.version" }
+        }
+      end
+
+      it "finds the declaration" do
+        expect(declaration_nodes.count).to eq(1)
+
+        declaration_node = declaration_nodes.first
+        expect(declaration_node).to be_a(Nokogiri::XML::Node)
+        expect(declaration_node.at_xpath("./*/version").content).to eq("${kotlin.version}")
+        expect(declaration_node.at_xpath("./*/artifactId").content).to eq("kotlin-maven-plugin")
+        expect(declaration_node.at_xpath("./*/groupId").content).to eq("org.jetbrains.kotlin")
+      end
+    end
   end
 end

--- a/maven/spec/fixtures/poms/nested_plugin.xml
+++ b/maven/spec/fixtures/poms/nested_plugin.xml
@@ -1,0 +1,81 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.dependabot</groupId>
+  <artifactId>basic-pom</artifactId>
+  <version>0.0.1-RELEASE</version>
+  <name>Dependabot Basic POM</name>
+
+  <properties>
+    <kotlin.version>1.4.30</kotlin.version>
+  </properties>
+
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>23.3-jre</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.3</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.mockk</groupId>
+      <artifactId>mockk</artifactId>
+      <version>1.0.0</version>
+      <classifier>sources</classifier>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <dependencies>
+          <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-maven-allopen</artifactId>
+            <version>${kotlin.version}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <jvmTarget>11</jvmTarget>
+          <compilerPlugins>
+            <plugin>spring</plugin>
+          </compilerPlugins>
+        </configuration>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
We've observed errors around pom files that have a nested `plugin`
section inside an outer plugin declaration.

Previously we used a regex to recursively scan the XML document, which
caused the inner `plugin` declarations closing tag to match the regex,
resulting in an incomplete XML section.

To demonstrate, given the following XML:

```xml
<plugins>
  <plugin>
    <configuration>
      <jvmTarget>11</jvmTarget>
      <compilerPlugins>
        <plugin>spring</plugin>
      </compilerPlugins>
    </configuration>
    <groupId>org.jetbrains.kotlin</groupId>
    <artifactId>kotlin-maven-plugin</artifactId>
    <version>${kotlin.version}</version>
  </plugin>
</plugin>
```

The `<plugin>spring</plugin>` declaration would cause a regex match,
resulting in the required information (the `version` in this case) to be
omitted from the XML snippet.

This is resolved by using Nokogiri to traverse the XML instead of using
regular expressions, and selecting the nodes by name.