### PR TITLE
Disable `docker` workflow on forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ jobs:
   push-core-image:
     name: Push dependabot-core image to docker hub
     runs-on: ubuntu-latest
+    if: github.repository == "dependabot/dependabot-core"
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Related to #4524 

When a fork of `dependabot-core` pushes a new commit, it triggers the ["Push docker images"](https://github.com/dependabot/dependabot-core/blob/main/.github/workflows/docker.yml) workflow. However, that workflow fails unless `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets are configured, which will be the case for pretty much everyone.

<img width="543" alt="Screen Shot 2021-12-14 at 06 27 54" src="https://user-images.githubusercontent.com/7659/146017561-9cd9bc77-cc6b-4122-8619-ffc9356ccfd8.png">

This PR conditionalizes the `push-core-image` step to run only in the `dependabot/dependabot-core` repository.