### PR TITLE
Bump cargo from 1.51.0 to 1.58.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,14 +202,14 @@ RUN curl -sSLfO https://packages.erlang-solutions.com/erlang-solutions_2.0_all.d
 
 ### RUST
 
-# Install Rust 1.51.0
+# Install Rust 1.57.0
 ENV RUSTUP_HOME=/opt/rust \
   CARGO_HOME=/opt/rust \
   PATH="${PATH}:/opt/rust/bin"
 RUN mkdir -p "$RUSTUP_HOME" && chown dependabot:dependabot "$RUSTUP_HOME"
 USER dependabot
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
-  && rustup toolchain install 1.51.0 && rustup default 1.51.0
+  && rustup toolchain install 1.57.0 && rustup default 1.57.0
 
 
 ### Terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -202,14 +202,14 @@ RUN curl -sSLfO https://packages.erlang-solutions.com/erlang-solutions_2.0_all.d
 
 ### RUST
 
-# Install Rust 1.57.0
+# Install Rust 1.58.0
 ENV RUSTUP_HOME=/opt/rust \
   CARGO_HOME=/opt/rust \
   PATH="${PATH}:/opt/rust/bin"
 RUN mkdir -p "$RUSTUP_HOME" && chown dependabot:dependabot "$RUSTUP_HOME"
 USER dependabot
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
-  && rustup toolchain install 1.57.0 && rustup default 1.57.0
+  && rustup toolchain install 1.58.0 && rustup default 1.58.0
 
 
 ### Terraform

--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -58,7 +58,8 @@ module Dependabot
 
         def handle_cargo_error(error)
           raise unless error.message.include?("failed to select a version") ||
-                       error.message.include?("no matching version")
+                       error.message.include?("no matching version") ||
+                       error.message.include?("unexpected end of input while parsing major version number")
           raise if error.message.include?("`#{dependency.name} ")
 
           raise Dependabot::DependencyFileNotResolvable, error.message

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -287,6 +287,7 @@ module Dependabot
           return true if message.include?("wasn't a root")
           return true if message.include?("requires a nightly version")
           return true if message.match?(/feature `[^\`]+` is required/)
+          return true if message.include?("unexpected end of input while parsing major version number")
 
           !original_requirements_resolvable?
         end

--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -158,9 +158,10 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
           [{ file: "Cargo.toml", requirement: nil, groups: [], source: nil }]
         end
 
-        it "updates the dependency version in the lockfile" do
-          expect(updated_lockfile_content).
-            to include(%(name = "time"\nversion = "0.1.40"))
+        it "raises a DependencyFileNotResolvable error" do
+          expect { subject }.to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
+            expect(error.message).to include("unexpected end of input while parsing major version")
+          end
         end
       end
 

--- a/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
           to raise_error do |error|
             expect(error).to be_a(Dependabot::DependencyFileNotResolvable)
             expect(error.message).
-              to include("version for the requirement `regex = \"=99.0.0\"`")
+              to include("version for the requirement `regex = \"^99.0.0\"`")
           end
       end
 
@@ -232,7 +232,11 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
       let(:lockfile_fixture_name) { "blank_version" }
       let(:string_req) { nil }
 
-      it { is_expected.to be >= Gem::Version.new("0.2.10") }
+      it "raises a DependencyFileNotResolvable error" do
+        expect { subject }.to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
+          expect(error.message).to include("unexpected end of input while parsing major version")
+        end
+      end
     end
 
     context "with an optional dependency" do
@@ -511,7 +515,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
         let(:manifest) do
           Dependabot::DependencyFile.new(
             name: "../../Cargo.toml",
-            content: fixture("manifests", "blank_version"),
+            content: fixture("manifests", "default_run"),
             directory: "/lib/sub_crate"
           )
         end


### PR DESCRIPTION
Reverts dependabot/dependabot-core#4588 and bumps to one version higher. The behavior for blank versions seems to have changed in this release of cargo, but the old behavior was not documented, so the tests have been updated to match cargo's new behavior