### PR TITLE
Prebuild and publish the dependabot/dependabot-core-development container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,3 +40,38 @@ jobs:
           VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)"
           docker tag "$CORE_IMAGE:latest" "$CORE_IMAGE:$VERSION"
           docker push "$CORE_IMAGE:$VERSION"
+  push-development-image:
+    runs-on: ubuntu-latest
+    needs: push-core-image
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Prepare environment variables
+        run: |
+          echo "BASE_IMAGE=ubuntu:18.04" >> $GITHUB_ENV
+          echo "CORE_IMAGE=dependabot/dependabot-core" >> $GITHUB_ENV
+          echo "DEV_IMAGE=dependabot/dependabot-core-development" >> $GITHUB_ENV
+      - name: Build dependabot-core image
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker build \
+            -t "$DEV_IMAGE:latest" \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --cache-from "$BASE_IMAGE" \
+            --cache-from "$CORE_IMAGE:latest" \
+            --cache-from "$DEV_IMAGE:lastest"
+            -f Dockerfile.development
+            .
+      - name: Log in to the Docker registry
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Push latest image
+        run: |
+          docker push "$DEV_IMAGE:latest"
+      - name: Push tagged image
+        if: "contains(github.ref, 'refs/tags')"
+        run: |
+          VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)"
+          docker tag "$DEV_IMAGE:latest" "$DEV_IMAGE:$VERSION"
+          docker push "$DEV_IMAGE:$VERSION"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,7 +56,7 @@ jobs:
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --cache-from "$BASE_IMAGE" \
             --cache-from "$CORE_IMAGE:latest" \
-            --cache-from "$DEV_IMAGE:lastest"
+            --cache-from "$DEV_IMAGE:latest"
             -f Dockerfile.development
             .
       - name: Log in to the Docker registry

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,7 @@
 name: Push docker images
+env:
+  BASE_IMAGE: "ubuntu:18.04"
+  CORE_IMAGE: "dependabot/dependabot-core"
 on:
   push:
     branches:
@@ -14,10 +17,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Prepare environment variables
-        run: |
-          echo "BASE_IMAGE=ubuntu:18.04" >> $GITHUB_ENV
-          echo "CORE_IMAGE=dependabot/dependabot-core" >> $GITHUB_ENV
       - name: Build dependabot-core image
         env:
           DOCKER_BUILDKIT: 1
@@ -43,14 +42,11 @@ jobs:
   push-development-image:
     runs-on: ubuntu-latest
     needs: push-core-image
+    env:
+      DEV_IMAGE: dependabot/dependabot-core-development
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Prepare environment variables
-        run: |
-          echo "BASE_IMAGE=ubuntu:18.04" >> $GITHUB_ENV
-          echo "CORE_IMAGE=dependabot/dependabot-core" >> $GITHUB_ENV
-          echo "DEV_IMAGE=dependabot/dependabot-core-development" >> $GITHUB_ENV
       - name: Build dependabot-core image
         env:
           DOCKER_BUILDKIT: 1


### PR DESCRIPTION
We currently build this container on the fly in `bin/docker-dev-shell` which means it can take ~10 minutes to boot up a development container.

The reason we have historically done this is to ensure we set the UID/GID of the `dependabot` user matches those of current user on linux hosts, e.g.

```bash
build_image() {
  export BUILT_IMAGE=true
  echo "$(tput setaf 2)=> building image from Dockerfile.development$(tput sgr0)"
  docker build \
    --build-arg BUILDKIT_INLINE_CACHE=1 \
    --build-arg "USER_UID=$(id -u)" \
    --build-arg "USER_GID=$(id -g)" \
    --cache-from "dependabot/dependabot-core-development:latest" \
    -t dependabot/dependabot-core-development Dockerfile.development
}
```

Internally, we primarily use this image in two environments that do not require these build arguments:
- MacOS developer laptops, the host uid/gid are already abstracted by the Docker VM as 1000/1000
- Codespaces, effectively docker-in-docker where both values are 1000/1000

I haven't updated the `bin/docker-dev-shell` script as part of this change as I want to get the image in place to begin with to continue to validate this approach before I modify anything else. Ideally, we will have the script pull this image as its default behaviour unless the host UID/GID are not the default value, in which case it will revert to the existing strategy so we don't break anyone's workflow.

As an added bonus, we can hopefully pull this image in our `devcontainer.json` and start making core's codespace provisioning significantly faster in future.

### Notes

I've added this to the docker workflow as a separate job which depends on core being pushed as:
- I don't want to do the double-work of building the image twice in two workflows
- I don't want to make the core publishing job itself take longer since the developer image is significantly slower to create
- I do want to be able to push a tagged version of the `dependabot/dependabot-core-development` image in addition to the latest SHA on `main` as I would like us to be able to pin to the version actually being ran in production by default as even the latest version will generally be a few commits behind `latest`
