### PR TITLE
Cargo: Update specs to reference latest version of dependency used

### DIFF
--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
 
         let(:dependency_name) { "utf8-ranges" }
         let(:dependency_version) do
-          "8d38a931b7e34f9da339c058cbbca6ded624ea58"
+          "be9b8dfcaf449453cbf83ac85260ee80323f4f77"
         end
         let(:dependency_previous_version) do
           "83141b376b93484341c68fbca3ca110ae5cd2708"
@@ -230,7 +230,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
 
         it "updates the dependency version in the lockfile" do
           expect(updated_lockfile_content).
-            to include("utf8-ranges#8d38a931b7e34f9da339c058cbbca6ded624ea58")
+            to include("utf8-ranges#be9b8dfcaf449453cbf83ac85260ee80323f4f77")
         end
 
         context "with an ssh URl" do
@@ -254,7 +254,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
           it "updates the dependency version in the lockfile" do
             expect(updated_lockfile_content).
               to include("git+ssh://git@github.com/BurntSushi/utf8-ranges#"\
-                         "8d38a931b7e34f9da339c058cbbca6ded624ea58")
+                         "be9b8dfcaf449453cbf83ac85260ee80323f4f77")
             expect(updated_lockfile_content).to_not include("git+https://")
 
             content = updated_lockfile_content

--- a/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
       let(:dependency_version) { "0.1.3" }
       let(:string_req) { "0.1.3" }
 
-      it { is_expected.to eq(Gem::Version.new("1.0.4")) }
+      it { is_expected.to eq(Gem::Version.new("1.0.5")) }
     end
 
     context "with a git dependency" do
@@ -264,7 +264,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
         }
       end
 
-      it { is_expected.to eq("8d38a931b7e34f9da339c058cbbca6ded624ea58") }
+      it { is_expected.to eq("be9b8dfcaf449453cbf83ac85260ee80323f4f77") }
 
       context "with a tag" do
         let(:manifest_fixture_name) { "git_dependency_with_tag" }

--- a/cargo/spec/dependabot/cargo/update_checker_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
         }
       end
 
-      it { is_expected.to eq("8d38a931b7e34f9da339c058cbbca6ded624ea58") }
+      it { is_expected.to eq("be9b8dfcaf449453cbf83ac85260ee80323f4f77") }
 
       context "with a tag" do
         let(:manifest_fixture_name) { "git_dependency_with_tag" }
@@ -302,7 +302,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
           }
         end
 
-        it { is_expected.to eq("8d38a931b7e34f9da339c058cbbca6ded624ea58") }
+        it { is_expected.to eq("be9b8dfcaf449453cbf83ac85260ee80323f4f77") }
       end
     end
 
@@ -394,7 +394,7 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
           )
       end
 
-      it { is_expected.to eq("8d38a931b7e34f9da339c058cbbca6ded624ea58") }
+      it { is_expected.to eq("be9b8dfcaf449453cbf83ac85260ee80323f4f77") }
 
       context "with a tag" do
         let(:manifest_fixture_name) { "git_dependency_with_tag" }


### PR DESCRIPTION
These tests rely on a publicly hosted dependency that was updated. We
should update these tests to reference dependencies that we own, but to
get our test-suite passing I've updated the references for now.