### PR TITLE
[WIP] Allow Azure client to set auto complete

### DIFF
--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -172,7 +172,7 @@ module Dependabot
 
       # rubocop:disable Metrics/ParameterLists
       def create_pull_request(pr_name, source_branch, target_branch,
-                              pr_description, labels, work_item = nil)
+                              pr_description, labels, work_item = nil, auto_complete = nil)
         pr_description = truncate_pr_description(pr_description)
 
         content = {
@@ -181,7 +181,8 @@ module Dependabot
           title: pr_name,
           description: pr_description,
           labels: labels.map { |label| { name: label } },
-          workItemRefs: [{ id: work_item }]
+          workItemRefs: [{ id: work_item }],
+          autoCompleteSetBy: { id: auto_complete }
         }
 
         post(source.api_endpoint +

--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -175,6 +175,7 @@ module Dependabot
         author_details: author_details,
         labeler: labeler,
         work_item: provider_metadata&.fetch(:work_item, nil)
+        auto_complete: provider_metadata&.fetch(:auto_complete, nil)
       )
     end
 

--- a/common/lib/dependabot/pull_request_creator/azure.rb
+++ b/common/lib/dependabot/pull_request_creator/azure.rb
@@ -8,11 +8,11 @@ module Dependabot
     class Azure
       attr_reader :source, :branch_name, :base_commit, :credentials,
                   :files, :commit_message, :pr_description, :pr_name,
-                  :author_details, :labeler, :work_item
+                  :author_details, :labeler, :work_item :auto_complete
 
       def initialize(source:, branch_name:, base_commit:, credentials:,
                      files:, commit_message:, pr_description:, pr_name:,
-                     author_details:, labeler:, work_item: nil)
+                     author_details:, labeler:, work_item: nil, auto_complete: nil)
         @source         = source
         @branch_name    = branch_name
         @base_commit    = base_commit
@@ -24,6 +24,7 @@ module Dependabot
         @author_details = author_details
         @labeler        = labeler
         @work_item      = work_item
+        @auto_complete  = auto_complete
       end
 
       def create
@@ -80,6 +81,7 @@ module Dependabot
           pr_description,
           labeler.labels_for_pr,
           work_item
+          auto_complete
         )
       end
 

--- a/common/spec/dependabot/pull_request_creator/azure_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/azure_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Dependabot::PullRequestCreator::Azure do
     )
   end
   let(:work_item) { 123 }
+  let(:auto_complete) { 456 }
   let(:custom_labels) { nil }
   let(:dependency) do
     Dependabot::Dependency.new(

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe Dependabot::PullRequestCreator do
     context "with an Azure source" do
       let(:source) { Dependabot::Source.new(provider: "azure", repo: "gc/bp") }
       let(:dummy_creator) { instance_double(described_class::Azure) }
-      let(:provider_metadata) { { work_item: 123 } }
+      let(:provider_metadata) { { work_item: 123, auto_complete: 456 } }
 
       it "delegates to PullRequestCreator::Azure with correct params" do
         expect(described_class::Azure).
@@ -257,6 +257,7 @@ RSpec.describe Dependabot::PullRequestCreator do
             author_details: author_details,
             labeler: instance_of(described_class::Labeler),
             work_item: 123
+            auto_complete: 456
           ).and_return(dummy_creator)
         expect(dummy_creator).to receive(:create)
         creator.create


### PR DESCRIPTION
Azure DevOps has an option to auto merge a PR after review and tests, this is to allow an option to set auto complete by dependabot, to save 1 click for the merge. The `auto_complete` property is the user id that enabled it. 

<img width="1123" alt="Screen Shot 2021-11-24 at 8 23 07 PM" src="https://user-images.githubusercontent.com/511355/143237937-3ffc4971-ff39-4cd5-8e5f-e6986bc3fd01.png">

API docs: https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/create?view=azure-devops-rest-5.0
