### PR TITLE
Consistency pass on composer native helper build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,13 +240,14 @@ USER dependabot
 RUN mkdir -p /opt/bundler/v1 /opt/bundler/v2
 RUN bash /opt/bundler/helpers/v1/build /opt/bundler/v1
 RUN bash /opt/bundler/helpers/v2/build /opt/bundler/v2
+RUN mkdir -p /opt/composer/v1 /opt/composer/v2
+RUN bash /opt/composer/helpers/v1/build /opt/composer/v1
+RUN bash /opt/composer/helpers/v2/build /opt/composer/v2
 RUN bash /opt/go_modules/helpers/build /opt/go_modules
 RUN bash /opt/hex/helpers/build /opt/hex
 RUN bash /opt/npm_and_yarn/helpers/build /opt/npm_and_yarn
 RUN bash /opt/python/helpers/build /opt/python
 RUN bash /opt/terraform/helpers/build /opt/terraform
-RUN bash /opt/composer/helpers/v1/build /opt/composer/v1
-RUN bash /opt/composer/helpers/v2/build /opt/composer/v2
 
 ENV HOME="/home/dependabot"
 

--- a/composer/helpers/v1/build
+++ b/composer/helpers/v1/build
@@ -9,7 +9,16 @@ if [ -z "$install_dir" ]; then
 fi
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
-cd "$helpers_dir"
+cp -r \
+  "$helpers_dir/bin" \
+  "$helpers_dir/src" \
+  "$helpers_dir/.php_cs" \
+  "$helpers_dir/composer.json" \
+  "$helpers_dir/composer.lock" \
+  "$helpers_dir/phpstan.neon" \
+  "$install_dir"
+
+cd "$install_dir"
 
 composer1 validate --no-check-publish
 composer1 install

--- a/composer/helpers/v2/build
+++ b/composer/helpers/v2/build
@@ -9,7 +9,16 @@ if [ -z "$install_dir" ]; then
 fi
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
-cd "$helpers_dir"
+cp -r \
+  "$helpers_dir/bin" \
+  "$helpers_dir/src" \
+  "$helpers_dir/.php-cs-fixer.php" \
+  "$helpers_dir/composer.json" \
+  "$helpers_dir/composer.lock" \
+  "$helpers_dir/phpstan.neon" \
+  "$install_dir"
+
+cd "$install_dir"
 
 composer validate --no-check-publish
 composer install

--- a/composer/lib/dependabot/composer/native_helpers.rb
+++ b/composer/lib/dependabot/composer/native_helpers.rb
@@ -8,7 +8,7 @@ module Dependabot
       end
 
       def self.composer_helpers_dir
-        File.join(native_helpers_root, "composer/helpers")
+        File.join(native_helpers_root, "composer")
       end
 
       def self.native_helpers_root


### PR DESCRIPTION
As part of streamlining how we mount the native helpers into the development shell, I noticed that the composer native helper install path is inconsistent with our other native helpers.

In all other cases we follow the pattern of:

```Dockerfile
COPY --chown=dependabot:dependabot $ECOSYSTEM/helpers /opt/$ECOSYSTEM/helpers

RUN bash /opt/$ECOSYSTEM/helpers/build /opt/$ECOSYSTEM/
```

Which results in the relevant contents of the `helpers/` folder being copied up a level in the directory structure.

In the case of Bundler, this results in a directory with `helpers, v1, v2` folders.

### The problem

My expectation is that the composer helpers should be in the same paths as bundler, but in reality we are using them in-situ without copying any files or actually using the `$install_dir` argument in the script.

### Rationale

My understanding for not using the native helpers in situ is to avoid artefacts such as tests and development dependencies being pulled into the 'production' code we use in the real image.

Although composer works without this step, it being inconsistent is surprising and breaks any convention we could use to automate generation of the relevant paths.

### ⚠️ Caution

One thing of note is that this makes a change to the base image directory structure _and_ the `dependabot-composer` gem that much be updated in unison or it will be a breaking change.

I'm not sure how we've managed this kind of change in the past.