### PR TITLE
Temporarily revert Docker arg from support

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -43,8 +43,6 @@ module Dependabot
           dockerfile.content.each_line do |line|
             if ARG.match(line)
               key_value = line.delete_prefix("ARG ").split("=")
-              next if key_value.count != 2 # The ARG has no default value that we can set
-
               args[key_value[0]] = key_value[1].delete_suffix("\n")
               next
             end

--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -16,16 +16,15 @@ module Dependabot
       # Details of Docker regular expressions is at
       # https://github.com/docker/distribution/blob/master/reference/regexp.go
       DOMAIN_COMPONENT =
-        /[[:alnum:]]|[[:alnum:]][[:alnum:]-]*[[:alnum:]]/.freeze
+        /(?:[[:alnum:]]|[[:alnum:]][[[:alnum:]]-]*[[:alnum:]])/.freeze
       DOMAIN = /(?:#{DOMAIN_COMPONENT}(?:\.#{DOMAIN_COMPONENT})+)/.freeze
       REGISTRY = /(?<registry>#{DOMAIN}(?::\d+)?)/.freeze
 
-      NAME_COMPONENT = /[a-z\d]+(?:(?:[._]|__|[-]*)[a-z\d]+)*/.freeze
+      NAME_COMPONENT = /(?:[a-z\d]+(?:(?:[._]|__|[-]*)[a-z\d]+)*)/.freeze
       IMAGE = %r{(?<image>#{NAME_COMPONENT}(?:/#{NAME_COMPONENT})*)}.freeze
 
-      ARG = /ARG/i.freeze
       FROM = /FROM/i.freeze
-      PLATFORM = /--platform=(?<platform>\S+)/.freeze
+      PLATFORM = /--platform\=(?<platform>\S+)/.freeze
       TAG = /:(?<tag>[\w][\w.-]{0,127})/.freeze
       DIGEST = /@(?<digest>[^\s]+)/.freeze
       NAME = /\s+AS\s+(?<name>[\w-]+)/.freeze
@@ -39,14 +38,7 @@ module Dependabot
         dependency_set = DependencySet.new
 
         dockerfiles.each do |dockerfile|
-          args = {}
           dockerfile.content.each_line do |line|
-            if ARG.match(line)
-              key_value = line.delete_prefix("ARG ").split("=")
-              args[key_value[0]] = key_value[1].delete_suffix("\n")
-              next
-            end
-            line = replace_args(line, args)
             next unless FROM_LINE.match?(line)
 
             parsed_from_line = FROM_LINE.match(line).named_captures
@@ -73,13 +65,6 @@ module Dependabot
       end
 
       private
-
-      def replace_args(line, args)
-        line.gsub(/\${?\w+}?/) do |s|
-          escaped = s.delete_prefix("$").delete_prefix("{").delete_suffix("}")
-          args[escaped]
-        end
-      end
 
       def dockerfiles
         # The Docker file fetcher only fetches Dockerfiles, so no need to

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -124,32 +124,6 @@ RSpec.describe Dependabot::Docker::FileParser do
       end
     end
 
-    context "arg from" do
-      let(:dockerfile_fixture_name) { "arg_from" }
-
-      describe "no curls" do
-        subject(:dependency) { dependencies.first }
-
-        it "can solve the dependency" do
-          expect(dependency).to be_a(Dependabot::Dependency)
-          expect(dependency.name).to eq("docker")
-        end
-      end
-    end
-
-    context "arg from" do
-      let(:dockerfile_fixture_name) { "arg_from_curls" }
-
-      describe "with curls" do
-        subject(:dependency) { dependencies.first }
-
-        it "can solve the dependency" do
-          expect(dependency).to be_a(Dependabot::Dependency)
-          expect(dependency.name).to eq("docker")
-        end
-      end
-    end
-
     context "with a non-numeric version" do
       let(:dockerfile_body) { "FROM ubuntu:artful" }
 

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -135,23 +135,17 @@ RSpec.describe Dependabot::Docker::FileParser do
           expect(dependency.name).to eq("docker")
         end
       end
+    end
+
+    context "arg from" do
+      let(:dockerfile_fixture_name) { "arg_from_curls" }
 
       describe "with curls" do
-        let(:dockerfile_fixture_name) { "arg_from_curls" }
-
         subject(:dependency) { dependencies.first }
 
         it "can solve the dependency" do
           expect(dependency).to be_a(Dependabot::Dependency)
           expect(dependency.name).to eq("docker")
-        end
-      end
-
-      describe "without a default value" do
-        let(:dockerfile_fixture_name) { "arg_from_no_default" }
-
-        it "can't solve the dependency" do
-          expect(dependencies).to be_empty
         end
       end
     end

--- a/docker/spec/fixtures/docker/dockerfiles/arg_from
+++ b/docker/spec/fixtures/docker/dockerfiles/arg_from
@@ -1,2 +1,0 @@
-ARG HUB=docker.io
-FROM $HUB/docker:20.10.7-dind

--- a/docker/spec/fixtures/docker/dockerfiles/arg_from_curls
+++ b/docker/spec/fixtures/docker/dockerfiles/arg_from_curls
@@ -1,2 +1,0 @@
-ARG HUB=docker.io
-FROM ${HUB}/docker:20.10.7-dind

--- a/docker/spec/fixtures/docker/dockerfiles/arg_from_no_default
+++ b/docker/spec/fixtures/docker/dockerfiles/arg_from_no_default
@@ -1,2 +1,0 @@
-ARG HUB
-FROM $HUB/docker:20.10.7-dind


### PR DESCRIPTION
This reverts the `ARG FROM` support that was previously added in https://github.com/dependabot/dependabot-core/pull/4598. It was discovered that the implementation was incomplete (https://github.com/dependabot/dependabot-core/issues/4725) as support needs to be extended to the `FileUpdater`. Currently we can detect versions specified as ARGs but we aren't able to create a PR to update them.

I think this is a great feature that would be great to finish but in the meantime the missing `FileUpdater` support is causing an increase in error reports. Reverting this will clear up the errors and give us more time to understand what `FileUpdater` changes will be needed to complete this.