### PR TITLE
feat(:git): do not decline valid git@... source

### DIFF
--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -289,7 +289,7 @@ module Dependabot
         return :path if source_string.start_with?(".")
         return :github if source_string.include?("github.com")
         return :bitbucket if source_string.start_with?("bitbucket.org/")
-        return :git if source_string.start_with?("git::")
+        return :git if source_string.start_with?("git::") || source_string.start_with?("git@")
         return :mercurial if source_string.start_with?("hg::")
         return :s3 if source_string.start_with?("s3::")
 

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -572,6 +572,32 @@ RSpec.describe Dependabot::Terraform::FileParser do
         end
       end
 
+      context "with git@xxx.yy sources" do
+        let(:files) { project_dependency_files("git_protocol") }
+
+        specify { expect(subject.length).to eq(1) }
+        specify { expect(subject).to all(be_a(Dependabot::Dependency)) }
+
+        it "has the right details for the first dependency (which uses git@gitlab.com)" do
+          dependency = subject.find do |x|
+            x.name == "gitlab_ssh_without_protocol::gitlab::cloudposse/terraform-aws-jenkins::tags/0.4.0"
+          end
+          expect(dependency).to_not be_nil
+          expect(dependency.version).to eq("0.4.0")
+          expect(dependency.requirements).to eq([{
+            requirement: nil,
+            groups: [],
+            file: "main.tf",
+            source: {
+              type: "git",
+              url: "git@gitlab.com:cloudposse/terraform-aws-jenkins.git",
+              ref: "tags/0.4.0",
+              branch: nil
+            }
+          }])
+        end
+      end
+
       context "with registry sources" do
         let(:files) { project_dependency_files("registry_012") }
 

--- a/terraform/spec/fixtures/projects/git_protocol/main.tf
+++ b/terraform/spec/fixtures/projects/git_protocol/main.tf
@@ -1,0 +1,9 @@
+module "gitlab_ssh_without_protocol" {
+  source     = "git@gitlab.com:cloudposse/terraform-aws-jenkins.git?ref=tags/0.4.0//some/dir"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  delimiter  = var.delimiter
+  attributes = ["${compact(concat(var.attributes, list("origin")))}"]
+  tags       = var.tags
+}


### PR DESCRIPTION
Now it will be possible to also pass the source_type(source_string) call 
with a terraform valid git@... source property being set.

The function [git_source_details_from(source_string)](https://github.com/dependabot/dependabot-core/blob/main/terraform/lib/dependabot/terraform/file_parser.rb#L225-L234) is already prepared 
to handle this type.