### PR TITLE
Support depname.version = "1.2.3" syntax in TOML

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
@@ -139,7 +139,7 @@ module Dependabot
         end
 
         def declaration_regex(dep)
-          /(?:^|^\s*|["'])#{Regexp.escape(dep.name)}["']?\s*=.*$/i
+          /(?:^|^\s*|["'])#{Regexp.escape(dep.name)}["']?(?:\s*\.version)?\s*=.*$/i
         end
 
         def feature_declaration_version_regex(dep)

--- a/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/manifest_updater_spec.rb
@@ -107,6 +107,12 @@ RSpec.describe Dependabot::Cargo::FileUpdater::ManifestUpdater do
         end
       end
 
+      context "with a dependency version in dotted key syntax" do
+        let(:manifest_fixture_name) { "dotted_key_version" }
+
+        it { is_expected.to include(%(time.version = "0.1.38")) }
+      end
+
       context "with a dependency name that includes the version range" do
         let(:manifest_fixture_name) { "version_in_name" }
         let(:dependency_name) { "curve25519-dalek" }

--- a/cargo/spec/fixtures/manifests/dotted_key_version
+++ b/cargo/spec/fixtures/manifests/dotted_key_version
@@ -1,0 +1,7 @@
+[package]
+name = "dependabot" # the name of the package
+version = "0.1.0"    # the current version, obeying semver
+authors = ["support@dependabot.com"]
+
+[dependencies]
+time.version = "0.1.12"


### PR DESCRIPTION
With cargo, it's possible to define a dependency using this syntax:

```
sentry.version = "1.2.3"
sentry.features = ["a", "b", "c"]
```

This PR adds support for this in dependabot-core's manifest updater.