### PR TITLE
Use GHCR as the canonical source for CI images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,22 +42,13 @@ jobs:
       BASE_IMAGE: ubuntu:18.04
       CORE_IMAGE: dependabot/dependabot-core
       CORE_BRANCH_IMAGE: ghcr.io/dependabot/dependabot-core-branch
-      CORE_CI_IMAGE: dependabot/dependabot-core-ci
-      CORE_CI_MIRROR: ghcr.io/dependabot/dependabot-core-ci
+      CORE_CI_IMAGE: ghcr.io/dependabot/dependabot-core-ci
       CODE_DIR: /home/dependabot/dependabot-core
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Prepare BRANCH_REF environment variable
         run: echo "BRANCH_REF=$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')" >> $GITHUB_ENV
-      - name: Log in to Docker registry
-        run: |
-          if [ -n "${{ secrets.DOCKER_USERNAME }}" ] && [ -n "${{ secrets.DOCKER_PASSWORD }}" ]; then
-            echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-            echo "DOCKER_LOGGED_IN=true" >> $GITHUB_ENV
-          else
-            echo "No Docker credentials, skipping login"
-          fi
       - name: Log in to GHCR
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -87,17 +78,10 @@ jobs:
             --cache-from "$CORE_CI_IMAGE:latest" \
             --cache-from "$CORE_CI_IMAGE:branch--$BRANCH_REF" \
             .
-      - name: Push dependabot-core-ci image to Docker registry
-        if: env.DOCKER_LOGGED_IN == 'true'
+      - name: Push dependabot-core-ci image to GHCR
         run: |
           docker push "$CORE_CI_IMAGE:latest"
           docker push "$CORE_CI_IMAGE:branch--$BRANCH_REF"
-      - name: Push dependabot-core-ci image to GHCR mirror
-        run: |
-          docker tag "$CORE_CI_IMAGE:latest" "$CORE_CI_MIRROR:latest"
-          docker push "$CORE_CI_MIRROR:latest"
-          docker tag "$CORE_CI_IMAGE:latest" "$CORE_CI_MIRROR:branch--$BRANCH_REF"
-          docker push "$CORE_CI_MIRROR:branch--$BRANCH_REF"
       - name: Run ${{ matrix.suite.name }} tests
         run: |
           docker run \


### PR DESCRIPTION
As of #4524, we are pushing our CI image to a mirror in GHCR.

This PR follows up to swap over from Dockerhub to GHCR as the canonical source for these images.