### PR TITLE
Fix flaky spec failure on Bundler 1 suite

### DIFF
--- a/bundler/helpers/v1/monkey_patches/resolver_spec_group_sane_eql.rb
+++ b/bundler/helpers/v1/monkey_patches/resolver_spec_group_sane_eql.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "bundler/resolver/spec_group"
+
+# Port
+# https://github.com/rubygems/bundler/commit/30a690edbdf5ee64ea54afc7d0c91d910ff2b80e
+# to fix flaky failures on Bundler 1
+
+module BundlerResolverSpecGroupSaneEql
+  def eql?(other)
+    return unless other.is_a?(self.class)
+
+    super(other)
+  end
+end
+
+Bundler::Resolver::SpecGroup.prepend(BundlerResolverSpecGroupSaneEql)

--- a/bundler/helpers/v1/run.rb
+++ b/bundler/helpers/v1/run.rb
@@ -15,6 +15,7 @@ end
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"
 require "git_source_patch"
+require "resolver_spec_group_sane_eql"
 
 require "functions"
 

--- a/bundler/helpers/v1/spec/native_spec_helper.rb
+++ b/bundler/helpers/v1/spec/native_spec_helper.rb
@@ -12,6 +12,7 @@ $LOAD_PATH.unshift(File.expand_path("../monkey_patches", __dir__))
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"
 require "git_source_patch"
+require "resolver_spec_group_sane_eql"
 
 require "functions"
 


### PR DESCRIPTION
Sometimes specs run into the following issue:

```
1) Dependabot::Bundler::UpdateChecker::VersionResolver#latest_resolvable_version_details with a rubygems source with no update possible due to a version conflict [:version]
    Failure/Error:
      SharedHelpers.run_helper_subprocess(
        command: command,
        function: function,
        args: args,
        env: {
          # Bundler will pick the matching installed major version
          "BUNDLER_VERSION" => bundler_version,
          "BUNDLE_GEMFILE" => File.join(helpers_path, "Gemfile"),
          # Prevent the GEM_HOME from being set to a folder owned by root
          "GEM_HOME" => File.join(helpers_path, ".bundle")

    Dependabot::SharedHelpers::HelperSubprocessFailed:
      undefined method `name' for "Gemfile":String
    # /home/dependabot/dependabot-core/common/lib/dependabot/shared_helpers.rb:120:in `run_helper_subprocess'
    # ./lib/dependabot/bundler/native_helpers.rb:40:in `run_bundler_subprocess'
    # ./lib/dependabot/bundler/update_checker/version_resolver.rb:82:in `block (2 levels) in fetch_latest_resolvable_version_details'
    # ./lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb:54:in `block in in_a_native_bundler_context'
    # /home/dependabot/dependabot-core/common/lib/dependabot/shared_helpers.rb:48:in `block in in_a_temporary_directory'
    # /home/dependabot/dependabot-core/common/lib/dependabot/shared_helpers.rb:48:in `chdir'
    # /home/dependabot/dependabot-core/common/lib/dependabot/shared_helpers.rb:48:in `in_a_temporary_directory'
    # /home/dependabot/dependabot-core/common/lib/dependabot/shared_helpers.rb:37:in `in_a_temporary_repo_directory'
    # ./lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb:50:in `in_a_native_bundler_context'
    # ./lib/dependabot/bundler/update_checker/version_resolver.rb:81:in `block in fetch_latest_resolvable_version_details'
    # /home/dependabot/dependabot-core/common/lib/dependabot/shared_helpers.rb:164:in `with_git_configured'
    # ./lib/dependabot/bundler/update_checker/version_resolver.rb:77:in `fetch_latest_resolvable_version_details'
    # ./lib/dependabot/bundler/update_checker/version_resolver.rb:43:in `latest_resolvable_version_details'
    # ./spec/dependabot/bundler/update_checker/version_resolver_spec.rb:53:in `block (3 levels) in <top (required)>'
    # ./spec/dependabot/bundler/update_checker/version_resolver_spec.rb:235:in `block (5 levels) in <top (required)>'
    # ./spec/spec_helper.rb:54:in `block (2 levels) in <top (required)>'
    # /home/dependabot/dependabot-core/common/spec/spec_helper.rb:49:in `block (2 levels) in <top (required)>'
    # ./.bundle/ruby/2.7.0/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

We never found the real culprit of this, but ruby-core run into the same
issue when testing Bundler, and it was fixed by
https://github.com/rubygems/bundler/commit/30a690edbdf5ee64ea54afc7d0c91d910ff2b80e.

This commit cherry-picks that patch to fix the issue here too.