### PR TITLE
Fix typo: `developerment` -> `development`

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# This script is does a full update run for a given repo (optionally for a
+# This script executes a full update run for a given repo (optionally for a
 # specific dependency only), and shows the proposed changes to any dependency
 # files without actually creating a pull request.
 #
@@ -38,7 +38,7 @@
 require "etc"
 unless Etc.getpwuid(Process.uid).name == "dependabot"
   puts <<~INFO
-    bin/dry-run.rb is only supported in a developerment container.
+    bin/dry-run.rb is only supported in a development container.
 
     Please use bin/docker-dev-shell first.
   INFO


### PR DESCRIPTION
A part of me considered leaving as-is, as it's one of the most context-appropriate typos I've encountered.