### PR TITLE
Remove unnecessary get_directory special cases for npm_and_yarn

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -131,11 +131,6 @@ module Dependabot
           return get_url(details).split("tree/master/").last.split("#").first
         end
 
-        # Special case DefinitelyTyped, which has predictable URLs.
-        # This can be removed once this PR is merged:
-        # https://github.com/Microsoft/types-publisher/pull/578
-        return dependency.name.gsub(/^@/, "") if source_from_url.repo == "DefinitelyTyped/DefinitelyTyped"
-
         # Only return a directory if it is explicitly specified
         return unless details.is_a?(Hash)
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -122,8 +122,6 @@ module Dependabot
       end
 
       def get_directory(details)
-        source_from_url = Source.from_url(get_url(details))
-
         # Only return a directory if it is explicitly specified
         return unless details.is_a?(Hash)
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -123,13 +123,6 @@ module Dependabot
 
       def get_directory(details)
         source_from_url = Source.from_url(get_url(details))
-        # Special case Gatsby, which specifies directories in URLs.
-        # This can be removed once this PR is merged:
-        # https://github.com/gatsbyjs/gatsby/pull/11145
-        if source_from_url.repo == "gatsbyjs/gatsby" &&
-           get_url(details).match?(%r{tree\/master\/.})
-          return get_url(details).split("tree/master/").last.split("#").first
-        end
 
         # Only return a directory if it is explicitly specified
         return unless details.is_a?(Hash)


### PR DESCRIPTION
- The underlying DefinitelyTyped issue was resolved in https://github.com/microsoft/types-publisher/commit/910368a4f23336b0245d9abfe654ac577f36d90c
- The underlying Gatsby issue was resolved in https://github.com/gatsbyjs/gatsby/commit/d6d18e29c0d16d6b5f6030157381584dfb85d4a9