### PR TITLE
code is unsused: main packages have no particular effect on dependencies

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -36,10 +36,6 @@ module Dependabot
           # Fetch the (optional) go.sum
           fetched_files << go_sum if go_sum
 
-          # Fetch the main.go file if present, as this will later identify
-          # this repo as an app.
-          fetched_files << main if main
-
           fetched_files
         end
       end
@@ -50,27 +46,6 @@ module Dependabot
 
       def go_sum
         @go_sum ||= fetch_file_if_present("go.sum")
-      end
-
-      def main
-        return @main if defined?(@main)
-
-        go_files = Dir.glob("*.go")
-
-        go_files.each do |filename|
-          file_content = File.read(filename)
-          next unless file_content.match?(/\s*package\s+main/)
-
-          return @main = DependencyFile.new(
-            name: Pathname.new(filename).cleanpath.to_path,
-            directory: "/",
-            type: "package_main",
-            support_file: true,
-            content: file_content
-          )
-        end
-
-        nil
       end
     end
   end

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -92,10 +92,6 @@ module Dependabot
         git_dependency?
       end
 
-      def library?
-        dependency_files.none? { |f| f.type == "package_main" }
-      end
-
       def version_from_tag(tag)
         # To compare with the current version we either use the commit SHA
         # (if that's what the parser picked up) or the tag name.

--- a/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
@@ -59,15 +59,4 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
         to raise_error(Dependabot::DependencyFileNotFound)
     end
   end
-
-  context "for an application" do
-    let(:repo) { "dependabot-fixtures/go-modules-app" }
-
-    it "fetches the main.go, too" do
-      expect(file_fetcher_instance.files.map(&:name)).
-        to include("main.go")
-      expect(file_fetcher_instance.files.
-        find { |f| f.name == "main.go" }.type).to eq("package_main")
-    end
-  end
 end


### PR DESCRIPTION
While looking at #4954 I noticed the code was gathering main files for some reason, so I pulled the thread and it wasn't attached to anything!

I assume this code was from the days of `dep`. Go modules don't give main files any special treatment, so removing this code. 