### PR TITLE
Fix Running with Docker section to find the image that was just pulled

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Start by pulling the developer image from the [GitHub Container Registry][ghcr-c
 
 ```shell
 $ docker pull ghcr.io/dependabot/dependabot-core-development:latest
+$ docker tag ghcr.io/dependabot/dependabot-core-development dependabot/dependabot-core-development
 $ bin/docker-dev-shell
 => running docker development shell
 [dependabot-core-dev] ~/dependabot-core $


### PR DESCRIPTION
When I tried running this, i got the following:

```
 dependabot-core git:(main) bin/docker-dev-shell
 > image dependabot/dependabot-core-development doesn't exist
```

There are two ways I was able to solve this:

```
$ docker pull ghcr.io/dependabot/dependabot-core-development:latest
$ docker tag ghcr.io/dependabot/dependabot-core-development dependabot/dependabot-core-development
$ bin/docker-dev-shell
```

AND

```
$ docker pull ghcr.io/dependabot/dependabot-core-development:latest
$ IMAGE_NAME=ghcr.io/dependabot/dependabot-core-development bin/docker-dev-shell
```

Maybe the dev shell also looks for the ghcr.io version too? Lots of solutions for this. I'm OK with just about any.

