### PR TITLE
[CI] Ensure CI builds pick up native helper changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: |
           docker build \
+            -t "$CORE_IMAGE:latest" \
             -t "$CORE_BRANCH_IMAGE:$BRANCH_REF" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --cache-from "$BASE_IMAGE" \


### PR DESCRIPTION
See: https://github.com/dependabot/dependabot-core/pull/4617

We've determined we have a green + green problem in CI where changes are made to native helpers are not fully tested on branches.

It turns out this was a result of my refactor of this file in https://github.com/dependabot/dependabot-core/pull/4524, where I removed `-t "$CORE_IMAGE:latest"` from the `docker build` that generated the 'branch image'.

Without this branch image tagged as `dependabot/dependabot-core:latest`, the `Dockerfile.ci` will pick up the base image pulled in, which is effectively `main`.

This results in us running Dependabot Core using the `native helpers` installed on `main` absent any changes made on branch.