### PR TITLE
v0.174.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.174.1, 22 February 2022
+
+- Temporarily revert Docker arg from support [#4759](https://github.com/dependabot/dependabot-core/pull/4759)
+- Fix references to changelog path/contents in bump_version.rb [#4756](https://github.com/dependabot/dependabot-core/pull/4756)
+
 ## v0.174.0, 18 February 2022
 
 - Bump Terraform from 1.0.11 to 1.1.6 [#4748](https://github.com/dependabot/dependabot-core/pull/4748)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.174.0"
+  VERSION = "0.174.1"
 end


### PR DESCRIPTION
Diff: https://github.com/dependabot/dependabot-core/compare/v0.174.0...v0.174.1-release-notes

## v0.174.1, 22 February 2022

- Temporarily revert Docker arg from support [#4759](https://github.com/dependabot/dependabot-core/pull/4759)
- Fix references to changelog path/contents in bump_version.rb [#4756](https://github.com/dependabot/dependabot-core/pull/4756)