### PR TITLE
Add support for Python packages with epoch version

### DIFF
--- a/python/lib/dependabot/python/requirement_parser.rb
+++ b/python/lib/dependabot/python/requirement_parser.rb
@@ -6,7 +6,7 @@ module Dependabot
       NAME = /[a-zA-Z0-9](?:[a-zA-Z0-9\-_\.]*[a-zA-Z0-9])?/.freeze
       EXTRA = /[a-zA-Z0-9\-_\.]+/.freeze
       COMPARISON = /===|==|>=|<=|<|>|~=|!=/.freeze
-      VERSION = /[0-9]+[a-zA-Z0-9\-_\.*]*(\+[0-9a-zA-Z]+(\.[0-9a-zA-Z]+)*)?/.
+      VERSION = /([1-9][0-9]*!)?[0-9]+[a-zA-Z0-9\-_.*]*(\+[0-9a-zA-Z]+(\.[0-9a-zA-Z]+)*)?/.
                 freeze
       REQUIREMENT =
         /(?<comparison>#{COMPARISON})\s*\\?\s*(?<version>#{VERSION})/.freeze

--- a/python/lib/dependabot/python/version.rb
+++ b/python/lib/dependabot/python/version.rb
@@ -68,7 +68,7 @@ module Dependabot
       private
 
       def epoch_comparison(other)
-        epoch.to_i - other.epoch.to_i
+        epoch.to_i <=> other.epoch.to_i
       end
 
       def post_version_comparison(other)
@@ -78,7 +78,7 @@ module Dependabot
 
         return -1 if post_release_version.nil?
 
-        post_release_version.to_i - other.post_release_version.to_i
+        post_release_version.to_i <=> other.post_release_version.to_i
       end
 
       def local_version_comparison(other)

--- a/python/lib/dependabot/python/version.rb
+++ b/python/lib/dependabot/python/version.rb
@@ -14,7 +14,6 @@ module Dependabot
       attr_reader :local_version
       attr_reader :post_release_version
 
-
       # See https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
       VERSION_PATTERN = 'v?([1-9][0-9]*!)?[0-9]+[0-9a-zA-Z]*(?>\.[0-9a-zA-Z]+)*' \
                         '(-[0-9A-Za-z-]+(\.[0-9a-zA-Z-]+)*)?' \

--- a/python/lib/dependabot/python/version.rb
+++ b/python/lib/dependabot/python/version.rb
@@ -14,6 +14,8 @@ module Dependabot
       attr_reader :local_version
       attr_reader :post_release_version
 
+
+      # See https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
       VERSION_PATTERN = 'v?([1-9][0-9]*!)?[0-9]+[0-9a-zA-Z]*(?>\.[0-9a-zA-Z]+)*' \
                         '(-[0-9A-Za-z-]+(\.[0-9a-zA-Z-]+)*)?' \
                         '(\+[0-9a-zA-Z]+(\.[0-9a-zA-Z]+)*)?'

--- a/python/spec/dependabot/python/requirement_parser_spec.rb
+++ b/python/spec/dependabot/python/requirement_parser_spec.rb
@@ -64,6 +64,13 @@ RSpec.describe Dependabot::Python::RequirementParser do
       it { is_expected.to be_nil }
     end
 
+    context "with an epoch specification" do
+      let(:line) { "luigi==1!1.1.0"}
+      its([:requirements]) do
+        is_expected.to eq [{ comparison: "==", version: "1!1.1.0" }]
+      end
+    end
+
     context "with a simple specification" do
       let(:line) { "luigi == 0.1.0" }
       its([:requirements]) do

--- a/python/spec/dependabot/python/requirement_parser_spec.rb
+++ b/python/spec/dependabot/python/requirement_parser_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Dependabot::Python::RequirementParser do
     end
 
     context "with an epoch specification" do
-      let(:line) { "luigi==1!1.1.0"}
+      let(:line) { "luigi==1!1.1.0" }
       its([:requirements]) do
         is_expected.to eq [{ comparison: "==", version: "1!1.1.0" }]
       end

--- a/python/spec/dependabot/python/version_spec.rb
+++ b/python/spec/dependabot/python/version_spec.rb
@@ -89,6 +89,8 @@ RSpec.describe Dependabot::Python::Version do
       "1.0.0+gc1",
       "1.post2",
       "1.post2+gc1",
+      "1.post2+gc1.2",
+      "1.post2+gc1.11",
       "1.0.0.post11",
       "1.0.2",
       "1.0.11",

--- a/python/spec/dependabot/python/version_spec.rb
+++ b/python/spec/dependabot/python/version_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Dependabot::Python::Version do
       "1.post2",
       "1.post2+gc1",
       "1.0.0.post11",
-      "1.0.1",
+      "1.0.2",
       "1.0.11",
       "2016.1",
       "1!0.1.0",

--- a/python/spec/dependabot/python/version_spec.rb
+++ b/python/spec/dependabot/python/version_spec.rb
@@ -86,7 +86,9 @@ RSpec.describe Dependabot::Python::Version do
       "1.0.0-rc.1",
       "1",
       # "1.0.0.post", TODO fails comparing to 1
+      "1.0.0+gc1",
       "1.post2",
+      "1.post2+gc1",
       "1.0.0.post11",
       "1.0.1",
       "1.0.11",


### PR DESCRIPTION
@kohder thanks for PR #4891!

While I was reviewing that PR I noticed we would also need to add epoch support to the `requirement_parser`, so I went ahead and did that in this branch on top of your changes. I also made a few simplifications to the code and brought in more thorough tests like those in the nuget spec.

Let me know what you think, and I will also get another @dependabot/reviewers to take a look at these changes as well!

Fixes #3165