### PR TITLE
Get bundler specs green when run on Ruby 3.1

### DIFF
--- a/bundler/helpers/v1/Gemfile
+++ b/bundler/helpers/v1/Gemfile
@@ -7,6 +7,6 @@ group :test do
   gem "debug", ">= 1.0.0"
   gem "rspec", "~> 3.8"
   gem "rspec-its", "~> 1.2"
-  gem "vcr", "6.0.0"
+  gem "vcr", "6.1.0"
   gem "webmock", "~> 3.4"
 end

--- a/bundler/helpers/v1/monkey_patches/fileutils_keyword_splat_patch.rb
+++ b/bundler/helpers/v1/monkey_patches/fileutils_keyword_splat_patch.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "bundler/vendor/fileutils/lib/fileutils"
+
+# Port
+# https://github.com/ruby/fileutils/commit/a5eca84a4240e29bb7886c3ef7085d464a972dd0
+# to fix keyword argument errors on Ruby 3.1
+
+module BundlerFileUtilsKeywordSplatPatch
+  def entries
+    opts = {}
+    opts[:encoding] = ::Encoding::UTF_8 if fu_windows?
+    Dir.entries(path, **opts).
+      reject { |n| [".", ".."].include?(n) }.
+      map { |n| self.class.new(prefix, join(rel, n.untaint)) }
+  end
+end
+
+Bundler::FileUtils::Entry_.prepend(BundlerFileUtilsKeywordSplatPatch)

--- a/bundler/helpers/v1/run.rb
+++ b/bundler/helpers/v1/run.rb
@@ -14,6 +14,7 @@ end
 # Bundler monkey patches
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"
+require "fileutils_keyword_splat_patch"
 require "git_source_patch"
 require "resolver_spec_group_sane_eql"
 

--- a/bundler/helpers/v1/spec/native_spec_helper.rb
+++ b/bundler/helpers/v1/spec/native_spec_helper.rb
@@ -11,6 +11,7 @@ $LOAD_PATH.unshift(File.expand_path("../monkey_patches", __dir__))
 # Bundler monkey patches
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"
+require "fileutils_keyword_splat_patch"
 require "git_source_patch"
 require "resolver_spec_group_sane_eql"
 

--- a/bundler/helpers/v2/Gemfile
+++ b/bundler/helpers/v2/Gemfile
@@ -7,6 +7,6 @@ group :test do
   gem "debug", ">= 1.0.0"
   gem "rspec", "~> 3.8"
   gem "rspec-its", "~> 1.2"
-  gem "vcr", "6.0.0"
+  gem "vcr", "6.1.0"
   gem "webmock", "~> 3.4"
 end

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.21.0"
   spec.add_development_dependency "simplecov-console", "~> 0.9.1"
   spec.add_development_dependency "stackprof", "~> 0.2.16"
-  spec.add_development_dependency "vcr", "6.0.0"
+  spec.add_development_dependency "vcr", "6.1.0"
   spec.add_development_dependency "webmock", "~> 3.4"
 
   next unless File.exist?("../.gitignore")


### PR DESCRIPTION
I was getting 3 spec failures when running dependabot bundler specs on my system.

I debugged it, and the cause turned out to be that I'm using Ruby 3.1.

This PR makes bundler specs fully pass on Ruby 3.1.

Only the first commit is necessary, the second one only fixes some annoying VCR warnings.