### PR TITLE
Allow whitespace at beginning of Cargo dependency declarations

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
@@ -139,7 +139,7 @@ module Dependabot
         end
 
         def declaration_regex(dep)
-          /(?:^|["'])#{Regexp.escape(dep.name)}["']?\s*=.*$/i
+          /(?:^|^\s*|^\t*|["'])#{Regexp.escape(dep.name)}["']?\s*=.*$/i
         end
 
         def feature_declaration_version_regex(dep)

--- a/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
@@ -139,7 +139,7 @@ module Dependabot
         end
 
         def declaration_regex(dep)
-          /(?:^|^\s*|^\t*|["'])#{Regexp.escape(dep.name)}["']?\s*=.*$/i
+          /(?:^|^\s*|["'])#{Regexp.escape(dep.name)}["']?\s*=.*$/i
         end
 
         def feature_declaration_version_regex(dep)

--- a/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
@@ -65,6 +65,14 @@ RSpec.describe Dependabot::Cargo::FileUpdater::ManifestUpdater do
         it { is_expected.to include(%(business_time = "0.1.12")) }
       end
 
+      context "with dependencies that include whitespace" do
+        let(:manifest_fixture_name) { "whitespace_names" }
+
+        it { is_expected.to include(%(time = "0.1.38")) }
+        it { is_expected.to include(%(regex = "0.1.41")) }
+        it { is_expected.to_not include(%("time" = "0.1.12")) }
+      end
+
       context "with a target-specific dependency" do
         let(:manifest_fixture_name) { "target_dependency" }
         it { is_expected.to include(%(time = "<= 0.1.38")) }

--- a/cargo/spec/fixtures/manifests/whitespace_names
+++ b/cargo/spec/fixtures/manifests/whitespace_names
@@ -4,6 +4,6 @@ version = "0.1.0"    # the current version, obeying semver
 authors = ["support@dependabot.com"]
 
 [dependencies]
-    time = "0.1.12"
+	time = "0.1.12"
   regex = "0.1.41"
 business_time = "0.1.12"

--- a/cargo/spec/fixtures/manifests/whitespace_names
+++ b/cargo/spec/fixtures/manifests/whitespace_names
@@ -1,0 +1,9 @@
+[package]
+name = "dependabot" # the name of the package
+version = "0.1.0"    # the current version, obeying semver
+authors = ["support@dependabot.com"]
+
+[dependencies]
+    time = "0.1.12"
+  regex = "0.1.41"
+business_time = "0.1.12"


### PR DESCRIPTION
Allows `cargo.toml` manifest files to have arbitrary whitespace at the beginning of dependency declarations.

Includes a new fixture file that contains dependencies with tabs or spaces at the start of their declaration.