### PR TITLE
Common: Constrain activesupport to < 7

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
   spec.required_rubygems_version = ">= 2.7.3"
 
-  spec.add_dependency "activesupport", ">= 6.0.0"
+  spec.add_dependency "activesupport", ">= 6.0.0", "< 7.0.0"
   spec.add_dependency "aws-sdk-codecommit", "~> 1.28"
   spec.add_dependency "aws-sdk-ecr", "~> 1.5"
   spec.add_dependency "bundler", ">= 1.16", "< 3.0.0"


### PR DESCRIPTION
We rely on some code that seems to be incompatible with activesupport 7,
which was just released. We'll want to dig into that and see if we can't
make our code play nice with the new version, but for now, since this is
breaking our builds etc let's ensure that we stay on major version 6.