### PR TITLE
Revert hashin upgrade for python native helper

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -1,7 +1,7 @@
 pip==21.3.1
 pip-tools==6.4.0
 flake8==4.0.1
-hashin==0.17.0
+hashin==0.15.0
 pipenv==2021.11.23
 pipfile==0.0.2
 poetry==1.1.12


### PR DESCRIPTION
Manually reverts https://github.com/dependabot/dependabot-core/pull/4610

CI failed on master and PRs subsequent to this merging, which is unexpected as the branch itself _did_ pass.

I built a base image of the previous [SHA on main](https://github.com/dependabot/dependabot-core/commit/4a33928a9c13fe665f24556c52f3a9033049f90e) locally and confirmed the failing python spec now passes:

```bash
$ bundle exec rspec spec/dependabot/python/file_updater/requirement_file_updater_spec.rb:177
Run options: include {:locations=>{"./spec/dependabot/python/file_updater/requirement_file_updater_spec.rb"=>[177]}}

Randomized with seed 4982
.

Finished in 2.41 seconds (files took 2.22 seconds to load)
1 example, 0 failures

Randomized with seed 4982
```

I want to see if CI agrees with me but there are two unknowns:
- why did the `hashin` bump break a ~3 year old test using a ~4 year old fixture, it doesn't seem like any out of band issue is involved ( e.g. remote fixture or real package changed in the wild )
- why did the branch CI not detect the problem?