### PR TITLE
v0.171.0-release-notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.171.0, 11 January 2022
+
+- Consistency pass on composer native helper build [#4554](https://github.com/dependabot/dependabot-core/pull/4554)
+  - NOTE: If you are using the `dependabot-composer` gem in your Dependabot scripts, you must ensure you upgrade
+    both the gem and the `dependabot/dependabot-core` image to v0.171.0 at the same time as this change modifies the
+    install path for composer's native helpers in both.
+
 ## v0.170.2, 11 January 2022
 
 - build(deps): bump pipenv from 2021.11.23 to 2022.1.8 in /python/helpers [#4609](https://github.com/dependabot/dependabot-core/pull/4609)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.170.2"
+  VERSION = "0.171.0"
 end


### PR DESCRIPTION
## v0.171.0, 11 January 2022

- Consistency pass on composer native helper build [#4554](https://github.com/dependabot/dependabot-core/pull/4554)
  - NOTE: If you are using the `dependabot-composer` gem in your Dependabot scripts, you must ensure you upgrade
    both the gem and the `dependabot/dependabot-core` image to v0.171.0 at the same time as this change modifies the
    install path for composer's native helpers in both.

#4620 must merge first.