### PR TITLE
python: Upgrade to pip 21.3.1

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -1,4 +1,4 @@
-pip==21.2.4
+pip==21.3.1
 pip-tools==6.4.0
 flake8==4.0.1
 hashin==0.15.0

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -25,7 +25,7 @@ module Dependabot
       # rubocop:disable Metrics/ClassLength
       class PipCompileVersionResolver
         GIT_DEPENDENCY_UNREACHABLE_REGEX =
-          /git clone -q (?<url>[^\s]+).* /.freeze
+          /git clone --filter=blob:none -q (?<url>[^\s]+).* /.freeze
         GIT_REFERENCE_NOT_FOUND_REGEX =
           /egg=(?<name>\S+).*.*WARNING: Did not find branch or tag \'(?<tag>[^\n"]+)\'/m.freeze
         NATIVE_COMPILATION_ERROR =


### PR DESCRIPTION
This patch contains #4345 plus a fix for the failing test.

Closes #4345.