### PR TITLE
NuGet versioning does not consider the "build part" in comparisons

### DIFF
--- a/nuget/spec/dependabot/nuget/version_spec.rb
+++ b/nuget/spec/dependabot/nuget/version_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Dependabot::Nuget::Version do
 
         context "but our version has build information" do
           let(:version_string) { "1.0.0+gc.1" }
-          it { is_expected.to eq(1) }
+          it { is_expected.to eq(0) }
         end
       end
 
@@ -113,12 +113,12 @@ RSpec.describe Dependabot::Nuget::Version do
 
         context "but our version has build information" do
           let(:version_string) { "1.0.0+gc.1" }
-          it { is_expected.to eq(1) }
+          it { is_expected.to eq(0) }
         end
 
         context "but the other version has build information" do
           let(:other_version) { described_class.new("1.0.0+gc.1") }
-          it { is_expected.to eq(-1) }
+          it { is_expected.to eq(0) }
         end
 
         context "and both sides have build information" do
@@ -131,17 +131,17 @@ RSpec.describe Dependabot::Nuget::Version do
 
           context "when our side is greater" do
             let(:version_string) { "1.0.0+gc.2" }
-            it { is_expected.to eq(1) }
+            it { is_expected.to eq(0) }
           end
 
           context "when our side is lower" do
             let(:version_string) { "1.0.0+gc" }
-            it { is_expected.to eq(-1) }
+            it { is_expected.to eq(0) }
           end
 
           context "when our side is longer" do
             let(:version_string) { "1.0.0+gc.1.1" }
-            it { is_expected.to eq(1) }
+            it { is_expected.to eq(0) }
           end
         end
       end
@@ -188,6 +188,14 @@ RSpec.describe Dependabot::Nuget::Version do
           let(:other_version) { "3.2.0-alpha" }
 
           it { is_expected.to eq(1) }
+        end
+
+        context "with comparison that is case insensitive" do
+          let(:version_string) { "3.2.0-alpha" }
+          let(:other_version) { "3.2.0-Alpha" }
+
+          # NuGetVersion uses case insensitive string comparisons for pre-release components.
+          it { is_expected.to eq(0) }
         end
 
         context "with one that is lexically shorter" do

--- a/nuget/spec/dependabot/nuget/version_spec.rb
+++ b/nuget/spec/dependabot/nuget/version_spec.rb
@@ -226,6 +226,13 @@ RSpec.describe Dependabot::Nuget::Version do
           it { is_expected.to eq(0) }
         end
 
+        context "with pre-release build info" do
+          let(:version_string) { "1.3.1-preview.8.2" }
+          let(:other_version) { "1.3.1-preview.8.2+123" }
+
+          it { is_expected.to eq(0) }
+        end
+
         context "with pre-release does not take precedence over non-pre-release" do
           let(:version_string) { "1.0.0" }
           let(:other_version) { "1.0.0-alpha" }


### PR DESCRIPTION
The [NuGet docs](https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#semantic-versioning-200) specify they use SemVer 2.0 [which says](https://semver.org/#spec-item-10):

> Build metadata MUST be ignored when determining version precedence.

Also the NuGet docs say [a little further down](https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#where-nugetversion-diverges-from-semantic-versioning) that they depart from SemVer 2.0 in a few ways:

> 1. NuGetVersion supports a 4th version segment, Revision, to be compatible with, or a superset of, [System.Version](https://docs.microsoft.com/en-us/dotnet/api/system.version). Therefore, excluding prerelease and metadata labels, a version string is Major.Minor.Patch.Revision. As per version normalization described above, if Revision is zero, it is omit from the normalized version string.
> 2. NuGetVersion only requires the major segment to be defined. All others are optional, and are equivalent to zero. This means that 1, 1.0, 1.0.0, and 1.0.0.0 are all accepted and equal.
> 3. NuGetVersion uses case insenstive string comparisons for pre-release components. This means that 1.0.0-alpha and 1.0.0-Alpha are equal.

So I wrote a quick C# app to verify the behaviors:

```c#
using NuGet.Versioning;

Console.WriteLine(SemanticVersion.Parse("1.0.0") == SemanticVersion.Parse("1.0.0+1")); // True
Console.WriteLine(SemanticVersion.Parse("1.0.0-alpha") == SemanticVersion.Parse("1.0.0-ALPHA")); // True
//SemanticVersion.Parse("1.0.0.1"); // ArgumentException
//SemanticVersion.Parse("1") // ArgumentException
```

Curiously `1.0.0.1` and `1` didn't parse even though the docs call them out, so I've only fixed the first two in the code for now.

fixes #4845
