### PR TITLE
npm7: Fix subdependency versoion resolver 

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -95,6 +95,7 @@ docker run --rm -ti \
   -v "$(pwd)/.core-bash_history:/home/dependabot/.bash_history" \
   -v "$(pwd)/.rubocop.yml:$CODE_DIR/.rubocop.yml" \
   -v "$(pwd)/bin:$CODE_DIR/bin" \
+  -v "$(pwd)/dry-run:$CODE_DIR/dry-run" \
   -v "$(pwd)/common/.rubocop.yml:$CODE_DIR/common/.rubocop.yml" \
   -v "$(pwd)/common/Gemfile:$CODE_DIR/common/Gemfile" \
   -v "$(pwd)/common/dependabot-common.gemspec:$CODE_DIR/common/dependabot-common.gemspec" \

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -478,7 +478,7 @@ fetcher_args = {
 $config_file = begin
   cfg_file = Dependabot::Config::FileFetcher.new(**fetcher_args).config_file
   Dependabot::Config::File.parse(cfg_file.content)
-rescue Dependabot::DependencyFileNotFound
+rescue Dependabot::RepoNotFound, Dependabot::DependencyFileNotFound
   Dependabot::Config::File.new(updates: [])
 end
 $update_config = $config_file.update_config(

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -208,23 +208,7 @@ module Dependabot
 
         def run_npm_7_subdependency_updater
           dependency_names = sub_dependencies.map(&:name)
-          # NOTE: npm options
-          # - `--force` ignores checks for platform (os, cpu) and engines
-          # - `--dry-run=false` the updater sets a global .npmrc with dry-run: true to
-          #   work around an issue in npm 6, we don't want that here
-          # - `--ignore-scripts` disables prepare and prepack scripts which are run
-          #   when installing git dependencies
-          command = [
-            "npm",
-            "update",
-            *dependency_names,
-            "--force",
-            "--dry-run",
-            "false",
-            "--ignore-scripts",
-            "--package-lock-only"
-          ].join(" ")
-          SharedHelpers.run_shell_command(command)
+          SharedHelpers.run_shell_command(NativeHelpers.npm7_subdependency_update_command(dependency_names))
           { lockfile_basename => File.read(lockfile_basename) }
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
@@ -13,6 +13,25 @@ module Dependabot
 
         File.join(__dir__, "../../../helpers")
       end
+
+      def self.npm7_subdependency_update_command(dependency_names)
+        # NOTE: npm options
+        # - `--force` ignores checks for platform (os, cpu) and engines
+        # - `--dry-run=false` the updater sets a global .npmrc with dry-run: true to
+        #   work around an issue in npm 6, we don't want that here
+        # - `--ignore-scripts` disables prepare and prepack scripts which are run
+        #   when installing git dependencies
+        [
+          "npm",
+          "update",
+          *dependency_names,
+          "--force",
+          "--dry-run",
+          "false",
+          "--ignore-scripts",
+          "--package-lock-only"
+        ].join(" ")
+      end
     end
   end
 end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -114,11 +114,16 @@ module Dependabot
             Dir.chdir(path) do
               npm_version = Dependabot::NpmAndYarn::Helpers.npm_version(lockfile_content)
 
-              SharedHelpers.run_helper_subprocess(
-                command: NativeHelpers.helper_path,
-                function: "#{npm_version}:updateSubdependency",
-                args: [Dir.pwd, lockfile_name, [dependency.to_h]]
-              )
+              if npm_version == "npm7"
+                SharedHelpers.run_shell_command(NativeHelpers.npm7_subdependency_update_command([dependency.name]))
+                { lockfile_name => File.read(lockfile_name) }
+              else
+                SharedHelpers.run_helper_subprocess(
+                  command: NativeHelpers.helper_path,
+                  function: "npm6:updateSubdependency",
+                  args: [Dir.pwd, lockfile_name, [dependency.to_h]]
+                )
+              end
             end
           end
         end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -88,7 +88,25 @@ RSpec.describe namespace::SubdependencyVersionResolver do
       it { is_expected.to eq(Gem::Version.new("5.7.4")) }
     end
 
-    context "with a package-lock.json" do
+    context "with a npm7 package-lock.json" do
+      let(:dependency_files) { project_dependency_files("npm7/subdependency_update") }
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "acorn",
+          version: "5.5.3",
+          requirements: [],
+          package_manager: "npm_and_yarn"
+        )
+      end
+      let(:latest_allowable_version) { "6.0.2" }
+
+      # NOTE: The latest vision is 6.0.2, but we can't reach it as other
+      # dependencies constrain us
+      it { is_expected.to eq(Gem::Version.new("5.7.4")) }
+    end
+
+    context "with a npm6 package-lock.json" do
       let(:dependency_files) { project_dependency_files("npm6/subdependency_update") }
 
       let(:dependency) do
@@ -104,37 +122,46 @@ RSpec.describe namespace::SubdependencyVersionResolver do
       # NOTE: The latest vision is 6.0.2, but we can't reach it as other
       # dependencies constrain us
       it { is_expected.to eq(Gem::Version.new("5.7.4")) }
+    end
 
-      context "when using npm5 lockfile" do
-        let(:dependency_files) { project_dependency_files("npm5/subdependency_update") }
+    context "with a npm5 package-lock.json" do
+      let(:dependency_files) { project_dependency_files("npm5/subdependency_update") }
 
-        # NOTE: npm5 lockfiles have exact version requires so can't easily
-        # update specific sub-dependencies to a new version, make sure we keep
-        # the same version
-        it { is_expected.to eq(Gem::Version.new("5.2.1")) }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "acorn",
+          version: "5.5.3",
+          requirements: [],
+          package_manager: "npm_and_yarn"
+        )
       end
 
-      context "when sub-dependency is bundled" do
-        let(:dependency_files) { project_dependency_files("npm6/bundled_sub_dependency") }
+      # NOTE: npm5 lockfiles have exact version requires so can't easily
+      # update specific sub-dependencies to a new version, make sure we keep
+      # the same version
+      it { is_expected.to eq(Gem::Version.new("5.2.1")) }
+    end
 
-        let(:dependency_name) { "tar" }
-        let(:version) { "4.4.10" }
-        let(:previous_version) { "4.4.1" }
-        let(:requirements) { [] }
-        let(:previous_requirements) { [] }
+    context "when sub-dependency is bundled" do
+      let(:dependency_files) { project_dependency_files("npm6/bundled_sub_dependency") }
 
-        let(:dependency) do
-          Dependabot::Dependency.new(
-            name: "tar",
-            version: "4.4.1",
-            requirements: [],
-            package_manager: "npm_and_yarn",
-            subdependency_metadata: [{ npm_bundled: true }]
-          )
-        end
+      let(:dependency_name) { "tar" }
+      let(:version) { "4.4.10" }
+      let(:previous_version) { "4.4.1" }
+      let(:requirements) { [] }
+      let(:previous_requirements) { [] }
 
-        it { is_expected.to eq(nil) }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "tar",
+          version: "4.4.1",
+          requirements: [],
+          package_manager: "npm_and_yarn",
+          subdependency_metadata: [{ npm_bundled: true }]
+        )
       end
+
+      it { is_expected.to eq(nil) }
     end
 
     context "with a yarn.lock and a package-lock.json" do


### PR DESCRIPTION
Fixes the npm 7 subdependency version resolver by doing an update using
the npm cli, similar to how we do subdependency updates in the lockfile
updater.

Dependabot currently says no update is possible for npm 7 subdependency
updates.

I ran into a few issues testing npm 8 so leaving this out of this PR.