### PR TITLE
feat: use tracepoint to capture and flush a stack trace

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -209,6 +209,7 @@ docker run --rm -ti \
   -v "$(pwd)/tmp:/$CODE_DIR/tmp" \
   --name "$CONTAINER_NAME" \
   --env "LOCAL_GITHUB_ACCESS_TOKEN=$LOCAL_GITHUB_ACCESS_TOKEN" \
+  --env "LOCAL_CONFIG_VARIABLES=$LOCAL_CONFIG_VARIABLES" \
   "${DOCKER_OPTS[@]}" \
   --cap-add=SYS_PTRACE \
   "$IMAGE_NAME" "${CONTAINER_ARGS[@]}"

--- a/bundler/helpers/v1/Gemfile
+++ b/bundler/helpers/v1/Gemfile
@@ -3,10 +3,10 @@
 source "https://rubygems.org"
 
 # NOTE: Used to run native helper specs
-group :test do
-  gem "byebug", "11.1.3"
-  gem "rspec", "3.10.0"
-  gem "rspec-its", "1.3.0"
-  gem "vcr", "6.0.0"
-  gem "webmock", "3.12.1"
-end
+# group :test do
+#   gem "byebug", "11.1.3"
+#   gem "rspec", "3.10.0"
+#   gem "rspec-its", "1.3.0"
+#   gem "vcr", "6.0.0"
+#   gem "webmock", "3.12.1"
+# end

--- a/bundler/helpers/v1/run.rb
+++ b/bundler/helpers/v1/run.rb
@@ -3,9 +3,8 @@
 require "logger"
 require "bundler"
 require "json"
-require "logger"
 
-$logger = Logger.new($stderr, formatter: proc { |severity, datetime, progname, msg|
+$logger = Logger.new($stderr, formatter: proc { |_severity, _datetime, _progname, msg|
   JSON.generate(msg.is_a?(Hash) ? msg : { msg: msg }) + "\n"
 })
 $LOAD_PATH.unshift(File.expand_path("./lib", __dir__))
@@ -25,8 +24,8 @@ class With
   def self.tracer
     @tracer ||= TracePoint.new(:call) do |x|
       stacktrace << { path: x.path, lineno: x.lineno, clazz: x.defined_class, method: x.method_id, args: args_from(x) }
-    rescue => error
-      $logger.error({ msg: error, stacktrace: error.backtrace })
+    rescue StandardError => e
+      $logger.error({ msg: e, stacktrace: e.backtrace })
     end
   end
 

--- a/bundler/helpers/v1/run.rb
+++ b/bundler/helpers/v1/run.rb
@@ -1,14 +1,49 @@
 # frozen_string_literal: true
 
+require "logger"
 require "bundler"
 require "json"
+require "logger"
 
+$logger = Logger.new($stderr, formatter: proc { |severity, datetime, progname, msg|
+  JSON.generate(msg.is_a?(Hash) ? msg : { msg: msg }) + "\n"
+})
 $LOAD_PATH.unshift(File.expand_path("./lib", __dir__))
 $LOAD_PATH.unshift(File.expand_path("./monkey_patches", __dir__))
 
 trap "HUP" do
-  puts JSON.generate(error: "timeout", error_class: "Timeout::Error", trace: [])
+  With.tracer.disable
+  puts JSON.generate(error: "timeout", error_class: "Timeout::Error", trace: With.stacktrace)
   exit 2
+end
+
+class With
+  def self.stacktrace
+    @stacktrace ||= []
+  end
+
+  def self.tracer
+    @tracer ||= TracePoint.new(:call) do |x|
+      stacktrace << { path: x.path, lineno: x.lineno, clazz: x.defined_class, method: x.method_id, args: args_from(x) }
+    rescue => error
+      $logger.error({ msg: error, stacktrace: error.backtrace })
+    end
+  end
+
+  def self.args_from(trace)
+    trace.parameters.map(&:last).map { |x| [x, trace.binding.eval(x.to_s)] }.to_h
+  end
+
+  def self.locals_from(trace)
+    trace.binding.local_variables.map { |x| [x, trace.binding.local_variable_get(x)] }.to_h
+  end
+
+  def self.trace
+    tracer.enable
+    yield
+  ensure
+    tracer.disable
+  end
 end
 
 # Bundler monkey patches
@@ -42,7 +77,9 @@ begin
   function = request["function"]
   args = request["args"].transform_keys(&:to_sym)
 
-  output({ result: Functions.send(function, **args) })
+  With.trace do
+    output({ result: Functions.send(function, **args) })
+  end
 rescue StandardError => e
   output(
     { error: e.message, error_class: e.class, trace: e.backtrace }

--- a/bundler/helpers/v2/Gemfile
+++ b/bundler/helpers/v2/Gemfile
@@ -3,10 +3,10 @@
 source "https://rubygems.org"
 
 # NOTE: Used to run native helper specs
-group :test do
-  gem "byebug", "11.1.3"
-  gem "rspec", "3.10.0"
-  gem "rspec-its", "1.3.0"
-  gem "vcr", "6.0.0"
-  gem "webmock", "3.12.1"
-end
+# group :test do
+#   gem "byebug", "11.1.3"
+#   gem "rspec", "4.10.0"
+#   gem "rspec-its", "1.3.0"
+#   gem "vcr", "6.0.0"
+#   gem "webmock", "3.12.1"
+# end

--- a/bundler/helpers/v2/run.rb
+++ b/bundler/helpers/v2/run.rb
@@ -7,7 +7,7 @@ require "logger"
 $LOAD_PATH.unshift(File.expand_path("./lib", __dir__))
 $LOAD_PATH.unshift(File.expand_path("./monkey_patches", __dir__))
 
-$logger = Logger.new($stderr, formatter: proc { |severity, datetime, progname, msg|
+$logger = Logger.new($stderr, formatter: proc { |_severity, _datetime, _progname, msg|
   JSON.generate(msg.is_a?(Hash) ? msg : { msg: msg }) + "\n"
 })
 
@@ -25,8 +25,8 @@ class With
   def self.tracer
     @tracer ||= TracePoint.new(:call) do |x|
       stacktrace << { path: x.path, lineno: x.lineno, clazz: x.defined_class, method: x.method_id, args: args_from(x) }
-    rescue => error
-      $logger.error({ msg: error, stacktrace: error.backtrace })
+    rescue StandardError => e
+      $logger.error({ msg: e, stacktrace: e.backtrace })
     end
   end
 

--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -27,7 +27,8 @@ module Dependabot
         end
 
         def clamp(seconds)
-          return 0 unless seconds
+          # Tweak this value to tune the default timeout in seconds
+          return 60 unless seconds
 
           seconds.to_i.clamp(MIN_SECONDS, MAX_SECONDS)
         end

--- a/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
@@ -142,7 +142,8 @@ module Dependabot
               next r if requirement_satisfied?(r, req[:groups])
 
               if req[:groups] == ["development"] then bumped_requirements(r)
-              else widened_requirements(r)
+              else
+                widened_requirements(r)
               end
             end
 
@@ -267,7 +268,8 @@ module Dependabot
               version_to_be_permitted.segments[index] + 1
             elsif index > version_to_be_permitted.segments.count - 1
               nil
-            else 0
+            else
+              0
             end
           end.compact
 

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -109,10 +109,11 @@ module Dependabot
         function: function,
         args: args,
         time_taken: time_taken,
-        stderr_output: stderr ? stderr[0..50_000] : "", # Truncate to ~100kb
+        stderr_output: stderr, # ? stderr[0..50_000] : "", # Truncate to ~100kb
         process_exit_value: process.to_s,
         process_termsig: process.termsig
       }
+      puts error_context.inspect
 
       response = JSON.parse(stdout)
       return response["result"] if process.success?


### PR DESCRIPTION
This is an *experimental* feature branch to capture additional context to
understand why updates are failing for specific dependencies.

It also changes the default timeout to 60 seconds per operation.

### Instructions

```bash
$ git clone https://github.com/dependabot/dependabot-core.git
$ cd dependabot-core
$ git checkout timeout-tracing
$ ./bin/docker-dev-shell --rebuild
$ export LOCAL_GITHUB_ACCESS_TOKEN="MY-PERSONAL-ACCESS-TOKEN"
$ export LOCAL_CONFIG_VARIABLES='[{"type":"rubygems_server","host":"gem.fury.io","token":"MY-TOKEN"}]'
$ ./bin/dry-run.rb bundler myorg/myrepo
```

Additional information on the `dry-run` script can be found here: https://github.com/dependabot/dependabot-core#dry-run-script
