### PR TITLE
Push dependabot/dependabot-core to GHCR in order to provide a mirror

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,7 @@ name: Push docker images
 env:
   BASE_IMAGE: "ubuntu:18.04"
   CORE_IMAGE: "dependabot/dependabot-core"
+  CORE_IMAGE_MIRROR: "ghcr.io/dependabot/dependabot-core"
 on:
   push:
     branches:
@@ -30,15 +31,22 @@ jobs:
       - name: Log in to the Docker registry
         run: |
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Push latest image
         run: |
           docker push "$CORE_IMAGE:latest"
+          docker tag "$CORE_IMAGE:latest" "$CORE_IMAGE_MIRROR:latest"
+          docker push "$CORE_IMAGE_MIRROR:latest"
       - name: Push tagged image
         if: "contains(github.ref, 'refs/tags')"
         run: |
           VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)"
           docker tag "$CORE_IMAGE:latest" "$CORE_IMAGE:$VERSION"
           docker push "$CORE_IMAGE:$VERSION"
+          docker tag "$CORE_IMAGE:latest" "$CORE_IMAGE_MIRROR:$VERSION"
+          docker push "$CORE_IMAGE_MIRROR:$VERSION"
   push-development-image:
     name: Push dependabot-core-development image to GHCR
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is not a migration, the default location of our image will remain on dockerhub, but we should make use of GHCR as a mirror, especially as we can pull from it more optimally in some places.