### PR TITLE
Python invalid url

### DIFF
--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -162,6 +162,8 @@ module Dependabot
               raise if MAIN_PYPI_INDEXES.include?(index_url)
 
               raise PrivateSourceTimedOut, sanitized_url
+            rescue URI::InvalidURIError
+              raise DependencyFileNotResolvable, "Invalid URL: #{sanitized_url}"
             end
         end
 

--- a/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
@@ -295,6 +295,19 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
         let(:requirements_fixture_name) { "custom_index.txt" }
         let(:dependency_files) { [requirements_file] }
         it { is_expected.to eq(Gem::Version.new("2.6.0")) }
+
+        context "and the url is invalid" do
+          let(:requirements_fixture_name) { "custom_index_invalid.txt" }
+
+          it "raises a helpful error" do
+            error_class = Dependabot::DependencyFileNotResolvable
+            expect { subject }.
+              to raise_error(error_class) do |error|
+                expect(error.message).
+                  to eq("Invalid URL: https://redacted@pypi.weasyldev.com/weasyl/source/+simple/")
+              end
+          end
+        end
       end
 
       context "set in a Pipfile" do

--- a/python/spec/fixtures/requirements/custom_index_invalid.txt
+++ b/python/spec/fixtures/requirements/custom_index_invalid.txt
@@ -1,0 +1,3 @@
+--index-url https://test:test^@pypi.weasyldev.com/weasyl/source/+simple
+psycopg2==2.6.1
+luigi==2.2.0


### PR DESCRIPTION
This PR rescues a InvalidURIError in Dependabot that was previously uncaught.