### PR TITLE
Modify ENV in a friendlier way during specs

### DIFF
--- a/bundler/spec/dependabot/bundler/native_helpers_spec.rb
+++ b/bundler/spec/dependabot/bundler/native_helpers_spec.rb
@@ -13,14 +13,15 @@ RSpec.describe Dependabot::Bundler::NativeHelpers do
 
     before do
       allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-      allow(ENV).to receive(:[]).with("DEPENDABOT_NATIVE_HELPERS_PATH").and_return(native_helpers_path)
 
-      subject.run_bundler_subprocess(
-        function: "noop",
-        args: [],
-        bundler_version: "2.0.0",
-        options: options
-      )
+      with_env("DEPENDABOT_NATIVE_HELPERS_PATH", native_helpers_path) do
+        subject.run_bundler_subprocess(
+          function: "noop",
+          args: [],
+          bundler_version: "2.0.0",
+          options: options
+        )
+      end
     end
 
     context "with a timeout provided" do
@@ -106,6 +107,16 @@ RSpec.describe Dependabot::Bundler::NativeHelpers do
             env: anything
           )
       end
+    end
+
+    private
+
+    def with_env(key, value)
+      previous_value = ENV[key]
+      ENV[key] = value
+      yield
+    ensure
+      ENV[key] = previous_value
     end
   end
 end


### PR DESCRIPTION
This is a follow up to #4835.

Right now, if one of these specs start failing, we'll get a very confusing error like the following:

```
Failures:

  1) Dependabot::Bundler::NativeHelpers.run_bundler_subprocess with DEPENDABOT_NATIVE_HELPERS_PATH not set uses the full path to the uninstalled run.rb command
     Failure/Error:
       expect(Dependabot::SharedHelpers).
         to have_received(:run_helper_subprocess).
         with(
           command: "bundle exec ruby #{File.expand_path('../../../v2/run.rb', __dir__)}",
           function: "noop",
           args: [],
           env: anything
         )

       {"SHELL"=>"/bin/zsh", (... rest of the env...), "GEM_HOME"=>"/Users/deivid/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0"} received :[] with unexpected arguments
         expected: ("DEPENDABOT_NATIVE_HELPERS_PATH")
              got: ("COLUMNS")
        Please stub a default value first if message might be received with other args as well.
     # ./spec/dependabot/bundler/native_helpers_spec.rb:100:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:54:in `block (2 levels) in <top (required)>'
     # /Users/deivid/Code/dependabot/dependabot-core/common/spec/spec_helper.rb:49:in `block (2 levels) in <top (required)>'
```

I think this might be because RSpec needs ENV to build its error messages, but it's still stubbed when error messages are built.

We could add `allow(ENV).to receive(:[])` to allow calls with other arguments on top of the current stub. But I think it would be a bit confusing to figure out why that's needed.

I think it's better to not mock ENV and instead change and restore the appropriate variable as needed.