### PR TITLE
Python: Move some more tests to the slow suite

### DIFF
--- a/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
         end
       end
 
-      context "with a path dependency" do
+      context "with a path dependency", :slow do
         let(:dependency_files) { [pipfile, lockfile, setupfile] }
         let(:setupfile) do
           Dependabot::DependencyFile.new(
@@ -419,7 +419,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
           )
         end
 
-        it "updates the lockfile and the requirements.txt" do
+        it "updates the lockfile and the requirements.txt", :slow do
           expect(updated_files.map(&:name)).
             to match_array(%w(Pipfile.lock requirements.txt))
 

--- a/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipenvVersionResolver do
       end
     end
 
-    context "with a path dependency" do
+    context "with a path dependency", :slow do
       let(:dependency_files) { [pipfile, lockfile, setupfile] }
       let(:setupfile) do
         Dependabot::DependencyFile.new(

--- a/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe namespace::PoetryVersionResolver do
       end
     end
 
-    context "with a dependency file that includes a git dependency" do
+    context "with a dependency file that includes a git dependency", :slow do
       let(:pyproject_fixture_name) { "git_dependency.toml" }
       let(:lockfile_fixture_name) { "git_dependency.lock" }
       let(:dependency_name) { "pytest" }


### PR DESCRIPTION
After noticing the regular python suite still takes ~20 minutes on CI
and the python_slow suite roughly half that, I moved another bunch of
the now top 10 slowest tests in the regular suite to the slow one.

I expect this to bring the total test suite down to ~15 minutes.