### PR TITLE
Cleanup after byebug removal

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,5 @@
 **/node_modules
 !**/spec/fixtures/*
 git.store
-.byebug_history
 .DS_Store
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ vendor
 /.vscode/
 /.vscode-server/
 /.vscode-server-insiders/
-.byebug_history
 /bundler/helpers/install-dir
 /npm_and_yarn/helpers/node_modules
 /npm_and_yarn/helpers/install-dir

--- a/common/.gitignore
+++ b/common/.gitignore
@@ -3,4 +3,3 @@
 /tmp
 /dependabot-*.gem
 Gemfile.lock
-.byebug_history

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -87,7 +87,7 @@ module Dependabot
       if ENV["DEBUG_FUNCTION"] == function
         puts helper_subprocess_bash_command(stdin_data: stdin_data, command: cmd, env: env)
         # Pause execution so we can run helpers inside the temporary directory
-        binding.break # rubocop:disable Lint/Debugger
+        debugger # rubocop:disable Lint/Debugger
       end
 
       env_cmd = [env, cmd].compact

--- a/npm_and_yarn/.gitignore
+++ b/npm_and_yarn/.gitignore
@@ -5,4 +5,3 @@
 /helpers/node_modules
 /helpers/install-dir
 Gemfile.lock
-.byebug_history


### PR DESCRIPTION
### `.byebug_history` removals

These artifacts are remnants of a [recently removed gem](https://github.com/dependabot/dependabot-core/pull/4559). Now that we're
using `debug`, we no longer need to ignore `.byebug_history`.

### `#debugger` aliasing

I wasn't aware that the major Ruby debuggers implement `debugger` as an
alias to their `binding` calls in source code. While I don't see this as
a necessary or important change, I think it's worth making.