### PR TITLE
Unify RSpec requirements in helpers Gemfiles to match dependabot-common

### DIFF
--- a/bundler/helpers/v1/Gemfile
+++ b/bundler/helpers/v1/Gemfile
@@ -5,8 +5,8 @@ source "https://rubygems.org"
 # NOTE: Used to run native helper specs
 group :test do
   gem "debug", ">= 1.0.0"
-  gem "rspec", "3.10.0"
-  gem "rspec-its", "1.3.0"
+  gem "rspec", "~> 3.8"
+  gem "rspec-its", "~> 1.2"
   gem "vcr", "6.0.0"
   gem "webmock", "~> 3.4"
 end

--- a/bundler/helpers/v2/Gemfile
+++ b/bundler/helpers/v2/Gemfile
@@ -5,8 +5,8 @@ source "https://rubygems.org"
 # NOTE: Used to run native helper specs
 group :test do
   gem "debug", ">= 1.0.0"
-  gem "rspec", "3.10.0"
-  gem "rspec-its", "1.3.0"
+  gem "rspec", "~> 3.8"
+  gem "rspec-its", "~> 1.2"
   gem "vcr", "6.0.0"
   gem "webmock", "~> 3.4"
 end


### PR DESCRIPTION
I run into a similar issue as #4838, because `bundle install` had installed RSpec versions compatible with `Dependabot-common` dependencies (RSpec 3.11), but these didn't match the specification in these Gemfiles (RSpec 3.10.2).

This PR proposes the same solution as in #4838. Now all development dependencies are consistent.