### PR TITLE
pub metadata_finder: Fall back to `homepage` if `repository` is not present

### DIFF
--- a/pub/lib/dependabot/pub/metadata_finder.rb
+++ b/pub/lib/dependabot/pub/metadata_finder.rb
@@ -12,6 +12,9 @@ module Dependabot
 
       def look_up_source
         repo = pub_listing.dig("latest", "pubspec", "repository")
+        # The repository field did not always exist in pubspec.yaml, and some 
+        # packages specify a git repository in the "homepage" field.
+        repo ||= pub_listing.dig("latest", "pubspec", "homepage")
         return nil unless repo
 
         Source.from_url(repo)


### PR DESCRIPTION
Fixes: https://github.com/dependabot/dependabot-core/issues/4878