### PR TITLE
Docker: Handle versions with underscore characters

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -43,12 +43,12 @@ module Dependabot
   module Docker
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       VERSION_REGEX =
-        /v?(?<version>[0-9]+(?:(?:\.[a-z0-9]+)|(?:-(?:kb)?[0-9]+))*)/i.freeze
-      VERSION_WITH_SFX = /^#{VERSION_REGEX}(?<suffix>-[a-z0-9.\-]+)?$/i.freeze
-      VERSION_WITH_PFX = /^(?<prefix>[a-z0-9.\-]+-)?#{VERSION_REGEX}$/i.freeze
-      VERSION_WITH_PFX_AND_SFX =
-        /^(?<prefix>[a-z\-]+-)?#{VERSION_REGEX}(?<suffix>-[a-z\-]+)?$/i.
-        freeze
+        /v?(?<version>[0-9]+(?:(?:\.[a-z0-9]+)|(?:-(?:kb)?[0-9]+)|(?:_[0-9]+))*)/i.freeze
+      PREFIX = /^(?<prefix>[a-z0-9.\-_]+(?:-|_))?/i.freeze
+      SUFFIX = /(?<suffix>(?:-|_)[a-z0-9.\-_]+)?$/i.freeze
+      VERSION_WITH_PFX = /#{PREFIX}#{VERSION_REGEX}$/i.freeze
+      VERSION_WITH_SFX = /^#{VERSION_REGEX}#{SUFFIX}/i.freeze
+      VERSION_WITH_PFX_AND_SFX = /#{PREFIX}#{VERSION_REGEX}#{SUFFIX}/i.freeze
       NAME_WITH_VERSION =
         /
           #{VERSION_WITH_PFX}|
@@ -316,7 +316,7 @@ module Dependabot
       def numeric_version_from(tag)
         return unless tag.match?(NAME_WITH_VERSION)
 
-        tag.match(NAME_WITH_VERSION).named_captures.fetch("version").downcase
+        tag.match(NAME_WITH_VERSION).named_captures.fetch("version").downcase.gsub(/_/i, ".")
       end
 
       def registry_hostname

--- a/docker/spec/fixtures/docker/registry_tags/eclipse-temurin.json
+++ b/docker/spec/fixtures/docker/registry_tags/eclipse-temurin.json
@@ -1,0 +1,17 @@
+{
+    "name": "library/eclipse-temurin",
+    "tags": [
+        "17.0.1_12-jre-windowsservercore-ltsc2022",
+        "17.0.2_8-jre-alpine",
+        "17.0.1_12-jre-alpine",
+        "17-jre-alpine",
+        "11.0.14_9-jre-alpine",
+        "11-jre-alpine",
+        "prefix1_jre_11.0.16",
+        "prefix1_jre_11.0.14",
+        "11.0.16_suffix1_jre",
+        "11.0.14_suffix1_jre",
+        "prefix2_jre_11.0.16_suffix2_jre",
+        "prefix2_jre_11.0.14_suffix2_jre"
+    ]
+}


### PR DESCRIPTION
Allows the underscore character to be present in the prefix, root or
suffix.

Also fixes a bug where numbers were not allowed to be present in the
prefix or in the suffix when prefix and suffix were present at the
same time.