### PR TITLE
Return name unless contains git dependency name notation

### DIFF
--- a/terraform/lib/dependabot/terraform.rb
+++ b/terraform/lib/dependabot/terraform.rb
@@ -26,7 +26,7 @@ Dependabot::Dependency.
     "terraform",
     lambda { |name|
       # Only modify the name if it a git source dependency
-      next unless name.include? "::"
+      return name unless name.include? "::"
 
       name.split("::").first + "::" + name.split("::")[2].split("/").last
     }

--- a/terraform/spec/dependabot/terraform_spec.rb
+++ b/terraform/spec/dependabot/terraform_spec.rb
@@ -6,4 +6,39 @@ require_common_spec "shared_examples_for_autoloading"
 
 RSpec.describe Dependabot::Terraform do
   it_behaves_like "it registers the required classes", "terraform"
+
+  describe "Dependency#display_name" do
+    subject(:display_name) do
+      Dependabot::Dependency.new(**dependency_args).display_name
+    end
+
+    let(:dependency_args) do
+      { name: name, requirements: [], package_manager: "terraform" }
+    end
+    
+    context "registry source" do
+      let(:name) { "hashicorp/consul/aws" }
+
+      it { is_expected.to eq("hashicorp/consul/aws") }
+    end
+
+    context "registry source with special case" do
+      let(:name) { "app.terraform.io/example-corp/k8s-cluster/azurerm" }
+
+      it { is_expected.to eq("app.terraform.io/example-corp/k8s-cluster/azurerm") }
+    end
+
+    context "git source with ref" do
+      let(:name) { "gitlab_ssh_without_protocol::gitlab::cloudposse/terraform-aws-jenkins::tags/0.4.0" }
+
+      it { is_expected.to eq("gitlab_ssh_without_protocol::terraform-aws-jenkins") }
+    end
+
+    context "git source without ref" do
+      let(:name) { "distribution_label::bitbucket::cloudposse/terraform-null-label" }
+
+      it { is_expected.to eq("distribution_label::terraform-null-label") }
+    end
+  end
+
 end

--- a/terraform/spec/dependabot/terraform_spec.rb
+++ b/terraform/spec/dependabot/terraform_spec.rb
@@ -15,14 +15,26 @@ RSpec.describe Dependabot::Terraform do
     let(:dependency_args) do
       { name: name, requirements: [], package_manager: "terraform" }
     end
-    
+
+    context "provider source" do
+      let(:name) { "hashicorp/aws" }
+
+      it { is_expected.to eq("hashicorp/aws") }
+    end
+
+    context "provider source with special chars" do
+      let(:name) { "terraform.example.com/examplecorp/ourcloud" }
+
+      it { is_expected.to eq("terraform.example.com/examplecorp/ourcloud") }
+    end
+
     context "registry source" do
       let(:name) { "hashicorp/consul/aws" }
 
       it { is_expected.to eq("hashicorp/consul/aws") }
     end
 
-    context "registry source with special case" do
+    context "registry source with special chars" do
       let(:name) { "app.terraform.io/example-corp/k8s-cluster/azurerm" }
 
       it { is_expected.to eq("app.terraform.io/example-corp/k8s-cluster/azurerm") }
@@ -40,5 +52,4 @@ RSpec.describe Dependabot::Terraform do
       it { is_expected.to eq("distribution_label::terraform-null-label") }
     end
   end
-
 end


### PR DESCRIPTION
Closes #4519  - returns name unless it contains git dependency name notation/