### PR TITLE
Ensure CI uses the latest image built on that branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
             --env "RAISE_ON_WARNINGS=true" \
             --env "DEPENDABOT_TEST_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }}" \
             --env "SUITE_NAME=${{ matrix.suite.name }}" \
-            --rm "$CORE_CI_IMAGE" bash -c \
+            --rm "$CORE_CI_IMAGE:branch--$BRANCH_REF" bash -c \
             "cd /home/dependabot/dependabot-core/${{ matrix.suite.path }} && ./script/ci-test"
   lint:
     name: lint


### PR DESCRIPTION
We tag a branch specific image when preparing for CI to run, but then reference the generic `CORE_CI_IMAGE`. This seems to cause race conditions when multiple branches build and push to the `CORE_CI_IMAGE:latest` ref.