### PR TITLE
Improve file_fetcher for GitHub Actions

### DIFF
--- a/github_actions/spec/dependabot/github_actions/file_fetcher_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_fetcher_spec.rb
@@ -236,4 +236,37 @@ RSpec.describe Dependabot::GithubActions::FileFetcher do
         )
     end
   end
+
+  context "with a repo containing a composite action file in a subdirectory" do
+    let(:composite_action_file_fixture) do
+      fixture("github", "contents_githubaction_composite_file.json")
+    end
+    let(:directory) { "action/subdir" }
+
+    before do
+      stub_request(:get, url + "action/subdir?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "contents_githubaction_repo_base_subdir.json"),
+          headers: { "content-type" => "application/json" }
+        )
+      stub_request(
+        :get,
+        File.join(url, "action/subdir/action.yaml?ref=sha")
+      ).with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: composite_action_file_fixture,
+          headers: { "content-type" => "application/json" }
+        )
+    end
+
+    it "fetches the composite action file" do
+      expect(file_fetcher_instance.files.map(&:name)).
+        to match_array(
+          %w(action.yaml)
+        )
+    end
+  end
 end

--- a/github_actions/spec/fixtures/github/contents_githubaction_repo_base_subdir.json
+++ b/github_actions/spec/fixtures/github/contents_githubaction_repo_base_subdir.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "action.yaml",
+    "path": "actions/ansible-docs-build-diff/action.yaml",
+    "sha": "54bcdc67fa62d9ce573779ec6bb0fd56a250d1ea",
+    "size": 7294,
+    "url": "https://api.github.com/repos/ansible-community/github-docs-build/contents/actions/ansible-docs-build-diff/action.yaml?ref=main",
+    "html_url": "https://github.com/ansible-community/github-docs-build/blob/main/actions/ansible-docs-build-diff/action.yaml",
+    "git_url": "https://api.github.com/repos/ansible-community/github-docs-build/git/blobs/54bcdc67fa62d9ce573779ec6bb0fd56a250d1ea",
+    "download_url": "https://raw.githubusercontent.com/ansible-community/github-docs-build/main/actions/ansible-docs-build-diff/action.yaml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/ansible-community/github-docs-build/contents/actions/ansible-docs-build-diff/action.yaml?ref=main",
+      "git": "https://api.github.com/repos/ansible-community/github-docs-build/git/blobs/54bcdc67fa62d9ce573779ec6bb0fd56a250d1ea",
+      "html": "https://github.com/ansible-community/github-docs-build/blob/main/actions/ansible-docs-build-diff/action.yaml"
+    }
+  }
+]


### PR DESCRIPTION
In an earlier [commit][1] we introduced the feature where dependabot
also looked for "action.ya?ml" files in the root directory in addition
to what could be found in the ".github/workflows/" folder. However,
what was not known at the time was that the action.yml files do not
need to reside directly in the root directory, but may be nested in
subdirectories.

While the code (unintentionally) worked with subdirectories it has now
been updated to be a bit more clear in what it will look for.

[1]: https://github.com/dependabot/dependabot-core/commit/c4f3e6eae592c5c42332719b9e597c8bd47a2db9