### PR TITLE
Bitbucket: creating pull-request-creator fails on labeler not supporting bitbucket

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -189,7 +189,7 @@ module Dependabot
         pr_description: message.pr_message,
         pr_name: message.pr_name,
         author_details: author_details,
-        labeler: labeler,
+        labeler: nil,
         work_item: provider_metadata&.fetch(:work_item, nil)
       )
     end

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -237,6 +237,32 @@ RSpec.describe Dependabot::PullRequestCreator do
       end
     end
 
+    context "with a Bitbucket source" do
+      let(:source) { Dependabot::Source.new(provider: "bitbucket", repo: "gc/bp") }
+      let(:dummy_creator) { instance_double(described_class::Bitbucket) }
+      let(:provider_metadata) { { work_item: 123 } }
+
+      it "delegates to PullRequestCreator::Bitbucket with correct params" do
+        expect(described_class::Bitbucket).
+          to receive(:new).
+          with(
+            source: source,
+            branch_name: "dependabot/bundler/business-1.5.0",
+            base_commit: base_commit,
+            credentials: credentials,
+            files: files,
+            commit_message: "Commit msg",
+            pr_description: "PR msg",
+            pr_name: "PR name",
+            author_details: author_details,
+            labeler: nil,
+            work_item: 123
+          ).and_return(dummy_creator)
+        expect(dummy_creator).to receive(:create)
+        creator.create
+      end
+    end
+
     context "with an Azure source" do
       let(:source) { Dependabot::Source.new(provider: "azure", repo: "gc/bp") }
       let(:dummy_creator) { instance_double(described_class::Azure) }


### PR DESCRIPTION
Labeler does not support bitbucket. So don't pass labeler to the pull_request_creator in case Bitbucket is involved.

```
vendor/ruby/2.7.0/gems/dependabot-common-0.154.0/lib/dependabot/pull_request_creator/labeler.rb:241:in `labels': Unsupported provider bitbucket (RuntimeError)
from vendor/ruby/2.7.0/gems/dependabot-common-0.154.0/lib/dependabot/pull_request_creator/labeler.rb:186:in `default_dependencies_label'
from vendor/ruby/2.7.0/gems/dependabot-common-0.154.0/lib/dependabot/pull_request_creator/labeler.rb:178:in `default_labels_for_pr'
from vendor/ruby/2.7.0/gems/dependabot-common-0.154.0/lib/dependabot/pull_request_creator/labeler.rb:49:in `labels_for_pr'
from vendor/ruby/2.7.0/gems/dependabot-common-0.154.0/lib/dependabot/pull_request_creator/bitbucket.rb:85:in `create_pull_request'
from vendor/ruby/2.7.0/gems/dependabot-common-0.154.0/lib/dependabot/pull_request_creator/bitbucket.rb:37:in `create'
from vendor/ruby/2.7.0/gems/dependabot-common-0.154.0/lib/dependabot/pull_request_creator.rb:105:in `create'
```

This PR supersedes PR #3197