### PR TITLE
Common: Consider all failed requests to check enterprise source as false

### DIFF
--- a/common/lib/dependabot/source.rb
+++ b/common/lib/dependabot/source.rb
@@ -89,7 +89,7 @@ module Dependabot
         # currently doesn't work with development environments
         resp.headers["X-GitHub-Request-Id"] &&
         !resp.headers["X-GitHub-Request-Id"].empty?
-    rescue Excon::Error
+    rescue StandardError
       false
     end
 


### PR DESCRIPTION
We've observed some failures when making requests to the `/status`
endpoint for some git hosts that end up not being reported as a
`Excon::Error`.

We make this request to check if the host is a GHES instance so we can
pull in relevant metadata from the host. However, when that request
fails, we should prefer opening the PR without that metadata, as we
likely wouldn't be able to source it any way.

Fixes https://github.com/dependabot/dependabot-core/issues/4538