### PR TITLE
Add section to debug native helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,48 @@ $ bundler/helpers/v1/build
 $ bin/dry-run.rb bundler dependabot/demo --dir="/ruby"
 ```
 
+### Debugging native helpers
+
+When you're making changes to native helpers or debugging a customer issue you often need to peek inside these scripts that run in a separate process.
+
+Print all log statements from native helpers:
+
+```bash
+DEBUG_HELPERS=true bin/dry-run.rb bundler dependabot/demo --dir="/ruby"
+```
+
+Pause execution to debug a single native helper function:
+
+```bash
+DEBUG_FUNCTION=parsed_gemfile bin/dry-run.rb bundler dependabot/demo --dir="/ruby"
+```
+
+The function maps to a native helper function name, for example, one of the functions in `bundler/helpers/v2/lib/functions.rb`.
+
+When this function is being executed a `debugger` is inserted, pausing execution of the `bin/dry-run.rb` script, this leaves the current updates tmp directory in place allowing you to cd into the directory and run the native helper function directly:
+
+```bash
+ DEBUG_FUNCTION=parsed_gemfile bin/dry-run.rb bundler dependabot/demo --dir="/ruby"
+=> fetching dependency files
+=> dumping fetched dependency files: ./dry-run/dependabot/demo/ruby
+=> parsing dependency files
+$ cd /home/dependabot/dependabot-core/tmp/dependabot_TEMP/ruby && echo "{\"function\":\"parsed_gemfile\",\"args\":{\"gemfile_name\":\"Gemfile\",\"lockfile_name\":\"Gemfile.lock\",\"dir\":\"/home/dependabot/dependabot-core/tmp/dependabot_TEMP/ruby\"}}" | BUNDLER_VERSION=1.17.3 BUNDLE_GEMFILE=/opt/bundler/v1/Gemfile GEM_HOME=/opt/bundler/v1/.bundle bundle exec ruby /opt/bundler/v1/run.rb
+```
+
+Copy and run the `cd... ` command:
+
+```bash
+cd /home/dependabot/dependabot-core/tmp/dependabot_TEMP/ruby && echo "{\"function\":\"parsed_gemfile\",\"args\":{\"gemfile_name\":\"Gemfile\",\"lockfile_name\":\"Gemfile.lock\",\"dir\":\"/home/dependabot/dependabot-core/tmp/dependabot_TEMP/ruby\"}}" | BUNDLER_VERSION=1.17.3 BUNDLE_GEMFILE=/opt/bundler/v1/Gemfile GEM_HOME=/opt/bundler/v1/.bundle bundle exec ruby /opt/bundler/v1/run.rb
+```
+
+This should log out the output of the `parsed_gemfile` function:
+
+```
+{"result":[{"name":"business","requirement":"~> 1.0.0","groups":["default"],"source":null,"type":"runtime"},{"name":"uk_phone_numbers","requirement":"~> 0.1.0","groups":["default"],"source":null,"type":"runtime"}]}
+```
+
+Edit the native helper function and re-run the above, for example: `vi /opt/bundler/v1/lib/functions/file_parser.rb`.
+
 ### Building the development image from source
 
 The developer shell uses volume mounts to incorporate your local changes to Dependabot's source


### PR DESCRIPTION
Documenting the `DEBUG_HELPERS` and `DEBUG_FUNCTION` env vars used to debug native helpers.