### PR TITLE
Bugfix: Include space in regex capturing group

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -14,7 +14,7 @@ module Dependabot
         RESOLVABILITY_ERROR_REGEXES = [
           # The checksum in go.sum does not match the downloaded content
           /verifying .*: checksum mismatch/.freeze,
-          /go (?:get)?: .*: go.mod has post-v\d+ module path/
+          /go(?: get)?: .*: go.mod has post-v\d+ module path/
         ].freeze
 
         REPO_RESOLVABILITY_ERROR_REGEXES = [


### PR DESCRIPTION
When the `get` is not part of the error message, the space won't
appear either, so this regex won't match a genuine error such as:
```
"go: github.com/jenkins-x/jx-api@v0.0.25: invalid version: go.mod has post-v0 module path \"github.com/jenkins-x/jx-api/v3\" at revision v0.0.25\n"
```

This is a bug from https://github.com/dependabot/dependabot-core/commit/b6fa7eecf7dfaaf1dbd30c80c1838a9e27484e79#diff-491ccbbf0ae3cfe37dca8fba172104cc5466631d946daf9639deac37b014692eR21.

I also double-checked the other regexes, and they already correctly include the extra space:
https://github.com/dependabot/dependabot-core/blob/0fd174fd3b49d308030cf57373f106b4fc3aed9f/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb#L40-L42

The error is only thrown by the tests when upgrading to `go 1.18`, but
I broke it out as a separate commit because I'm confident this bug is not version-dependent...
It's just that the tests only exposed it in `go 1.18`. There is a high probability this is present in
`go 1.17` and older code.