### PR TITLE
v0.172.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.172.2, 10 February 2022
+
+- Bump go from 1.17.5 to 1.17.7 [#4730](https://github.com/dependabot/dependabot-core/pull/4730)
+
 ## v0.172.1, 9 February 2022
 
 - Docker: Ignore ARGs without default values [#4723](https://github.com/dependabot/dependabot-core/pull/4723)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.172.1"
+  VERSION = "0.172.2"
 end


### PR DESCRIPTION
Diff: https://github.com/dependabot/dependabot-core/compare/v0.172.1...v0.172.2-release-notes

## v0.172.2, 10 February 2022

- Bump go from 1.17.5 to 1.17.7 [#4730](https://github.com/dependabot/dependabot-core/pull/4730)