### PR TITLE
Remove reliance on `PandocRuby`

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gitlab", "4.17.0"
   spec.add_dependency "nokogiri", "~> 1.8"
   spec.add_dependency "octokit", "~> 4.6"
-  spec.add_dependency "pandoc-ruby", "~> 2.0"
   spec.add_dependency "parser", ">= 2.5", "< 4.0"
   spec.add_dependency "toml-rb", ">= 1.1.2", "< 3.0"
 

--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "excon"
-require "pandoc-ruby"
 
 require "dependabot/clients/github_with_retries"
 require "dependabot/clients/gitlab_with_retries"
@@ -37,29 +36,10 @@ module Dependabot
         def changelog_text
           return unless full_changelog_text
 
-          pruned_text = ChangelogPruner.new(
+          ChangelogPruner.new(
             dependency: dependency,
             changelog_text: full_changelog_text
           ).pruned_text
-
-          return pruned_text unless changelog.name.end_with?(".rst")
-
-          begin
-            PandocRuby.convert(
-              pruned_text,
-              from: :rst,
-              to: :markdown,
-              wrap: :none,
-              timeout: 10
-            )
-          rescue Errno::ENOENT => e
-            raise unless e.message == "No such file or directory - pandoc"
-
-            # If pandoc isn't installed just return the rst
-            pruned_text
-          rescue RuntimeError
-            pruned_text
-          end
         end
 
         def upgrade_guide_url

--- a/common/spec/dependabot/metadata_finders/base/changelog_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/changelog_finder_spec.rb
@@ -798,18 +798,9 @@ RSpec.describe Dependabot::MetadataFinders::Base::ChangelogFinder do
             "* Fixed `issue <https://github.com/pytest-dev/"\
             "pytest-selenium/issues/216>`_ with TestingBot local tunnel."
           end
-          let(:converted_text) do
-            "1.16.0 (2019-02-12)\n"\
-            "===================\n"\
-            "\n"\
-            "-   `pytest-selenium` now requires pytest 3.6 or later.\n"\
-            "-   Fixed [issue](https://github.com/pytest-dev/"\
-            "pytest-selenium/issues/216) with TestingBot local tunnel.\n"
-          end
 
-          it "converts the rst properly (or falls back)" do
-            expect([converted_text, unconverted_text]).
-              to include(changelog_text)
+          it "does not convert the rst" do
+            expect(changelog_text).to eq(unconverted_text)
           end
         end
       end


### PR DESCRIPTION
PandocRuby has been used to convert RestructuredText (rst), a
markdown-like format widely used in the Python ecosystem, to markdown.
We recently noticed new errors surfacing around Pandoc and started to
investigate.  This led to the discovery that Pandoc was not installed in
the Docker container GitHub is using to run Dependabot against
repositories.

I'm opting to remove this dependency as PandocRuby is effectively
unused.

Note: There is the possibility that some users rely on this
functionality. As has been noted in a recent PR-review, non-Docker usage
of dependabot-core is poorly supported, so this seems unlikely.