### PR TITLE
Update pub dependency service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -249,7 +249,7 @@ RUN DART_ARCH=${TARGETARCH} \
 # We pull the dependency_services from the dart-lang/pub repo as it is not
 # exposed from the Dart SDK (yet...).
 RUN git clone https://github.com/dart-lang/pub.git /opt/dart/pub \
-  && git -C /opt/dart/pub checkout 3082796f8ba9b3f509265ac3a223312fb5033988 \
+  && git -C /opt/dart/pub checkout 62bb244059415cf0c78b24151472efd46ad7569a \
   && dart pub global activate --source path /opt/dart/pub \
   && chmod -R o+r "/opt/dart/pub" \
   && chown -R dependabot:dependabot "$PUB_CACHE" \


### PR DESCRIPTION
New commits: 
```
> git log --format="%C(auto) %h %s" 3082796f8ba9b3f509265ac3a223312fb5033988...62bb244059415cf0c78b24151472efd46ad7569a
 62bb2440 Fix `dependency_services apply` for packages with relative imports (#3374)
 a949b329 Fix handling of 'git@github.com:dart-lang/pub.git' style urls in git source (#3381)
 c6cd3758 Always use forward slash for relative paths in lockfile (#3379)
 7d48f902 Remove unused function (#3370)
 b1373d4c Fix import prefix (#3369)
 a3a102a5 Fix equality and hashcode for the sdk descriptors (#3367)
 94ae66a6 Refine what a relative uri means in a git path (#3212)
 cc4c1292 Only call Package.listFiles once per publish. (#3346)
 f4484073 Fix test/global/activate/git_package_test test on windows (#3361)
 610ce7f2 Refactor descriptors (#3305)
 953b6097 Substitute pub.dartlang.org for of pub.dev (#3358)
 7a6ea396 Add support for pubspec overrides file (#3215)
 8abfed9d Global activate git path and ref (#3356)
 d1c0e3f9 Revert "Add flag controlling creation of `.packages` file. (#2757)" (#3357)
 274f5ad9 Fix signals test (#3359)
 83437005 Avoid failing in gitignore validator (#3354)
 ```
 Relevant for dependabot is:
 ```
  62bb2440 Fix `dependency_services apply` for packages with relative imports (#3374)
 ```
 That fixes: https://github.com/dart-lang/pub/issues/3373