### PR TITLE
Enabling parsing of complex workspace glob patterns (Azure client)

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -151,6 +151,14 @@ module Dependabot
         raise Dependabot::DependencyFileNotFound, path
       end
 
+      def fetch_repo_paths_for_code_search(search_text, directory)
+        case source.provider
+        when "azure"
+          azure_client.fetch_repo_paths_for_code_search(search_text, directory)
+        else []
+        end
+      end
+
       def repo_contents(dir: ".", ignore_base_directory: false,
                         raise_errors: true, fetch_submodules: false)
         dir = File.join(directory, dir) unless ignore_base_directory

--- a/common/spec/fixtures/azure/repository_details.json
+++ b/common/spec/fixtures/azure/repository_details.json
@@ -1,0 +1,45 @@
+{
+	"id": "repo-id",
+	"name": "repo",
+	"url": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e",
+	"project": {
+		"id": "project-id",
+		"name": "project",
+		"description": "Test project"
+	},
+	"defaultBranch": "refs/heads/main",
+	"size": 8469699983,
+	"remoteUrl": "https://org@dev.azure.com/org/project/_git/repo",
+	"sshUrl": "git@ssh.dev.azure.com:v3/org/project/repo",
+	"webUrl": "https://dev.azure.com/org/project/_git/repo",
+	"_links": {
+		"self": {
+			"href": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e"
+		},
+		"project": {
+			"href": "vstfs:///Classification/TeamProject/6e261f3b-5e35-4762-a6d6-14043c738628"
+		},
+		"web": {
+			"href": "https://dev.azure.com/org/project/_git/repo"
+		},
+		"ssh": {
+			"href": "git@ssh.dev.azure.com:v3/org/project/repo"
+		},
+		"commits": {
+			"href": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e/commits"
+		},
+		"refs": {
+			"href": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e/refs"
+		},
+		"pullRequests": {
+			"href": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e/pullRequests"
+		},
+		"items": {
+			"href": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e/items"
+		},
+		"pushes": {
+			"href": "https://dev.azure.com/org/6e261f3b-5e35-4762-a6d6-14043c738628/_apis/git/repositories/99c1b1f9-b4e5-4b3f-bc34-13f6cda8697e/pushes"
+		}
+	},
+	"isDisabled": false
+}

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -1141,6 +1141,101 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         end
       end
 
+      context "specified using complex glob pattern like packages/**/*" do
+        let(:package_json_code_search_results) do
+          [
+            "/packages/folderA/subfolderA/packageA/package.json",
+            "/packages/folderA/subfolderB/packageA/package.json",
+            "/packages/folderB/subfolderA/packageA/package1.json",
+            "/paster/folderA/subfolderA/packageA/package.json",
+            "/packages1/folderA/subfolderA/packageA/package2.json"
+          ]
+        end
+
+        before do
+          stub_request(:get, File.join(url, "package.json?ref=sha")).
+            with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body:
+                fixture("github", "package_json_with_complex_workspaces.json"),
+              headers: json_header
+            )
+
+          stub_request(
+            :get,
+            File.join(url, "packages/folderA/subfolderA/packageA/package.json?ref=sha")
+          ).with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "package_json_content.json"),
+              headers: json_header
+            )
+
+          stub_request(
+            :get,
+            File.join(url, "packages/folderA/subfolderB/packageA/package.json?ref=sha")
+          ).with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "package_json_content.json"),
+              headers: json_header
+            )
+
+          allow(file_fetcher_instance).to receive(:fetch_repo_paths_for_code_search).
+            with("package.json", source.directory).
+            and_return(package_json_code_search_results)
+        end
+
+        it "fetches package.json from the workspace dependencies" do
+          expect(file_fetcher_instance.files.map(&:name)).
+            to match_array(
+              %w(
+                package.json
+                package-lock.json
+                packages/folderA/subfolderA/packageA/package.json
+                packages/folderA/subfolderB/packageA/package.json
+              )
+            )
+        end
+
+        it "ignores excluded workspaces while fetching package.json from workspace dependencies" do
+          stub_request(:get, File.join(url, "package.json?ref=sha")).
+            with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body:
+                fixture("github", "package_json_with_complex_and_exclusion_workspaces.json"),
+              headers: json_header
+            )
+          expect(file_fetcher_instance.files.count).to eq(3)
+          expect(file_fetcher_instance.files.map(&:name)).
+            not_to include("packages/folderA/subfolderB/packageA/package.json")
+        end
+
+        it "tries to fetch package.json from condensed glob pattern in case no paths are detected via code search" do
+          stub_request(:get, File.join(url, "packages?ref=sha")).
+            with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "packages_files.json"),
+              headers: json_header
+            )
+
+          allow(file_fetcher_instance).to receive(:fetch_repo_paths_for_code_search).
+            with("package.json", source.directory).
+            and_return([])
+
+          expect(file_fetcher_instance.files.map(&:name)).
+            to match_array(
+              %w(
+                package.json
+                package-lock.json
+              )
+            )
+        end
+      end
+
       context "specified using a hash" do
         before do
           stub_request(:get, File.join(url, "package.json?ref=sha")).

--- a/npm_and_yarn/spec/fixtures/github/package_json_with_complex_and_exclusion_workspaces.json
+++ b/npm_and_yarn/spec/fixtures/github/package_json_with_complex_and_exclusion_workspaces.json
@@ -1,0 +1,18 @@
+{
+    "name": "package.json",
+    "path": "package.json",
+    "sha": "5c7b3419e0056515122b981f1566ebe22c208251",
+    "size": 594,
+    "url": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+    "html_url": "https://github.com/gocardless/bump/blob/master/package.json",
+    "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+    "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/package.json?token=ABMwe0apDiKCctWHnEHnszRBAebVHjQnks5WJWD9wA%3D%3D",
+    "type": "file",
+    "content": "ewoibmFtZSI6ICJUZXN0IHJlcG8iLAoidmVyc2lvbiI6ICIzLjAuMCIsCiJkZXNjcmlwdGlvbiI6ICJUaGUgbmV4dCB2ZXJzaW9uIG9mIHRlc3QgcmVwbywgd3JpdHRlbiBpbiBUeXBlc2NyaXB0IiwKIm1haW4iOiAiaW5kZXguanMiLAoiYXV0aG9yIjogIlhZWiIsCiJsaWNlbnNlIjogIlVOTElDRU5TRUQiLAoicHJpdmF0ZSI6IHRydWUsCiJ3b3Jrc3BhY2VzIjogWyJwYWNrYWdlcy8qKi8qIiwgInBhY2thZ2VzLyovIShzdWJmb2xkZXJCKS8qIl0KfQ==",
+    "encoding": "base64",
+    "_links": {
+      "self": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+      "git": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+      "html": "https://github.com/gocardless/bump/blob/master/package.json"
+    }
+  }

--- a/npm_and_yarn/spec/fixtures/github/package_json_with_complex_workspaces.json
+++ b/npm_and_yarn/spec/fixtures/github/package_json_with_complex_workspaces.json
@@ -1,0 +1,18 @@
+{
+    "name": "package.json",
+    "path": "package.json",
+    "sha": "5c7b3419e0056515122b981f1566ebe22c208251",
+    "size": 594,
+    "url": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+    "html_url": "https://github.com/gocardless/bump/blob/master/package.json",
+    "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+    "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/package.json?token=ABMwe0apDiKCctWHnEHnszRBAebVHjQnks5WJWD9wA%3D%3D",
+    "type": "file",
+    "content": "ewoibmFtZSI6ICJUZXN0IHJlcG8iLAoidmVyc2lvbiI6ICIzLjAuMCIsCiJkZXNjcmlwdGlvbiI6ICJUaGUgbmV4dCB2ZXJzaW9uIG9mIHRlc3QgcmVwbywgd3JpdHRlbiBpbiBUeXBlc2NyaXB0IiwKIm1haW4iOiAiaW5kZXguanMiLAoiYXV0aG9yIjogIlhZWiIsCiJsaWNlbnNlIjogIlVOTElDRU5TRUQiLAoicHJpdmF0ZSI6IHRydWUsCiJ3b3Jrc3BhY2VzIjogWyJwYWNrYWdlcy8qKi8qIl0KfQ==",
+    "encoding": "base64",
+    "_links": {
+      "self": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+      "git": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+      "html": "https://github.com/gocardless/bump/blob/master/package.json"
+    }
+  }


### PR DESCRIPTION
Currently, dependabot only understand workspaces defined in `package.json` using simpler regexes like `packages/*`, `packages/folder/*`, `abcd`. However, some large monorepos define workspaces with regexes like `packages/**/*`,`*/packages/*` which with the current logic would not be supported and hence not included in dependency update process and the created PR.

Solution (**This currently only works for AzureDevOps repos**) - 
For repos having complex workspace regexes, using this ADO code search REST API: https://docs.microsoft.com/en-us/rest/api/azure/devops/search/code-search-results/fetch-code-search-results?view=azure-devops-rest-6.1 (works in a similar that we use the code search feature in AzureDevOps UI), we can get the references for “package.json” string in the entire repo in a given repo path. For every code path result obtained in this search, we can do these two checks – 
1)	Check if the path is for a “package.json” file and lies in the given repo source directory
2)	Check if the path satisfies any of the workspace regexes mentioned in the package.json

If both of the conditions are met, then we will include this path while updating any dependency and also fetch its `package.json` in the file fetcher phase.

**Drawback** - The Code search API by default works only on the repo default branch unless the code search feature is enabled for a particular branch in the repo policies in AzureDevOps

Therefore, in case of repo clients other than ADO and for branches on which code search feature is not enabled in case of ADO repos, we will fallback to the old logic of condensing the workspace regex to simpler form in case of complex glob pattern

For repos which don't have any complex workspace regexes and all workspace patterns are of the form packages/folder1/folder2.../* or simpler (i.e exact workspace directory is specified), we will still use the old logic present in dependabot