### PR TITLE
Refresh the workflow for native helpers within the docker dev shell, Consistency pass on native dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,12 +17,10 @@ vendor
 /.vscode/
 /.vscode-server/
 /.vscode-server-insiders/
-/bundler/helpers/install-dir
+.byebug_history
+**/helpers/install-dir
 /npm_and_yarn/helpers/node_modules
-/npm_and_yarn/helpers/install-dir
 /npm_and_yarn/helpers/.node-version
-/go_modules/helpers/install-dir
-/terraform/helpers/install-dir
 /dry-run
 **/bin/helper
 /.core-bash_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -244,7 +244,7 @@ RUN mkdir -p /opt/composer/v1 /opt/composer/v2
 RUN bash /opt/composer/helpers/v1/build
 RUN bash /opt/composer/helpers/v2/build
 RUN bash /opt/go_modules/helpers/build
-RUN bash /opt/hex/helpers/build /opt/hex
+RUN bash /opt/hex/helpers/build
 RUN bash /opt/npm_and_yarn/helpers/build /opt/npm_and_yarn
 RUN bash /opt/python/helpers/build /opt/python
 RUN bash /opt/terraform/helpers/build /opt/terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -243,7 +243,7 @@ RUN bash /opt/bundler/helpers/v2/build
 RUN mkdir -p /opt/composer/v1 /opt/composer/v2
 RUN bash /opt/composer/helpers/v1/build
 RUN bash /opt/composer/helpers/v2/build
-RUN bash /opt/go_modules/helpers/build /opt/go_modules
+RUN bash /opt/go_modules/helpers/build
 RUN bash /opt/hex/helpers/build /opt/hex
 RUN bash /opt/npm_and_yarn/helpers/build /opt/npm_and_yarn
 RUN bash /opt/python/helpers/build /opt/python

--- a/Dockerfile
+++ b/Dockerfile
@@ -247,7 +247,7 @@ RUN bash /opt/go_modules/helpers/build
 RUN bash /opt/hex/helpers/build
 RUN bash /opt/npm_and_yarn/helpers/build
 RUN bash /opt/python/helpers/build
-RUN bash /opt/terraform/helpers/build /opt/terraform
+RUN bash /opt/terraform/helpers/build
 
 ENV HOME="/home/dependabot"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -239,7 +239,6 @@ ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt" \
 USER dependabot
 RUN bash /opt/bundler/helpers/v1/build
 RUN bash /opt/bundler/helpers/v2/build
-RUN mkdir -p /opt/composer/v1 /opt/composer/v2
 RUN bash /opt/composer/helpers/v1/build
 RUN bash /opt/composer/helpers/v2/build
 RUN bash /opt/go_modules/helpers/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -237,7 +237,6 @@ ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt" \
   MIX_HOME="/opt/hex/mix"
 
 USER dependabot
-RUN mkdir -p /opt/bundler/v1 /opt/bundler/v2
 RUN bash /opt/bundler/helpers/v1/build
 RUN bash /opt/bundler/helpers/v2/build
 RUN mkdir -p /opt/composer/v1 /opt/composer/v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -238,8 +238,8 @@ ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt" \
 
 USER dependabot
 RUN mkdir -p /opt/bundler/v1 /opt/bundler/v2
-RUN bash /opt/bundler/helpers/v1/build /opt/bundler/v1
-RUN bash /opt/bundler/helpers/v2/build /opt/bundler/v2
+RUN bash /opt/bundler/helpers/v1/build
+RUN bash /opt/bundler/helpers/v2/build
 RUN mkdir -p /opt/composer/v1 /opt/composer/v2
 RUN bash /opt/composer/helpers/v1/build /opt/composer/v1
 RUN bash /opt/composer/helpers/v2/build /opt/composer/v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -241,8 +241,8 @@ RUN mkdir -p /opt/bundler/v1 /opt/bundler/v2
 RUN bash /opt/bundler/helpers/v1/build
 RUN bash /opt/bundler/helpers/v2/build
 RUN mkdir -p /opt/composer/v1 /opt/composer/v2
-RUN bash /opt/composer/helpers/v1/build /opt/composer/v1
-RUN bash /opt/composer/helpers/v2/build /opt/composer/v2
+RUN bash /opt/composer/helpers/v1/build
+RUN bash /opt/composer/helpers/v2/build
 RUN bash /opt/go_modules/helpers/build /opt/go_modules
 RUN bash /opt/hex/helpers/build /opt/hex
 RUN bash /opt/npm_and_yarn/helpers/build /opt/npm_and_yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -245,8 +245,8 @@ RUN bash /opt/composer/helpers/v1/build
 RUN bash /opt/composer/helpers/v2/build
 RUN bash /opt/go_modules/helpers/build
 RUN bash /opt/hex/helpers/build
-RUN bash /opt/npm_and_yarn/helpers/build /opt/npm_and_yarn
-RUN bash /opt/python/helpers/build /opt/python
+RUN bash /opt/npm_and_yarn/helpers/build
+RUN bash /opt/python/helpers/build
 RUN bash /opt/terraform/helpers/build /opt/terraform
 
 ENV HOME="/home/dependabot"

--- a/README.md
+++ b/README.md
@@ -99,16 +99,16 @@ $ bin/dry-run.rb go_modules rsc/quote
 Run the tests by running `rspec spec` inside each of the packages, e.g.
 
 ```bash
-cd go_modules
-bundle exec rspec spec
+$ cd go_modules
+$ bundle exec rspec spec
 ```
 
 Style is enforced by RuboCop. To check for style violations, simply run `rubocop` in
 each of the packages, e.g.
 
 ```bash
-cd go_modules
-bundle exec rubocop
+$ cd go_modules
+$ bundle exec rubocop
 ```
 
 ### Making changes to native helpers
@@ -121,8 +121,10 @@ Once you have made any edits to the helper files, run the appropriate build scri
 installed version with your changes like so:
 
 ```bash
-bundler/helpers/v1/build
-bin/dry-run.rb bundler dependabot/demo --dir="/ruby"
+$ bin/docker-dev-shell
+=> running docker development shell
+$ bundler/helpers/v1/build
+$ bin/dry-run.rb bundler dependabot/demo --dir="/ruby"
 ```
 
 ### Building the development image from source

--- a/README.md
+++ b/README.md
@@ -37,12 +37,9 @@ Highlights include:
 
 ## Other Dependabot resources
 
-In addition to this library, you may be interested in:
-
-- The [dependabot-script][dependabot-script] repo, which provides a collection
-  of scripts that use this library to update dependencies on GitHub Enterprise,
-  GitLab or Azure DevOps
-- The [API docs][api-docs] for Dependabot's hosted instance (dependabot.com)
+In addition to this library, you may be interested in the [dependabot-script][dependabot-script] repo,
+which provides a collection of scripts that use this library to update dependencies on GitHub Enterprise, GitLab
+or Azure DevOps
 
 ## Cloning the repository
 Clone the repository with Git using:
@@ -65,30 +62,73 @@ To run all of Dependabot Core, you'll need Ruby, Python, PHP, Elixir, Node, Go,
 Elm, and Rust installed. However, if you just wish to run it for a single
 language you can get away with just having that language and Ruby.
 
-The main library is written in Ruby, while JavaScript, Python, PHP, Elm,
-Elixir, Go, and Rust are required for dealing with updates for their respective
-languages.
+While you can run Dependabot Core without Docker, we provide a development
+Dockerfile that bakes in all required dependencies. In most cases this is the
+best way to work with the project.
 
-To install the helpers for each language:
+## Running with Docker
 
-1. `cd npm_and_yarn/helpers && npm install --production && cd -`
-2. `cd composer/helpers && composer install --no-dev && cd -`
-3. `cd python/helpers && pyenv exec pip install -r requirements.txt && cd -`
-4. `cd hex/helpers && mix deps.get && cd -`
-5. `cd terraform && helpers/build "$(pwd)/helpers/install-dir/terraform" && cd -`
-6. `cd go_modules && helpers/build "$(pwd)/helpers/install-dir/go_modules" && cd -`
+Start by pulling the developer image from the [GitHub Container Registry][ghcr-core-dev] and then start the developer shell:
 
-## Local development & Running tests
+```shell
+$ docker pull ghcr.io/dependabot/dependabot-core-development:latest
+$ bin/docker-dev-shell
+=> running docker development shell
+[dependabot-core-dev] ~/dependabot-core $
+```
 
-Run the tests by running `rspec spec` inside each of the packages. Style is
-enforced by RuboCop. To check for style violations, simply run `rubocop` in
-each of the packages.
+### Dry run script
 
-### Running with Docker
+You can use the "dry-run" script to simulate a dependency update job, printing
+the diff that would be generated to the terminal. It takes two positional
+arguments: the package manager and the GitHub repo name (including the
+account):
 
-While you can run Dependabot Core without Docker, we also provide a development
-Dockerfile. In most cases, you'll be better off running Dependabot in the
-development Docker container as it bakes in all required dependencies.
+```bash
+$ bin/docker-dev-shell
+=> running docker development shell
+$ bin/dry-run.rb go_modules rsc/quote
+=> fetching dependency files
+=> parsing dependency files
+=> updating 2 dependencies
+...
+```
+
+### Running the tests
+
+Run the tests by running `rspec spec` inside each of the packages, e.g.
+
+```bash
+cd go_modules
+bundle exec rspec spec
+```
+
+Style is enforced by RuboCop. To check for style violations, simply run `rubocop` in
+each of the packages, e.g.
+
+```bash
+cd go_modules
+bundle exec rubocop
+```
+
+### Making changes to native helpers
+
+Several Dependabot packages make use of 'native helpers', small executables in their host language.
+
+**Changes to these files are not automatically reflected inside the development container**
+
+Once you have made any edits to the helper files, run the appropriate build script to update the
+installed version with your changes like so:
+
+```bash
+bundler/helpers/v1/build
+bin/dry-run.rb bundler dependabot/demo --dir="/ruby"
+```
+
+### Building the development image from source
+
+The developer shell uses volume mounts to incorporate your local changes to Dependabot's source
+code. If you need to make changes to the development shell itself, you can rebuild it locally.
 
 Start by building the initial Dependabot Core image, or pull it from the
 Docker registry.
@@ -114,27 +154,17 @@ $ bin/docker-dev-shell
 [dependabot-core-dev] ~/dependabot-core $ cd go_modules && rspec spec # to run tests for a particular package
 ```
 
-### Dry run script
+## Running locally on your computer
 
-You can use the "dry-run" script to simulate a dependency update job, printing
-the diff that would be generated to the terminal. It takes two positional
-arguments: the package manager and the GitHub repo name (including the
-account):
+To work with Dependabot packages on your local machine you will need Ruby and the package's specific language installed.
 
-```bash
-$ bin/docker-dev-shell
-$ bin/dry-run.rb go_modules rsc/quote
-=> fetching dependency files
-=> parsing dependency files
-=> updating 2 dependencies
-...
-```
+For some languages there are additional steps required, please refer to the README file in each package.
 
 ## Debugging with Visual Studio Code and Docker
 
 There's built-in support for leveraging Visual Studio Code's [ability for
-debugging](https://code.visualstudio.com/docs/remote/containers) inside a Docker container.
-After installing the recommended [`Remote - Containers` extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers),
+debugging][vsc-remote-containers] inside a Docker container.
+After installing the recommended [`Remote - Containers` extension][vsc-remote-containers-ext],
 simply press `Ctrl+Shift+P` (`⇧⌘P` on macOS) and select `Remote-Containers: Reopen in Container`.
 You can also access the dropdown by clicking on the green button in the bottom-left corner of the editor.
 If the development Docker image isn't present on your machine, it will be built automatically.
@@ -249,8 +279,10 @@ recurring payments from Europe, check them out.
 [dependabot-status]: https://api.dependabot.com/badges/status?host=github&identifier=93163073
 [dependabot-script]: https://github.com/dependabot/dependabot-script
 [contributing]: https://github.com/dependabot/dependabot-core/blob/main/CONTRIBUTING.md
-[api-docs]: https://github.com/dependabot/api-docs
 [bump]: https://github.com/gocardless/bump
 [bump-core]: https://github.com/gocardless/bump-core
 [gocardless]: https://gocardless.com
+[ghcr-core-dev]: https://github.com/dependabot/dependabot-core/pkgs/container/dependabot-core-development
 [support]: https://support.github.com/
+[vsc-remote-containers]: https://code.visualstudio.com/docs/remote/containers
+[vsc-remote-containers-ext]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -105,6 +105,7 @@ docker run --rm -ti \
   -v "$(pwd)/terraform/.rubocop.yml:$CODE_DIR/terraform/.rubocop.yml" \
   -v "$(pwd)/terraform/Gemfile:$CODE_DIR/terraform/Gemfile" \
   -v "$(pwd)/terraform/dependabot-terraform.gemspec:$CODE_DIR/terraform/dependabot-terraform.gemspec" \
+  -v "$(pwd)/terraform/helpers:$CODE_DIR/terraform/helpers" \
   -v "$(pwd)/terraform/lib:$CODE_DIR/terraform/lib" \
   -v "$(pwd)/terraform/spec:$CODE_DIR/terraform/spec" \
   -v "$(pwd)/terraform/script:$CODE_DIR/terraform/script" \
@@ -135,8 +136,7 @@ docker run --rm -ti \
   -v "$(pwd)/python/.rubocop.yml:$CODE_DIR/python/.rubocop.yml" \
   -v "$(pwd)/python/Gemfile:$CODE_DIR/python/Gemfile" \
   -v "$(pwd)/python/dependabot-python.gemspec:$CODE_DIR/python/dependabot-python.gemspec" \
-  -v "$(pwd)/python/helpers:/opt/python" \
-  -v "$(pwd)/python/helpers:/opt/python/helpers" \
+  -v "$(pwd)/python/helpers:$CODE_DIR/python/helpers" \
   -v "$(pwd)/python/lib:$CODE_DIR/python/lib" \
   -v "$(pwd)/python/spec:$CODE_DIR/python/spec" \
   -v "$(pwd)/python/script:$CODE_DIR/python/script" \
@@ -161,6 +161,7 @@ docker run --rm -ti \
   -v "$(pwd)/hex/.rubocop.yml:$CODE_DIR/hex/.rubocop.yml" \
   -v "$(pwd)/hex/Gemfile:$CODE_DIR/hex/Gemfile" \
   -v "$(pwd)/hex/dependabot-hex.gemspec:$CODE_DIR/hex/dependabot-hex.gemspec" \
+  -v "$(pwd)/hex/helpers:$CODE_DIR/hex/helpers" \
   -v "$(pwd)/hex/lib:$CODE_DIR/hex/lib" \
   -v "$(pwd)/hex/spec:$CODE_DIR/hex/spec" \
   -v "$(pwd)/hex/script:$CODE_DIR/hex/script" \
@@ -180,12 +181,14 @@ docker run --rm -ti \
   -v "$(pwd)/npm_and_yarn/.rubocop.yml:$CODE_DIR/npm_and_yarn/.rubocop.yml" \
   -v "$(pwd)/npm_and_yarn/Gemfile:$CODE_DIR/npm_and_yarn/Gemfile" \
   -v "$(pwd)/npm_and_yarn/dependabot-npm_and_yarn.gemspec:$CODE_DIR/npm_and_yarn/dependabot-npm_and_yarn.gemspec" \
+  -v "$(pwd)/npm_and_yarn/helpers:$CODE_DIR/npm_and_yarn/helpers" \
   -v "$(pwd)/npm_and_yarn/lib:$CODE_DIR/npm_and_yarn/lib" \
   -v "$(pwd)/npm_and_yarn/spec:$CODE_DIR/npm_and_yarn/spec" \
   -v "$(pwd)/npm_and_yarn/script:$CODE_DIR/npm_and_yarn/script" \
   -v "$(pwd)/composer/.rubocop.yml:$CODE_DIR/composer/.rubocop.yml" \
   -v "$(pwd)/composer/Gemfile:$CODE_DIR/composer/Gemfile" \
   -v "$(pwd)/composer/dependabot-composer.gemspec:$CODE_DIR/composer/dependabot-composer.gemspec" \
+  -v "$(pwd)/composer/helpers:$CODE_DIR/composer/helpers" \
   -v "$(pwd)/composer/lib:$CODE_DIR/composer/lib" \
   -v "$(pwd)/composer/spec:$CODE_DIR/composer/spec" \
   -v "$(pwd)/composer/script:$CODE_DIR/composer/script" \
@@ -195,8 +198,6 @@ docker run --rm -ti \
   -v "$(pwd)/bundler/lib:$CODE_DIR/bundler/lib" \
   -v "$(pwd)/bundler/helpers:$CODE_DIR/bundler/helpers" \
   -v "$(pwd)/bundler/spec:$CODE_DIR/bundler/spec" \
-  -v "$(pwd)/bundler/helpers:/opt/bundler" \
-  -v "$(pwd)/bundler/helpers:/opt/bundler/helpers" \
   -v "$(pwd)/bundler/script:$CODE_DIR/bundler/script" \
   -v "$(pwd)/omnibus/.rubocop.yml:$CODE_DIR/omnibus/.rubocop.yml" \
   -v "$(pwd)/omnibus/Gemfile:$CODE_DIR/omnibus/Gemfile" \

--- a/bundler/README.md
+++ b/bundler/README.md
@@ -4,7 +4,14 @@ Ruby (bundler) support for [`dependabot-core`][core-repo].
 
 ### Running locally
 
-1. Install Ruby dependencies
+1. Install native helpers
+    ```
+    $ export DEPENDABOT_NATIVE_HELPERS_PATH=$PWD/helpers/install-dir
+    $ helpers/v1/build
+    $ helpers/v2/build
+    ```
+
+2. Install Ruby dependencies
    ```
    $ bundle install
    ```

--- a/bundler/helpers/v1/build
+++ b/bundler/helpers/v1/build
@@ -2,12 +2,12 @@
 
 set -e
 
-install_dir=$1
-if [ -z "$install_dir" ]; then
-  echo "usage: $0 INSTALL_DIR"
+if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+  echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
 
+install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/bundler/v1"
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/lib" \

--- a/bundler/helpers/v1/build
+++ b/bundler/helpers/v1/build
@@ -8,7 +8,6 @@ if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/bundler/v1"
-
 mkdir -p $install_dir
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"

--- a/bundler/helpers/v1/build
+++ b/bundler/helpers/v1/build
@@ -8,6 +8,9 @@ if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/bundler/v1"
+
+mkdir -p $install_dir
+
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/lib" \

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -8,6 +8,9 @@ if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/bundler/v2"
+
+mkdir -p $install_dir
+
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/lib" \

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -8,7 +8,6 @@ if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/bundler/v2"
-
 mkdir -p $install_dir
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -2,12 +2,12 @@
 
 set -e
 
-install_dir=$1
-if [ -z "$install_dir" ]; then
-  echo "usage: $0 INSTALL_DIR"
+if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+  echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
 
+install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/bundler/v2"
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/lib" \

--- a/composer/README.md
+++ b/composer/README.md
@@ -6,8 +6,13 @@ PHP (Composer) support for [`dependabot-core`][core-repo].
 
 1. Install native helpers
    ```
-   $ helpers/build helpers/install-dir/composer
+   $ export DEPENDABOT_NATIVE_HELPERS_PATH=$PWD/helpers/install-dir
+   $ helpers/v1/build
+   $ helpers/v2/build
    ```
+
+   Note: We expect Composer v1 to be available as `composer`, you can skip `helpers/v1/build` if you are working on the
+   latest version, but some test may fail.
 
 2. Install Ruby dependencies
    ```

--- a/composer/helpers/v1/build
+++ b/composer/helpers/v1/build
@@ -8,7 +8,6 @@ if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/composer/v1"
-
 mkdir -p $install_dir
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"

--- a/composer/helpers/v1/build
+++ b/composer/helpers/v1/build
@@ -2,12 +2,12 @@
 
 set -e
 
-install_dir=$1
-if [ -z "$install_dir" ]; then
-  echo "usage: $0 INSTALL_DIR"
+if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+  echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
 
+install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/composer/v1"
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/bin" \

--- a/composer/helpers/v1/build
+++ b/composer/helpers/v1/build
@@ -8,6 +8,9 @@ if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/composer/v1"
+
+mkdir -p $install_dir
+
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/bin" \

--- a/composer/helpers/v2/build
+++ b/composer/helpers/v2/build
@@ -8,6 +8,9 @@ if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/composer/v2"
+
+mkdir -p $install_dir
+
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/bin" \

--- a/composer/helpers/v2/build
+++ b/composer/helpers/v2/build
@@ -2,12 +2,12 @@
 
 set -e
 
-install_dir=$1
-if [ -z "$install_dir" ]; then
-  echo "usage: $0 INSTALL_DIR"
+if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+  echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
 
+install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/composer/v2"
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/bin" \

--- a/composer/helpers/v2/build
+++ b/composer/helpers/v2/build
@@ -8,7 +8,6 @@ if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/composer/v2"
-
 mkdir -p $install_dir
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"

--- a/go_modules/README.md
+++ b/go_modules/README.md
@@ -6,7 +6,8 @@ Go modules support for [`dependabot-core`][core-repo].
 
 1. Install native helpers
    ```
-   $ helpers/build "$(pwd)/helpers/install-dir/go_modules"
+   $ export DEPENDABOT_NATIVE_HELPERS_PATH=$PWD/helpers/install-dir
+   $ helpers/build
    ```
 
 2. Install Ruby dependencies

--- a/go_modules/helpers/build
+++ b/go_modules/helpers/build
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
   echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi

--- a/go_modules/helpers/build
+++ b/go_modules/helpers/build
@@ -2,11 +2,12 @@
 
 set -e
 
-install_dir=$1
-if [ -z "$install_dir" ]; then
-  echo "usage: $0 INSTALL_DIR"
+if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+  echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
+
+install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/go_modules"
 
 if ! [[ "$install_dir" =~ ^/ ]]; then
   echo "$install_dir must be an absolute path"

--- a/hex/README.md
+++ b/hex/README.md
@@ -6,7 +6,8 @@ Elixir support for [`dependabot-core`][core-repo].
 
 1. Install native helpers
    ```
-   $ helpers/build helpers/install-dir/hex
+   $ export DEPENDABOT_NATIVE_HELPERS_PATH=$PWD/helpers/install-dir
+   $ helpers/build
    ```
 
 2. Install Ruby dependencies
@@ -16,7 +17,6 @@ Elixir support for [`dependabot-core`][core-repo].
 
 3. Run tests
    ```
-   $ export DEPENDABOT_NATIVE_HELPERS_PATH=$PWD/helpers/install-dir
    $ bundle exec rspec spec
    ```
 

--- a/hex/helpers/build
+++ b/hex/helpers/build
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
   echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi

--- a/hex/helpers/build
+++ b/hex/helpers/build
@@ -2,12 +2,12 @@
 
 set -e
 
-install_dir=$1
-if [ -z "$install_dir" ]; then
-  echo "usage: $0 INSTALL_DIR"
+if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+  echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
 
+install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/hex"
 mkdir -p "$install_dir"
 
 mix local.hex --force

--- a/npm_and_yarn/README.md
+++ b/npm_and_yarn/README.md
@@ -7,7 +7,8 @@ Yarn and npm support for [`dependabot-core`][core-repo].
 1. Install native helpers
 
    ```
-   $ cd helpers && npm install && cd -
+   $ export DEPENDABOT_NATIVE_HELPERS_PATH=$PWD/helpers/install-dir
+   $ helpers/build
    ```
 
 2. Install Ruby dependencies

--- a/npm_and_yarn/helpers/build
+++ b/npm_and_yarn/helpers/build
@@ -8,6 +8,8 @@ if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/npm_and_yarn"
+mkdir -p $install_dir
+
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/lib" \

--- a/npm_and_yarn/helpers/build
+++ b/npm_and_yarn/helpers/build
@@ -2,12 +2,12 @@
 
 set -e
 
-install_dir=$1
-if [ -z "$install_dir" ]; then
-  echo "usage: $0 INSTALL_DIR"
+if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+  echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
 
+install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/npm_and_yarn"
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/lib" \

--- a/npm_and_yarn/helpers/build
+++ b/npm_and_yarn/helpers/build
@@ -2,13 +2,13 @@
 
 set -e
 
-if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
   echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/npm_and_yarn"
-mkdir -p $install_dir
+mkdir -p "$install_dir"
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \

--- a/python/README.md
+++ b/python/README.md
@@ -19,7 +19,8 @@ Updating the list of known versions might be tricky, here are the steps:
 
 1. Install native helpers
    ```
-   $ helpers/build helpers/install-dir/python
+   $ export DEPENDABOT_NATIVE_HELPERS_PATH=$PWD/helpers/install-dir
+   $ helpers/build
    ```
 
 2. Install Ruby dependencies

--- a/python/helpers/build
+++ b/python/helpers/build
@@ -8,6 +8,9 @@ if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/python"
+
+mkdir -p $install_dir
+
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/lib" \

--- a/python/helpers/build
+++ b/python/helpers/build
@@ -2,13 +2,13 @@
 
 set -e
 
-if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
   echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/python"
-mkdir -p $install_dir
+mkdir -p "$install_dir"
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \

--- a/python/helpers/build
+++ b/python/helpers/build
@@ -2,12 +2,12 @@
 
 set -e
 
-install_dir=$1
-if [ -z "$install_dir" ]; then
-  echo "usage: $0 INSTALL_DIR"
+if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+  echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
 
+install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/python"
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/lib" \

--- a/python/helpers/build
+++ b/python/helpers/build
@@ -8,7 +8,6 @@ if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/python"
-
 mkdir -p $install_dir
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,7 +6,8 @@ Terraform support for [`dependabot-core`][core-repo].
 
 1. Install native helpers
    ```
-   $ helpers/build helpers/install-dir/terraform
+   $ export DEPENDABOT_NATIVE_HELPERS_PATH=$PWD/helpers/install-dir
+   $ helpers/build
    ```
 
 2. Install Ruby dependencies

--- a/terraform/helpers/build
+++ b/terraform/helpers/build
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
   echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi

--- a/terraform/helpers/build
+++ b/terraform/helpers/build
@@ -2,11 +2,12 @@
 
 set -e
 
-install_dir=$1
-if [ -z "$install_dir" ]; then
-  echo "usage: $0 INSTALL_DIR"
+if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+  echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
+
+install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/terraform"
 
 if [ ! -d "$install_dir/bin" ]; then
   mkdir -p "$install_dir/bin"


### PR DESCRIPTION
Follow on from https://github.com/dependabot/dependabot-core/pull/4554, which should merge first

Our `docker-dev-shell` script currently uses volume mounting to ensure that changes made to core's code on the host machine are reflected in the container without rebuilding, and vice versa.

As part of this volume mounting strategy we are inconsistent on how we handle the 'native helpers' used by some languages.

These helpers are installed into `/opt/` in the base `dependabot/dependabot-core` image via `build` scripts which ensure they have any dependencies available in a path _outside_ the working directory.

For bundler and python, we currently volume mount the native helpers from the host machine into `/opt/` like so:

```bash
  -v "$(pwd)/bundler/helpers:/opt/bundler" \
  -v "$(pwd)/bundler/helpers:/opt/bundler/helpers" \
  -v "$(pwd)/python/helpers:/opt/python" \
  -v "$(pwd)/python/helpers:/opt/python/helpers" \
```

The intent of this is so to make it easier to debug/iterate on these helpers without rebuilding everything from `dependabot/dependabot-core` up -or- editing `/opt/` files in place before transcribing the changes back to the host machine to commit.

### The problem

The main issue with this approach is that by volume mounting the helpers directory from the host, **the host version of the directory must be properly built first**.

This creates a chicken and the egg problem, where before using the development container - to avoid installing the native dependencies for the relevant language on your host - you need to manually run some instructions from the relevant `build` script.

Secondly, we don't provide this volume mounting for all native helpers so contributors are left having to work out how to get native helpers in the right state and the documentation for each dependabot package has gone stale in some cases.

### Proposed changes

This PR aims to do two things:
- Avoid trampling the installed native helpers in `/opt/` with host versions that may not be in the correct state
- Provide a consistent workflow for _all_ native helpers to repeatably apply host changes without rebuilding everything

### The approach

Our current build scripts accept an argument for an `install_dir` that we use in the `Dockerfile` to place them in `/opt/` - but this argument is somewhat redundant as they will _always_ be installed in the same place, which is determined conventionally by the value of `DEPENDABOT_NATIVE_HELPERS` - which is set early in the `Dockerfile` itself.

I decided to remove the `install_dir` input from all scripts and just have it target this location as:
- Removing the need for a directory input means you can just re-run `$foo/helpers/build` to apply the latest changes to `/opt` without knowing anything about Dependabot's installation internals
- Making the entire `build` script repeatable ensures your local changes are correctly placed into `/opt/` by repeating the precise install commands ad verbatim, avoiding transcription errors or missed steps ( e.g. bundling the Ruby native helper gems into the wrong path )
- `DEPENDABOT_NATIVE_HELPERS` is already used by the Ruby code to determine where the native helpers should be on disk, so this means both the installer and calling code are aligned on the same convention

Finally, I added a statement to each script to `mkdir -p` their conventional directory as we were doing this for _some_ native helpers, but by making it consistent we ensure the convention for working on native helpers on your host machine follows the convention of placing an install in `$foo/helpers/install-dir` is consistent.

### Proposed new workflow

I've updated the README to:
1. Emphasise developing inside the container is the preferred approach
2. Describe pulling our pre-built developer container as a speed boost for this workflow
3. Describe how to make and apply native helper changes via the `$foo/helpers/build` script

### Out of scope

I deliberately left our `.devcontainer.json` alone as part of this pass. It duplicates some of the configuration we use for `bin/docker-dev-shell`, but it's use-case is a distinct contribution to support a VS Code automation that wraps our `bin/dry-run.rb` script.

I think there are improvements to be made here, such as using the prebuilt image, but I'd rather address those separately to solicit feedback from developers more familiar with this workflow as it was a community contribution.