### PR TITLE
Add option `get` to regex that match the `go` cmd

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -21,24 +21,24 @@ module Dependabot
           /fatal: The remote end hung up unexpectedly/,
           /repository '.+' not found/,
           # (Private) module could not be fetched
-          /go: .*: git (fetch|ls-remote) .*: exit status 128/m.freeze,
+          /go(?: get)?: .*: git (fetch|ls-remote) .*: exit status 128/m.freeze,
           # (Private) module could not be found
           /cannot find module providing package/.freeze,
           # Package in module was likely renamed or removed
           /module .* found \(.*\), but does not contain package/m.freeze,
           # Package pseudo-version does not match the version-control metadata
           # https://golang.google.cn/doc/go1.13#version-validation
-          /go: .*: invalid pseudo-version/m.freeze,
+          /go(?: get)?: .*: invalid pseudo-version/m.freeze,
           # Package does not exist, has been pulled or cannot be reached due to
           # auth problems with either git or the go proxy
           /go: .*: unknown revision/m.freeze,
           # Package pointing to a proxy that 404s
-          /go: .*: unrecognized import path/m.freeze
+          /go(?: get)?: .*: unrecognized import path/m.freeze
         ].freeze
 
         MODULE_PATH_MISMATCH_REGEXES = [
           /go(?: get)?: ([^@\s]+)(?:@[^\s]+)?: .* has non-.* module path "(.*)" at/,
-          /go: ([^@\s]+)(?:@[^\s]+)?: .* unexpected module path "(.*)"/,
+          /go(?: get)?: ([^@\s]+)(?:@[^\s]+)?: .* unexpected module path "(.*)"/,
           /go(?: get)?: ([^@\s]+)(?:@[^\s]+)?:? .* declares its path as: ([\S]*)/m
         ].freeze
 


### PR DESCRIPTION
There's been several annoying bugs that turned out to be caused by error
messages that used to be emitted as `go: ABC` now emitted as `go get:
ABC`:
* https://github.com/dependabot/dependabot-core/pull/4868
* https://github.com/dependabot/dependabot-core/pull/4910

Given this, we should proactively handle this in the other regexes that
look like they might be susceptible to this.

There are two ways to do this:
1. Add an optional non-capturing group: `(?: get)?`
2. Completely remove the `go: ` prefix from the regex.

I went with the first option, because I was concerned the second might
match individual lines within a _legitimate_ multi-line error message.

IE, I've seen go error messages that list a mult-line dep tree, with
only the last line listing the actual error text. But the first line
listed the `go: ` prefix. And by keeping the regex wide, it reported the
entire error in the Dependabot status page, which was very useful for
tracking down what was throwing the error.

Whereas if we go with option two, then since that will match an
individual line, the "stack trace" of the error will be dropped.

But I'm open to feedback if there's something I'm overlooking here.