### PR TITLE
v0.176.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.176.0, 28 February 2022
+
+- Beta: Dart/Flutter pub support (@sigurdm) [#4510](https://github.com/dependabot/dependabot-core/pull/4510)
+  While now available in dependabot-core, this will require some more work before we
+  can roll this out in the GitHub-hosted version of Dependabot.
+- Disable flaky bundler1 test [#4767](https://github.com/dependabot/dependabot-core/pull/4767)
+
 ## v0.175.0, 25 February 2022
 
 - Update to npm 8 [#4763](https://github.com/dependabot/dependabot-core/pull/4763)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.175.0"
+  VERSION = "0.176.0"
 end


### PR DESCRIPTION
- Beta: Dart/Flutter pub support (@sigurdm) [#4510](https://github.com/dependabot/dependabot-core/pull/4510)
  While now available in dependabot-core, this will require some more work before we
  can roll this out in the GitHub-hosted version of Dependabot.
- Disable flaky bundler1 test [#4767](https://github.com/dependabot/dependabot-core/pull/4767)