### PR TITLE
Docker: Ignore ARGs without default values

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -43,6 +43,8 @@ module Dependabot
           dockerfile.content.each_line do |line|
             if ARG.match(line)
               key_value = line.delete_prefix("ARG ").split("=")
+              next if key_value.count != 2 # The ARG has no default value that we can set
+
               args[key_value[0]] = key_value[1].delete_suffix("\n")
               next
             end

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -135,17 +135,23 @@ RSpec.describe Dependabot::Docker::FileParser do
           expect(dependency.name).to eq("docker")
         end
       end
-    end
-
-    context "arg from" do
-      let(:dockerfile_fixture_name) { "arg_from_curls" }
 
       describe "with curls" do
+        let(:dockerfile_fixture_name) { "arg_from_curls" }
+
         subject(:dependency) { dependencies.first }
 
         it "can solve the dependency" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("docker")
+        end
+      end
+
+      describe "without a default value" do
+        let(:dockerfile_fixture_name) { "arg_from_no_default" }
+
+        it "can't solve the dependency" do
+          expect(dependencies).to be_empty
         end
       end
     end

--- a/docker/spec/fixtures/docker/dockerfiles/arg_from_no_default
+++ b/docker/spec/fixtures/docker/dockerfiles/arg_from_no_default
@@ -1,0 +1,2 @@
+ARG HUB
+FROM $HUB/docker:20.10.7-dind


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/4598 we added
support for ARG FROM. However, this assumed that a default value is
always specified, when it isn't the code would crash.

This is not that common, however:

Due to how we parse Dockerfiles, this actually also happened for regular
`ARG`s in a Dockerfile, even if it didn't belong to the `FROM`, meaning
that any ARG without a default would cause our update to fail.