### PR TITLE
Limit the GitHub PR description message to API max

### DIFF
--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -9,6 +9,9 @@ module Dependabot
   class PullRequestCreator
     # rubocop:disable Metrics/ClassLength
     class Github
+
+      MAX_PR_DESCRIPTION_LENGTH = 65536
+
       attr_reader :source, :branch_name, :base_commit, :credentials,
                   :files, :pr_description, :pr_name, :commit_message,
                   :author_details, :signature_key, :custom_headers,
@@ -347,6 +350,18 @@ module Dependabot
       end
 
       def create_pull_request
+        # Limit PR description to MAX_PR_DESCRIPTION_LENGTH (65,536) characters
+        # and truncate with message if over. The API limit is 262,144 bytes
+        # (https://github.community/t/maximum-length-for-the-comment-body-in-issues-and-pr/148867/2).
+        # As Ruby strings are UTF-8 encoded, this is a pessimistic limit: it
+        # presumes the case where all characters are 4 bytes.
+        pr_description = @pr_description.dup
+        if pr_description && pr_description.length > MAX_PR_DESCRIPTION_LENGTH
+          truncated_msg = "...\n\n_Description has been truncated_"
+          truncate_length = MAX_PR_DESCRIPTION_LENGTH - truncated_msg.length
+          pr_description = (pr_description[0, truncate_length] + truncated_msg)
+        end
+
         github_client_for_source.create_pull_request(
           source.repo,
           target_branch,

--- a/common/spec/dependabot/pull_request_creator/github_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/github_spec.rb
@@ -1088,6 +1088,26 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
           )
         end
       end
+
+    context "the PR description is too long" do
+      let(:pr_description) { "a" * (described_class::MAX_PR_DESCRIPTION_LENGTH + 1) }
+
+      it "truncates the description" do
+        creator.create
+
+        expect(WebMock).
+          to have_requested(:post, "#{repo_api_url}/pulls").
+          with(
+            body: {
+              base: "master",
+              head: "dependabot/bundler/business-1.5.0",
+              title: "PR name",
+              body: lambda { |body| expect(body.length).to be <= described_class::MAX_PR_DESCRIPTION_LENGTH }
+            }
+          )
+      end
+    end
+
     end
   end
 end


### PR DESCRIPTION
Limit the PR description message length to the maximum supported by GitHub API (65,536 characters).

Strictly speaking, the API can support up to 262,144 _bytes_. As Ruby strings are UTF-8 encoded, which represents each character with 1 to 4 bytes, a longer message could be sent. This is pessimistic and assumes 4-bytes per character. However, the API responds with an error message saying the limit is 65536 characters. This is easier to support--we don't have to figure out what to do if the truncation occurs at the end of a multi-byte character, which can be tricky.
