### PR TITLE
Test PR for supporting complex workspace regexes

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -85,6 +85,14 @@ module Dependabot
         raise Dependabot::RepoNotFound, source
       end
 
+      def fetch_code_paths_for_search_text(provider:, search_text:)
+        case provider
+        when "azure"
+          azure_client.fetch_code_paths_for_search_text(search_text: search_text)
+        else raise "Unsupported provider!"
+        end
+      end
+
       private
 
       def fetch_file_if_present(filename, fetch_submodules: false)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -291,13 +291,27 @@ module Dependabot
           else [] # Invalid lerna.json, which must not be in use
           end
 
-        paths_array.flat_map do |path|
-          # The packages/!(not-this-package) syntax is unique to Yarn
-          if path.include?("*") || path.include?("!(")
-            expanded_paths(path)
-          else path
+          # Will need to cover regexes like "!(" for exclusions
+          workspace_directories = []
+          code_paths = fetch_code_paths_for_search_text(search_text: "package.json")
+
+          code_paths.each do |code_path|
+            p = code_path[1..-1]
+            next unless p.end_with?("/package.json") && paths_array.any? { |path| File.fnmatch?(path, p) }
+
+            directory_path = p.chomp("/package.json")
+            workspace_directories.append(directory_path)
           end
-        end
+
+          workspace_directories
+
+          # paths_array.flat_map do |path|
+          # The packages/!(not-this-package) syntax is unique to Yarn
+          # if path.include?("*") || path.include?("!(")
+          # expanded_paths(path)
+          # else path
+          # end
+          # end
       end
 
       # Only expands globs one level deep, so path/**/* gets expanded to path/


### PR DESCRIPTION
This PR deals with changes required for supporting complex workspace regexes like packages/**/* in dependabot-core. This solution currently only works for AzureDevOps