### PR TITLE
Add releases to list of changelog file strings

### DIFF
--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -16,7 +16,7 @@ module Dependabot
 
         # Earlier entries are preferred
         CHANGELOG_NAMES = %w(
-          changelog news changes history release whatsnew
+          changelog news changes history release whatsnew releases
         ).freeze
 
         attr_reader :source, :dependency, :credentials, :suggested_changelog_url


### PR DESCRIPTION
For example, this project puts their changelog in Releases.md
https://github.com/denoland/deno/blob/main/Releases.md

I think it is spiritually similar to "release" which is already on
the list.