### PR TITLE
fix error due to not handling case statements in Gemfile

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb
@@ -73,7 +73,7 @@ module Dependabot
         class Rewriter < Parser::TreeRewriter
           # TODO: Ideally we wouldn't have to ignore all of these, but
           # implementing each one will be tricky.
-          SKIPPED_TYPES = %i(send lvar dstr begin if splat const or).freeze
+          SKIPPED_TYPES = %i(send lvar dstr begin if case splat const or).freeze
 
           def initialize(dependency:, file_type:, updated_requirement:,
                          insert_if_bare:)

--- a/bundler/spec/dependabot/bundler/file_updater/requirement_replacer_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/requirement_replacer_spec.rb
@@ -186,6 +186,11 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RequirementReplacer do
         end
       end
 
+      context "with a case statement" do
+        let(:content) { %(gem "business",  case true\n when true\n "1.0.0"\n else\n "1.2.0"\n end) }
+        it { is_expected.to eq(content) }
+      end
+
       context "with a conditional" do
         let(:content) { %(gem "business", ENV["ROUGE"] if ENV["ROUGE"]) }
         it { is_expected.to eq(content) }


### PR DESCRIPTION
Users with case statements in their Gemfile such as this:

```ruby
gem "activemodel", case activemodel_version
                   when "default"
                     ">= 6.1"
                   else
                     "~> #{activemodel_version}"
                   end
```

Are seeing an error like this:

```
NoMethodError:
 undefined method `begin' for #<Parser::Source::Map:0x000000010f824140 @expression=#<Parser::Source::Range (gemfile_content) 22...26>, @node=s(:true)>

                 requirement_nodes.first.children.first.loc.begin.source,
                                                           ^^^^^^
# ./lib/dependabot/bundler/file_updater/requirement_replacer.rb:147:in `extract_quote_characters_from'
# ./lib/dependabot/bundler/file_updater/requirement_replacer.rb:99:in `on_send'
# ./lib/dependabot/bundler/file_updater/requirement_replacer.rb:32:in `rewrite'
```

While rewriting the Gemfile, the code skips over certain AST nodes that would be difficult to handle. 

Adding the case statement to the skip list fixes the error.