### PR TITLE
Improve `DEBUG_HELPERS` output

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -95,6 +95,7 @@ module Dependabot
       time_taken = Time.now - start
 
       if ENV["DEBUG_HELPERS"] == "true"
+        puts env_cmd
         puts stdout
         puts stderr
       end


### PR DESCRIPTION
When debugging the result of subcommands, I think it's very useful to know which command failed to run, and the environment that it used.

At least this was helpful for me for figuring out some spec failures I was getting.