### PR TITLE
Add raise_on_ignore support to Pub

### DIFF
--- a/pub/lib/dependabot/pub/update_checker.rb
+++ b/pub/lib/dependabot/pub/update_checker.rb
@@ -10,7 +10,13 @@ module Dependabot
       include Dependabot::Pub::Helpers
 
       def latest_version
-        Dependabot::Pub::Version.new(current_report["latest"])
+        version = Dependabot::Pub::Version.new(current_report["latest"])
+
+        return version if ignore_requirements.none? { |r| r.satisfied_by?(version) }
+        return version if version == version_class.new(dependency.version)
+        return nil unless @raise_on_ignored
+
+        raise AllVersionsIgnored
       end
 
       def latest_resolvable_version_with_no_unlock

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -58,21 +58,24 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       options: {
         pub_hosted_url: "http://localhost:#{@server[:Port]}"
       },
+      raise_on_ignored: raise_on_ignored,
       requirements_update_strategy: requirements_update_strategy
     )
   end
 
   let(:ignored_versions) { [] }
+  let(:raise_on_ignored) { false }
 
   let(:dependency) do
     Dependabot::Dependency.new(
       name: dependency_name,
       # This version is ignored by dependency_services, but will be seen by base
-      version: "0.0.0",
+      version: dependency_version,
       requirements: requirements,
       package_manager: "pub"
     )
   end
+  let(:dependency_version) { "0.0.0" }
 
   let(:requirements_update_strategy) { nil } # nil means "auto".
   let(:dependency_name) { "retry" }
@@ -444,6 +447,51 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
       it "can update" do
         expect(checker.latest_version.to_s).to eq "1.0.0"
         expect(can_update).to be_falsey
+      end
+    end
+  end
+
+  context "when raise_on_ignored is true" do
+    let(:raise_on_ignored) { true }
+
+    context "when later versions are allowed" do
+      let(:dependency_name) { "collection" }
+      let(:dependency_version) { "1.14.13" }
+      let(:ignored_versions) { ["< 1.14.13"] }
+
+      it "doesn't raise an error" do
+        expect { checker.latest_version }.to_not raise_error
+      end
+    end
+
+    context "when the user is on the latest version" do
+      let(:dependency_name) { "path" }
+      let(:dependency_version) { "1.8.0" }
+      let(:ignored_versions) { ["> 1.8.0"] }
+
+      it "doesn't raise an error" do
+        expect { checker.latest_version }.to_not raise_error
+      end
+    end
+
+    context "when the user is on the latest version but it's ignored" do
+      let(:dependency_name) { "path" }
+      let(:dependency_version) { "1.8.0" }
+      let(:ignored_versions) { [">= 0"] }
+
+      it "doesn't raise an error" do
+        expect { checker.latest_version }.to_not raise_error
+      end
+    end
+
+    context "when the user is ignoring all later versions" do
+      let(:dependency_name) { "collection" }
+      let(:dependency_version) { "1.14.13" }
+      let(:ignored_versions) { ["> 1.14.13"] }
+      let(:raise_on_ignored) { true }
+
+      it "raises an error" do
+        expect { checker.latest_version }.to raise_error(Dependabot::AllVersionsIgnored)
       end
     end
   end


### PR DESCRIPTION
When running on GitHub, Dependabot sets `raise_on_ignore` to true in order to determine when a version update is not possible because the user has ignored all possible updates. It's expected that calling the updater's `latest_version` method will raise `AllVersionsIgnored` when that is the case.

cc: @sigurdm, @jonasfj 