### PR TITLE
Update to npm 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,11 +97,11 @@ USER root
 
 ### JAVASCRIPT
 
-# Install Node 16.0 and npm v7
+# Install Node 16.0 and npm v8
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
   && apt-get install -y --no-install-recommends nodejs \
   && rm -rf /var/lib/apt/lists/* \
-  && npm install -g npm@v7.21.0 \
+  && npm install -g npm@v8.5.1 \
   && rm -rf ~/.npm
 
 

--- a/npm_and_yarn/spec/fixtures/projects/npm7/subdependency_update_tab_indentation/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm7/subdependency_update_tab_indentation/package.json
@@ -1,14 +1,14 @@
 {
-	"name": "npm-sub-dep-test",
-	"version": "1.0.0",
-	"description": "",
-	"main": "index.js",
-	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
-	},
-	"author": "",
-	"license": "ISC",
-	"dependencies": {
-		"test-old-npm-sub-dependency": "github:dependabot-fixtures/test-old-npm-sub-dependency"
-	}
+		"name": "npm-sub-dep-test",
+		"version": "1.0.0",
+		"description": "",
+		"main": "index.js",
+		"scripts": {
+				"test": "echo \"Error: no test specified\" && exit 1"
+		},
+		"author": "",
+		"license": "ISC",
+		"dependencies": {
+				"test-old-npm-sub-dependency": "github:dependabot-fixtures/test-old-npm-sub-dependency"
+		}
 }


### PR DESCRIPTION
This updates npm to version 8, which is mostly backwards compatible with v7, but drops support for an old version of node.

We've left the references to `npm7` in the codebase (test fixtures and npm version that we reference) as is, because it would become a fairly noisy change and functionally it doesn't change anything. We do plan to follow this up with a PR to update all of those references to `npm8`.

~There is currently one issue that we're digging into which is that the formatting of lockfiles is not respected between updates, and this seems to be caused by a change in npm where in version 8 it bases the formatting (indentation) on the `package.json` instead. When Dependabot performs updates to the `package-lock.json` we strip formatting, so in our case this always results in a large diff in the lockfile, however, I don't think we should assume consistent formatting between the package.json and lockfile either, so ideally this is something that can be resolved in npm.~

There is one functional change here:

On npm7 (due to a bug in npm), the lockfile would keep it's original formatting (indentation depth, tabs vs spaces) between updates, even if it was different from the package.json. In npm 8, the `package-lock.json` will always use the JSON formatting from the `package.json`.

Because of how dependabot updates lockfiles for npm, we modify the JSON in ruby and then spit it back out in a temporary folder. This causes us to lose any formatting, so I've added some code that attempts to figure out how the file was formatted, but the approach is fairly naive, so if someone mixes tabs and spaces, we assume it's tabs, if they mix indentation depth, we use the shallowest indentation. npm will default to indenting with 2 spaces in cases where the is no indentation in the package.json, which I think is preferable in most cases.

I don't expect this to be a huge issue, but it might trip up a few users that rely on this behavior and still use npm 7. We should advise them to update their version of npm because v7 is not officially supported anymore.