### PR TITLE
Check for access before ghcr push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
             --cache-from "$CORE_BRANCH_IMAGE:$BRANCH_REF" \
             .
       - name: Push dependabot-core-branch image to GHCR
+        env:
+          ACCESS_CANARY: ${{ secrets.ACCESS_CANARY }}
+        if: env.ACCESS_CANARY != ''
         run: |
           docker push "$CORE_BRANCH_IMAGE:$BRANCH_REF"
       - name: Build dependabot-core-ci image
@@ -79,6 +82,9 @@ jobs:
             --cache-from "$CORE_CI_IMAGE:branch--$BRANCH_REF" \
             .
       - name: Push dependabot-core-ci image to GHCR
+        env:
+          ACCESS_CANARY: ${{ secrets.ACCESS_CANARY }}
+        if: env.ACCESS_CANARY != ''
         run: |
           docker push "$CORE_CI_IMAGE:latest"
           docker push "$CORE_CI_IMAGE:branch--$BRANCH_REF"


### PR DESCRIPTION
Our CI workflow currently fails on PRs opened from forks or Dependabot. Workflows for those PRs run with a read-only access token and no secrets so the push to ghcr fails.

Previously we avoided this failure by [checking](https://github.com/dependabot/dependabot-core/commit/c9314d37da7ca29c94fa63b28ed7cab9fa2e91f3#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL91) if the docker credentials were available to the workflow and skipping the push step if not. I've recreated that mechanism by adding a dummy secret, `ACCESS_CANARY`, that the workflow can check for before pushing. It's currently set to a random guid. The secret won't be available to fork PRs or Dependabot PRs so it should cause them to skip the push step.