### PR TITLE
Link to GitHub feedback discussion for Dependabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Welcome to the public home of Dependabot. This repository serves 2 purposes:
 
 ## Got feedback?
 
-Please file an issue. Bug reports, feature requests, and general feedback are all welcome.
+https://github.com/github/feedback/discussions/categories/dependabot-feedback
 
 ## Contributing to Dependabot
 


### PR DESCRIPTION
We now have a Dependabot category in the GitHub feedback discussions repo: https://github.com/github/feedback/discussions/categories/dependabot-feedback. Let the people know about this!