### PR TITLE
Fix syntax for setting bundle config

### DIFF
--- a/bundler/helpers/v1/build
+++ b/bundler/helpers/v1/build
@@ -20,6 +20,6 @@ cd "$install_dir"
 
 # NOTE: Sets `BUNDLED WITH` to match the installed v1 version in Gemfile.lock
 # forcing native helpers to run with the same version
-BUNDLER_VERSION=1.17.3 bundle config set --local path ".bundle"
-BUNDLER_VERSION=1.17.3 bundle config set --local without "test"
+BUNDLER_VERSION=1.17.3 bundle config --local path ".bundle"
+BUNDLER_VERSION=1.17.3 bundle config --local without "test"
 BUNDLER_VERSION=1.17.3 bundle install

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -20,6 +20,6 @@ cd "$install_dir"
 
 # NOTE: Sets `BUNDLED WITH` to match the installed v2 version in Gemfile.lock
 # forcing specs and native helpers to run with the same version
-BUNDLER_VERSION=2.2.26 bundle config set --local path ".bundle"
-BUNDLER_VERSION=2.2.26 bundle config set --local without "test"
+BUNDLER_VERSION=2.2.26 bundle config --local path ".bundle"
+BUNDLER_VERSION=2.2.26 bundle config --local without "test"
 BUNDLER_VERSION=2.2.26 bundle install


### PR DESCRIPTION
The syntax in our native bundler helpers is unintentionally modifying a config variable called `set`:

```bash
dependabot@4891a24fb822:/opt/bundler/v1$ BUNDLER_VERSION=1.17.3 bundle config set --local path ".bundle"
dependabot@4891a24fb822:/opt/bundler/v1$ BUNDLER_VERSION=1.17.3 bundle config set --local without "test" 
You are replacing the current global value of set, which is currently "--local without test"
# ☝🏻 That looks suspect, let's check the config:

dependabot@4891a24fb822:/opt/bundler/v1$ bundle config --local
Settings are listed in order of priority. The top value will be used.
set
Set for the current user (/home/dependabot/.bundle/config): "--local without test"
# 🤔  That's not right

path
Set via BUNDLE_PATH: ".bundle"

silence_root_warning
Set via BUNDLE_SILENCE_ROOT_WARNING: true

bin
Set via BUNDLE_BIN: ".bundle/bin"

gemfile
Set via BUNDLE_GEMFILE: "/opt/bundler/v1/Gemfile"
```

The reason this is working is that we set `BUNDLE_PATH=".bundle"` [in the Dockerfile](https://github.com/dependabot/dependabot-core/blob/6344adda43d26a70f0fbd70469ebe8579632d5af/Dockerfile#L71-L72) so we bundle to the right place, but we are bundling our test gems into the native helpers unintentionally as with `without` directive is missed:

```bash
dependabot@4891a24fb822:/opt/bundler/v1$ bundle info byebug
  * byebug (11.1.3)
        Summary: Ruby fast debugger - base + CLI
        Homepage: https://github.com/deivid-rodriguez/byebug
        Path: /opt/bundler/v1/.bundle/gems/byebug-11.1.3
```

I think this explains at least one issue we've seen reporting a conflict with `byebug` or `rspec` when running updates.

This change should stop the native helpers bundling those gems anymore, when I try this on a fresh image using these changes I see:
```bash
dependabot@a987cd924543:/opt/bundler/v1$ bundler info byebug
Could not find gem 'byebug'.
Did you mean byebug?
```