### PR TITLE
Skip GHCR push if using a fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
         if: env.ACCESS_CANARY != '' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           docker push "$CORE_BRANCH_IMAGE:$BRANCH_REF"
-        else:
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
           echo "Using fork of Dependabot Core, skipping GHCR push"
       - name: Build dependabot-core-ci image
         env:
@@ -90,7 +91,8 @@ jobs:
         run: |
           docker push "$CORE_CI_IMAGE:latest"
           docker push "$CORE_CI_IMAGE:branch--$BRANCH_REF"
-        else:
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
           echo "Using fork of Dependabot Core, skipping GHCR push"
       - name: Run ${{ matrix.suite.name }} tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,11 @@ jobs:
       - name: Push dependabot-core-branch image to GHCR
         env:
           ACCESS_CANARY: ${{ secrets.ACCESS_CANARY }}
-        if: env.ACCESS_CANARY != ''
+        if: env.ACCESS_CANARY != '' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           docker push "$CORE_BRANCH_IMAGE:$BRANCH_REF"
+        else:
+          echo "Using fork of Dependabot Core, skipping GHCR push"
       - name: Build dependabot-core-ci image
         env:
           DOCKER_BUILDKIT: 1
@@ -84,10 +86,12 @@ jobs:
       - name: Push dependabot-core-ci image to GHCR
         env:
           ACCESS_CANARY: ${{ secrets.ACCESS_CANARY }}
-        if: env.ACCESS_CANARY != ''
+        if: env.ACCESS_CANARY != '' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           docker push "$CORE_CI_IMAGE:latest"
           docker push "$CORE_CI_IMAGE:branch--$BRANCH_REF"
+        else:
+          echo "Using fork of Dependabot Core, skipping GHCR push"
       - name: Run ${{ matrix.suite.name }} tests
         run: |
           docker run \


### PR DESCRIPTION
Fixes an issue noted in https://github.com/dependabot/dependabot-core/pull/4524/files#r775637616

These changes skip over the GHCR push step for branches and the core CI image if the PR is against a fork of Dependabot-Core.

The matrix suite of tests should still run okay since the images are built locally.

❓ It would be helpful to test this against a fork PR _prior_ to merging. Is there any way to do that?