### PR TITLE
Update the CI workflow to use GHPR for branch images and as a mirror for CI images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,16 @@ jobs:
         - { path: omnibus, name: omnibus }
         - { path: python, name: python }
         - { path: terraform, name: terraform }
+    env:
+      BASE_IMAGE: ubuntu:18.04
+      CORE_IMAGE: dependabot/dependabot-core
+      CORE_CI_IMAGE: dependabot/dependabot-core-ci
+      CODE_DIR: /home/dependabot/dependabot-core
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Prepare environment variables
-        run: |
-          echo "BRANCH_REF=$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')" >> $GITHUB_ENV
-          echo "BASE_IMAGE=ubuntu:18.04" >> $GITHUB_ENV
-          echo "CORE_IMAGE=dependabot/dependabot-core" >> $GITHUB_ENV
-          echo "CORE_CI_IMAGE=dependabot/dependabot-core-ci" >> $GITHUB_ENV
-          echo "CODE_DIR=/home/dependabot/dependabot-core" >> $GITHUB_ENV
+      - name: Prepare BRANCH_REF environment variable
+        run: echo "BRANCH_REF=$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')" >> $GITHUB_ENV
       - name: Log in to Docker registry
         run: |
           if [ -n "${{ secrets.DOCKER_USERNAME }}" ] && [ -n "${{ secrets.DOCKER_PASSWORD }}" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 on:
   push:
     branches:
-      - "actions/**"
-      - "wip/**"
       - "main"
   pull_request:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       CORE_IMAGE: dependabot/dependabot-core
       CORE_BRANCH_IMAGE: ghcr.io/dependabot/dependabot-core-branch
       CORE_CI_IMAGE: dependabot/dependabot-core-ci
+      CORE_CI_MIRROR: ghcr.io/dependabot/dependabot-core-ci
       CODE_DIR: /home/dependabot/dependabot-core
     steps:
       - name: Checkout code
@@ -90,6 +91,12 @@ jobs:
         run: |
           docker push "$CORE_CI_IMAGE:latest"
           docker push "$CORE_CI_IMAGE:branch--$BRANCH_REF"
+      - name: Push dependabot-core-ci image to GHCR mirror
+        run: |
+          docker tag "$CORE_CI_IMAGE:latest" "$CORE_CI_MIRROR:latest"
+          docker push "$CORE_CI_MIRROR:latest"
+          docker tag "$CORE_CI_IMAGE:latest" "$CORE_CI_MIRROR:branch--$BRANCH_REF"
+          docker push "$CORE_CI_MIRROR:branch--$BRANCH_REF"
       - name: Run ${{ matrix.suite.name }} tests
         run: |
           docker run \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - "main"
   pull_request:
     branches:
-      - "**"
+      - "main"
   schedule:
     - cron: '0 0 * * *'
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
     - cron: '0 0 * * *'
 permissions:
   contents: read
+  packages: write
 jobs:
   ci:
     name: CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
     env:
       BASE_IMAGE: ubuntu:18.04
       CORE_IMAGE: dependabot/dependabot-core
+      CORE_BRANCH_IMAGE: ghcr.io/dependabot/dependabot-core-branch
       CORE_CI_IMAGE: dependabot/dependabot-core-ci
       CODE_DIR: /home/dependabot/dependabot-core
     steps:
@@ -55,23 +56,28 @@ jobs:
           else
             echo "No Docker credentials, skipping login"
           fi
-      - name: Build dependabot-core image
+      - name: Log in to GHCR
         run: |
-          DOCKER_BUILDKIT=1 docker build \
-            -t "$CORE_IMAGE:latest" \
-            -t "$CORE_IMAGE:branch--$BRANCH_REF" \
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build dependabot-core image for branch
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker build \
+            -t "$CORE_BRANCH_IMAGE:$BRANCH_REF" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --cache-from "$BASE_IMAGE" \
-            --cache-from "$CORE_IMAGE:branch--$BRANCH_REF" \
             --cache-from "$CORE_IMAGE:latest" \
+            --cache-from "$CORE_BRANCH_IMAGE:$BRANCH_REF" \
             .
-      - name: Push dependabot-core image to Docker registry
-        if: env.DOCKER_LOGGED_IN == 'true'
+      - name: Push dependabot-core-branch image to GHCR
         run: |
-          docker push "$CORE_IMAGE:branch--$BRANCH_REF"
+          docker push "$CORE_BRANCH_IMAGE:$BRANCH_REF"
       - name: Build dependabot-core-ci image
+        env:
+          DOCKER_BUILDKIT: 1
         run: |
-          DOCKER_BUILDKIT=1 docker build \
+          docker build \
             -t "$CORE_CI_IMAGE:latest" \
             -t "$CORE_CI_IMAGE:branch--$BRANCH_REF" \
             -f Dockerfile.ci \


### PR DESCRIPTION
This PR follows on from #4523 to increase our use of GHPR.

The high level intent of this change is to move our development images out of dockerhub as they aren't relevant to downstream consumers of Dependabot.

Rather than a breaking change where everyone's builds are suddenly much slower, this is a gradual switch over that just mirrors the CI image to GHPR for now, we'll follow up with a change to consume from this image in a few days once it has an opportunity to propagate on a few WIP PRs.

## Changes to branch builds

One major change is that we _immediately_ start pushing and consuming the branch-specific build of `dependabot-core` to and from GHPR instead of the main `dependabot/dependabot-core` image.

This is due to a decision the team has made that these branch builds should live in a separate project to avoid any confusion over which refs of `dependabot/dependabot-core` are properly tested for distribution.