### PR TITLE
Bump bundler from 2.3.8 to 2.3.9 and automate it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN apt-add-repository ppa:brightbox/ruby-ng \
   && apt-get install -y --no-install-recommends ruby2.7 ruby2.7-dev \
   && gem update --system 3.2.20 \
   && gem install bundler -v 1.17.3 --no-document \
-  && gem install bundler -v 2.3.8 --no-document \
+  && gem install bundler -v 2.3.9 --no-document \
   && rm -rf /var/lib/gems/2.7.0/cache/* \
   && rm -rf /var/lib/apt/lists/*
 

--- a/bin/update-bundler.rb
+++ b/bin/update-bundler.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This script bumps the bundler version used, since we reference it in a few
+# different places.
+
+require "excon"
+require "json"
+
+LATEST_VERSION = JSON.parse(Excon.get("https://rubygems.org/api/v1/gems/bundler.json").body)["version"]
+CURRENT_VERSION = File.read("Dockerfile").match(/gem install bundler -v (2.\d+\.\d+)/)[1]
+
+def update_file(filename)
+  File.open(filename, "r+") do |f|
+    contents = f.read
+    f.rewind
+    f.write(contents.gsub(CURRENT_VERSION, LATEST_VERSION))
+  end
+end
+
+update_file("Dockerfile")
+update_file("bundler/helpers/v2/build")
+update_file("bundler/lib/dependabot/bundler/helpers.rb")
+update_file("bundler/spec/dependabot/bundler/helper_spec.rb")
+update_file("bundler/script/ci-test")
+update_file("bundler/spec/spec_helper.rb")

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -22,6 +22,6 @@ cd "$install_dir"
 
 # NOTE: Sets `BUNDLED WITH` to match the installed v2 version in Gemfile.lock
 # forcing specs and native helpers to run with the same version
-BUNDLER_VERSION=2.3.8 bundle config --local path ".bundle"
-BUNDLER_VERSION=2.3.8 bundle config --local without "test"
-BUNDLER_VERSION=2.3.8 bundle install
+BUNDLER_VERSION=2.3.9 bundle config --local path ".bundle"
+BUNDLER_VERSION=2.3.9 bundle config --local without "test"
+BUNDLER_VERSION=2.3.9 bundle install

--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -4,7 +4,7 @@ module Dependabot
   module Bundler
     module Helpers
       V1 = "1.17.3"
-      V2 = "2.3.8"
+      V2 = "2.3.9"
       # If we are updating a project with no Gemfile.lock, we default to the
       # newest version we support
       DEFAULT = V2

--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -15,7 +15,7 @@ fi
 
 if [[ "$SUITE_NAME" == "bundler2" ]]; then
   cd helpers/v2 \
-    && BUNDLER_VERSION=2.3.8 bundle install \
-    && BUNDLER_VERSION=2.3.8 bundle exec rspec spec \
+    && BUNDLER_VERSION=2.3.9 bundle install \
+    && BUNDLER_VERSION=2.3.9 bundle exec rspec spec \
     && cd -
 fi

--- a/bundler/spec/dependabot/bundler/helper_spec.rb
+++ b/bundler/spec/dependabot/bundler/helper_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Dependabot::Bundler::Helpers do
   end
 
   let(:v1) { "1.17.3" }
-  let(:v2) { "2.3.8" }
+  let(:v2) { "2.3.9" }
 
   describe "#bundler_version" do
     def described_method(lockfile)

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -20,7 +20,7 @@ module PackageManagerHelper
   end
 
   def self.bundler_version
-    use_bundler_2? ? "2.3.8" : "1.17.3"
+    use_bundler_2? ? "2.3.9" : "1.17.3"
   end
 
   def self.bundler_major_version


### PR DESCRIPTION
This bumps the bundler version to the latest release, and adds a quick
'n dirty script to do it for us going forward.

This solution isn't ideal as places where we reference the version might
change, but I think it's an improvement over manually going through the
files. Also, if we happen to reference the same value as the bundler version
to mean something else in the same file, it'll get updated. 