### PR TITLE
fixes comparison between prerelease identifiers for NuGet

### DIFF
--- a/nuget/lib/dependabot/nuget/version.rb
+++ b/nuget/lib/dependabot/nuget/version.rb
@@ -88,8 +88,8 @@ module Dependabot
       end
 
       def compare_dot_separated_part(lhs, rhs)
-        return 1 if lhs.nil?
-        return -1 if rhs.nil?
+        return -1 if lhs.nil?
+        return 1 if rhs.nil?
 
         return lhs.to_i <=> rhs.to_i if lhs.match?(/^\d+$/) && rhs.match?(/^\d+$/)
 

--- a/nuget/lib/dependabot/nuget/version.rb
+++ b/nuget/lib/dependabot/nuget/version.rb
@@ -74,8 +74,26 @@ module Dependabot
 
         return -1 if prerelease_string && !other_prerelease_string
         return 1 if !prerelease_string && other_prerelease_string
+        return 0 if !prerelease_string && !other_prerelease_string
 
-        prerelease_string.<=>(other_prerelease_string)
+        split_prerelease_string = prerelease_string.split(".")
+        other_split_prerelease_string = other_prerelease_string.split(".")
+
+        split_prerelease_string.zip(other_split_prerelease_string).each do |lhs, rhs|
+          result = compare_dot_separated_part(lhs, rhs)
+          return result unless result.zero?
+        end
+
+        0
+      end
+
+      def compare_dot_separated_part(lhs, rhs)
+        return 1 if lhs.nil?
+        return -1 if rhs.nil?
+
+        return lhs.to_i <=> rhs.to_i if lhs.match?(/^\d+$/) && rhs.match?(/^\d+$/)
+
+        lhs.<=>(rhs)
       end
 
       # rubocop:enable Metrics/PerceivedComplexity

--- a/nuget/lib/dependabot/nuget/version.rb
+++ b/nuget/lib/dependabot/nuget/version.rb
@@ -89,6 +89,10 @@ module Dependabot
         0
       end
 
+      # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/AbcSize
+
       def compare_dot_separated_part(lhs, rhs)
         return -1 if lhs.nil?
         return 1 if rhs.nil?
@@ -97,8 +101,6 @@ module Dependabot
 
         lhs <=> rhs
       end
-
-      # rubocop:enable Metrics/PerceivedComplexity
 
       def compare_build_info(other)
         return build_info.nil? ? 0 : 1 unless other.is_a?(Nuget::Version)

--- a/nuget/lib/dependabot/nuget/version.rb
+++ b/nuget/lib/dependabot/nuget/version.rb
@@ -55,6 +55,8 @@ module Dependabot
       end
 
       # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/AbcSize
       def compare_prerelease_part(other)
         release_str = @version_string.split("-").first&.split("+")&.first || ""
         prerelease_string = @version_string.
@@ -93,7 +95,7 @@ module Dependabot
 
         return lhs.to_i <=> rhs.to_i if lhs.match?(/^\d+$/) && rhs.match?(/^\d+$/)
 
-        lhs.<=>(rhs)
+        lhs <=> rhs
       end
 
       # rubocop:enable Metrics/PerceivedComplexity

--- a/nuget/spec/dependabot/nuget/version_spec.rb
+++ b/nuget/spec/dependabot/nuget/version_spec.rb
@@ -175,6 +175,34 @@ RSpec.describe Dependabot::Nuget::Version do
 
           it { is_expected.to eq(-1) }
         end
+
+        context "with one version having a longer prerelease identifier" do
+          let(:version_string) { "3.2.0-alpha.1" }
+          let(:other_version) { "3.2.0-alpha" }
+
+          it { is_expected.to eq(-1) }
+        end
+
+        context "with a prerelease that is lexicographically shorter" do
+          let(:version_string) { "3.2.0-alpha0014" }
+          let(:other_version) { "3.2.0-alpha.66" } # the .66 doesn't matter because alpha < alpha0014 lexicographically
+
+          it { is_expected.to eq(1) }
+        end
+
+        context "with a dot separated pre-release identifier containing integers" do
+          let(:version_string) { "1.3.1-preview.8" }
+          let(:other_version) { "1.3.1-preview.24" }
+
+          it { is_expected.to eq(-1) }
+        end
+
+        context "with a dot separated pre-release identifier containing integers" do
+          let(:version_string) { "1.3.1-preview.8.2" }
+          let(:other_version) { "1.3.1-preview.8.1" }
+
+          it { is_expected.to eq(1) }
+        end
       end
 
       context "that is a blank version" do

--- a/nuget/spec/dependabot/nuget/version_spec.rb
+++ b/nuget/spec/dependabot/nuget/version_spec.rb
@@ -175,39 +175,48 @@ RSpec.describe Dependabot::Nuget::Version do
 
           it { is_expected.to eq(-1) }
         end
+      end
 
-        context "with one version having a longer prerelease identifier" do
+      context "that is a blank version" do
+        let(:other_version) { described_class.new("") }
+        it { is_expected.to eq(1) }
+      end
+
+      context "that has pre-release identifiers" do
+        context "with one version having a longer dot-separated prerelease identifier" do
           let(:version_string) { "3.2.0-alpha.1" }
           let(:other_version) { "3.2.0-alpha" }
 
-          it { is_expected.to eq(-1) }
+          it { is_expected.to eq(1) }
         end
 
-        context "with a prerelease that is lexicographically shorter" do
+        context "with one that is lexicographically shorter" do
           let(:version_string) { "3.2.0-alpha0014" }
           let(:other_version) { "3.2.0-alpha.66" } # the .66 doesn't matter because alpha < alpha0014 lexicographically
 
           it { is_expected.to eq(1) }
         end
 
-        context "with a dot separated pre-release identifier containing integers" do
+        context "with a dot separated identifier containing integers" do
           let(:version_string) { "1.3.1-preview.8" }
           let(:other_version) { "1.3.1-preview.24" }
 
           it { is_expected.to eq(-1) }
         end
 
-        context "with a dot separated pre-release identifier containing integers" do
+        context "with a longer dot separated identifier containing integers" do
           let(:version_string) { "1.3.1-preview.8.2" }
           let(:other_version) { "1.3.1-preview.8.1" }
 
           it { is_expected.to eq(1) }
         end
-      end
 
-      context "that is a blank version" do
-        let(:other_version) { described_class.new("") }
-        it { is_expected.to eq(1) }
+        context "with equal dot separated integers" do
+          let(:version_string) { "1.3.1-preview.8.2" }
+          let(:other_version) { "1.3.1-preview.8.2" }
+
+          it { is_expected.to eq(0) }
+        end
       end
     end
   end

--- a/nuget/spec/dependabot/nuget/version_spec.rb
+++ b/nuget/spec/dependabot/nuget/version_spec.rb
@@ -190,9 +190,9 @@ RSpec.describe Dependabot::Nuget::Version do
           it { is_expected.to eq(1) }
         end
 
-        context "with one that is lexicographically shorter" do
+        context "with one that is lexically shorter" do
           let(:version_string) { "3.2.0-alpha0014" }
-          let(:other_version) { "3.2.0-alpha.66" } # the .66 doesn't matter because alpha < alpha0014 lexicographically
+          let(:other_version) { "3.2.0-alpha.66" } # the .66 doesn't matter because alpha < alpha0014 lexically
 
           it { is_expected.to eq(1) }
         end
@@ -216,6 +216,27 @@ RSpec.describe Dependabot::Nuget::Version do
           let(:other_version) { "1.3.1-preview.8.2" }
 
           it { is_expected.to eq(0) }
+        end
+
+        context "with pre-release does not take precedence over non-pre-release" do
+          let(:version_string) { "1.0.0" }
+          let(:other_version) { "1.0.0-alpha" }
+
+          it { is_expected.to eq(1) }
+        end
+
+        context "with numeric taking lower precedence than non-numeric" do
+          let(:version_string) { "1.0.0-1" }
+          let(:other_version) { "1.0.0-alpha" }
+
+          it { is_expected.to eq(-1) }
+        end
+
+        context "with a pre-release identifier containing hyphens" do
+          let(:version_string) { "1.0.0-1" }
+          let(:other_version) { "1.0.0-1-1" }
+
+          it { is_expected.to eq(-1) }
         end
       end
     end


### PR DESCRIPTION
Fixes #1972

The pre-release section of the version string was being compared as a single string. Now it is correctly breaking up the dot-separated pre-release identifier and comparing those parts numerically when possible per the semver spec.

Verified this was the issue by running `bin/dry-run.rb nuget "ecoAPM/SrcSet" --dir="/." --commit=d2ec33dd1ea80b40a4f163780281cd4678d5db12 --cache=files` and seeing it no longer bumps Statiq.Web from 1.0.0-beta.33 to 1.0.0-beta.9, instead it chooses 1.0.0-beta.46.