### PR TITLE
Allow configuration of GOPRIVATE

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -209,7 +209,7 @@ option_parse = OptionParser.new do |opts|
                   "available options depend on PACKAGE_MANAGER"
   opts.on("--updater-options OPTIONS", opts_opt_desc) do |value|
     $options[:updater_options] = value.split(",").map do |o|
-      if o.include?("=")
+      if o.include?("=") # key/value pair, e.g. "goprivate=true"
         o.split("=", 2).map.with_index do |v, i|
           if i == 0
             v.strip.downcase.to_sym
@@ -217,7 +217,7 @@ option_parse = OptionParser.new do |opts|
             v.strip
           end
         end
-      else
+      else # just a key, e.g. "vendor"
         [o.strip.downcase.to_sym, true]
       end
     end.to_h

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -209,7 +209,17 @@ option_parse = OptionParser.new do |opts|
                   "available options depend on PACKAGE_MANAGER"
   opts.on("--updater-options OPTIONS", opts_opt_desc) do |value|
     $options[:updater_options] = value.split(",").map do |o|
-      [o.strip.downcase.to_sym, true]
+      if o.include?("=")
+        o.split("=", 2).map.with_index do |v, i|
+          if i == 0
+            v.strip.downcase.to_sym
+          else
+            v.strip
+          end
+        end
+      else
+        [o.strip.downcase.to_sym, true]
+      end
     end.to_h
   end
 
@@ -527,7 +537,8 @@ def update_checker_for(dependency)
     repo_contents_path: $repo_contents_path,
     requirements_update_strategy: $options[:requirements_update_strategy],
     ignored_versions: ignored_versions_for(dependency),
-    security_advisories: security_advisories
+    security_advisories: security_advisories,
+    options: $options[:updater_options]
   )
 end
 

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -76,14 +76,6 @@ module Dependabot
             stdout, stderr, status = Open3.capture3(command)
             handle_parser_error(path, stderr) unless status.success?
             JSON.parse(stdout)["Require"] || []
-          rescue Dependabot::DependencyFileNotResolvable
-            # We sometimes see this error if a host times out.
-            # In such cases, retrying (a maximum of 3 times) may fix it.
-            retry_count ||= 0
-            raise if retry_count >= 3
-
-            retry_count += 1
-            retry
           end
       end
 

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -73,11 +73,7 @@ module Dependabot
 
             command = "go mod edit -json"
 
-            # Turn off the module proxy for now, as it's causing issues with
-            # private git dependencies
-            env = { "GOPRIVATE" => "*" }
-
-            stdout, stderr, status = Open3.capture3(env, command)
+            stdout, stderr, status = Open3.capture3(command)
             handle_parser_error(path, stderr) unless status.success?
             JSON.parse(stdout)["Require"] || []
           rescue Dependabot::DependencyFileNotResolvable
@@ -109,11 +105,7 @@ module Dependabot
             # directives
             command = "go mod edit -json"
 
-            # Turn off the module proxy for now, as it's causing issues with
-            # private git dependencies
-            env = { "GOPRIVATE" => "*" }
-
-            stdout, stderr, status = Open3.capture3(env, command)
+            stdout, stderr, status = Open3.capture3(command)
             handle_parser_error(path, stderr) unless status.success?
 
             JSON.parse(stdout)

--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -14,6 +14,7 @@ module Dependabot
                      credentials:, options: {})
         super
 
+        @goprivate = options.fetch(:goprivate, "*")
         use_repo_contents_stub if repo_contents_path.nil?
       end
 
@@ -114,7 +115,7 @@ module Dependabot
             credentials: credentials,
             repo_contents_path: repo_contents_path,
             directory: directory,
-            options: { tidy: tidy?, vendor: vendor? }
+            options: { tidy: tidy?, vendor: vendor?, goprivate: @goprivate }
           )
       end
 

--- a/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
+++ b/go_modules/lib/dependabot/go_modules/resolvability_errors.rb
@@ -5,7 +5,7 @@ module Dependabot
     module ResolvabilityErrors
       GITHUB_REPO_REGEX = %r{github.com/[^:@]*}.freeze
 
-      def self.handle(message, credentials:)
+      def self.handle(message, credentials:, goprivate:)
         mod_path = message.scan(GITHUB_REPO_REGEX).last
         raise Dependabot::DependencyFileNotResolvable, message unless mod_path
 
@@ -22,7 +22,7 @@ module Dependabot
                           mod_path
                         end
 
-            env = { "GOPRIVATE" => "*" }
+            env = { "GOPRIVATE" => goprivate }
             _, _, status = Open3.capture3(env, SharedHelpers.escape_command("go list -m -versions #{repo_path}"))
             raise Dependabot::DependencyFileNotResolvable, message if status.success?
 

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -71,7 +71,8 @@ module Dependabot
             credentials: credentials,
             ignored_versions: ignored_versions,
             security_advisories: security_advisories,
-            raise_on_ignored: raise_on_ignored
+            raise_on_ignored: raise_on_ignored,
+            goprivate: options.fetch(:goprivate, "*")
           )
       end
 

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -28,13 +28,15 @@ module Dependabot
         PSEUDO_VERSION_REGEX = /\b\d{14}-[0-9a-f]{12}$/.freeze
 
         def initialize(dependency:, dependency_files:, credentials:,
-                       ignored_versions:, security_advisories:, raise_on_ignored: false)
+                       ignored_versions:, security_advisories:, raise_on_ignored: false,
+                       goprivate:)
           @dependency          = dependency
           @dependency_files    = dependency_files
           @credentials         = credentials
           @ignored_versions    = ignored_versions
           @security_advisories = security_advisories
           @raise_on_ignored    = raise_on_ignored
+          @goprivate           = goprivate
         end
 
         def latest_version
@@ -78,16 +80,15 @@ module Dependabot
               manifest = parse_manifest
 
               # Set up an empty go.mod so 'go list -m' won't attempt to download dependencies. This
-              # appears to be a side effect of operating with GOPRIVATE=*. We'll retain any exclude
-              # directives to omit those versions.
+              # appears to be a side effect of operating with modules included in GOPRIVATE. We'll
+              # retain any exclude directives to omit those versions.
               File.write("go.mod", "module dummy\n")
               manifest["Exclude"]&.each do |r|
                 SharedHelpers.run_shell_command("go mod edit -exclude=#{r['Path']}@#{r['Version']}")
               end
 
-              # Turn off the module proxy for now, as it's causing issues with
-              # private git dependencies
-              env = { "GOPRIVATE" => "*" }
+              # Turn off the module proxy for private dependencies
+              env = { "GOPRIVATE" => @goprivate }
 
               versions_json = SharedHelpers.run_shell_command("go list -m -versions -json #{dependency.name}", env: env)
               version_strings = JSON.parse(versions_json)["Versions"]
@@ -108,7 +109,7 @@ module Dependabot
 
         def handle_subprocess_error(error)
           if RESOLVABILITY_ERROR_REGEXES.any? { |rgx| error.message =~ rgx }
-            ResolvabilityErrors.handle(error.message, credentials: credentials)
+            ResolvabilityErrors.handle(error.message, credentials: credentials, goprivate: @goprivate)
           elsif INVALID_VERSION_REGEX =~ error.message
             raise Dependabot::DependencyFileNotResolvable, error.message
           end

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -82,6 +82,18 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
           it { is_expected.to include(%(rsc.io/quote v1.5.2\n)) }
         end
 
+        context "with an unrestricted goprivate" do
+          let(:goprivate) { "" }
+
+          it { is_expected.to include(%(rsc.io/quote v1.5.2\n)) }
+        end
+
+        context "with an org specific goprivate" do
+          let(:goprivate) { "rsc.io/*" }
+
+          it { is_expected.to include(%(rsc.io/quote v1.5.2\n)) }
+        end
+
         context "for a go 1.11 go.mod" do
           let(:project_name) { "go_1.11" }
 
@@ -624,6 +636,24 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
           expect(error.message).to include("dependabot-fixtures/go-modules-private")
           expect(error.dependency_urls).
             to eq(["github.com/dependabot-fixtures/go-modules-private"])
+        end
+      end
+
+      context "with an unrestricted goprivate" do
+        let(:goprivate) { "" }
+
+        it "raises the correct error" do
+          expect { updater.updated_go_sum_content }.
+            to raise_error(Dependabot::GitDependenciesNotReachable)
+        end
+      end
+
+      context "with an org specific goprivate" do
+        let(:goprivate) { "github.com/dependabot-fixtures/*" }
+
+        it "raises the correct error" do
+          expect { updater.updated_go_sum_content }.
+            to raise_error(Dependabot::GitDependenciesNotReachable)
         end
       end
     end

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
       credentials: credentials,
       repo_contents_path: repo_contents_path,
       directory: directory,
-      options: { tidy: tidy, vendor: false }
+      options: { tidy: tidy, vendor: false, goprivate: goprivate }
     )
   end
 
@@ -21,6 +21,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
   let(:go_mod_content) { fixture("projects", project_name, "go.mod") }
   let(:tidy) { true }
   let(:directory) { "/" }
+  let(:goprivate) { "*" }
 
   let(:credentials) { [] }
 

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
             credentials: anything,
             repo_contents_path: anything,
             directory: anything,
-            options: { tidy: false, vendor: false }
+            options: { tidy: false, vendor: false, goprivate: "*" }
           ).and_return(double)
 
         updater.updated_dependency_files

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -66,6 +66,22 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
       it "returns the latest minor version for the dependency's current major version" do
         expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("1.1.0"))
       end
+
+      context "with an unrestricted goprivate" do
+        let(:goprivate) { "" }
+
+        it "returns the latest minor version for the dependency's current major version" do
+          expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("1.1.0"))
+        end
+      end
+
+      context "with an org specific goprivate" do
+        let(:goprivate) { "github.com/dependabot-fixtures/*" }
+
+        it "returns the latest minor version for the dependency's current major version" do
+          expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("1.1.0"))
+        end
+      end
     end
 
     context "when already on the latest version" do
@@ -235,6 +251,34 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
           expect(error.message).to include("github.com/dependabot-fixtures/go-modules-private")
           expect(error.dependency_urls).
             to eq(["github.com/dependabot-fixtures/go-modules-private"])
+        end
+      end
+
+      context "with an unrestricted goprivate" do
+        let(:goprivate) { "" }
+
+        it "raises a GitDependenciesNotReachable error" do
+          error_class = Dependabot::GitDependenciesNotReachable
+          expect { finder.latest_version }.
+            to raise_error(error_class) do |error|
+            expect(error.message).to include("github.com/dependabot-fixtures/go-modules-private")
+            expect(error.dependency_urls).
+              to eq(["github.com/dependabot-fixtures/go-modules-private"])
+          end
+        end
+      end
+
+      context "with an org specific goprivate" do
+        let(:goprivate) { "github.com/dependabot-fixtures/*" }
+
+        it "raises a GitDependenciesNotReachable error" do
+          error_class = Dependabot::GitDependenciesNotReachable
+          expect { finder.latest_version }.
+            to raise_error(error_class) do |error|
+            expect(error.message).to include("github.com/dependabot-fixtures/go-modules-private")
+            expect(error.dependency_urls).
+              to eq(["github.com/dependabot-fixtures/go-modules-private"])
+          end
         end
       end
     end

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
 
   let(:raise_on_ignored) { false }
 
+  let(:goprivate) { "*" }
+
   let(:finder) do
     described_class.new(
       dependency: dependency,
@@ -54,7 +56,8 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
       credentials: [],
       ignored_versions: ignored_versions,
       security_advisories: security_advisories,
-      raise_on_ignored: raise_on_ignored
+      raise_on_ignored: raise_on_ignored,
+      goprivate: goprivate
     )
   end
 


### PR DESCRIPTION
Previously we've hardcoded setting `GOPRIVATE=*` to prevent failures if private go modules are validated against the public sumdb. That works but incurs a performance penalty when public go modules are updated. This change allows a custom `GOPRIVATE` to be specified. This could be leveraged in the future to:
- Use an unrestricted `GOPRIVATE=` when checking updates for a public repo
- Use a more specific `GOPRIVATE=github.com/owner/*` when checking updates for a private repo
- Use a more customized `GOPRIVATE` when private registries are defined

Those changes would allow updates to perform more efficiently (less time and less disk usage).

In the first 2 commits I made some minor cleanup to the `FileParser`. In the past `FileParser` ran `go get` and required `GOPRIVATE` and resolvability error handling. That was later [removed](https://github.com/dependabot/dependabot-core/commit/18d48b4f4c97764ede719f2a975756267da29b1d) so I was able to remove the remaining parts that were no longer required.

I've added some tests for this as well but they aren't particularly effective as they just check that different variations of `GOPRIVATE` don't have any effect on the output. They might be useful in detecting behavior changes in future go updates but I'd also be OK to remove them if preferred. A better test would require a test case that used private credentials but that would only work in CI. For now I tested manually:
<details>
<summary>`GOPRIVATE=` fails with private deps</summary>

```
dependabot-core-dev] ~/dependabot-core $ go clean -modcache && bin/dry-run.rb go_modules dependabot-fixtures/go-modules-private-dependency --updater-options goprivate=
=> cloning into /home/dependabot/dependabot-core/tmp/dependabot-fixtures/go-modules-private-dependency
=> parsing dependency files
=> updating 1 dependencies: github.com/dependabot-fixtures/go-modules-private

=== github.com/dependabot-fixtures/go-modules-private (0.0.1)
 => checking for updates 1/1
 => handled error whilst updating github.com/dependabot-fixtures/go-modules-private: git_dependencies_not_reachable {:"dependency-urls"=>["github.com/dependabot-fixtures/go-modules-private"]}
```
</details>

<details>
<summary>`GOPRIVATE=github.com/dependabot-fixtures/*` succeeds with private deps</summary>

```
[dependabot-core-dev] ~/dependabot-core $ go clean -modcache && bin/dry-run.rb go_modules dependabot-fixtures/go-modules-private-dependency --updater-options goprivate=github.com/dependabot-fixtures/*
=> cloning into /home/dependabot/dependabot-core/tmp/dependabot-fixtures/go-modules-private-dependency
=> parsing dependency files
=> updating 1 dependencies: github.com/dependabot-fixtures/go-modules-private

=== github.com/dependabot-fixtures/go-modules-private (0.0.1)
 => checking for updates 1/1
 => latest available version is 0.0.1
 => latest allowed version is 0.0.1
    (no update needed as it's already up-to-date)
```
</details>

<details>
<summary>default `GOPRIVATE` succeeds with private deps</summary>

```
[dependabot-core-dev] ~/dependabot-core $ go clean -modcache && bin/dry-run.rb go_modules dependabot-fixtures/go-modules-private-dependency=> cloning into /home/dependabot/dependabot-core/tmp/dependabot-fixtures/go-modules-private-dependency
=> parsing dependency files
=> updating 1 dependencies: github.com/dependabot-fixtures/go-modules-private

=== github.com/dependabot-fixtures/go-modules-private (0.0.1)
 => checking for updates 1/1
 => latest available version is 0.0.1
 => latest allowed version is 0.0.1
    (no update needed as it's already up-to-date)
```
</details>