### PR TITLE
v0.170.2-release-notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.170.2, 11 January 2022
+
+- build(deps): bump pipenv from 2021.11.23 to 2022.1.8 in /python/helpers [#4609](https://github.com/dependabot/dependabot-core/pull/4609)
+
 ## v0.170.1, 10 January 2022
 
 - Ensure CI builds pick up native helper changes [#4618](https://github.com/dependabot/dependabot-core/pull/4618)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.170.1"
+  VERSION = "0.170.2"
 end


### PR DESCRIPTION
## v0.170.2, 11 January 2022

- build(deps): bump pipenv from 2021.11.23 to 2022.1.8 in /python/helpers [#4609](https://github.com/dependabot/dependabot-core/pull/4609)

This is a minor patch to release any changes on main prior to https://github.com/dependabot/dependabot-core/pull/4554, which is a breaking change for anyone who is not using the same version of the dependabot-omnibus/dependabot-composer gems and the docker image.

It will ship in isolation as v0.171.0 to minimise churn.