### PR TITLE
Use a temporary Ruby requirement for updating lockfile

### DIFF
--- a/bundler/spec/dependabot/bundler/file_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater_spec.rb
@@ -439,6 +439,27 @@ RSpec.describe Dependabot::Bundler::FileUpdater do
         end
       end
 
+      context "with an imported gemspec that specifies a minimum Ruby version not satisfied by the running Ruby" do
+        let(:dependency_files) { bundler_project_dependency_files("unsatisfied_required_ruby_version") }
+
+        before do
+          require "dependabot/bundler/file_updater/ruby_requirement_setter"
+
+          stub_const(
+            "#{described_class}::RubyRequirementSetter::RUBY_VERSIONS",
+            described_class::RubyRequirementSetter::RUBY_VERSIONS + ["99.0.0"]
+          )
+        end
+
+        it "locks the updated gem to the latest version" do
+          expect(file.content).to include("business (1.5.0)")
+        end
+
+        it "doesn't add in a RUBY VERSION" do
+          expect(file.content).not_to include("RUBY VERSION")
+        end
+      end
+
       context "when the Gemfile specifies a Ruby version" do
         let(:dependency_files) { bundler_project_dependency_files("explicit_ruby_in_lockfile") }
 

--- a/bundler/spec/fixtures/projects/bundler1/unsatisfied_required_ruby_version/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/unsatisfied_required_ruby_version/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "business", "~> 1.4.0"

--- a/bundler/spec/fixtures/projects/bundler1/unsatisfied_required_ruby_version/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/unsatisfied_required_ruby_version/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+
+BUNDLED WITH
+   1.17.3

--- a/bundler/spec/fixtures/projects/bundler1/unsatisfied_required_ruby_version/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/unsatisfied_required_ruby_version/example.gemspec
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 99.0.0"
+end

--- a/bundler/spec/fixtures/projects/bundler2/unsatisfied_required_ruby_version/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/unsatisfied_required_ruby_version/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "business", "~> 1.4.0"

--- a/bundler/spec/fixtures/projects/bundler2/unsatisfied_required_ruby_version/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler2/unsatisfied_required_ruby_version/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+
+BUNDLED WITH
+   2.2.10

--- a/bundler/spec/fixtures/projects/bundler2/unsatisfied_required_ruby_version/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler2/unsatisfied_required_ruby_version/example.gemspec
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 99.0.0"
+end


### PR DESCRIPTION
To ensure that no Ruby resolution conflicts are generated.

This PR fixes the issue mentioned in [this comment](https://github.com/dependabot/dependabot-core/issues/4987#issuecomment-1098804316).