### PR TITLE
Allow open_timeout to be configured by ENV var

### DIFF
--- a/common/lib/dependabot/clients/github_with_retries.rb
+++ b/common/lib/dependabot/clients/github_with_retries.rb
@@ -5,11 +5,16 @@ require "octokit"
 module Dependabot
   module Clients
     class GithubWithRetries
-      OPEN_TIMEOUT_IN_SECONDS = ENV["DEPENDABOT_OPEN_TIMEOUT_IN_SECONDS"] || 2
+      DEFAULT_OPEN_TIMEOUT_IN_SECONDS = 2
+
+      def self.open_timeout_in_seconds
+        ENV.fetch("DEPENDABOT_OPEN_TIMEOUT_IN_SECONDS", DEFAULT_OPEN_TIMEOUT_IN_SECONDS).to_i
+      end
+
       DEFAULT_CLIENT_ARGS = {
         connection_options: {
           request: {
-            open_timeout: OPEN_TIMEOUT_IN_SECONDS.to_i,
+            open_timeout: open_timeout_in_seconds,
             timeout: 5
           }
         }

--- a/common/lib/dependabot/clients/github_with_retries.rb
+++ b/common/lib/dependabot/clients/github_with_retries.rb
@@ -5,10 +5,11 @@ require "octokit"
 module Dependabot
   module Clients
     class GithubWithRetries
+      OPEN_TIMEOUT_IN_SECONDS = ENV["OPEN_TIMEOUT_IN_SECONDS"] || 2
       DEFAULT_CLIENT_ARGS = {
         connection_options: {
           request: {
-            open_timeout: 2,
+            open_timeout: OPEN_TIMEOUT_IN_SECONDS.to_i,
             timeout: 5
           }
         }

--- a/common/lib/dependabot/clients/github_with_retries.rb
+++ b/common/lib/dependabot/clients/github_with_retries.rb
@@ -5,7 +5,7 @@ require "octokit"
 module Dependabot
   module Clients
     class GithubWithRetries
-      OPEN_TIMEOUT_IN_SECONDS = ENV["OPEN_TIMEOUT_IN_SECONDS"] || 2
+      OPEN_TIMEOUT_IN_SECONDS = ENV["DEPENDABOT_OPEN_TIMEOUT_IN_SECONDS"] || 2
       DEFAULT_CLIENT_ARGS = {
         connection_options: {
           request: {

--- a/common/spec/dependabot/clients/github_with_retries_spec.rb
+++ b/common/spec/dependabot/clients/github_with_retries_spec.rb
@@ -50,4 +50,22 @@ RSpec.describe Dependabot::Clients::GithubWithRetries do
       its(:name) { is_expected.to eq("Gemfile") }
     end
   end
+
+  describe ".open_timeout_in_seconds" do
+    context "when DEPENDABOT_OPEN_TIMEOUT_IN_SECONDS is set" do
+      it "returns the provided value" do
+        override_value = 10
+        stub_const("ENV", ENV.to_hash.merge("DEPENDABOT_OPEN_TIMEOUT_IN_SECONDS" => override_value))
+
+        expect(described_class.open_timeout_in_seconds).to eq(override_value)
+      end
+    end
+
+    context "when ENV does not provide an override" do
+      it "falls back to a default value" do
+        expect(described_class.open_timeout_in_seconds).
+          to eq(described_class::DEFAULT_OPEN_TIMEOUT_IN_SECONDS)
+      end
+    end
+  end
 end


### PR DESCRIPTION
We want this value to be configurable so that it can vary by
environment. For example, GHES customers might run Dependabot in a
higher latency network. In these cases, the previous timeout of two
seconds is not enough.

Note: I had wanted to get some tests on these, but relying on constants
to store the values makes the scope of this change larger than I would
like. I'm open to re-architecting if needed. Verification of this change
would also be somewhat sticky as we'd need to reach into the Octokit
client and inspect its values. While I've done that in a debugger, doing
so in a test seems less than ideal.