### PR TITLE
Fix conditional in `docker` workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
   push-core-image:
     name: Push dependabot-core image to docker hub
     runs-on: ubuntu-latest
-    if: github.repository == "dependabot/dependabot-core"
+    if: ${{ github.repository == 'dependabot/dependabot-core' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Fixes regression introduced by #4525.

Double quotes (`"`) aren't valid in expressions, so this PR changes them to use single quotes (`'`). This also wraps the expression in `${{ }}`; the documentation mentions that single-line expressions don't need to be escaped like this, but I'd rather follow [the examples in the docs](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-contexts).