### PR TITLE
Avoid setting HTTP_PROXY for docker in the dev shell

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -72,13 +72,11 @@ if [ -n "$RUNNING" ]; then
 fi
 
 DOCKER_OPTS=()
-if [ -n "$HTTP_PROXY" ]; then
-  DOCKER_OPTS+=(-e "http_proxy=$HTTP_PROXY")
-  DOCKER_OPTS+=(-e "HTTP_PROXY=$HTTP_PROXY")
-fi
-if [ -n "$HTTPS_PROXY" ]; then
-  DOCKER_OPTS+=(-e "https_proxy=$HTTPS_PROXY")
-  DOCKER_OPTS+=(-e "HTTPS_PROXY=$HTTPS_PROXY")
+if [ -n "$DEPENDABOT_PROXY" ]; then
+  DOCKER_OPTS+=(-e "http_proxy=$DEPENDABOT_PROXY")
+  DOCKER_OPTS+=(-e "HTTP_PROXY=$DEPENDABOT_PROXY")
+  DOCKER_OPTS+=(-e "https_proxy=$DEPENDABOT_PROXY")
+  DOCKER_OPTS+=(-e "HTTPS_PROXY=$DEPENDABOT_PROXY")
 fi
 
 if [ -n "$DOCKER_NETWORK" ]; then

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -58,7 +58,7 @@ else
 fi
 
 set +e
-RUNNING=$(docker ps --format '{{.Names}}' | grep "$CONTAINER_NAME")
+RUNNING=$(docker ps --format '{{.Names}}' | grep "$CONTAINER_NAME$")
 set -e
 echo "$RUNNING"
 if [ -n "$RUNNING" ]; then


### PR DESCRIPTION
Passing in `HTTP_PROXY` and `HTTPS_PROXY` to `bin/docker-dev-shell` means that they are picked up as envvars by any other processes that aware of them within the script.

Let's use `DOCKER_PROXY` as a relay value so we exclusively inject them into the `docker run` command and avoid any side effects.

### Other Changes

When checking if there is a container runner with `$CONTAINER_NAME`, we will currently match any container with _starts_ with this value, e.g. `$CONTAINER_NAME=foo` will also match `foo-sidecar`.