### PR TITLE
Make maven repo upstream configurable

### DIFF
--- a/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
+++ b/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
@@ -23,7 +23,7 @@ module Dependabot
 
         # The Central Repository is included in the Super POM, which is
         # always inherited from.
-        CENTRAL_REPO_URL = "https://repo.maven.apache.org/maven2"
+        CENTRAL_REPO_URL = ENV['SETTINGS_CENTRAL_REPO_URL'] || "https://repo.maven.apache.org/maven2"
 
         def initialize(dependency_files:, evaluate_properties: true)
           @dependency_files = dependency_files


### PR DESCRIPTION
Since we are behind a corporate firewall and the proxy settings http_proxy and https_proxy settings are not respected, find that this could be an easy minimal change to accommodate our needs.

Not really coder anymore so if the syntax is incorrect please let me know the correct way of doing it. Should be easy enough:

https://github.com/dependabot/dependabot-core/issues/3806