### PR TITLE
Bump to `go` `1.18`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,8 +167,8 @@ USER root
 ### GO
 
 # Install Go
-ARG GOLANG_VERSION=1.17.7
-ARG GOLANG_CHECKSUM=02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259
+ARG GOLANG_VERSION=1.18
+ARG GOLANG_CHECKSUM=e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f
 ENV PATH=/opt/go/bin:$PATH
 RUN cd /tmp \
   && curl --http1.1 -o go.tar.gz https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,7 @@ USER root
 
 # Install Go
 ARG GOLANG_VERSION=1.18
+# You can find the sha here: https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz.sha256
 ARG GOLANG_CHECKSUM=e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f
 ENV PATH=/opt/go/bin:$PATH
 RUN cd /tmp \

--- a/go_modules/helpers/go.mod
+++ b/go_modules/helpers/go.mod
@@ -1,5 +1,5 @@
 module github.com/dependabot/dependabot-core/go_modules/helpers
 
-go 1.17
+go 1.18
 
 require github.com/Masterminds/vcs v1.13.1

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -162,8 +162,7 @@ module Dependabot
 
           File.write(tmp_go_file, "package dummypkg\n") unless package
 
-          # TODO: go 1.18 will make `-d` the default behavior, so remove the flag then
-          command = +"go get -d"
+          command = +"go get"
           # `go get` accepts multiple packages, each separated by a space
           dependencies.each do |dep|
             version = "v" + dep.version.sub(/^v/i, "")
@@ -195,7 +194,7 @@ module Dependabot
 
         def build_module_stubs(stub_paths)
           # Create a fake empty module for each local module so that
-          # `go get -d` works, even if some modules have been `replace`d
+          # `go get` works, even if some modules have been `replace`d
           # with a local module that we don't have access to.
           stub_paths.each do |stub_path|
             Dir.mkdir(stub_path) unless Dir.exist?(stub_path)

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
 
       before do
         allow(Open3).to receive(:capture3).and_call_original
-        allow(Open3).to receive(:capture3).with(anything, "go get -d").and_return(["", stderr, exit_status])
+        allow(Open3).to receive(:capture3).with(anything, "go get").and_return(["", stderr, exit_status])
       end
 
       it { expect { subject }.to raise_error(Dependabot::DependencyFileNotResolvable, /The remote end hung up/) }

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
       before do
         exit_status = double(success?: false)
         allow(Open3).to receive(:capture3).and_call_original
-        allow(Open3).to receive(:capture3).with(anything, "go get -d").and_return(["", stderr, exit_status])
+        allow(Open3).to receive(:capture3).with(anything, "go get").and_return(["", stderr, exit_status])
       end
 
       it "raises a helpful error" do


### PR DESCRIPTION
From https://golang.org/dl/:
* go1.18.linux-amd64.tar.gz
* `e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f`