### PR TITLE
Fix failing Cargo test

### DIFF
--- a/cargo/spec/fixtures/projects/version_conflict/Cargo.toml
+++ b/cargo/spec/fixtures/projects/version_conflict/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["support@dependabot.com"]
 
 [dependencies]
-askama = { git = "https://github.com/djc/askama", branch = "main" }
+askama = { git = "https://github.com/djc/askama", rev = "d45e106bf219d6da94538e2816472ca8026500ba" }
 
 [build-dependencies]
 ructe = { git = "https://github.com/kaj/ructe" }


### PR DESCRIPTION
[The test](https://github.com/dependabot/dependabot-core/blob/a5efcdaba81d5d4e1034e773f565b248f0346df8/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb#L537-L546) made sure no update occurred if there is a transitive dependency conflict. The transitive dependency used in this test, `nom`, was [updated in the direct dependency askama](https://github.com/djc/askama/pull/530), so we pin `askama` to a commit SHA prior to that update.