### PR TITLE
Docker: ARG Support: Only replace args outside build stage

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -40,8 +40,9 @@ module Dependabot
 
         dockerfiles.each do |dockerfile|
           args = {}
+          found_from = false
           dockerfile.content.each_line do |line|
-            if ARG.match(line)
+            if !found_from && ARG.match(line)
               key_value = line.delete_prefix("ARG ").split("=")
               next if key_value.count != 2 # The ARG has no default value that we can set
 
@@ -51,6 +52,7 @@ module Dependabot
             line = replace_args(line, args)
             next unless FROM_LINE.match?(line)
 
+            found_from = true
             parsed_from_line = FROM_LINE.match(line).named_captures
             parsed_from_line["registry"] = nil if parsed_from_line["registry"] == "docker.io"
 

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -154,6 +154,23 @@ RSpec.describe Dependabot::Docker::FileParser do
           expect(dependencies).to be_empty
         end
       end
+
+      describe "with multiple args" do
+        let(:dockerfile_fixture_name) { "multiple_args" }
+
+        subject(:docker_dependency) { dependencies.first }
+        subject(:ubuntu_dependency) { dependencies.last }
+
+        it "only replaces the args before first FROM" do
+          expect(dependencies.length).to eq(2)
+
+          expect(docker_dependency).to be_a(Dependabot::Dependency)
+          expect(docker_dependency.name).to eq("docker")
+
+          expect(ubuntu_dependency).to be_a(Dependabot::Dependency)
+          expect(ubuntu_dependency.name).to eq("ubuntu")
+        end
+      end
     end
 
     context "with a non-numeric version" do

--- a/docker/spec/fixtures/docker/dockerfiles/multiple_args
+++ b/docker/spec/fixtures/docker/dockerfiles/multiple_args
@@ -1,0 +1,10 @@
+ARG HUB=docker.io
+
+FROM $HUB/docker:20.10.7-dind
+ARG version=8
+# version is part of docker builder, not java builder
+
+FROM $HUB/java:$version
+# version is unknown!
+
+FROM ubuntu:20.04


### PR DESCRIPTION
First PR of fixing Docker ARG support...

https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
`
An ARG declared before a FROM is outside of a build stage, so it can’t be used in any instruction after a FROM. 
To use the default value of an ARG declared before the first FROM use an ARG instruction without a value inside of a build stage:
`
