### PR TITLE
Enable support for ActiveSupport 7

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -68,7 +68,7 @@ Bundler.setup
 
 require "optparse"
 require "json"
-require "byebug"
+require "debug"
 require "logger"
 require "dependabot/logger"
 require "stackprof"

--- a/bundler/helpers/v1/Gemfile
+++ b/bundler/helpers/v1/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 # NOTE: Used to run native helper specs
 group :test do
-  gem "byebug", "11.1.3"
+  gem "debug", ">= 1.0.0"
   gem "rspec", "3.10.0"
   gem "rspec-its", "1.3.0"
   gem "vcr", "6.0.0"

--- a/bundler/helpers/v1/spec/native_spec_helper.rb
+++ b/bundler/helpers/v1/spec/native_spec_helper.rb
@@ -2,7 +2,7 @@
 
 require "rspec/its"
 require "webmock/rspec"
-require "byebug"
+require "debug"
 require "tmpdir"
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))

--- a/bundler/helpers/v2/Gemfile
+++ b/bundler/helpers/v2/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 # NOTE: Used to run native helper specs
 group :test do
-  gem "byebug", "11.1.3"
+  gem "debug", ">= 1.0.0"
   gem "rspec", "3.10.0"
   gem "rspec-its", "1.3.0"
   gem "vcr", "6.0.0"

--- a/bundler/helpers/v2/spec/native_spec_helper.rb
+++ b/bundler/helpers/v2/spec/native_spec_helper.rb
@@ -2,7 +2,7 @@
 
 require "rspec/its"
 require "webmock/rspec"
-require "byebug"
+require "debug"
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 $LOAD_PATH.unshift(File.expand_path("../monkey_patches", __dir__))

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
   spec.required_rubygems_version = ">= 2.7.3"
 
-  spec.add_dependency "activesupport", ">= 6.0.0", "< 7.0.0"
+  spec.add_dependency "activesupport", ">= 6.0.0"
   spec.add_dependency "aws-sdk-codecommit", "~> 1.28"
   spec.add_dependency "aws-sdk-ecr", "~> 1.5"
   spec.add_dependency "bundler", ">= 1.16", "< 3.0.0"
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "parser", ">= 2.5", "< 4.0"
   spec.add_dependency "toml-rb", ">= 1.1.2", "< 3.0"
 
-  spec.add_development_dependency "byebug", "~> 11.0"
+  spec.add_development_dependency "debug", ">= 1.0.0"
   spec.add_development_dependency "gpgme", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13"
   spec.add_development_dependency "rspec", "~> 3.8"

--- a/common/lib/dependabot/notifications.rb
+++ b/common/lib/dependabot/notifications.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support"
 require "active_support/notifications"
 
 module Dependabot

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -87,7 +87,7 @@ module Dependabot
       if ENV["DEBUG_FUNCTION"] == function
         puts helper_subprocess_bash_command(stdin_data: stdin_data, command: cmd, env: env)
         # Pause execution so we can run helpers inside the temporary directory
-        byebug # rubocop:disable Lint/Debugger
+        binding.break # rubocop:disable Lint/Debugger
       end
 
       env_cmd = [env, cmd].compact

--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require "rspec/its"
 require "webmock/rspec"
 require "vcr"
-require "byebug"
+require "debug"
 require "simplecov"
 require "simplecov-console"
 require "stackprof"


### PR DESCRIPTION
We encountered an issue recently where upgrading to ActiveSupport 7 caused our builds to fail. Upon investigation, I found that `byebug` was no longer a dependency of ActiveSupport. The library now depends on `debug`, which is a gem now but will ship with Ruby 3.1.