### PR TITLE
Disable flaky bundler1 test

### DIFF
--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -1232,7 +1232,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       context "that is old" do
         let(:dependency_files) { bundler_project_dependency_files("explicit_ruby_old") }
 
-        it { is_expected.to eq(Gem::Version.new("2.0.1")) }
+        xit { is_expected.to eq(Gem::Version.new("2.0.1")) }
       end
     end
 


### PR DESCRIPTION
This test intermittently fails, which often trips up external
contributors and ends up wasting CI cycles when we have to retry the
whole thing. We also consistently ignore this failing test, so it seems
better to disable it altogether for now.