### PR TITLE
Python: unwrap arbitrary parentheses from requirement string

### DIFF
--- a/python/lib/dependabot/python/requirement.rb
+++ b/python/lib/dependabot/python/requirement.rb
@@ -20,7 +20,7 @@ module Dependabot
 
       PATTERN_RAW = "\\s*(#{quoted})?\\s*(#{version_pattern})\\s*"
       PATTERN = /\A#{PATTERN_RAW}\z/.freeze
-      PARENS_PATTERN = /\A*\(([^)]+)\)*\z/.freeze
+      PARENS_PATTERN = /\A\(([^)]+)\)\z/.freeze
 
       def self.parse(obj)
         return ["=", Python::Version.new(obj.to_s)] if obj.is_a?(Gem::Version)

--- a/python/lib/dependabot/python/requirement.rb
+++ b/python/lib/dependabot/python/requirement.rb
@@ -6,7 +6,7 @@ require "dependabot/python/version"
 module Dependabot
   module Python
     class Requirement < Gem::Requirement
-      OR_SEPARATOR = /(?<=[a-zA-Z0-9*])\s*\|+/.freeze
+      OR_SEPARATOR = /(?<=[a-zA-Z0-9)*])\s*\|+/.freeze
 
       # Add equality and arbitrary-equality matchers
       OPS = OPS.merge(
@@ -20,11 +20,17 @@ module Dependabot
 
       PATTERN_RAW = "\\s*(#{quoted})?\\s*(#{version_pattern})\\s*"
       PATTERN = /\A#{PATTERN_RAW}\z/.freeze
+      PARENS_PATTERN = /\A*\(([^)]+)\)*\z/.freeze
 
       def self.parse(obj)
         return ["=", Python::Version.new(obj.to_s)] if obj.is_a?(Gem::Version)
 
-        unless (matches = PATTERN.match(obj.to_s))
+        line = obj.to_s
+        if (matches = PARENS_PATTERN.match(line))
+          line = matches[1]
+        end
+
+        unless (matches = PATTERN.match(line))
           msg = "Illformed requirement [#{obj.inspect}]"
           raise BadRequirementError, msg
         end
@@ -40,6 +46,10 @@ module Dependabot
       # NOTE: Or requirements are only valid for Poetry.
       def self.requirements_array(requirement_string)
         return [new(nil)] if requirement_string.nil?
+
+        if (matches = PARENS_PATTERN.match(requirement_string))
+          requirement_string = matches[1]
+        end
 
         requirement_string.strip.split(OR_SEPARATOR).map do |req_string|
           new(req_string.strip)

--- a/python/spec/dependabot/python/requirement_spec.rb
+++ b/python/spec/dependabot/python/requirement_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Dependabot::Python::Requirement do
     end
 
     context "with a illformed parentheses" do
-      let(:requirement_string) { "(== 1.2).1'" }
+      let(:requirement_string) { "(== 1.2).1" }
 
       it "raises a helpful error" do
         expect { subject }.
@@ -189,6 +189,15 @@ RSpec.describe Dependabot::Python::Requirement do
           to match_array(
             [Gem::Requirement.new("1.2.1"), Gem::Requirement.new(">= 1.5.0")]
           )
+      end
+    end
+
+    context "with illformed parentheses inside an || requirement" do
+      let(:requirement_string) { "1.2.1) || >= 1.5.0" }
+
+      it "raises a helpful error" do
+        expect { subject }.
+          to raise_error(Gem::Requirement::BadRequirementError)
       end
     end
   end

--- a/python/spec/dependabot/python/requirement_spec.rb
+++ b/python/spec/dependabot/python/requirement_spec.rb
@@ -139,9 +139,13 @@ RSpec.describe Dependabot::Python::Requirement do
       it { is_expected.to eq([Gem::Requirement.new("1.2.1")]) }
     end
 
-    context "wrapped in parentheses" do
-      let(:requirement_string) { "(1.2.1)" }
-      it { is_expected.to eq([Gem::Requirement.new("1.2.1")]) }
+    context "with a illformed parentheses" do
+      let(:requirement_string) { "(== 1.2).1'" }
+
+      it "raises a helpful error" do
+        expect { subject }.
+          to raise_error(Gem::Requirement::BadRequirementError)
+      end
     end
 
     context "with an || requirement" do

--- a/python/spec/dependabot/python/requirement_spec.rb
+++ b/python/spec/dependabot/python/requirement_spec.rb
@@ -139,6 +139,11 @@ RSpec.describe Dependabot::Python::Requirement do
       it { is_expected.to eq([Gem::Requirement.new("1.2.1")]) }
     end
 
+    context "wrapped in parentheses" do
+      let(:requirement_string) { "(1.2.1)" }
+      it { is_expected.to eq([Gem::Requirement.new("1.2.1")]) }
+    end
+
     context "with an || requirement" do
       let(:requirement_string) { "1.2.1 || >= 1.5.0" }
 
@@ -158,6 +163,28 @@ RSpec.describe Dependabot::Python::Requirement do
               [described_class.new("^0.8.0"), described_class.new("^1.2.0")]
             )
         end
+      end
+    end
+
+    context "with parens wrapping an || requirement" do
+      let(:requirement_string) { "(1.2.1 || >= 1.5.0)" }
+
+      it "generates the correct array of requirements" do
+        expect(requirements_array).
+          to match_array(
+            [Gem::Requirement.new("1.2.1"), Gem::Requirement.new(">= 1.5.0")]
+          )
+      end
+    end
+
+    context "with parens inside an || requirement" do
+      let(:requirement_string) { "(1.2.1) || (>= 1.5.0)" }
+
+      it "generates the correct array of requirements" do
+        expect(requirements_array).
+          to match_array(
+            [Gem::Requirement.new("1.2.1"), Gem::Requirement.new(">= 1.5.0")]
+          )
       end
     end
   end


### PR DESCRIPTION
When encountering a Python requirement containing parentheses, dependabot-core would throw `Illformed requirement`. 

This fixes that error by unwrapping simple parenthesis patterns. 

I tried looking in the [packaging](https://github.com/pypa/packaging/blob/main/tests/test_requirements.py) and [poetry](https://github.com/python-poetry/poetry-core/blob/master/tests/version/test_requirements.py) tests for more complex examples but could only find simple ones. Hopefully that means this will catch most of the use cases for parentheses inside of a requirement string!