### PR TITLE
Remove rust toolchains to save space in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -209,7 +209,8 @@ ENV RUSTUP_HOME=/opt/rust \
 RUN mkdir -p "$RUSTUP_HOME" && chown dependabot:dependabot "$RUSTUP_HOME"
 USER dependabot
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
-  && rustup toolchain install 1.58.0 && rustup default 1.58.0
+  && rustup toolchain install 1.58.0 && rustup default 1.58.0 \
+  && rm -rf /opt/rust/toolchains
 
 
 ### Terraform


### PR DESCRIPTION
The rust toolchains take around 2GB of space.

```
[dependabot-core-dev] ~/dependabot-core $ du -sk /opt/rust/toolchains/*
1067576 /opt/rust/toolchains/1.58.0-x86_64-unknown-linux-gnu
1067648 /opt/rust/toolchains/stable-x86_64-unknown-linux-gnu
```

Removing them slims down the image from 4.3GB to 2.3GB!

This is an experiment to see if we can still do cargo updates.