### PR TITLE
Handle when `go: downloading` is emitted before an unknown revision error

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -31,7 +31,7 @@ module Dependabot
           /go: .*: invalid pseudo-version/m.freeze,
           # Package does not exist, has been pulled or cannot be reached due to
           # auth problems with either git or the go proxy
-          /go: .*: unknown revision/m.freeze,
+          /go(?: get)?: .*: unknown revision/m.freeze,
           # Package pointing to a proxy that 404s
           /go: .*: unrecognized import path/m.freeze
         ].freeze


### PR DESCRIPTION
When `go get github.com/org/repo@v1.2.3` starts with an empty module
cache, it appears to prepend an additional status string (copied from https://github.com/dependabot/dependabot-core/issues/4625#issuecomment-1067578732):

    # first run throws full error - note that repo2 is a direct dependency of repo1
    [dependabot-core-dev] ~/dependabot-core/tmp/<redacted-org>/repo1 $ GOPRIVATE=* go get -d github.com/<redacted-org>/repo2@v0.39.0
    go: downloading github.com/<redacted-org>/repo2 v0.39.0
    go get: reading google.golang.org/grpc/go.mod at revision v1.33.0: unknown revision

    # second run doesn't include the `go: downloading...` line
    [dependabot-core-dev] ~/dependabot-core/tmp/<redacted-org>/repo1 $ GOPRIVATE=* go get -d github.com/<redacted-org>/repo2@v0.39.0
    go get: reading google.golang.org/grpc/go.mod at revision v1.33.0: unknown revision v1.33.0

    # clean the modcache
    [dependabot-core-dev] ~/dependabot-core/tmp/<redacted-org>/repo1 $ go clean -modcache

    # the full error shows up again
    [dependabot-core-dev] ~/dependabot-core/tmp/<redacted-org>/repo1 $ GOPRIVATE=* go get -d github.com/<redacted-org>/repo2@v0.39.0
    go: downloading github.com/<redacted-org>/repo2 v0.39.0
    go get: reading google.golang.org/grpc/go.mod at revision v1.33.0: unknown revision

This `go: downloading abc` line causes the entire multi-line string to
match the regex for unknown revision:

```
go: .*: unknown revision
```

However, it doesn't match the single line that we care about:
```
go get: reading google.golang.org/grpc/go.mod at revision v1.33.0: unknown revision
```

So within `filter_error_message()`, the entire multi-line string is
returned, even though the first line is a simple status message, and we
only care about the second line:
https://github.com/dependabot/dependabot-core/blob/bc6162c1ae44c431ae2f394dccd270a762da6af8/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb#L266-L272

Because the entire line matches the regex, it's still correctly caught
as a repo resolvability error and ends up here:
https://github.com/dependabot/dependabot-core/blob/c4f3e6eae592c5c42332719b9e597c8bd47a2db9/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb#L243-L246

But then things go sideways, because this line grabs the wrong repo URL:
https://github.com/dependabot/dependabot-core/blob/c4f3e6eae592c5c42332719b9e597c8bd47a2db9/go_modules/lib/dependabot/go_modules/resolvability_errors.rb#L9

And from there it eventually manifests as the inscrutable error:
```
updater | INFO <job_254312325> Handled error whilst updating github.com/company/redactedrepo: git_dependencies_not_reachable {:"dependency-urls"=>["github.com/company/redactedrepo v0.50.0\ngo get"]}
```

While there's a number of additional defensive checks that can be added
later on in the process, ultimately the root problem is that the regex
simply needs to check for `go get:`, not just `go:`.

Even more confusingly, this problem seems to have disappeared with `go`
`1.18`. When I dug into the logs, it's because the `go get:` line now
reports itself as `go:`, so the original regex now matches.

But we've seen this `get` come and go... for example `go` `1.18`
actually added it back for something else: https://github.com/dependabot/dependabot-core/pull/4868

I don't actually know if the root cause is racy output within the `go
get` tooling (ie, intermittently appears in all versions), or if
refactoring from one `go` version to the next changes which section of
code outputs the status messages.

So in summary, we should add a non-capturing group to handle if/when the
`get` ever re-appears.

Fix #4625