### PR TITLE
Disable spec fetching retries which are not functioning properly

### DIFF
--- a/bundler/helpers/v2/lib/functions/dependency_source.rb
+++ b/bundler/helpers/v2/lib/functions/dependency_source.rb
@@ -40,7 +40,7 @@ module Functions
       bundler_source.
         fetchers.flat_map do |fetcher|
           fetcher.
-            specs_with_retry([dependency_name], bundler_source).
+            specs([dependency_name], bundler_source).
             search_all(dependency_name)
         end.
         map(&:version)


### PR DESCRIPTION
### Summary 
While investigating a [flaky bundler 2 test](https://github.com/dependabot/dependabot-core/blob/248d927865e172c380992af0f815458ca4026f63/bundler/helpers/v2/spec/functions/dependency_source_spec.rb#L107) I found with the latest bundler update the retries are not idempotent and can lead to an incorrect result. This works around the issue for now by not retrying.

We could add a manual retry to this but in our current test cases of 40x errors a retry is actually not helpful. I think it would be better to observe if not doing a retry leads to a noticeable number of recoverable errors before adding any additional complexity here. We could also end up restoring the built in retries in a future bundler update although I've found it's lacking features like backoff and detecting 400 errors as not retryable.

### Issue details

We were previously calling `specs_with_retry(gem_names, source)` which wraps `specs(gem_names, source)` with a retry mechanism.
https://github.com/rubygems/rubygems/blob/4e812b9ca55745269e1e7810e37acccc26c1d886/bundler/lib/bundler/fetcher.rb#L116-L121

On the first try the 400 response from our mocks would result in the expected `Bundler::HTTPError` which the retry mechanism caught and retried. However, on the 2nd retry the call to `specs(gem_names, source)` succeeded and returns an empty array which is not expected. This behavior was also inconsistent depending on whether others tests have run beforehand which makes me think might be involved here.

edit: I've narrowed down the 2.3.5 release of bundler as the first version that caused this issue: https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md#235-january-12-2022