### PR TITLE
Npm: Handle `.tar.gz` extensions for path dependencies

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -123,7 +123,7 @@ module Dependabot
           filename = path
           # NPM/Yarn support loading path dependencies from tarballs:
           # https://docs.npmjs.com/cli/pack.html
-          filename = File.join(filename, "package.json") unless filename.end_with?(".tgz", ".tar")
+          filename = File.join(filename, "package.json") unless filename.end_with?(".tgz", ".tar", ".tar.gz")
           cleaned_name = Pathname.new(filename).cleanpath.to_path
           next if fetched_files.map(&:name).include?(cleaned_name)
 
@@ -132,7 +132,7 @@ module Dependabot
             package_json_files << file
           rescue Dependabot::DependencyFileNotFound
             # Unfetchable tarballs should not be re-fetched as a package
-            unfetchable_deps << [name, path] unless path.end_with?(".tgz", ".tar")
+            unfetchable_deps << [name, path] unless path.end_with?(".tgz", ".tar", ".tar.gz")
           end
         end
 


### PR DESCRIPTION
Dependabot has support for loading file dependencies for npm, and when
these files are larger than 1mb, we have some logic in place to retry
using the Git Data API.

We ran into a case where this would surface a `Blob too large` error,
indicating that the retry via the Git Data API wasn't working as expected,
and it turns out it's because we did not support the `.tar.gz` extension
in our code.

Previously this would cause us to assume this was a nested package.json,
(see [here][npm path dependency ref]) so we'd tack `package.json` onto the
filename, which in turn would cause a 404, which in turn would cause us to
retry without `package.json` attached, only this time using
`_github_repo_contents` instead of `_fetch_file_content_from_github`,
which does not have logic to retry using the Git Data API.

[npm path dependency ref]: https://github.com/dependabot/dependabot-core/blob/ea8fbaf64af5af477d5b69d0b985782340ca3b36/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb#L124-L128
