### PR TITLE
Fix Ruby version conflict error detection for new Bundler versions

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -16,7 +16,6 @@ module Dependabot
         require_relative "gemspec_updater"
         require_relative "gemspec_sanitizer"
         require_relative "gemspec_dependency_name_finder"
-        require_relative "ruby_requirement_setter"
 
         LOCKFILE_ENDING =
           /(?<ending>\s*(?:RUBY VERSION|BUNDLED WITH).*)/m.freeze
@@ -80,23 +79,10 @@ module Dependabot
               )
             end
           post_process_lockfile(lockfile_body)
-        rescue SharedHelpers::HelperSubprocessFailed => e
-          raise unless ruby_lock_error?(e)
-
-          @dont_lock_ruby_version = true
-          retry
-        end
-
-        def ruby_lock_error?(error)
-          return false unless error.error_class == "Bundler::VersionConflict"
-          return false unless error.message.include?(" for gem \"ruby\0\"")
-          return false if @dont_lock_ruby_version
-
-          dependency_files.any? { |f| f.name.end_with?(".gemspec") }
         end
 
         def write_temporary_dependency_files
-          File.write(gemfile.name, prepared_gemfile_content(gemfile))
+          File.write(gemfile.name, updated_gemfile_content(gemfile))
           File.write(lockfile.name, sanitized_lockfile_body)
 
           top_level_gemspecs.each do |gemspec|
@@ -235,21 +221,6 @@ module Dependabot
           spec&.version || gemspec_specs.first&.version || "0.0.1"
         end
         # rubocop:enable Metrics/PerceivedComplexity
-
-        def prepared_gemfile_content(file)
-          content =
-            GemfileUpdater.new(
-              dependencies: dependencies,
-              gemfile: file
-            ).updated_gemfile_content
-          return content if @dont_lock_ruby_version
-
-          top_level_gemspecs.each do |gs|
-            content = RubyRequirementSetter.new(gemspec: gs).rewrite(content)
-          end
-
-          content
-        end
 
         def updated_gemfile_content(file)
           GemfileUpdater.new(

--- a/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/version_resolver.rb
@@ -139,7 +139,8 @@ module Dependabot
         end
 
         def ruby_lock_error?(error)
-          return false unless error.message.include?(" for gem \"ruby\0\"")
+          return false unless error.message.include?(" for the Ruby\0 version") || # Bundler 2
+                              error.message.include?(" for gem \"ruby\0\"") # Bundler 1
           return false if @gemspec_ruby_unlocked
 
           dependency_files.any? { |f| f.name.end_with?(".gemspec") }

--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -462,15 +462,15 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
             to eq(Gem::Version.new("2.0.1"))
         end
 
-        context "that isn't satisfied by the dependencies", :bundler_v2_only do
+        context "that isn't satisfied by the dependencies" do
           let(:dependency_files) do
             bundler_project_dependency_files("imports_gemspec_version_clash_old_required_ruby_no_lockfile")
           end
           let(:current_version) { "3.0.1" }
 
-          it "raises a DependencyFileNotResolvable error" do
-            expect { subject }.
-              to raise_error(Dependabot::DependencyFileNotResolvable)
+          it "ignores the minimum ruby version in the gemspec" do
+            expect(resolver.latest_resolvable_version_details[:version]).
+              to eq(Gem::Version.new("7.2.0"))
           end
         end
       end


### PR DESCRIPTION
Hello!

I'm having some issues running specs locally, and I won't be able to finish this work (and possibly write some specs) today, but I want to open a WIP PR if that's ok, so that I don't lose the context and that I can check whether the current version of my patch is ok with your CI.

On some of my repositories I'm getting mysterious Ruby version conflict errors that make dependabot updates fail. See for example: https://github.com/activeadmin/arbre/security/dependabot/9, which shows this error:

```
Bundler::VersionConflict with message: Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
    Ruby (~> 2.6.7.0)

    rails (~> 7.0.2) was resolved to 7.0.2.2, which depends on
      actionpack (= 7.0.2.2) was resolved to 7.0.2.2, which depends on
        Ruby (>= 2.7.0)
```

However, my library does not impose any Ruby version requirements, so I wasn't sure where this was coming from.

After investigation, I noticed that dependabot is automatically adding this Ruby version constraint to the resolution when updating libraries.

After further investigation, I noticed that dependabot also wants to retry without this constraint, in case adding it fails.  It does this by checking the content of the specific error message given by Bundler in this case. In particular

> Bundler could not find compatible versions __for gem "ruby\0"__

However, in https://github.com/rubygems/bundler/pull/6647 (released with Bundler 2.1.0.pre.1), this message was changed to

> Bundler found conflicting requirements for the __Ruby\0__ version

That means that when using recent Bundler versions, the error message not longer matches, so dependabot leaves the extra Ruby version constraint there, and update fails.

This PR fixes the issue by also checking for the new error message in order to remove the extra Ruby version constraint.

I tried `dependabot-script` and it worked just fine with this change, but I want to check full CI too.