### PR TITLE
Adding "devDependencies" support for nuget projects.

### DIFF
--- a/nuget/lib/dependabot/nuget/file_parser/packages_config_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/packages_config_parser.rb
@@ -33,7 +33,7 @@ module Dependabot
                 requirements: [{
                   requirement: dependency_version(dependency_node),
                   file: packages_config.name,
-                  groups: [],
+                  groups: [dependency_type(dependency_node)],
                   source: nil
                 }]
               )
@@ -56,6 +56,12 @@ module Dependabot
           # specified requirement is always an exact version.
           dependency_node.attribute("version")&.value&.strip ||
             dependency_node.at_xpath("./version")&.content&.strip
+        end
+
+        def dependency_type(dependency_node)
+          val = dependency_node.attribute("developmentDependency")&.value&.strip ||
+                dependency_node.at_xpath("./developmentDependency")&.content&.strip
+          val.to_s.downcase == "true" ? "devDependencies" : "dependencies"
         end
       end
     end

--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -122,7 +122,7 @@ module Dependabot
         end
 
         # rubocop:disable Metrics/ParameterLists
-        def build_dependency(name, req, version, prop_name, project_file, dev = false)
+        def build_dependency(name, req, version, prop_name, project_file, dev: false)
           return unless name
 
           # Exclude any dependencies specified using interpolation

--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -51,7 +51,7 @@ module Dependabot
             version = dependency_version(dependency_node, project_file)
             prop_name = req_property_name(dependency_node)
 
-            dependency = build_dependency(name, req, version, prop_name, project_file, true)
+            dependency = build_dependency(name, req, version, prop_name, project_file, dev: true)
             dependency_set << dependency if dependency
           end
 

--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -111,7 +111,6 @@ module Dependabot
           end
         end
 
-        # rubocop:disable Metrics/ParameterLists
         def build_dependency(name, req, version, prop_name, project_file, dev: false)
           return unless name
 
@@ -140,7 +139,6 @@ module Dependabot
             requirements: [requirement]
           )
         end
-        # rubocop:enable Metrics/ParameterLists
 
         # rubocop:disable Metrics/PerceivedComplexity
         def dependency_name(dependency_node, project_file)

--- a/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/project_file_parser.rb
@@ -17,8 +17,8 @@ module Dependabot
         DEPENDENCY_SELECTOR = "ItemGroup > PackageReference, "\
                               "ItemGroup > GlobalPackageReference, "\
                               "ItemGroup > PackageVersion, "\
-                              "ItemGroup > Dependency"
-        DEV_SELECTOR = "ItemGroup > DevelopmentDependency"
+                              "ItemGroup > Dependency, "\
+                              "ItemGroup > DevelopmentDependency"
 
         PROJECT_SDK_REGEX   = %r{^([^/]+)/(\d+(?:[.]\d+(?:[.]\d+)?)?(?:[+-].*)?)$}.freeze
         PROPERTY_REGEX      = /\$\((?<property>.*?)\)/.freeze
@@ -33,25 +33,15 @@ module Dependabot
 
           doc = Nokogiri::XML(project_file.content)
           doc.remove_namespaces!
-          # Look for regular package references (production)
+          # Look for regular package references
           doc.css(DEPENDENCY_SELECTOR).each do |dependency_node|
             name = dependency_name(dependency_node, project_file)
             req = dependency_requirement(dependency_node, project_file)
             version = dependency_version(dependency_node, project_file)
             prop_name = req_property_name(dependency_node)
+            is_dev = dependency_node.name == "DevelopmentDependency"
 
-            dependency = build_dependency(name, req, version, prop_name, project_file)
-            dependency_set << dependency if dependency
-          end
-
-          # Look for regular package references (development)
-          doc.css(DEV_SELECTOR).each do |dependency_node|
-            name = dependency_name(dependency_node, project_file)
-            req = dependency_requirement(dependency_node, project_file)
-            version = dependency_version(dependency_node, project_file)
-            prop_name = req_property_name(dependency_node)
-
-            dependency = build_dependency(name, req, version, prop_name, project_file, dev: true)
+            dependency = build_dependency(name, req, version, prop_name, project_file, dev: is_dev)
             dependency_set << dependency if dependency
           end
 

--- a/nuget/spec/dependabot/nuget/file_parser/packages_config_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser/packages_config_parser_spec.rb
@@ -34,7 +34,26 @@ RSpec.describe Dependabot::Nuget::FileParser::PackagesConfigParser do
             [{
               requirement: "1.0.0",
               file: "packages.config",
-              groups: [],
+              groups: ["dependencies"],
+              source: nil
+            }]
+          )
+        end
+      end
+
+      describe "the second dependency" do
+        subject(:dependency) { dependencies.at(1) }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).
+            to eq("Microsoft.Net.Compilers")
+          expect(dependency.version).to eq("1.0.1")
+          expect(dependency.requirements).to eq(
+            [{
+              requirement: "1.0.1",
+              file: "packages.config",
+              groups: ["devDependencies"],
               source: nil
             }]
           )

--- a/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser/project_file_parser_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
             [{
               requirement: "1.1.1",
               file: "my.csproj",
-              groups: [],
+              groups: ["dependencies"],
               source: nil
             }]
           )
@@ -51,7 +51,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
             [{
               requirement: nil,
               file: "my.csproj",
-              groups: [],
+              groups: ["dependencies"],
               source: nil
             }]
           )
@@ -69,7 +69,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
             [{
               requirement: "4.3.0",
               file: "my.csproj",
-              groups: [],
+              groups: ["dependencies"],
               source: nil
             }]
           )
@@ -167,7 +167,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
               [{
                 requirement: "0.1.434",
                 file: "my.csproj",
-                groups: [],
+                groups: ["dependencies"],
                 source: nil,
                 metadata: { property_name: "NukeVersion" }
               }]
@@ -192,7 +192,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
               [{
                 requirement: "0.1.434",
                 file: "my.csproj",
-                groups: [],
+                groups: ["dependencies"],
                 source: nil,
                 metadata: { property_name: "NukeVersion" }
               }]
@@ -218,7 +218,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
                 [{
                   requirement: "$(UnknownVersion)",
                   file: "my.csproj",
-                  groups: [],
+                  groups: ["dependencies"],
                   source: nil,
                   metadata: { property_name: "UnknownVersion" }
                 }]
@@ -231,9 +231,40 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
       context "with a nuproj" do
         let(:file_body) { fixture("csproj", "basic.nuproj") }
 
-        it "has the right details" do
-          expect(dependencies.map(&:name)).
-            to match_array(%w(nanoFramework.CoreLibrary))
+        it "gets the right number of dependencies" do
+          expect(dependencies.count).to eq(2)
+        end
+
+        describe "the first dependency" do
+          subject(:dependency) { dependencies.first }
+
+          it "has the right details" do
+            expect(dependency).to be_a(Dependabot::Dependency)
+            expect(dependency.name).to eq("nanoFramework.CoreLibrary")
+            expect(dependency.version).to eq("1.0.0-preview062")
+            expect(dependency.requirements).to eq([{
+              requirement: "[1.0.0-preview062]",
+              file: "my.csproj",
+              groups: ["dependencies"],
+              source: nil
+            }])
+          end
+        end
+
+        describe "the second dependency" do
+          subject(:dependency) { dependencies.at(1) }
+
+          it "has the right details" do
+            expect(dependency).to be_a(Dependabot::Dependency)
+            expect(dependency.name).to eq("nanoFramework.CoreExtra")
+            expect(dependency.version).to eq("1.0.0-preview061")
+            expect(dependency.requirements).to eq([{
+              requirement: "[1.0.0-preview061]",
+              file: "my.csproj",
+              groups: ["devDependencies"],
+              source: nil
+            }])
+          end
         end
       end
 
@@ -261,7 +292,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
               expect(dependency.requirements).to eq([{
                 requirement: "1.2.3",
                 file: "my.csproj",
-                groups: [],
+                groups: ["dependencies"],
                 source: nil
               }])
             end
@@ -277,7 +308,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
               expect(dependency.requirements).to eq([{
                 requirement: "0.1.0-beta",
                 file: "my.csproj",
-                groups: [],
+                groups: ["dependencies"],
                 source: nil
               }])
             end
@@ -299,7 +330,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
               expect(dependency.requirements).to eq([{
                 requirement: "1.2.3",
                 file: "my.csproj",
-                groups: [],
+                groups: ["dependencies"],
                 source: nil
               }])
             end
@@ -315,7 +346,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
               expect(dependency.requirements).to eq([{
                 requirement: "0.1.0-beta",
                 file: "my.csproj",
-                groups: [],
+                groups: ["dependencies"],
                 source: nil
               }])
             end
@@ -337,7 +368,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
               expect(dependency.requirements).to eq([{
                 requirement: "1.2.3",
                 file: "my.csproj",
-                groups: [],
+                groups: ["dependencies"],
                 source: nil
               }])
             end
@@ -353,7 +384,7 @@ RSpec.describe Dependabot::Nuget::FileParser::ProjectFileParser do
               expect(dependency.requirements).to eq([{
                 requirement: "0.1.0-beta",
                 file: "my.csproj",
-                groups: [],
+                groups: ["dependencies"],
                 source: nil
               }])
             end

--- a/nuget/spec/dependabot/nuget/file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Dependabot::Nuget::FileParser do
           [{
             requirement: "1.1.1",
             file: "my.csproj",
-            groups: [],
+            groups: ["dependencies"],
             source: nil
           }]
         )
@@ -56,7 +56,7 @@ RSpec.describe Dependabot::Nuget::FileParser do
           [{
             requirement: "4.3.0",
             file: "my.csproj",
-            groups: [],
+            groups: ["dependencies"],
             source: nil
           }]
         )
@@ -85,12 +85,12 @@ RSpec.describe Dependabot::Nuget::FileParser do
             [{
               requirement: "1.1.1",
               file: "my.csproj",
-              groups: [],
+              groups: ["dependencies"],
               source: nil
             }, {
               requirement: "1.0.1",
               file: "my.vbproj",
-              groups: [],
+              groups: ["dependencies"],
               source: nil
             }]
           )
@@ -108,7 +108,7 @@ RSpec.describe Dependabot::Nuget::FileParser do
             [{
               requirement: "2.3.0",
               file: "my.vbproj",
-              groups: [],
+              groups: ["dependencies"],
               source: nil
             }]
           )
@@ -139,7 +139,26 @@ RSpec.describe Dependabot::Nuget::FileParser do
             [{
               requirement: "1.0.0",
               file: "packages.config",
-              groups: [],
+              groups: ["dependencies"],
+              source: nil
+            }]
+          )
+        end
+      end
+
+      describe "the second dependency" do
+        subject(:dependency) { dependencies.at(1) }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).
+            to eq("Microsoft.Net.Compilers")
+          expect(dependency.version).to eq("1.0.1")
+          expect(dependency.requirements).to eq(
+            [{
+              requirement: "1.0.1",
+              file: "packages.config",
+              groups: ["devDependencies"],
               source: nil
             }]
           )
@@ -167,7 +186,26 @@ RSpec.describe Dependabot::Nuget::FileParser do
               [{
                 requirement: "1.0.0",
                 file: "dir/packages.config",
-                groups: [],
+                groups: ["dependencies"],
+                source: nil
+              }]
+            )
+          end
+        end
+
+        describe "the second dependency" do
+          subject(:dependency) { dependencies.at(1) }
+
+          it "has the right details" do
+            expect(dependency).to be_a(Dependabot::Dependency)
+            expect(dependency.name).
+              to eq("Microsoft.Net.Compilers")
+            expect(dependency.version).to eq("1.0.1")
+            expect(dependency.requirements).to eq(
+              [{
+                requirement: "1.0.1",
+                file: "dir/packages.config",
+                groups: ["devDependencies"],
                 source: nil
               }]
             )
@@ -234,7 +272,7 @@ RSpec.describe Dependabot::Nuget::FileParser do
             [{
               requirement: "2.3.0",
               file: "commonprops.props",
-              groups: [],
+              groups: ["dependencies"],
               source: nil
             }]
           )
@@ -264,7 +302,7 @@ RSpec.describe Dependabot::Nuget::FileParser do
             [{
               requirement: "1.1.1",
               file: "packages.props",
-              groups: [],
+              groups: ["dependencies"],
               source: nil
             }]
           )
@@ -294,7 +332,7 @@ RSpec.describe Dependabot::Nuget::FileParser do
             [{
               requirement: "1.1.1",
               file: "directory.packages.props",
-              groups: [],
+              groups: ["dependencies"],
               source: nil
             }]
           )

--- a/nuget/spec/dependabot/nuget/file_updater/packages_config_declaration_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater/packages_config_declaration_finder_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe namespace::PackagesConfigDeclarationFinder do
     {
       requirement: declaring_requirement_string,
       file: "packages.config",
-      groups: [],
+      groups: ["dependencies"],
       source: nil
     }
   end

--- a/nuget/spec/dependabot/nuget/file_updater/project_file_declaration_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater/project_file_declaration_finder_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe namespace::ProjectFileDeclarationFinder do
     {
       requirement: declaring_requirement_string,
       file: "my.csproj",
-      groups: [],
+      groups: ["dependencies"],
       source: nil
     }
   end

--- a/nuget/spec/dependabot/nuget/file_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
     [{
       file: "my.csproj",
       requirement: "1.1.2",
-      groups: [],
+      groups: ["dependencies"],
       source: nil
     }]
   end
@@ -52,7 +52,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
     [{
       file: "my.csproj",
       requirement: "1.1.1",
-      groups: [],
+      groups: ["dependencies"],
       source: nil
     }]
   end
@@ -87,7 +87,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
           [{
             file: "my.csproj",
             requirement: "[1.0,2.1]",
-            groups: [],
+            groups: ["dependencies"],
             source: nil
           }]
         end
@@ -95,7 +95,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
           [{
             file: "my.csproj",
             requirement: "[1.0,2.0]",
-            groups: [],
+            groups: ["dependencies"],
             source: nil
           }]
         end
@@ -114,7 +114,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
           [{
             requirement: "0.1.500",
             file: "my.csproj",
-            groups: [],
+            groups: ["dependencies"],
             source: nil,
             metadata: { property_name: "NukeVersion" }
           }]
@@ -123,7 +123,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
           [{
             requirement: "0.1.434",
             file: "my.csproj",
-            groups: [],
+            groups: ["dependencies"],
             source: nil,
             metadata: { property_name: "NukeVersion" }
           }]
@@ -147,7 +147,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
           [{
             requirement: "1.2.3",
             file: "my.csproj",
-            groups: [],
+            groups: ["dependencies"],
             source: nil
           }]
         end
@@ -155,7 +155,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
           [{
             requirement: "1.1.1",
             file: "my.csproj",
-            groups: [],
+            groups: ["dependencies"],
             source: nil
           }]
         end
@@ -195,7 +195,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
         [{
           file: "packages.config",
           requirement: "8.0.4",
-          groups: [],
+          groups: ["dependencies"],
           source: nil
         }]
       end
@@ -203,7 +203,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
         [{
           file: "packages.config",
           requirement: "8.0.3",
-          groups: [],
+          groups: ["dependencies"],
           source: nil
         }]
       end
@@ -237,7 +237,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
           [{
             file: "dir/packages.config",
             requirement: "8.0.4",
-            groups: [],
+            groups: ["dependencies"],
             source: nil
           }]
         end
@@ -245,7 +245,7 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
           [{
             file: "dir/packages.config",
             requirement: "8.0.3",
-            groups: [],
+            groups: ["dependencies"],
             source: nil
           }]
         end
@@ -281,23 +281,23 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
           requirements: [{
             file: "my.csproj",
             requirement: "1.1.2",
-            groups: [],
+            groups: ["dependencies"],
             source: nil
           }, {
             file: "my.vbproj",
             requirement: "1.1.*",
-            groups: [],
+            groups: ["dependencies"],
             source: nil
           }],
           previous_requirements: [{
             file: "my.csproj",
             requirement: "1.1.1",
-            groups: [],
+            groups: ["dependencies"],
             source: nil
           }, {
             file: "my.vbproj",
             requirement: "1.0.1",
-            groups: [],
+            groups: ["dependencies"],
             source: nil
           }],
           package_manager: "nuget"

--- a/nuget/spec/dependabot/nuget/metadata_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/metadata_finder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Dependabot::Nuget::MetadataFinder do
       requirements: [{
         file: "my.csproj",
         requirement: dependency_version,
-        groups: [],
+        groups: ["dependencies"],
         source: source
       }],
       package_manager: "nuget"

--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RepositoryFinder do
       requirements: [{
         requirement: "1.1.1",
         file: "my.csproj",
-        groups: [],
+        groups: ["dependencies"],
         source: nil
       }],
       package_manager: "nuget"

--- a/nuget/spec/dependabot/nuget/update_checker/requirements_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/requirements_updater_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RequirementsUpdater do
     {
       file: "my.csproj",
       requirement: csproj_req_string,
-      groups: [],
+      groups: ["dependencies"],
       source: nil
     }
   end
@@ -100,7 +100,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RequirementsUpdater do
           {
             file: "another/my.csproj",
             requirement: other_requirement_string,
-            groups: [],
+            groups: ["dependencies"],
             source: nil
           }
         end
@@ -112,7 +112,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RequirementsUpdater do
             [{
               file: "my.csproj",
               requirement: "23.6-jre",
-              groups: [],
+              groups: ["dependencies"],
               source: {
                 type: "nuget_repo",
                 url: "https://api.nuget.org/v3/index.json",
@@ -124,7 +124,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RequirementsUpdater do
             }, {
               file: "another/my.csproj",
               requirement: "[23.6-jre]",
-              groups: [],
+              groups: ["dependencies"],
               source: {
                 type: "nuget_repo",
                 url: "https://api.nuget.org/v3/index.json",
@@ -145,7 +145,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RequirementsUpdater do
               [{
                 file: "my.csproj",
                 requirement: "23.6-jre",
-                groups: [],
+                groups: ["dependencies"],
                 source: {
                   type: "nuget_repo",
                   url: "https://api.nuget.org/v3/index.json",
@@ -157,7 +157,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RequirementsUpdater do
               }, {
                 file: "another/my.csproj",
                 requirement: "[23.0,)",
-                groups: [],
+                groups: ["dependencies"],
                 source: nil
               }]
             )

--- a/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/version_finder_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
     )
   end
   let(:dependency_requirements) do
-    [{ file: "my.csproj", requirement: "1.1.1", groups: [], source: nil }]
+    [{ file: "my.csproj", requirement: "1.1.1", groups: ["dependencies"], source: nil }]
   end
   let(:dependency_name) { "Microsoft.Extensions.DependencyModel" }
   let(:dependency_version) { "1.1.1" }
@@ -286,7 +286,9 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
 
     context "with a package that returns paginated api results when using the v2 nuget api", :vcr do
       let(:dependency_files) { project_dependency_files("paginated_package_v2_api") }
-      let(:dependency_requirements) { [{ file: "my.csproj", requirement: "4.7.1", groups: [], source: nil }] }
+      let(:dependency_requirements) do
+        [{ file: "my.csproj", requirement: "4.7.1", groups: ["dependencies"], source: nil }]
+      end
       let(:dependency_name) { "FakeItEasy" }
       let(:dependency_version) { "4.7.1" }
 
@@ -361,7 +363,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::VersionFinder do
       let(:dependency_files) { project_dependency_files("version_range") }
       let(:dependency_version) { "1.1.0" }
       let(:dependency_requirements) do
-        [{ file: "my.csproj", requirement: "[1.1.0, 3.0.0)", groups: [], source: nil }]
+        [{ file: "my.csproj", requirement: "[1.1.0, 3.0.0)", groups: ["dependencies"], source: nil }]
       end
 
       its([:version]) { is_expected.to eq(version_class.new("2.1.0")) }

--- a/nuget/spec/dependabot/nuget/update_checker_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
     )
   end
   let(:dependency_requirements) do
-    [{ file: "my.csproj", requirement: "1.1.1", groups: [], source: nil }]
+    [{ file: "my.csproj", requirement: "1.1.1", groups: ["dependencies"], source: nil }]
   end
   let(:dependency_name) { "Microsoft.Extensions.DependencyModel" }
   let(:dependency_version) { "1.1.1" }
@@ -83,7 +83,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
           [{
             requirement: "$(NukeVersion)",
             file: "my.csproj",
-            groups: [],
+            groups: ["dependencies"],
             source: nil,
             metadata: { property_name: "NukeVersion" }
           }]
@@ -150,7 +150,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
         [{
           requirement: "0.1.434",
           file: "my.csproj",
-          groups: [],
+          groups: ["dependencies"],
           source: nil,
           metadata: { property_name: "NukeVersion" }
         }]
@@ -216,7 +216,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
         [{
           requirement: "0.1.434",
           file: "my.csproj",
-          groups: [],
+          groups: ["dependencies"],
           source: nil,
           metadata: { property_name: "NukeVersion" }
         }]
@@ -294,7 +294,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
         [{
           file: "my.csproj",
           requirement: "2.1.0",
-          groups: [],
+          groups: ["dependencies"],
           source: {
             type: "nuget_repo",
             url: "https://api.nuget.org/v3/index.json",
@@ -335,7 +335,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
           [{
             file: "my.csproj",
             requirement: "2.0.0",
-            groups: [],
+            groups: ["dependencies"],
             source: {
               type: "nuget_repo",
               url: "https://api.nuget.org/v3/index.json",
@@ -425,7 +425,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
             [{
               file: "my.csproj",
               requirement: "4.8.1",
-              groups: [],
+              groups: ["dependencies"],
               source: {
                 type: "nuget_repo",
                 url: "https://www.nuget.org/api/v2",
@@ -449,7 +449,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
         [{
           requirement: "0.1.434",
           file: "my.csproj",
-          groups: [],
+          groups: ["dependencies"],
           source: nil,
           metadata: { property_name: "NukeVersion" }
         }]
@@ -464,7 +464,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
           [{
             requirement: "$(NukeVersion)",
             file: "my.csproj",
-            groups: [],
+            groups: ["dependencies"],
             source: nil,
             metadata: { property_name: "NukeVersion" }
           }]
@@ -486,7 +486,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
         [{
           requirement: "0.1.434",
           file: "my.csproj",
-          groups: [],
+          groups: ["dependencies"],
           source: nil,
           metadata: { property_name: "NukeVersion" }
         }]
@@ -531,7 +531,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                   requirements: [{
                     requirement: "0.9.0",
                     file: "my.csproj",
-                    groups: [],
+                    groups: ["dependencies"],
                     source: {
                       type: "nuget_repo",
                       url: "https://api.nuget.org/v3/index.json",
@@ -544,7 +544,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                   previous_requirements: [{
                     requirement: "0.1.434",
                     file: "my.csproj",
-                    groups: [],
+                    groups: ["dependencies"],
                     source: nil,
                     metadata: { property_name: "NukeVersion" }
                   }],
@@ -557,7 +557,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                   requirements: [{
                     requirement: "0.9.0",
                     file: "my.csproj",
-                    groups: [],
+                    groups: ["dependencies"],
                     source: {
                       type: "nuget_repo",
                       url: "https://api.nuget.org/v3/index.json",
@@ -570,7 +570,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker do
                   previous_requirements: [{
                     requirement: "0.1.434",
                     file: "my.csproj",
-                    groups: [],
+                    groups: ["dependencies"],
                     source: nil,
                     metadata: { property_name: "NukeVersion" }
                   }],

--- a/nuget/spec/fixtures/csproj/basic.nuproj
+++ b/nuget/spec/fixtures/csproj/basic.nuproj
@@ -34,6 +34,9 @@
     <Dependency Include="nanoFramework.CoreLibrary">
       <Version>[1.0.0-preview062]</Version>
     </Dependency>
+    <DevelopmentDependency Include="nanoFramework.CoreExtra">
+      <Version>[1.0.0-preview061]</Version>
+    </DevelopmentDependency>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>43cd93bb-c6c4-4f8e-b1ed-406469d9db42</ProjectGuid>

--- a/nuget/spec/fixtures/packages_configs/packages.config
+++ b/nuget/spec/fixtures/packages_configs/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="1.0.1" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net46" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.3" allowedVersions="[8,10)" targetFramework="net46" />


### PR DESCRIPTION
- Addresses issue #4659
- Supports `ItemGroup > DevelopmentDependency` groups in `.csproj` files
- Supports `developmentDependency="true"` in `packages.config`
- Does **not** support development dependencies specified using the `Condition=` property in `<Import />`, etc.