### PR TITLE
Use GitHub-flavored Markdown as the output from Pandoc

### DIFF
--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -48,7 +48,7 @@ module Dependabot
             PandocRuby.convert(
               pruned_text,
               from: :rst,
-              to: :markdown,
+              to: :gfm,
               wrap: :none,
               timeout: 10
             )


### PR DESCRIPTION
Per Pandoc's docs[^1]
> Pandoc’s parsers can exhibit pathological performance on some corner
  cases. It is wise to put any pandoc operations under a timeout, to avoid
  DOS attacks that exploit these issues. If you are using the pandoc
  executable, you can add the command line options +RTS -M512M -RTS (for
  example) to limit the heap size to 512MB. Note that the commonmark
  parser (including commonmark_x and gfm) is much less vulnerable to
  pathological performance than the markdown parser, so it is a better
  choice when processing untrusted input.

[^1]: https://pandoc.org/MANUAL.html