### PR TITLE
Fix some specs to pass outside of Docker

### DIFF
--- a/bundler/spec/dependabot/bundler/native_helpers_spec.rb
+++ b/bundler/spec/dependabot/bundler/native_helpers_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Dependabot::Bundler::NativeHelpers do
 
     before do
       allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+      allow(ENV).to receive(:[]).with("DEPENDABOT_NATIVE_HELPERS_PATH").and_return("/opt")
 
       subject.run_bundler_subprocess(
         function: "noop",


### PR DESCRIPTION
When running specs outside of a Docker context, the `DEPENDABOT_NATIVE_HELPERS_PATH` might not be set, and most likely not to "/opt" if set.

This commit makes the related specs independent of this.

With this patch I only have three spec failures when running `CI=true RAISE_ON_WARNINGS=true SUITE_NAME=bundler1 script/ci-test` outside of a Docker context.