### PR TITLE
Add pandoc to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,6 @@ ENV DEBIAN_FRONTEND="noninteractive" \
   LC_ALL="en_US.UTF-8" \
   LANG="en_US.UTF-8"
 
-# Everything from `make` onwards in apt-get install is only installed to ensure
-# Python support works with all packages (which may require specific libraries
-# at install time).
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
@@ -32,6 +29,8 @@ RUN apt-get update \
     openssh-client \
     software-properties-common \
     make \
+# All packages from here onward are installed to ensure the Python ecosystem
+# is properly supported as Python packages may depend on them.
     libpq-dev \
     libssl-dev \
     libbz2-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update \
     libxmlsec1-dev \
     libgeos-dev \
     python3-enchant \
+    pandoc \
   && locale-gen en_US.UTF-8 \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,43 +12,43 @@ RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
     build-essential \
-    dirmngr \
-    git \
     bzr \
-    mercurial \
-    gnupg2 \
     ca-certificates \
     curl \
+    dirmngr \
     file \
-    zlib1g-dev \
+    git \
+    gnupg2 \
     liblzma-dev \
-    tzdata \
-    zip \
-    unzip \
     locales \
-    openssh-client \
-    software-properties-common \
     make \
+    mercurial \
+    openssh-client \
+    pandoc \
+    software-properties-common \
+    tzdata \
+    unzip \
+    zip \
+    zlib1g-dev \
 # All packages from here onward are installed to ensure the Python ecosystem
 # is properly supported as Python packages may depend on them.
-    libpq-dev \
-    libssl-dev \
     libbz2-dev \
-    libffi-dev \
-    libreadline-dev \
-    libsqlite3-dev \
     libcurl4-openssl-dev \
-    llvm \
+    libffi-dev \
+    libgeos-dev \
+    libmysqlclient-dev \
     libncurses5-dev \
     libncursesw5-dev \
-    libmysqlclient-dev \
-    xz-utils \
-    tk-dev \
+    libpq-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libssl-dev \
     libxml2-dev \
     libxmlsec1-dev \
-    libgeos-dev \
+    llvm \
     python3-enchant \
-    pandoc \
+    tk-dev \
+    xz-utils \
   && locale-gen en_US.UTF-8 \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

PandocRuby is used to convert RestructuredText (rst), a markdown-like
format widely used in the Python ecosystem, to markdown. We recently
noticed new errors surfacing around Pandoc and started to investigate.
This led to the discovery that Pandoc was not installed in the Docker
container GitHub is using to run Dependabot against repositories.

There was error handling to make this hard to discover, and rst is
similar enough to markdown that there were no reported problems.
Since the conversion was intentional at some point in the past, and
since we can't _know_ that users of `dependabot-core` rely on Pandoc one
way or another, I'm opting to add it to the Docker image.

---

### Cleanup

I made two additional changes while adding Pandoc to the image:
* Localizing the Python-specific comment: It doesn't seem that any packages were included to the wrong place since the comment was added, but I thought the potential for it was high.
* Sorting the list of packages to install: Actually, I chose to sort the lists separately. This builds off the previous idea of keeping Python-specific packages grouped. Sorting lists is included as a [Dockerfile best practice](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#sort-multi-line-arguments). I don't see the downside outside of surprises that might come from install order. I would expect our test suite to surface errors related to that, but it's not guaranteed.