### PR TITLE
Update ci-test script to use bundler 2.3.8

### DIFF
--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -15,7 +15,7 @@ fi
 
 if [[ "$SUITE_NAME" == "bundler2" ]]; then
   cd helpers/v2 \
-    && BUNDLER_VERSION=2.2.33 bundle install \
-    && BUNDLER_VERSION=2.2.33 bundle exec rspec spec \
+    && BUNDLER_VERSION=2.3.8 bundle install \
+    && BUNDLER_VERSION=2.3.8 bundle exec rspec spec \
     && cd -
 fi


### PR DESCRIPTION
I think it was unintentionally left out from the recent update to Bundler 2.3.8.