### PR TITLE
Reinstate the dev container build, pushing to GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,12 +8,12 @@ on:
       - main
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
-permissions:
-  contents: read
 jobs:
   push-core-image:
     name: Push dependabot-core image to docker hub
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -39,35 +39,38 @@ jobs:
           VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)"
           docker tag "$CORE_IMAGE:latest" "$CORE_IMAGE:$VERSION"
           docker push "$CORE_IMAGE:$VERSION"
-# TODO: Reinstate once we've fixed the permission problem on push
-#   push-development-image:
-#     runs-on: ubuntu-latest
-#     needs: push-core-image
-#     env:
-#       DEV_IMAGE: dependabot/dependabot-core-development
-#     steps:
-#       - name: Checkout code
-#         uses: actions/checkout@v2
-#       - name: Build dependabot-core image
-#         env:
-#           DOCKER_BUILDKIT: 1
-#         run: |
-#           docker build \
-#             -t "$DEV_IMAGE:latest" \
-#             --build-arg BUILDKIT_INLINE_CACHE=1 \
-#             --cache-from "$BASE_IMAGE" \
-#             --cache-from "$CORE_IMAGE:latest" \
-#             --cache-from "$DEV_IMAGE:latest" \
-#             -f Dockerfile.development .
-#       - name: Log in to the Docker registry
-#         run: |
-#           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-#       - name: Push latest image
-#         run: |
-#           docker push "$DEV_IMAGE:latest"
-#       - name: Push tagged image
-#         if: "contains(github.ref, 'refs/tags')"
-#         run: |
-#           VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)"
-#           docker tag "$DEV_IMAGE:latest" "$DEV_IMAGE:$VERSION"
-#           docker push "$DEV_IMAGE:$VERSION"
+  push-development-image:
+    name: Push dependabot-core-development image to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    needs: push-core-image
+    env:
+      DEV_IMAGE: ghcr.io/dependabot/dependabot-core-development
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build dependabot-core image
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker build \
+            -t "$DEV_IMAGE:latest" \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --cache-from "$BASE_IMAGE" \
+            --cache-from "$CORE_IMAGE:latest" \
+            --cache-from "$DEV_IMAGE:latest" \
+            -f Dockerfile.development .
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Push latest image
+        run: |
+          docker push "$DEV_IMAGE:latest"
+      - name: Push tagged image
+        if: "contains(github.ref, 'refs/tags')"
+        run: |
+          VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)"
+          docker tag "$DEV_IMAGE:latest" "$DEV_IMAGE:$VERSION"
+          docker push "$DEV_IMAGE:$VERSION"


### PR DESCRIPTION
Follows up on #4511, #4513 

This reinstates the matrix build to push the development image of core, using GHCR as a target instead of docker.io.

Since this image is a development tool, it makes less sense to have it on `docker.io` for general consumption, GHCR is a better home for this - and likely our CI image which I will migrate in a follow up.