### PR TITLE
Explicitly import process in npm_and_yarn helper

### DIFF
--- a/npm_and_yarn/helpers/run.js
+++ b/npm_and_yarn/helpers/run.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+const process = require('process');
+
 function output(obj) {
   process.stdout.write(JSON.stringify(obj));
 }


### PR DESCRIPTION
I noticed that our helper script currently accesses `process` as an implicit global, rather than an explicit import.

From the [Node.js docs](https://nodejs.org/api/process.html#process):

> The process object provides information about, and control over, the current Node.js process. While it is available as a global, it is recommended to explicitly access it via require or import. 

Not a big deal right now, but this is the kind of thing I could see being deprecated / removed in future releases.