### PR TITLE
Dependabot config: ignore npm lib major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,10 @@ updates:
     directory: "/npm_and_yarn/helpers"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "npm"
+        # We explicitly need npm 6 here, in order to support npm 6.
+        versions: ["version-update:semver-major"]
   - package-ecosystem: "pip"
     directory: "/python/helpers"
     schedule:


### PR DESCRIPTION
These helpers exist to support npm 6, so we require that specific major version and should not update it.