### PR TITLE
Translate from `@types` package to library name

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_name.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_name.rb
@@ -74,11 +74,11 @@ module Dependabot
       end
 
       def scoped_types_package?
-        SCOPED_TYPES_PACKAGE_REGEX.match?(self.to_s)
+        SCOPED_TYPES_PACKAGE_REGEX.match?(to_s)
       end
 
       def unscoped_types_package_name
-        match = SCOPED_TYPES_PACKAGE_REGEX.match(self.to_s)
+        match = SCOPED_TYPES_PACKAGE_REGEX.match(to_s)
         raise InvalidPackageName unless match
 
         "@#{match[:scope]}/#{match[:name]}"

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package_name_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package_name_spec.rb
@@ -65,6 +65,36 @@ RSpec.describe Dependabot::NpmAndYarn::PackageName do
     end
   end
 
+  describe "#library_name" do
+    it "returns self if it is not a types package" do
+      jquery = "jquery"
+
+      library_name = described_class.new(jquery).library_name.to_s
+
+      expect(library_name).to eq(jquery)
+    end
+
+    it "returns the corresponding library for a types package" do
+      lodash_types = "@types/lodash"
+      lodash       = "lodash"
+
+      library_name = described_class.new(lodash_types).library_name
+
+      expect(library_name.to_s).to eq(lodash)
+    end
+
+    context "when it is a scoped types package" do
+      it "returns the type packages scoped name" do
+        babel_core_types = "@types/babel__core"
+        babel_core       = "@babel/core"
+
+        library_name = described_class.new(babel_core_types).library_name
+
+        expect(library_name.to_s).to eq(babel_core)
+      end
+    end
+  end
+
   describe "#eql?" do
     it "compares the string representation of the package name" do
       package       = described_class.new("package")


### PR DESCRIPTION
Now that we can translate from library to types package (e.g. `jquery` -> `@types/jquery`), we need to be able to translate in the other direction (e.g. `@types/jquery` -> `jquery`).