### PR TITLE
Add tech-debt issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tech-debt.md
+++ b/.github/ISSUE_TEMPLATE/tech-debt.md
@@ -1,0 +1,15 @@
+---
+name: "\U00002699 Tech Debt"
+about: Tech debt is for code improvements that do not change the user-facing behavior (ie, neither adding features nor fixing bugs).
+title: ''
+labels: 'T: tech-debt'
+assignees: ''
+
+---
+
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+<!-- The Dependabot team is currently at reduced capacity, because of this our
+response times on issues will be slower than we'd like. -->
+
+<!-- Describe the code improvement you'd like. -->


### PR DESCRIPTION
Create a issue template for the new `T: tech-debt` label 
added as part of https://github.com/dependabot/dependabot-core/issues/3611.