### PR TITLE
Update contributor from Dependabot Ltd to GitHub Inc

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The Prosperity Public License 2.0.0
 
-Contributor: Dependabot Ltd
+Contributor: GitHub Inc.
 
 Source Code: https://github.com/dependabot/dependabot-core
 


### PR DESCRIPTION
Dependabot was acquired back in 2019 and is now a part of GitHub. This is a small change to reflect GitHub as the contributor in the license.