### PR TITLE
Bump Terraform from 1.0.11 to 1.1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -214,7 +214,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.58.0 --pr
 ### Terraform
 
 USER root
-ARG TERRAFORM_VERSION=1.0.11
+ARG TERRAFORM_VERSION=1.1.6
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 RUN apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
   && apt-get update -y \

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -149,7 +149,13 @@ module Dependabot
           output = e.message
 
           if output.match?(PRIVATE_MODULE_ERROR)
-            raise PrivateSourceAuthenticationFailure, output.match(PRIVATE_MODULE_ERROR).named_captures.fetch("repo")
+            repo = output.match(PRIVATE_MODULE_ERROR).named_captures.fetch("repo")
+            git_https_prefix = %r{^git::https://}
+            if repo.match?(git_https_prefix)
+              repo = repo.sub(git_https_prefix, "")
+              repo = repo.sub(%r{\.git$}, "")
+            end
+            raise PrivateSourceAuthenticationFailure, repo
           end
 
           raise Dependabot::DependencyFileNotResolvable, "Error running `terraform init`: #{output}"

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -153,7 +153,7 @@ module Dependabot
             git_https_prefix = %r{^git::https://}
             if repo.match?(git_https_prefix)
               repo = repo.sub(git_https_prefix, "")
-              repo = repo.sub(%r{\.git$}, "")
+              repo = repo.sub(/\.git$/, "")
             end
             raise PrivateSourceAuthenticationFailure, repo
           end

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -13,6 +13,7 @@ module Dependabot
 
       PRIVATE_MODULE_ERROR = /Could not download module.*code from\n.*\"(?<repo>\S+)\":/.freeze
       MODULE_NOT_INSTALLED_ERROR =  /Module not installed.*module\s*\"(?<mod>\S+)\"/m.freeze
+      GIT_HTTPS_PREFIX = %r{^git::https://}.freeze
 
       def self.updated_files_regex
         [/\.tf$/, /\.hcl$/]
@@ -150,9 +151,8 @@ module Dependabot
 
           if output.match?(PRIVATE_MODULE_ERROR)
             repo = output.match(PRIVATE_MODULE_ERROR).named_captures.fetch("repo")
-            git_https_prefix = %r{^git::https://}
-            if repo.match?(git_https_prefix)
-              repo = repo.sub(git_https_prefix, "")
+            if repo.match?(GIT_HTTPS_PREFIX)
+              repo = repo.sub(GIT_HTTPS_PREFIX, "")
               repo = repo.sub(/\.git$/, "")
             end
             raise PrivateSourceAuthenticationFailure, repo


### PR DESCRIPTION
This is a minor release from our last version and includes some new features.

https://github.com/hashicorp/terraform/blob/v1.1/CHANGELOG.md#116-february-16-2022

This update triggered a test failure:
```
 1) Dependabot::Terraform::FileUpdater#updated_dependency_files when using a lockfile that requires access to an unreachable module raises a helpful error
     Failure/Error:
       expect { subject }.to raise_error(Dependabot::PrivateSourceAuthenticationFailure) do |error|
         expect(error.source).to eq("github.com/dependabot-fixtures/private-terraform-module")
       end

       expected: "github.com/dependabot-fixtures/private-terraform-module"
            got: "git::https://github.com/dependabot-fixtures/private-terraform-module.git"

       (compared using ==)
     # ./spec/dependabot/terraform/file_updater_spec.rb:905:in `block (4 levels) in <top (required)>'
     # /home/dependabot/dependabot-core/common/spec/spec_helper.rb:49:in `block (2 levels) in <top (required)>'
     # ./.bundle/ruby/2.7.0/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

I've addressed this by stripping the `git::https://` and `.git` from `git::https://github.com/dependabot-fixtures/private-terraform-module.git` to match the previous behavior. It might be possible to see other prefixes like `git::ssl://` but the handling of this error is only concerned with https access so I'm allowing other prefixes to pass through unchanged.