### PR TITLE
Note that the `--dir` flag is required for subdirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ $ bin/dry-run.rb go_modules rsc/quote
 ...
 ```
 
+Note: If the dependency files are not in the top-level directory, then you must
+also pass the path to the subdirectory as an argument: `--dir /<subdirectory>`.
+
 ### Running the tests
 
 Run the tests by running `rspec spec` inside each of the packages, e.g.


### PR DESCRIPTION
When I tried to run `dry-run.rb` against a repo where the
dependency files were in a subdirectory, I got a very confusing error.

It took me _way_ too long to realize that parsing `.github/dependabot.yml`
wasn't part of `dependabot-core` therefore I needed to manually pass in
the subdirectory. So document this better for folks doing drive-by PRs.

Temporarily addresses https://github.com/dependabot/dependabot-core/issues/4811, at least until a better runtime error can be emitted.