### PR TITLE
Pub: use system root certificates

### DIFF
--- a/pub/lib/dependabot/pub/helpers.rb
+++ b/pub/lib/dependabot/pub/helpers.rb
@@ -60,6 +60,7 @@ module Dependabot
               stdout, stderr, status = Open3.capture3(
                 env.compact,
                 "dart",
+                "--root-certs-file=/etc/ssl/certs/ca-certificates.crt",
                 "--no-analytics",
                 "pub",
                 "global",


### PR DESCRIPTION
By default Dart uses it's own certificate store. This is problematic for
us in production where we send traffic through a proxy to add
authentication headers to requests being made, which uses a randomly
generated certificate that we add to the systems cert store, which will
then be ignored by dart.

This instructs dart to use the system certificates instead.

cc @jonasfj, did I explain that correctly?