### PR TITLE
Update Bundler from 2.3.10 to 2.3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN apt-add-repository ppa:brightbox/ruby-ng \
   && apt-get install -y --no-install-recommends ruby2.7 ruby2.7-dev \
   && gem update --system 3.2.20 \
   && gem install bundler -v 1.17.3 --no-document \
-  && gem install bundler -v 2.3.10 --no-document \
+  && gem install bundler -v 2.3.12 --no-document \
   && rm -rf /var/lib/gems/2.7.0/cache/* \
   && rm -rf /var/lib/apt/lists/*
 

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -22,6 +22,6 @@ cd "$install_dir"
 
 # NOTE: Sets `BUNDLED WITH` to match the installed v2 version in Gemfile.lock
 # forcing specs and native helpers to run with the same version
-BUNDLER_VERSION=2.3.10 bundle config --local path ".bundle"
-BUNDLER_VERSION=2.3.10 bundle config --local without "test"
-BUNDLER_VERSION=2.3.10 bundle install
+BUNDLER_VERSION=2.3.12 bundle config --local path ".bundle"
+BUNDLER_VERSION=2.3.12 bundle config --local without "test"
+BUNDLER_VERSION=2.3.12 bundle install

--- a/bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb
@@ -5,15 +5,31 @@ require "bundler/definition"
 module BundlerDefinitionRubyVersionPatch
   def source_requirements
     if ruby_version
-      requested_version = ruby_version.to_gem_version_with_patchlevel
+      requested_version = ruby_version.gem_version
       sources.metadata_source.specs <<
         Gem::Specification.new("Ruby\0", requested_version)
     end
 
     sources.metadata_source.specs <<
-      Gem::Specification.new("Ruby\0", "2.5.3p105")
+      Gem::Specification.new("Ruby\0", "2.5.3")
 
     super
+  end
+
+  def metadata_dependencies
+    @metadata_dependencies ||=
+      [
+        Bundler::Dependency.new("Ruby\0", ruby_version_requirements),
+        Bundler::Dependency.new("RubyGems\0", Gem::VERSION)
+      ]
+  end
+
+  def ruby_version_requirements
+    return [] unless ruby_version
+
+    ruby_version.versions.map do |version|
+      Gem::Requirement.new(version)
+    end
   end
 end
 

--- a/bundler/lib/dependabot/bundler/helpers.rb
+++ b/bundler/lib/dependabot/bundler/helpers.rb
@@ -4,7 +4,7 @@ module Dependabot
   module Bundler
     module Helpers
       V1 = "1.17.3"
-      V2 = "2.3.10"
+      V2 = "2.3.12"
       # If we are updating a project with no Gemfile.lock, we default to the
       # newest version we support
       DEFAULT = V2

--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -15,7 +15,7 @@ fi
 
 if [[ "$SUITE_NAME" == "bundler2" ]]; then
   cd helpers/v2 \
-    && BUNDLER_VERSION=2.3.10 bundle install \
-    && BUNDLER_VERSION=2.3.10 bundle exec rspec spec \
+    && BUNDLER_VERSION=2.3.12 bundle install \
+    && BUNDLER_VERSION=2.3.12 bundle exec rspec spec \
     && cd -
 fi

--- a/bundler/spec/dependabot/bundler/helper_spec.rb
+++ b/bundler/spec/dependabot/bundler/helper_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Dependabot::Bundler::Helpers do
   end
 
   let(:v1) { "1.17.3" }
-  let(:v2) { "2.3.10" }
+  let(:v2) { "2.3.12" }
 
   describe "#bundler_version" do
     def described_method(lockfile)

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -20,7 +20,7 @@ module PackageManagerHelper
   end
 
   def self.bundler_version
-    use_bundler_2? ? "2.3.10" : "1.17.3"
+    use_bundler_2? ? "2.3.12" : "1.17.3"
   end
 
   def self.bundler_major_version


### PR DESCRIPTION
Includes a small change in monkeypatches to catch up with
https://github.com/rubygems/rubygems/commit/21c145cb232c5266b330d4f6df2c8c635930e23c.

https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md#2311-april-7-2022
https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md#2312-april-20-2022

Dependabot should give slightly better errors on Ruby version conflicts with this version.