### PR TITLE
Metadetafinders: Use the default branch instead of master for gitlab

### DIFF
--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -271,6 +271,7 @@ module Dependabot
         end
 
         def fetch_gitlab_file_list
+          branch = default_gitlab_branch
           gitlab_client.repo_tree(source.repo).map do |file|
             type = case file.type
                    when "blob" then "file"
@@ -281,8 +282,8 @@ module Dependabot
               name: file.name,
               type: type,
               size: 100, # GitLab doesn't return file size
-              html_url: "#{source.url}/blob/master/#{file.path}",
-              download_url: "#{source.url}/raw/master/#{file.path}"
+              html_url: "#{source.url}/blob/#{branch}/#{file.path}",
+              download_url: "#{source.url}/raw/#{branch}/#{file.path}"
             )
           end
         rescue Gitlab::Error::NotFound
@@ -354,6 +355,11 @@ module Dependabot
         def default_bitbucket_branch
           @default_bitbucket_branch ||=
             bitbucket_client.fetch_default_branch(source.repo)
+        end
+
+        def default_gitlab_branch
+          @default_gitlab_branch ||=
+            gitlab_client.fetch_default_branch(source.repo)
         end
       end
     end

--- a/common/lib/dependabot/metadata_finders/base/commits_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/commits_finder.rb
@@ -210,7 +210,7 @@ module Dependabot
           elsif new_tag
             "commits/#{new_tag}"
           else
-            "commits/master"
+            "commits/#{default_gitlab_branch}"
           end
         end
 
@@ -320,6 +320,11 @@ module Dependabot
         def reliable_source_directory?
           MetadataFinders::Base::PACKAGE_MANAGERS_WITH_RELIABLE_DIRECTORIES.
             include?(dependency.package_manager)
+        end
+
+        def default_gitlab_branch
+          @default_gitlab_branch ||=
+            gitlab_client.fetch_default_branch(source.repo)
         end
       end
     end

--- a/common/spec/dependabot/metadata_finders/base/changelog_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/changelog_finder_spec.rb
@@ -499,6 +499,9 @@ RSpec.describe Dependabot::MetadataFinders::Base::ChangelogFinder do
       let(:gitlab_raw_changelog_url) do
         "https://gitlab.com/org/business/raw/master/CHANGELOG.md"
       end
+      let(:gitlab_repo_url) do
+        "https://gitlab.com/api/v4/projects/org%2Fbusiness"
+      end
 
       let(:gitlab_status) { 200 }
       let(:gitlab_response) { fixture("gitlab", "business_files.json") }
@@ -513,6 +516,10 @@ RSpec.describe Dependabot::MetadataFinders::Base::ChangelogFinder do
         stub_request(:get, gitlab_url).
           to_return(status: gitlab_status,
                     body: gitlab_response,
+                    headers: { "Content-Type" => "application/json" })
+        stub_request(:get, gitlab_repo_url).
+          to_return(status: 200,
+                    body: fixture("gitlab", "bump_repo.json"),
                     headers: { "Content-Type" => "application/json" })
         stub_request(:get, gitlab_raw_changelog_url).
           to_return(status: 200,
@@ -857,6 +864,9 @@ RSpec.describe Dependabot::MetadataFinders::Base::ChangelogFinder do
       let(:gitlab_raw_changelog_url) do
         "https://gitlab.com/org/business/raw/master/CHANGELOG.md"
       end
+      let(:gitlab_repo_url) do
+        "https://gitlab.com/api/v4/projects/org%2Fbusiness"
+      end
 
       let(:gitlab_contents_response) do
         fixture("gitlab", "business_files.json")
@@ -872,6 +882,10 @@ RSpec.describe Dependabot::MetadataFinders::Base::ChangelogFinder do
         stub_request(:get, gitlab_url).
           to_return(status: 200,
                     body: gitlab_contents_response,
+                    headers: { "Content-Type" => "application/json" })
+        stub_request(:get, gitlab_repo_url).
+          to_return(status: 200,
+                    body: fixture("gitlab", "bump_repo.json"),
                     headers: { "Content-Type" => "application/json" })
         stub_request(:get, gitlab_raw_changelog_url).
           to_return(status: 200,

--- a/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
@@ -582,12 +582,22 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
         "https://gitlab.com/org/business.git/info/refs"\
         "?service=git-upload-pack"
       end
+      let(:gitlab_repo_url) do
+        "https://gitlab.com/api/v4/projects/org%2Fbusiness"
+      end
 
       let(:source) do
         Dependabot::Source.new(
           provider: "gitlab",
           repo: "org/#{dependency_name}"
         )
+      end
+
+      before do
+        stub_request(:get, gitlab_repo_url).
+          to_return(status: 200,
+                    body: fixture("gitlab", "bump_repo.json"),
+                    headers: { "Content-Type" => "application/json" })
       end
 
       context "with old and new tags" do


### PR DESCRIPTION
This pull request Fixes #4897 by replacing the hard-coded `master` with the default branch of the repository

