### PR TITLE
Fix rejecting duplicate credentials without auth headers for maven/gradle

### DIFF
--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -210,7 +210,7 @@ module Dependabot
 
           @repositories =
             details.reject do |repo|
-              next if repo["auth_headers"]
+              next unless repo["auth_headers"].empty?
 
               # Reject this entry if an identical one with non-empty auth_headers exists
               details.any? { |r| r["url"] == repo["url"] && r["auth_headers"] != {} }

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -694,6 +694,34 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
           )
       end
 
+      context "with credentials" do
+        let(:credentials) do
+          [{
+            "type" => "maven_repository",
+            "url" => "https://dl.bintray.com/magnusja/maven/",
+            "username" => "username",
+            "password" => "password"
+          }]
+        end
+
+        before do
+          stub_request(:get, google_metadata_url).
+            to_return(status: 404, body: "")
+          stub_request(:get, magnusja_metadata_url).
+            with(basic_auth: %w(username password)).
+            to_return(
+              status: 200,
+              body: fixture("google_metadata", "com_google_guava.xml")
+            )
+        end
+
+        it "calls custom repo using defined credentials" do
+          subject
+
+          expect(a_request(:get, magnusja_metadata_url)).to have_been_made.once
+        end
+      end
+
       describe "the first version" do
         subject { versions.first }
 

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -190,7 +190,7 @@ module Dependabot
 
           @repositories =
             details.reject do |repo|
-              next if repo["auth_headers"]
+              next unless repo["auth_headers"].empty?
 
               # Reject this entry if an identical one with non-empty auth_headers exists
               details.any? { |r| r["url"] == repo["url"] && r["auth_headers"] != {} }

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -546,6 +546,32 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       its([:source_url]) do
         is_expected.to eq("http://repository.jboss.org/maven2")
       end
+
+      context "with custom repository and credentials" do
+        let(:credentials) do
+          [{
+            "type" => "maven_repository",
+            "url" => "http://repository.jboss.org/maven2/",
+            "username" => "username",
+            "password" => "password"
+          }]
+        end
+
+        before do
+          stub_request(:get, jboss_metadata_url).
+            with(basic_auth: %w(username password)).
+            to_return(
+              status: 200,
+              body: fixture("maven_central_metadata", "with_release.xml")
+            )
+        end
+
+        it "calls custom repo once" do
+          subject
+
+          expect(a_request(:get, jboss_metadata_url)).to have_been_requested.once
+        end
+      end
     end
   end
 


### PR DESCRIPTION
It seems that https://github.com/dependabot/dependabot-core/pull/3403 introduced a bug in rejecting duplicate credentials without any auth headers.

With introduction of `AuthHeadersFinder`, registry object without any credentials will always have empty hash for auth headers. https://github.com/dependabot/dependabot-core/blob/582ad92118e637139730519ddde072aca07cec00/maven/lib/dependabot/maven/utils/auth_headers_finder.rb#L21

Because of that, check `next if repo["auth_headers"]` will always resolve to true, since empty hash is a truthy value which leads to having duplicate registry object without auth headers:

Here is an example from my testing with configured private registry. The mapbox registry without credentials which is fetched from dependency file, did not get rejected and as a result due to array order, it was picked first and failed authentication.

```ruby
[
  {"url"=>"https://repo.maven.apache.org/maven2", "auth_headers"=>{}},
  {"url"=>"https://api.mapbox.com/downloads/v2/releases/maven", "auth_headers"=>{}},
  {"url"=>"https://api.mapbox.com/downloads/v2/releases/maven", "auth_headers"=> {"Authorization"=>"Basic ..."}}
]
```