### PR TITLE
Tweak command order in `bundler/script/ci-test`

### DIFF
--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -4,18 +4,25 @@ set -e
 
 bundle install
 bundle exec rubocop .
-bundle exec rspec spec
+
+cd helpers/v1 \
+  && BUNDLER_VERSION=1.17.3 bundle install \
+  && cd -
 
 if [[ "$SUITE_NAME" == "bundler1" ]]; then
   cd helpers/v1 \
-    && BUNDLER_VERSION=1.17.3 bundle install \
     && BUNDLER_VERSION=1.17.3 bundle exec rspec spec\
     && cd -
 fi
 
+cd helpers/v2 \
+  && BUNDLER_VERSION=2.3.8 bundle install \
+  && cd -
+
 if [[ "$SUITE_NAME" == "bundler2" ]]; then
   cd helpers/v2 \
-    && BUNDLER_VERSION=2.3.8 bundle install \
     && BUNDLER_VERSION=2.3.8 bundle exec rspec spec \
     && cd -
 fi
+
+bundle exec rspec spec


### PR DESCRIPTION
I was running the `bundler/script/ci-test` script (well, actually each command separately since I assume it would fail), and I was getting hundreds of errors when running the `bundle exec rspec spec` command after running `bundle install` on the bundler subfolder of the repository.

Errors looked like this (with the output tweak from #4827):

```
$ DEBUG_HELPERS=true bundle exec rspec ./spec/dependabot/bundler/file_parser_spec.rb:400
Run options: include {:locations=>{"./spec/dependabot/bundler/file_parser_spec.rb"=>[400]}}

Randomized with seed 18517
{"BUNDLER_VERSION"=>"2.3.8", "BUNDLE_GEMFILE"=>"/Users/deivid/Code/dependabot/dependabot-core/bundler/lib/dependabot/bundler/../../../helpers/v2/Gemfile", "GEM_HOME"=>"/Users/deivid/Code/dependabot/dependabot-core/bundler/lib/dependabot/bundler/../../../helpers/v2/.bundle"}
bundle exec ruby /Users/deivid/Code/dependabot/dependabot-core/bundler/lib/dependabot/bundler/../../../helpers/v2/run.rb

/Users/deivid/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.8/lib/bundler/definition.rb:481:in `materialize': Could not find webmock-3.12.1 in any of the sources (Bundler::GemNotFound)
	from /Users/deivid/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.8/lib/bundler/definition.rb:190:in `specs'
	from /Users/deivid/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.8/lib/bundler/definition.rb:238:in `specs_for'
	from /Users/deivid/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.8/lib/bundler/runtime.rb:18:in `setup'
	from /Users/deivid/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.8/lib/bundler.rb:151:in `setup'
	from /Users/deivid/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.8/lib/bundler/setup.rb:20:in `block in <top (required)>'
	from /Users/deivid/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.8/lib/bundler/ui/shell.rb:136:in `with_level'
	from /Users/deivid/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.8/lib/bundler/ui/shell.rb:88:in `silence'
	from /Users/deivid/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.8/lib/bundler/setup.rb:20:in `<top (required)>'
	from <internal:/Users/deivid/.rbenv/versions/3.1.1/lib/ruby/site_ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/Users/deivid/.rbenv/versions/3.1.1/lib/ruby/site_ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
F

Failures:

  1) Dependabot::Bundler::FileParser parse with a gem from a plugin gem source raises a helpful error
     Failure/Error:
       expect { parser.parse }.
         to raise_error do |error|
         expect(error.class).to eq(Dependabot::DependencyFileNotEvaluatable)
         expect(error.message).
           to include("No plugin sources available for aws-s3")
       end

       expected "Error evaluating your dependency files:" to include "No plugin sources available for aws-s3"
     # ./spec/dependabot/bundler/file_parser_spec.rb:401:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:54:in `block (2 levels) in <top (required)>'
     # /Users/deivid/Code/dependabot/dependabot-core/common/spec/spec_helper.rb:49:in `block (2 levels) in <top (required)>'

Finished in 0.22643 seconds (files took 0.82763 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/dependabot/bundler/file_parser_spec.rb:400 # Dependabot::Bundler::FileParser parse with a gem from a plugin gem source raises a helpful error

Randomized with seed 18517
```

So it turns out that `bundle exec rspec spec` needs `bundle install` to also be run inside helpers folders, so tweaking the order of commands in the script fixes things.