### PR TITLE
Update pub dependency_service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -238,7 +238,7 @@ RUN curl --connect-timeout 15 --retry 5 "https://storage.googleapis.com/dart-arc
 # We pull the dependency_services from the dart-lang/pub repo as it is not
 # exposed from the Dart SDK (yet...).
 RUN git clone https://github.com/dart-lang/pub.git /opt/dart/pub \
-  && git -C /opt/dart/pub checkout fbc9732eeeed2c219a84c155f05f5b6222dccd9c \
+  && git -C /opt/dart/pub checkout 3082796f8ba9b3f509265ac3a223312fb5033988 \
   && dart pub global activate --source path /opt/dart/pub \
   && chmod -R o+r "/opt/dart/pub" \
   && chown -R dependabot:dependabot "$PUB_CACHE" \


### PR DESCRIPTION
    
    ```
    > git log --format="%C(auto) %h %s" fbc9732eeeed2c219a84c155f05f5b6222dccd9c..3082796f8ba9b3f509265ac3a223312fb5033988
     3082796f dependency_services: Don't download archives on apply (#3352)
     48d0ffaf dependency_services: Use ^ constraints for widened intervals when possible (#3349)
     826e2086 Remove obsolete test (#3347)
     35e5140b Bump analyzer from 2.8.0 to 3.3.1 (#3341)
     52f2bdc2 Enable dependabot (#3340)
     1e70c0c7 Remove `uploader` command (#3335)
     3174a264 Warn if git version is not high enough for supporting all features (#3332)
     3f7a3cb7 Don't analyze ignored directories in directory-validator (#3331)
     e8f36614 Allow use of token for talking to pub.dev (#3330)
     b93bf88f Upgrade `package:tar` to version `0.5.4`. (#3313)
     ```
    
     The relevant new commits are: 3082796f and 48d0ffaf fixing:
     * https://github.com/dart-lang/pub/issues/3348
     * https://github.com/dart-lang/pub/issues/3342