### PR TITLE
Use correct file paths in Bitbucket commits

### DIFF
--- a/common/lib/dependabot/clients/bitbucket.rb
+++ b/common/lib/dependabot/clients/bitbucket.rb
@@ -106,8 +106,7 @@ module Dependabot
         }
 
         files.each do |file|
-          absolute_path = file.name.start_with?("/") ? file.name : "/" + file.name
-          parameters[absolute_path] = file.content
+          parameters[file.path] = file.content
         end
 
         body = encode_form_parameters(parameters)


### PR DESCRIPTION
If a dependency file is not in the repository root, it's currently being committed as a new file in the root directory when creating a Bitbucket commit.
This change should ensure that it will be committed in the right place.

I removed the `starts_with("/")` check, assuming it's no longer necessary and seeing how dumped file path starts with the `/` character. I haven't tested all possible scenarios (or indeed any) though, Hopefully the CI will make sure that everything works as it should.