### PR TITLE
Use expanded path when DEPENDABOT_NATIVE_HELPERS_PATH not set

### DIFF
--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -69,7 +69,7 @@ module Dependabot
         helpers_root = ENV["DEPENDABOT_NATIVE_HELPERS_PATH"]
         return File.join(helpers_root, "bundler") unless helpers_root.nil?
 
-        File.join(__dir__, "../../../helpers")
+        File.expand_path("../../../helpers", __dir__)
       end
     end
   end

--- a/bundler/spec/dependabot/bundler/native_helpers_spec.rb
+++ b/bundler/spec/dependabot/bundler/native_helpers_spec.rb
@@ -9,9 +9,11 @@ RSpec.describe Dependabot::Bundler::NativeHelpers do
   describe ".run_bundler_subprocess" do
     let(:options) { {} }
 
+    let(:native_helpers_path) { "/opt" }
+
     before do
       allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-      allow(ENV).to receive(:[]).with("DEPENDABOT_NATIVE_HELPERS_PATH").and_return("/opt")
+      allow(ENV).to receive(:[]).with("DEPENDABOT_NATIVE_HELPERS_PATH").and_return(native_helpers_path)
 
       subject.run_bundler_subprocess(
         function: "noop",
@@ -84,6 +86,21 @@ RSpec.describe Dependabot::Bundler::NativeHelpers do
           to have_received(:run_helper_subprocess).
           with(
             command: "bundle exec ruby /opt/bundler/v2/run.rb",
+            function: "noop",
+            args: [],
+            env: anything
+          )
+      end
+    end
+
+    context "with DEPENDABOT_NATIVE_HELPERS_PATH not set" do
+      let(:native_helpers_path) { nil }
+
+      it "uses the full path to the uninstalled run.rb command" do
+        expect(Dependabot::SharedHelpers).
+          to have_received(:run_helper_subprocess).
+          with(
+            command: "bundle exec ruby #{File.expand_path('../../../helpers/v2/run.rb', __dir__)}",
             function: "noop",
             args: [],
             env: anything


### PR DESCRIPTION
This makes the `DEBUG_HELPERS` output a bit easier to read.

Before you got something like

```
{"BUNDLER_VERSION"=>"2.3.8", "BUNDLE_GEMFILE"=>"/Users/deivid/Code/dependabot/dependabot-core/bundler/lib/dependabot/bundler/../../../helpers/v2/Gemfile", "GEM_HOME"=>"/Users/deivid/Code/dependabot/dependabot-core/bundler/lib/dependabot/bundler/../../../helpers/v2/.bundle"}
bundle exec ruby /Users/deivid/Code/dependabot/dependabot-core/bundler/lib/dependabot/bundler/../../../helpers/v2/run.rb
```

Now you get something like:

```
{"BUNDLER_VERSION"=>"2.3.8", "BUNDLE_GEMFILE"=>"/Users/deivid/Code/dependabot/dependabot-core/bundler/helpers/v2/Gemfile", "GEM_HOME"=>"/Users/deivid/Code/dependabot/dependabot-core/bundler/helpers/v2/.bundle"}
bundle exec ruby /Users/deivid/Code/dependabot/dependabot-core/bundler/helpers/v2/run.rb
```