### PR TITLE
Optimize rust toolchain installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -208,8 +208,7 @@ ENV RUSTUP_HOME=/opt/rust \
   PATH="${PATH}:/opt/rust/bin"
 RUN mkdir -p "$RUSTUP_HOME" && chown dependabot:dependabot "$RUSTUP_HOME"
 USER dependabot
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
-  && rustup toolchain install 1.58.0 && rustup default 1.58.0
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.58.0 --profile minimal
 
 
 ### Terraform


### PR DESCRIPTION
This makes 2 optimizations to the rust installation process to reduce of the size of the docker image from 4.3GB to 2.8GB.
- Use the [minimal profile](https://rust-lang.github.io/rustup/concepts/profiles.html) which takes less space.
- Specify the desired version at install so we don't additionally install the latest stable version by default.

Pre optimization:
```
[dependabot-core-dev] ~/dependabot-core $ du -sk /opt/rust/toolchains/*
1067576 /opt/rust/toolchains/1.58.0-x86_64-unknown-linux-gnu
1067648 /opt/rust/toolchains/stable-x86_64-unknown-linux-gnu # installed by rustup-init
```

Post optimization:
```
[dependabot-core-dev] ~/dependabot-core $ du -sk /opt/rust/toolchains/*
431624  /opt/rust/toolchains/1.58.0-x86_64-unknown-linux-gnu
```

rustup-init docs:
```
[dependabot-core-dev] ~/dependabot-core $ curl https://sh.rustup.rs -sSf | sh -s -- --help
rustup-init 1.24.3 (c1c769109 2021-05-31)
The installer for rustup

USAGE:
    rustup-init [FLAGS] [OPTIONS]

FLAGS:
    -v, --verbose           Enable verbose output
    -q, --quiet             Disable progress output
    -y                      Disable confirmation prompt.
        --no-modify-path    Don't configure the PATH environment variable
    -h, --help              Prints help information
    -V, --version           Prints version information

OPTIONS:
        --default-host <default-host>              Choose a default host triple
        --default-toolchain <default-toolchain>    Choose a default toolchain to install
        --default-toolchain none                   Do not install any toolchains
        --profile [minimal|default|complete]       Choose a profile
    -c, --component <components>...                Component name to also install
    -t, --target <targets>...                      Target name to also install
```

If needed we could reduce the size further by using `--default-toolchain none`. Updates would still work but would incur a performance hit as they'd need to install a toolchain on demand (see https://github.com/dependabot/dependabot-core/pull/4702#issuecomment-1031115107). I don't think that's something we need to consider yet as the size of the minimal install is pretty reasonable compared to other ecosystems.