### PR TITLE
Remove workaround for broken ruby gems compare

### DIFF
--- a/python/lib/dependabot/python/version.rb
+++ b/python/lib/dependabot/python/version.rb
@@ -45,7 +45,7 @@ module Dependabot
       end
 
       def <=>(other)
-        version_comparison = old_comp(other)
+        version_comparison = super(other)
         return version_comparison unless version_comparison.zero?
 
         return post_version_comparison(other) unless post_version_comparison(other).zero?
@@ -108,44 +108,6 @@ module Dependabot
           tr("-", ".").
           gsub(/(\d)([a-z])/i, '\1.\2')
       end
-
-      # TODO: Delete this once we're using a version of Rubygems that includes
-      # https://github.com/rubygems/rubygems/pull/2651
-      #
-      # rubocop:disable Metrics/PerceivedComplexity
-      # rubocop:disable Style/CaseEquality
-      # rubocop:disable Style/ParallelAssignment
-      # rubocop:disable Style/RedundantReturn
-      def old_comp(other)
-        return unless Gem::Version === other
-        return 0 if @version == other._version || canonical_segments == other.canonical_segments
-
-        lhsegments = canonical_segments
-        rhsegments = other.canonical_segments
-
-        lhsize = lhsegments.size
-        rhsize = rhsegments.size
-        limit  = (lhsize > rhsize ? lhsize : rhsize) - 1
-
-        i = 0
-
-        while i <= limit
-          lhs, rhs = lhsegments[i] || 0, rhsegments[i] || 0
-          i += 1
-
-          next      if lhs == rhs
-          return -1 if String  === lhs && Numeric === rhs
-          return  1 if Numeric === lhs && String  === rhs
-
-          return lhs <=> rhs
-        end
-
-        return 0
-      end
-      # rubocop:enable Metrics/PerceivedComplexity
-      # rubocop:enable Style/CaseEquality
-      # rubocop:enable Style/ParallelAssignment
-      # rubocop:enable Style/RedundantReturn
     end
   end
 end


### PR DESCRIPTION
This was added in https://github.com/dependabot/dependabot-core/commit/cdb346e6653e217e6726e44eaefb92b1a8c6c126 as a temporary workaround
until https://github.com/rubygems/rubygems/pull/2651 shipped.

It looks like that shipped in Ruby Gems `3.1.0`, and Dependabot is currently on 
Ruby Gems `3.2.20`: https://github.com/dependabot/dependabot-core/blob/9c090f6fe573aa3b6b05d20920c7c48f5f00403f/Dockerfile#L77

So this should be safe to remove.

Note that I removed the code workaround from the original commit, but
not the test cases... so they should catch any regressions.