### PR TITLE
Use npm 7 for lockfileVersion 3

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -5,6 +5,7 @@ module Dependabot
     module Helpers
       def self.npm_version(lockfile_content)
         return "npm7" unless lockfile_content
+        return "npm7" if JSON.parse(lockfile_content)["lockfileVersion"] == 3
         return "npm7" if JSON.parse(lockfile_content)["lockfileVersion"] == 2
 
         "npm6"


### PR DESCRIPTION
This should fix #4361 

Ideally, Dependabot should be updated to npm 8 (as it's the version that comes with node 16, the latest LTS version of node, contrary to npm 7). npm 8 isn't that different from npm 7 (besides a few small fixes and the deprecation of node 12, which should not be a problem for this).

However, this PR is much simpler and straightforward fix that directly upgrading to npm 8 and it shouldn't break anything, while keeping proper compatibility with the people that already wanted to have their setups upgraded to the v3 ``lockfileVersion``