### PR TITLE
Autofix all rubocop lint

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
@@ -142,7 +142,8 @@ module Dependabot
               next r if requirement_satisfied?(r, req[:groups])
 
               if req[:groups] == ["development"] then bumped_requirements(r)
-              else widened_requirements(r)
+              else
+                widened_requirements(r)
               end
             end
 
@@ -267,7 +268,8 @@ module Dependabot
               version_to_be_permitted.segments[index] + 1
             elsif index > version_to_be_permitted.segments.count - 1
               nil
-            else 0
+            else
+              0
             end
           end.compact
 

--- a/cargo/lib/dependabot/cargo/requirement.rb
+++ b/cargo/lib/dependabot/cargo/requirement.rb
@@ -58,7 +58,8 @@ module Dependabot
         elsif req_string.match?(/^~[^>]/) then convert_tilde_req(req_string)
         elsif req_string.match?(/^[\d^]/) then convert_caret_req(req_string)
         elsif req_string.match?(/[<=>]/) then req_string
-        else ruby_range(req_string)
+        else
+          ruby_range(req_string)
         end
       end
 
@@ -92,7 +93,8 @@ module Dependabot
         upper_bound = parts.map.with_index do |part, i|
           if i < first_non_zero_index then part
           elsif i == first_non_zero_index then (part.to_i + 1).to_s
-          else 0
+          else
+            0
           end
         end.join(".")
 

--- a/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
@@ -144,7 +144,8 @@ module Dependabot
               version_to_be_permitted.segments[index]
             elsif index == index_to_update
               version_to_be_permitted.segments[index] + 1
-            else 0
+            else
+              0
             end
           end.join(".")
         end

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -327,7 +327,8 @@ module Dependabot
 
         def write_manifest_files(prepared: true)
           manifest_files = if prepared then prepared_manifest_files
-                           else original_manifest_files
+                           else
+                             original_manifest_files
                            end
 
           manifest_files.each do |file|

--- a/common/lib/dependabot/file_parsers/base/dependency_set.rb
+++ b/common/lib/dependabot/file_parsers/base/dependency_set.rb
@@ -68,7 +68,8 @@ module Dependabot
             elsif !v_cls.correct?(old_dep.version) then new_dep.version
             elsif v_cls.new(new_dep.version) > v_cls.new(old_dep.version)
               old_dep.version
-            else new_dep.version
+            else
+              new_dep.version
             end
 
           subdependency_metadata = (

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -244,7 +244,8 @@ module Dependabot
 
       if comparison.commits.none? then "behind"
       elsif comparison.compare_same_ref then "identical"
-      else "ahead"
+      else
+        "ahead"
       end
     end
 
@@ -261,7 +262,8 @@ module Dependabot
       # Conservatively assume that ref2 is ahead in the equality case, of
       # if we get an unexpected format (e.g., due to a 404)
       if JSON.parse(response.body).fetch("values", ["x"]).none? then "behind"
-      else "ahead"
+      else
+        "ahead"
       end
     end
 

--- a/common/lib/dependabot/git_metadata_fetcher.rb
+++ b/common/lib/dependabot/git_metadata_fetcher.rb
@@ -167,7 +167,8 @@ module Dependabot
     def uri_with_auth(uri)
       bare_uri =
         if uri.include?("git@") then uri.split("git@").last.sub(%r{:/?}, "/")
-        else uri.sub(%r{.*?://}, "")
+        else
+          uri.sub(%r{.*?://}, "")
         end
       cred = credentials.select { |c| c["type"] == "git_source" }.
              find { |c| bare_uri.start_with?(c["host"]) }

--- a/composer/lib/dependabot/composer/requirement.rb
+++ b/composer/lib/dependabot/composer/requirement.rb
@@ -48,7 +48,8 @@ module Dependabot
         elsif req_string.match?(/^~[^>]/) then convert_tilde_req(req_string)
         elsif req_string.include?(".x") then convert_wildcard_req(req_string)
         elsif req_string.match?(/\s-\s/) then convert_hyphen_req(req_string)
-        else req_string
+        else
+          req_string
         end
       end
 
@@ -76,7 +77,8 @@ module Dependabot
         upper_bound = parts.map.with_index do |part, i|
           if i < first_non_zero_index then part
           elsif i == first_non_zero_index then (part.to_i + 1).to_s
-          else 0
+          else
+            0
           end
         end.join(".")
 

--- a/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
+++ b/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
@@ -236,7 +236,8 @@ module Dependabot
               version_to_be_permitted.segments[index]
             elsif index == index_to_update
               version_to_be_permitted.segments[index] + 1
-            else 0
+            else
+              0
             end
           end.join(".")
         end

--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -79,7 +79,8 @@ module Dependabot
         old_tags.each do |old_tag|
           old_declaration =
             if private_registry_url(file) then "#{private_registry_url(file)}/"
-            else ""
+            else
+              ""
             end
           old_declaration += "#{dependency.name}:#{old_tag}"
           escaped_declaration = Regexp.escape(old_declaration)

--- a/elm/lib/dependabot/elm/file_parser.rb
+++ b/elm/lib/dependabot/elm/file_parser.rb
@@ -48,7 +48,8 @@ module Dependabot
                 name: name, group: dep_type, requirement: req, direct: true
               )
             end
-          else raise "Unexpected repo type for Elm repo: #{repo_type}"
+          else
+            raise "Unexpected repo type for Elm repo: #{repo_type}"
           end
         end
 

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -37,7 +37,8 @@ module Dependabot
       def dependency_from_details(details)
         source =
           if rev_identifier?(details) then git_source(details)
-          else { type: "default", source: details["Path"] }
+          else
+            { type: "default", source: details["Path"] }
           end
 
         version = details["Version"]&.sub(/^v?/, "")

--- a/go_modules/lib/dependabot/go_modules/requirement.rb
+++ b/go_modules/lib/dependabot/go_modules/requirement.rb
@@ -68,7 +68,8 @@ module Dependabot
         elsif req_string.include?(" - ") then convert_hyphen_req(req_string)
         elsif req_string.match?(/^[\dv^]/) then convert_caret_req(req_string)
         elsif req_string.match?(/[<=>]/) then req_string
-        else ruby_range(req_string)
+        else
+          ruby_range(req_string)
         end
       end
 

--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -196,11 +196,13 @@ module Dependabot
 
         dependency_name =
           if group == "plugins" then name
-          else "#{group}:#{name}"
+          else
+            "#{group}:#{name}"
           end
         groups =
           if group == "plugins" then ["plugins"] + extra_groups
-          else []
+          else
+            []
           end
         source =
           source_from(group, name, version)

--- a/gradle/lib/dependabot/gradle/metadata_finder.rb
+++ b/gradle/lib/dependabot/gradle/metadata_finder.rb
@@ -105,7 +105,8 @@ module Dependabot
         artifact_id =
           if kotlin_plugin? then "#{KOTLIN_PLUGIN_REPO_PREFIX}.#{dependency.name}.gradle.plugin"
           elsif plugin? then "#{dependency.name}.gradle.plugin"
-          else dependency.name.split(":").last
+          else
+            dependency.name.split(":").last
           end
 
         response = Excon.get(
@@ -157,7 +158,8 @@ module Dependabot
             ["#{KOTLIN_PLUGIN_REPO_PREFIX}.#{dependency.name}",
              "#{KOTLIN_PLUGIN_REPO_PREFIX}.#{dependency.name}.gradle.plugin"]
           elsif plugin? then [dependency.name, "#{dependency.name}.gradle.plugin"]
-          else dependency.name.split(":")
+          else
+            dependency.name.split(":")
           end
 
         "#{maven_repo_url}/#{group_id.tr('.', '/')}/#{artifact_id}"

--- a/gradle/lib/dependabot/gradle/requirement.rb
+++ b/gradle/lib/dependabot/gradle/requirement.rb
@@ -81,13 +81,15 @@ module Dependabot
         lower_b =
           if ["(", "["].include?(lower_b) then nil
           elsif lower_b.start_with?("(") then "> #{lower_b.sub(/\(\s*/, '')}"
-          else ">= #{lower_b.sub(/\[\s*/, '').strip}"
+          else
+            ">= #{lower_b.sub(/\[\s*/, '').strip}"
           end
 
         upper_b =
           if [")", "]"].include?(upper_b) then nil
           elsif upper_b.end_with?(")") then "< #{upper_b.sub(/\s*\)/, '')}"
-          else "<= #{upper_b.sub(/\s*\]/, '').strip}"
+          else
+            "<= #{upper_b.sub(/\s*\]/, '').strip}"
           end
 
         [lower_b, upper_b].compact

--- a/hex/lib/dependabot/hex/update_checker/requirements_updater.rb
+++ b/hex/lib/dependabot/hex/update_checker/requirements_updater.rb
@@ -136,7 +136,8 @@ module Dependabot
               version_to_be_permitted.segments[index]
             elsif index == index_to_update
               version_to_be_permitted.segments[index] + 1
-            else 0
+            else
+              0
             end
           end
 

--- a/hex/lib/dependabot/hex/update_checker/version_resolver.rb
+++ b/hex/lib/dependabot/hex/update_checker/version_resolver.rb
@@ -134,7 +134,8 @@ module Dependabot
 
         def write_temporary_sanitized_dependency_files(prepared: true)
           files = if prepared then prepared_dependency_files
-                  else original_dependency_files
+                  else
+                    original_dependency_files
                   end
 
           files.each do |file|

--- a/maven/lib/dependabot/maven/requirement.rb
+++ b/maven/lib/dependabot/maven/requirement.rb
@@ -81,13 +81,15 @@ module Dependabot
         lower_b =
           if ["(", "["].include?(lower_b) then nil
           elsif lower_b.start_with?("(") then "> #{lower_b.sub(/\(\s*/, '')}"
-          else ">= #{lower_b.sub(/\[\s*/, '').strip}"
+          else
+            ">= #{lower_b.sub(/\[\s*/, '').strip}"
           end
 
         upper_b =
           if [")", "]"].include?(upper_b) then nil
           elsif upper_b.end_with?(")") then "< #{upper_b.sub(/\s*\)/, '')}"
-          else "<= #{upper_b.sub(/\s*\]/, '').strip}"
+          else
+            "<= #{upper_b.sub(/\s*\]/, '').strip}"
           end
 
         [lower_b, upper_b].compact

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -288,14 +288,16 @@ module Dependabot
           if workspace_object.is_a?(Hash)
             workspace_object.values_at("packages", "nohoist").flatten.compact
           elsif workspace_object.is_a?(Array) then workspace_object
-          else [] # Invalid lerna.json, which must not be in use
+          else
+            [] # Invalid lerna.json, which must not be in use
           end
 
         paths_array.flat_map do |path|
           # The packages/!(not-this-package) syntax is unique to Yarn
           if path.include?("*") || path.include?("!(")
             expanded_paths(path)
-          else path
+          else
+            path
           end
         end
       end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -270,7 +270,8 @@ module Dependabot
                    split("#").first
                elsif prefix.include?("bitbucket") then "bitbucket.org"
                elsif prefix.include?("gitlab") then "gitlab.com"
-               else "github.com"
+               else
+                 "github.com"
                end
 
         {
@@ -296,7 +297,8 @@ module Dependabot
             # Sonatype Nexus / Artifactory JFrog format
             resolved_url.split("/#{name}/-/#{name.split('/').last}").first
           elsif (cred_url = url_for_relevant_cred(resolved_url)) then cred_url
-          else resolved_url.split("/")[0..2].join("/")
+          else
+            resolved_url.split("/")[0..2].join("/")
           end
 
         { type: "registry", url: url }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -750,7 +750,8 @@ module Dependabot
             trimmed_url = url.gsub(/(\d+\.)*tgz$/, "")
             incorrect_url = if url.start_with?("https")
                               trimmed_url.gsub(/^https:/, "http:")
-                            else trimmed_url.gsub(/^http:/, "https:")
+                            else
+                              trimmed_url.gsub(/^http:/, "https:")
                             end
             updated_lockfile_content = updated_lockfile_content.gsub(
               /#{Regexp.quote(incorrect_url)}(?=(\d+\.)*tgz")/,

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -25,7 +25,8 @@ module Dependabot
           initial_content =
             if npmrc_file then complete_npmrc_from_credentials
             elsif yarnrc_file then build_npmrc_from_yarnrc
-            else build_npmrc_content_from_lockfile
+            else
+              build_npmrc_content_from_lockfile
             end
 
           return initial_content || "" unless registry_credentials.any?

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_preparer.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_preparer.rb
@@ -42,7 +42,8 @@ module Dependabot
               workspace_object.values_at("packages", "nohoist").
                 flatten.compact
             elsif workspace_object.is_a?(Array) then workspace_object
-            else raise "Unexpected workspace object"
+            else
+              raise "Unexpected workspace object"
             end
 
           paths_array.each { |path| path.gsub!(%r{^\./}, "") }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -336,7 +336,8 @@ module Dependabot
               workspace_object.values_at("packages", "nohoist").
                 flatten.compact
             elsif workspace_object.is_a?(Array) then workspace_object
-            else raise "Unexpected workspace object"
+            else
+              raise "Unexpected workspace object"
             end
 
           paths_array.each { |path| path.gsub!(%r{^\./}, "") }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -197,7 +197,8 @@ module Dependabot
       def dependency_url
         registry_url =
           if new_source.nil? then "https://registry.npmjs.org"
-          else new_source.fetch(:url)
+          else
+            new_source.fetch(:url)
           end
 
         # NPM registries expect slashes to be escaped
@@ -213,7 +214,8 @@ module Dependabot
 
       def dependency_registry
         if new_source.nil? then "registry.npmjs.org"
-        else new_source.fetch(:url).gsub("https://", "").gsub("http://", "")
+        else
+          new_source.fetch(:url).gsub("https://", "").gsub("http://", "")
         end
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/requirement.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/requirement.rb
@@ -68,7 +68,8 @@ module Dependabot
         elsif req_string.start_with?("^") then convert_caret_req(req_string)
         elsif req_string.include?(" - ") then convert_hyphen_req(req_string)
         elsif req_string.match?(/[<>]/) then req_string
-        else ruby_range(req_string)
+        else
+          ruby_range(req_string)
         end
       end
 
@@ -122,7 +123,8 @@ module Dependabot
           if i < first_non_zero_index then part
           elsif i == first_non_zero_index then (part.to_i + 1).to_s
           elsif i > first_non_zero_index && i == 2 then "0.a"
-          else 0
+          else
+            0
           end
         end.join(".")
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -62,7 +62,8 @@ module Dependabot
           secure_versions =
             if specified_dist_tag_requirement?
               [version_from_dist_tags].compact
-            else possible_versions(filter_ignored: false)
+            else
+              possible_versions(filter_ignored: false)
             end
 
           secure_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(secure_versions,

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
@@ -178,7 +178,8 @@ module Dependabot
               version_to_be_permitted.segments[index]
             elsif index == index_to_update
               version_to_be_permitted.segments[index] + 1
-            else 0
+            else
+              0
             end
           end.join(".")
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -262,7 +262,8 @@ module Dependabot
                 e.message.scan(YARN_PEER_DEP_ERROR_REGEX) do
                   errors << Regexp.last_match.named_captures
                 end
-              else raise
+              else
+                raise
               end
               errors
             end.compact

--- a/nuget/lib/dependabot/nuget/requirement.rb
+++ b/nuget/lib/dependabot/nuget/requirement.rb
@@ -65,13 +65,15 @@ module Dependabot
         lower_b =
           if ["(", "["].include?(lower_b) then nil
           elsif lower_b.start_with?("(") then "> #{lower_b.sub(/\(\s*/, '')}"
-          else ">= #{lower_b.sub(/\[\s*/, '').strip}"
+          else
+            ">= #{lower_b.sub(/\[\s*/, '').strip}"
           end
 
         upper_b =
           if [")", "]"].include?(upper_b) then nil
           elsif upper_b.end_with?(")") then "< #{upper_b.sub(/\s*\)/, '')}"
-          else "<= #{upper_b.sub(/\s*\]/, '').strip}"
+          else
+            "<= #{upper_b.sub(/\s*\]/, '').strip}"
           end
 
         [lower_b, upper_b].compact

--- a/python/lib/dependabot/python/authed_url_builder.rb
+++ b/python/lib/dependabot/python/authed_url_builder.rb
@@ -13,7 +13,8 @@ module Dependabot
           elsif Base64.decode64(token).ascii_only? &&
                 Base64.decode64(token).include?(":")
             Base64.decode64(token)
-          else token
+          else
+            token
           end
 
         if basic_auth_details.include?(":")

--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -106,7 +106,8 @@ module Dependabot
 
       def group_from_filename(filename)
         if filename.include?("dev") then ["dev-dependencies"]
-        else ["dependencies"]
+        else
+          ["dependencies"]
         end
       end
 

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -327,7 +327,8 @@ module Dependabot
             elsif user_specified_python_requirement
               parts = user_specified_python_requirement.split(".")
               parts.fill("*", (parts.length)..2).join(".")
-            else PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.first
+            else
+              PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.first
             end
 
           # Ideally, the requirement is satisfied by a Python version we support

--- a/python/lib/dependabot/python/requirement.rb
+++ b/python/lib/dependabot/python/requirement.rb
@@ -82,7 +82,8 @@ module Dependabot
         if req_string.match?(/~[^>]/) then convert_tilde_req(req_string)
         elsif req_string.start_with?("^") then convert_caret_req(req_string)
         elsif req_string.include?(".*") then convert_wildcard(req_string)
-        else req_string
+        else
+          req_string
         end
       end
 
@@ -108,7 +109,8 @@ module Dependabot
           if i < first_non_zero_index then part
           elsif i == first_non_zero_index then (part.to_i + 1).to_s
           elsif i > first_non_zero_index && i == 2 then "0.a"
-          else 0
+          else
+            0
           end
         end.join(".")
 

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -271,7 +271,8 @@ module Dependabot
             FileUtils.mkdir_p(Pathname.new(path).dirname)
             updated_content =
               if update_requirement then update_req_file(file, updated_req)
-              else file.content
+              else
+                file.content
               end
             File.write(path, updated_content)
           end

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -405,7 +405,8 @@ module Dependabot
             elsif user_specified_python_requirement
               parts = user_specified_python_requirement.split(".")
               parts.fill("*", (parts.length)..2).join(".")
-            else PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.first
+            else
+              PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.first
             end
 
           # Ideally, the requirement is satisfied by a Python version we support

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -90,7 +90,8 @@ module Dependabot
 
                 updated_lockfile =
                   if File.exist?("poetry.lock") then File.read("poetry.lock")
-                  else File.read("pyproject.lock")
+                  else
+                    File.read("pyproject.lock")
                   end
                 updated_lockfile = TomlRB.parse(updated_lockfile)
 

--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -311,7 +311,8 @@ module Dependabot
             version.segments.count - 2
           elsif req_string.strip.start_with?("~")
             req_string.split(".").count == 1 ? 0 : 1
-          else raise "Don't know how to convert #{req_string} to range"
+          else
+            raise "Don't know how to convert #{req_string} to range"
           end
         end
 
@@ -335,7 +336,8 @@ module Dependabot
               version_to_be_permitted.segments[index]
             elsif index == index_to_update
               version_to_be_permitted.segments[index] + 1
-            else 0
+            else
+              0
             end
           end
 

--- a/terraform/lib/dependabot/terraform/requirements_updater.rb
+++ b/terraform/lib/dependabot/terraform/requirements_updater.rb
@@ -161,7 +161,8 @@ module Dependabot
             version_to_be_permitted.segments[index]
           elsif index == index_to_update
             version_to_be_permitted.segments[index] + 1
-          else 0
+          else
+            0
           end
         end
 


### PR DESCRIPTION
This PR autofixes all of the lint identified by the upgrade to rubocop 1.23.0 (#4413). No manual fixes were made. The merge target is the Dependabot PR branch.

I figured this was an easier way to identify the changes and add any configuration for lint we disagree with. Comment on any lines where we disagree with the style change.

It seems the primary change is that [ElseLayout](https://docs.rubocop.org/rubocop/cops_lint.html#lintelselayout) now applies to single lines (part of [v1.22.0](https://github.com/rubocop/rubocop/releases/tag/v1.22.0))