### PR TITLE
Bump minimum to 1.17

### DIFF
--- a/go_modules/helpers/go.mod
+++ b/go_modules/helpers/go.mod
@@ -1,5 +1,5 @@
 module github.com/dependabot/dependabot-core/go_modules/helpers
 
-go 1.16
+go 1.17
 
 require github.com/Masterminds/vcs v1.13.1


### PR DESCRIPTION
This isn't strictly necessary, but since the rest of the infra bumped to 1.17,
might as well bump it here too. Esp since the `go.mod` behavior changed
a bit in `1.17`... so if more libs get added ever, this makes it so `go.mod`/`go.sum`
will follow the new behavior...