### PR TITLE
Dockerfile: arm64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -219,13 +219,13 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.58.0 --pr
 
 USER root
 ARG TERRAFORM_VERSION=1.1.6
-RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
-RUN apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
-  && apt-get update -y \
-  && apt-get install -y --no-install-recommends terraform=${TERRAFORM_VERSION} \
-  && terraform -help \
-  && rm -rf /var/lib/apt/lists/*
-
+ARG TERRAFORM_AMD64_CHECKSUM=3e330ce4c8c0434cdd79fe04ed6f6e28e72db44c47ae50d01c342c8a2b05d331
+ARG TERRAFORM_ARM64_CHECKSUM=a53fb63625af3572f7252b9fb61d787ab153132a8984b12f4bb84b8ee408ec53
+RUN cd /tmp \
+  && curl -o terraform-${TARGETARCH}.tar.gz https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip \
+  && printf "$TERRAFORM_AMD64_CHECKSUM terraform-amd64.tar.gz\n$TERRAFORM_ARM64_CHECKSUM terraform-arm64.tar.gz\n" | sha256sum -c --ignore-missing - \
+  && unzip -d /usr/local/bin terraform-${TARGETARCH}.tar.gz \
+  && rm terraform-${TARGETARCH}.tar.gz
 
 ### DART
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,11 +108,15 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
 ### ELM
 
 # Install Elm 0.19
+# This is amd64 only, see:
+# - https://github.com/elm/compiler/issues/2007
+# - https://github.com/elm/compiler/issues/2232
 ENV PATH="$PATH:/node_modules/.bin"
-RUN curl -sSLfO "https://github.com/elm/compiler/releases/download/0.19.0/binaries-for-linux.tar.gz" \
+RUN [ "$TARGETARCH" != "amd64" ] \
+  || (curl -sSLfO "https://github.com/elm/compiler/releases/download/0.19.0/binaries-for-linux.tar.gz" \
   && tar xzf binaries-for-linux.tar.gz \
   && mv elm /usr/local/bin/elm19 \
-  && rm -f binaries-for-linux.tar.gz
+  && rm -f binaries-for-linux.tar.gz)
 
 
 ### PHP

--- a/Dockerfile
+++ b/Dockerfile
@@ -234,7 +234,9 @@ ENV PUB_CACHE=/opt/dart/pub-cache \
   PUB_ENVIRONMENT="dependabot" \
   PATH="${PATH}:/opt/dart/dart-sdk/bin"
 ARG DART_VERSION=2.15.1
-RUN curl --connect-timeout 15 --retry 5 "https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/dartsdk-linux-x64-release.zip" > "/tmp/dart-sdk.zip" \
+RUN DART_ARCH=${TARGETARCH} \
+  && if [ "$TARGETARCH" = "amd64" ]; then DART_ARCH=x64; fi \
+  && curl --connect-timeout 15 --retry 5 "https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/dartsdk-linux-${DART_ARCH}-release.zip" > "/tmp/dart-sdk.zip" \
   && mkdir -p "$PUB_CACHE" \
   && chown dependabot:dependabot "$PUB_CACHE" \
   && unzip "/tmp/dart-sdk.zip" -d "/opt/dart" > /dev/null \
@@ -256,6 +258,8 @@ RUN curl --connect-timeout 15 --retry 5 "https://storage.googleapis.com/flutter_
   && tar xf "/tmp/flutter.xz" -C /opt/dart \
   && rm "/tmp/flutter.xz" \
   && chmod -R o+rx "/opt/dart/flutter" \
+  && rm -Rf /opt/dart/flutter/bin/cache/dart-sdk \
+  && ln -s /opt/dart/dart-sdk /opt/dart/flutter/bin/cache/dart-sdk \
   && chown -R dependabot:dependabot "/opt/dart/flutter" \
   && runuser -l dependabot -c "/opt/dart/flutter/bin/flutter --version" \
   # To reduce space usage we delete all of the flutter sdk except the few

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ARG TARGETARCH=amd64
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -261,10 +261,7 @@ RUN curl --connect-timeout 15 --retry 5 "https://storage.googleapis.com/flutter_
   && tar xf "/tmp/flutter.xz" -C /opt/dart \
   && rm "/tmp/flutter.xz" \
   && chmod -R o+rx "/opt/dart/flutter" \
-  && rm -Rf /opt/dart/flutter/bin/cache/dart-sdk \
-  && ln -s /opt/dart/dart-sdk /opt/dart/flutter/bin/cache/dart-sdk \
   && chown -R dependabot:dependabot "/opt/dart/flutter" \
-  && runuser -l dependabot -c "/opt/dart/flutter/bin/flutter --version" \
   # To reduce space usage we delete all of the flutter sdk except the few
   # things needed for pub resolutions:
   # * The version file

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
 
+ARG TARGETARCH=amd64
+
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ### SYSTEM DEPENDENCIES
@@ -172,13 +174,14 @@ USER root
 
 # Install Go
 ARG GOLANG_VERSION=1.17.7
-ARG GOLANG_CHECKSUM=02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259
+ARG GOLANG_AMD64_CHECKSUM=02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259
+ARG GOLANG_ARM64_CHECKSUM=a5aa1ed17d45ee1d58b4a4099b12f8942acbd1dd09b2e9a6abb1c4898043c5f5
 ENV PATH=/opt/go/bin:$PATH
 RUN cd /tmp \
-  && curl --http1.1 -o go.tar.gz https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz \
-  && echo "$GOLANG_CHECKSUM go.tar.gz" | sha256sum -c - \
-  && tar -xzf go.tar.gz -C /opt \
-  && rm go.tar.gz
+  && curl --http1.1 -o go-${TARGETARCH}.tar.gz https://dl.google.com/go/go${GOLANG_VERSION}.linux-${TARGETARCH}.tar.gz \
+  && printf "$GOLANG_AMD64_CHECKSUM go-amd64.tar.gz\n$GOLANG_ARM64_CHECKSUM go-arm64.tar.gz\n" | sha256sum -c --ignore-missing - \
+  && tar -xzf go-${TARGETARCH}.tar.gz -C /opt \
+  && rm go-${TARGETARCH}.tar.gz
 
 
 ### ELIXIR

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -36,9 +36,18 @@ fi
 build_image() {
   export BUILT_IMAGE=true
   echo "$(tput setaf 2)=> building image from Dockerfile$(tput sgr0)"
+
+  local TARGETARCH;
+  case "$(uname -m)"
+  in
+    amd64 | x86_64) TARGETARCH=amd64 ;;
+    arm64 | aarch64) TARGETARCH=arm64 ;;
+    *) TARGETARCH=amd64 ;;
+  esac
+
   docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
-    --build-arg "TARGETARCH=$(uname -m)" \
+    --build-arg "TARGETARCH=${TARGETARCH}" \
     --build-arg "USER_UID=$(id -u)" \
     --build-arg "USER_GID=$(id -g)" \
     --cache-from "dependabot/dependabot-core:latest" \

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -38,6 +38,7 @@ build_image() {
   echo "$(tput setaf 2)=> building image from Dockerfile$(tput sgr0)"
   docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --build-arg "TARGETARCH=$(uname -m)" \
     --build-arg "USER_UID=$(id -u)" \
     --build-arg "USER_GID=$(id -g)" \
     --cache-from "dependabot/dependabot-core:latest" \

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -73,7 +73,9 @@ require "json"
 require "debug"
 require "logger"
 require "dependabot/logger"
-require "stackprof"
+unless RUBY_PLATFORM == "aarch64-linux-gnu"
+  require "stackprof"
+end
 
 Dependabot.logger = Logger.new($stdout)
 

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -73,9 +73,7 @@ require "json"
 require "debug"
 require "logger"
 require "dependabot/logger"
-unless RUBY_PLATFORM == "aarch64-linux-gnu"
-  require "stackprof"
-end
+require "stackprof"
 
 Dependabot.logger = Logger.new($stdout)
 


### PR DESCRIPTION
This PR amends the `Dockerfile` and `bin/docker-dev-shell` commands to support native builds on arm64, as provided by an M1 Mac.

* Initial commits walk the Dockerfile and provide arm64-native alternatives when binaries are fetched.
   * There is no Elm, sorry.
   * There are no Terraform Debian packages, so I switched to fetching zips.
   * In places where the digest of downloaded files is verified, you have two digests to maintain now.
* No attempt is made to build `arm64` in CI, or publish `arm64` releases.

The resulting build stands up OK to light testing: I could dry-run a golang, node and gradle repository.

I hit an error in the bundler that I didn't try to debug:
```
	 1: from /home/dependabot/dependabot-core/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb:54:in `block in in_a_native_bundler_context'
/home/dependabot/dependabot-core/bundler/lib/dependabot/bundler/update_checker/conflicting_dependency_resolver.rb:44:in `block in conflicting_dependencies': undefined method `name' for nil:NilClass (NoMethodError)
```