### PR TITLE
Detect dependencies in Gradle included builds

### DIFF
--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -36,8 +36,8 @@ module Dependabot
         files = [buildfile(root_dir), settings_file(root_dir)].compact
         files += subproject_buildfiles(root_dir)
         files += dependency_script_plugins(root_dir)
-        files += included_builds(root_dir).
-          flat_map { |dir| all_buildfiles_in_build(dir) }
+        files + included_builds(root_dir).
+                flat_map { |dir| all_buildfiles_in_build(dir) }
       end
 
       def included_builds(root_dir)
@@ -45,15 +45,15 @@ module Dependabot
 
         # buildSrc is implicit: included but not declared in settings.gradle
         buildsrc = repo_contents(dir: root_dir, raise_errors: false).
-          find { |item| item.type == 'dir' && item.name == 'buildSrc' }
+                   find { |item| item.type == "dir" && item.name == "buildSrc" }
         builds << clean_join(root_dir, "buildSrc") if buildsrc
 
         return builds unless settings_file(root_dir)
 
         builds += SettingsFileParser.
-          new(settings_file: settings_file(root_dir)).
-          included_build_paths.
-          map { |p| clean_join(root_dir, p) }
+                  new(settings_file: settings_file(root_dir)).
+                  included_build_paths.
+                  map { |p| clean_join(root_dir, p) }
 
         builds.uniq
       end
@@ -133,15 +133,15 @@ module Dependabot
 
       def find_first(dir, supported_names)
         paths = supported_names.
-          map { |name| clean_join(dir, name) }.
-          each do |path|
-            return cached_files[path] || next
-          end
+                map { |name| clean_join(dir, name) }.
+                each do |path|
+          return cached_files[path] || next
+        end
         fetch_first_if_present(paths)
       end
 
       def cached_files
-        @cached_files ||= Hash.new
+        @cached_files ||= {}
       end
 
       def fetch_first_if_present(paths)

--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -70,7 +70,7 @@ module Dependabot
           new(settings_file: settings_file(root_dir)).
           subproject_paths
 
-        subproject_paths.map do |path|
+        subproject_paths.filter_map do |path|
           if @buildfile_name
             fetch_file_from_host(File.join(root_dir, path, @buildfile_name))
           else
@@ -79,7 +79,7 @@ module Dependabot
         rescue Dependabot::DependencyFileNotFound
           # Gradle itself doesn't worry about missing subprojects, so we don't
           nil
-        end.compact
+        end
       end
 
       # rubocop:disable Metrics/PerceivedComplexity

--- a/gradle/lib/dependabot/gradle/file_fetcher/settings_file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher/settings_file_parser.rb
@@ -10,6 +10,15 @@ module Dependabot
           @settings_file = settings_file
         end
 
+        def included_build_paths
+          paths = []
+          comment_free_content.scan(function_regex("includeBuild")) do
+            arg = Regexp.last_match.named_captures.fetch("args")
+            paths << arg.gsub(/["']/, "").strip
+          end
+          paths.uniq
+        end
+
         def subproject_paths
           subprojects = []
 

--- a/gradle/spec/dependabot/gradle/file_fetcher/settings_file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_fetcher/settings_file_parser_spec.rb
@@ -6,13 +6,13 @@ require "dependabot/gradle/file_fetcher/settings_file_parser"
 
 RSpec.describe Dependabot::Gradle::FileFetcher::SettingsFileParser do
   let(:finder) { described_class.new(settings_file: settings_file) }
-
   let(:settings_file) do
     Dependabot::DependencyFile.new(
-      name: "settings.gradle",
+      name: settings_file_name,
       content: fixture("settings_files", fixture_name)
-    )
+      )
   end
+  let(:settings_file_name) { "settings.gradle" }
   let(:fixture_name) { "simple_settings.gradle" }
 
   describe "#subproject_paths" do
@@ -37,12 +37,7 @@ RSpec.describe Dependabot::Gradle::FileFetcher::SettingsFileParser do
     end
 
     context "when kotlin" do
-      let(:settings_file) do
-        Dependabot::DependencyFile.new(
-          name: "settings.gradle.kts",
-          content: fixture("settings_files", fixture_name)
-        )
-      end
+      let(:settings_file_name) { "settings.gradle.kts" }
       let(:fixture_name) { "settings.gradle.kts" }
 
       it "includes the additional declarations" do
@@ -82,6 +77,65 @@ RSpec.describe Dependabot::Gradle::FileFetcher::SettingsFileParser do
       it "uses the custom declarations" do
         expect(subproject_paths).
           to match_array(%w(subprojects/chrome-trace examples/java))
+      end
+    end
+  end
+
+  describe "#included_build_paths" do
+    subject(:included_build_paths) { finder.included_build_paths }
+
+    context "when there are no included build declarations" do
+      let(:fixture_name) { "simple_settings.gradle" }
+
+      it "includes no declaration" do
+        expect(included_build_paths).to match_array([])
+      end
+    end
+
+    context "with single included build" do
+      let(:fixture_name) { "composite_build_simple_settings.gradle" }
+
+      it "includes the declaration" do
+        expect(included_build_paths).to match_array(%w(./included))
+      end
+    end
+
+    context "with multiple included builds" do
+      let(:fixture_name) { "composite_build_settings.gradle" }
+
+      it "includes the additional declarations" do
+        expect(included_build_paths).to match_array(
+          %w(./plugins/lint-plugins ./plugins/settings-plugins ./publishing)
+        )
+      end
+    end
+
+    context "with various call styles" do
+      let(:fixture_name) { "call_style_settings.gradle" }
+
+      it "includes all declarations" do
+        expect(included_build_paths).to match_array(
+          %w(without_space with_space implicit implicit_with_many_spaces ./standard-path)
+        )
+      end
+    end
+
+    context "with commented out included build declarations" do
+      let(:fixture_name) { "comment_settings.gradle" }
+
+      it "includes only uncommented declarations" do
+        expect(included_build_paths).to match_array(%w(./included))
+      end
+    end
+
+    # TODO context "with commented out included build declarations"
+
+    context "when kotlin" do
+      let(:settings_file_name) { "settings.gradle.kts" }
+      let(:fixture_name) { "settings.gradle.kts" }
+
+      it "includes the additional declarations" do
+        expect(included_build_paths).to match_array(%w(./settings-plugins ./project-plugins))
       end
     end
   end

--- a/gradle/spec/dependabot/gradle/file_fetcher/settings_file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_fetcher/settings_file_parser_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Dependabot::Gradle::FileFetcher::SettingsFileParser do
     Dependabot::DependencyFile.new(
       name: settings_file_name,
       content: fixture("settings_files", fixture_name)
-      )
+    )
   end
   let(:settings_file_name) { "settings.gradle" }
   let(:fixture_name) { "simple_settings.gradle" }
@@ -128,7 +128,7 @@ RSpec.describe Dependabot::Gradle::FileFetcher::SettingsFileParser do
       end
     end
 
-    # TODO context "with commented out included build declarations"
+    # TODO: context "with commented out included build declarations"
 
     context "when kotlin" do
       let(:settings_file_name) { "settings.gradle.kts" }

--- a/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
           to match_array(%w(build.gradle settings.gradle app/build.gradle))
       end
 
-      context "when the subproject can't fe found" do
+      context "when the subproject can't be found" do
         before do
           stub_request(:get, File.join(url, "app/build.gradle?ref=sha")).
             with(headers: { "Authorization" => "token token" }).

--- a/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
@@ -81,7 +81,6 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
     end
 
     context "with included builds" do
-
       context "when has buildSrc" do
         before do
           stub_content_request("buildSrc?ref=sha", "contents_java.json")
@@ -182,12 +181,14 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
           stub_content_request("included/app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_content_request("included/included?ref=sha", "contents_java_with_settings.json")
           stub_content_request("included/included/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
-          stub_content_request("included/included/settings.gradle?ref=sha", "contents_java_settings_1_included_build.json")
+          stub_content_request("included/included/settings.gradle?ref=sha",
+                               "contents_java_settings_1_included_build.json")
           stub_content_request("included/included/app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_content_request("included/included/included?ref=sha", "contents_java_with_buildsrc.json")
           stub_content_request("included/included/included/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_content_request("included/included/included/buildSrc?ref=sha", "contents_java.json")
-          stub_content_request("included/included/included/buildSrc/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
+          stub_content_request("included/included/included/buildSrc/build.gradle?ref=sha",
+                               "contents_java_basic_buildfile.json")
         end
 
         it "fetches all buildfiles transitively" do

--- a/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
@@ -82,6 +82,42 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
 
     context "with included builds" do
 
+      context "when has buildSrc" do
+        before do
+          stub_content_request("buildSrc?ref=sha", "contents_java.json")
+          stub_content_request("buildSrc/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
+        end
+
+        context "implicitly included" do
+          before do
+            stub_content_request("?ref=sha", "contents_java_with_buildsrc.json")
+          end
+
+          it "fetches all buildfiles" do
+            expect(file_fetcher_instance.files.map(&:name)).
+              to match_array(%w(build.gradle buildSrc/build.gradle))
+          end
+        end
+
+        context "explicitly included" do
+          before do
+            stub_content_request("?ref=sha", "contents_java_with_buildsrc_and_settings.json")
+            stub_content_request("settings.gradle?ref=sha", "contents_java_settings_explicit_buildsrc.json")
+            stub_content_request("included?ref=sha", "contents_java.json")
+            stub_content_request("included/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
+          end
+
+          it "doesn't fetch buildSrc buildfiles twice" do
+            expect(file_fetcher_instance.files.map(&:name)).
+              to match_array(%w(
+                build.gradle settings.gradle
+                buildSrc/build.gradle
+                included/build.gradle
+              ))
+          end
+        end
+      end
+
       context "when only one" do
         before do
           stub_content_request("?ref=sha", "contents_java_with_settings.json")
@@ -148,10 +184,10 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
           stub_content_request("included/included/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
           stub_content_request("included/included/settings.gradle?ref=sha", "contents_java_settings_1_included_build.json")
           stub_content_request("included/included/app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
-          stub_content_request("included/included/included?ref=sha", "contents_java_with_settings.json")
+          stub_content_request("included/included/included?ref=sha", "contents_java_with_buildsrc.json")
           stub_content_request("included/included/included/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
-          stub_content_request("included/included/included/settings.gradle?ref=sha", "contents_java_simple_settings.json")
-          stub_content_request("included/included/included/app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
+          stub_content_request("included/included/included/buildSrc?ref=sha", "contents_java.json")
+          stub_content_request("included/included/included/buildSrc/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
         end
 
         it "fetches all buildfiles transitively" do
@@ -164,8 +200,7 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
               included/included/build.gradle included/included/settings.gradle
               included/included/app/build.gradle
               included/included/included/build.gradle
-              included/included/included/settings.gradle
-              included/included/included/app/build.gradle
+              included/included/included/buildSrc/build.gradle
             ))
         end
       end

--- a/gradle/spec/fixtures/github/contents_java_settings_1_included_build.json
+++ b/gradle/spec/fixtures/github/contents_java_settings_1_included_build.json
@@ -1,0 +1,18 @@
+{
+  "name": "settings.gradle",
+  "path": "settings.gradle",
+  "sha": "e7b4def49cb53d9aa04228dd3edb14c9e635e003",
+  "size": 15,
+  "url": "https://api.github.com/repos/git/git/contents/settings.gradle?ref=develop",
+  "html_url": "https://github.com/git/git/blob/develop/settings.gradle",
+  "git_url": "https://api.github.com/repos/git/git/git/blobs/e7b4def49cb53d9aa04228dd3edb14c9e635e003",
+  "download_url": "https://raw.githubusercontent.com/git/git/develop/settings.gradle",
+  "type": "file",
+  "content": "aW5jbHVkZUJ1aWxkICcuL2luY2x1ZGVkJwppbmNsdWRlICc6YXBwJw==\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/git/git/contents/settings.gradle?ref=develop",
+    "git": "https://api.github.com/repos/git/git/git/blobs/e7b4def49cb53d9aa04228dd3edb14c9e635e003",
+    "html": "https://github.com/git/git/blob/develop/settings.gradle"
+  }
+}

--- a/gradle/spec/fixtures/github/contents_java_settings_2_included_builds.json
+++ b/gradle/spec/fixtures/github/contents_java_settings_2_included_builds.json
@@ -1,0 +1,18 @@
+{
+  "name": "settings.gradle",
+  "path": "settings.gradle",
+  "sha": "e7b4def49cb53d9aa04228dd3edb14c9e635e003",
+  "size": 15,
+  "url": "https://api.github.com/repos/git/git/contents/settings.gradle?ref=develop",
+  "html_url": "https://github.com/git/git/blob/develop/settings.gradle",
+  "git_url": "https://api.github.com/repos/git/git/git/blobs/e7b4def49cb53d9aa04228dd3edb14c9e635e003",
+  "download_url": "https://raw.githubusercontent.com/git/git/develop/settings.gradle",
+  "type": "file",
+  "content": "aW5jbHVkZUJ1aWxkICcuL2luY2x1ZGVkJwppbmNsdWRlQnVpbGQgIi4vaW5jbHVkZWQyLyIKCmluY2x1ZGUgJzphcHAnCg==\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/git/git/contents/settings.gradle?ref=develop",
+    "git": "https://api.github.com/repos/git/git/git/blobs/e7b4def49cb53d9aa04228dd3edb14c9e635e003",
+    "html": "https://github.com/git/git/blob/develop/settings.gradle"
+  }
+}

--- a/gradle/spec/fixtures/github/contents_java_settings_explicit_buildsrc.json
+++ b/gradle/spec/fixtures/github/contents_java_settings_explicit_buildsrc.json
@@ -1,0 +1,18 @@
+{
+  "name": "settings.gradle",
+  "path": "settings.gradle",
+  "sha": "e7b4def49cb53d9aa04228dd3edb14c9e635e003",
+  "size": 15,
+  "url": "https://api.github.com/repos/git/git/contents/settings.gradle?ref=develop",
+  "html_url": "https://github.com/git/git/blob/develop/settings.gradle",
+  "git_url": "https://api.github.com/repos/git/git/git/blobs/e7b4def49cb53d9aa04228dd3edb14c9e635e003",
+  "download_url": "https://raw.githubusercontent.com/git/git/develop/settings.gradle",
+  "type": "file",
+  "content": "aW5jbHVkZUJ1aWxkICcuL2J1aWxkU3JjJwppbmNsdWRlQnVpbGQgJy4vaW5jbHVkZWQvJwo=\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/git/git/contents/settings.gradle?ref=develop",
+    "git": "https://api.github.com/repos/git/git/git/blobs/e7b4def49cb53d9aa04228dd3edb14c9e635e003",
+    "html": "https://github.com/git/git/blob/develop/settings.gradle"
+  }
+}

--- a/gradle/spec/fixtures/github/contents_java_with_buildsrc.json
+++ b/gradle/spec/fixtures/github/contents_java_with_buildsrc.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "build.gradle",
+    "path": "build.gradle",
+    "sha": "f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+    "size": 2355,
+    "url": "https://api.github.com/repos/git/git/contents/build.gradle?ref=main",
+    "html_url": "https://github.com/git/git/blob/main/build.gradle",
+    "git_url": "https://api.github.com/repos/git/git/git/blobs/f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+    "download_url": "https://raw.githubusercontent.com/git/git/main/build.gradle",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/git/git/contents/build.gradle?ref=main",
+      "git": "https://api.github.com/repos/git/git/git/blobs/f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+      "html": "https://github.com/git/git/blob/main/build.gradle"
+    }
+  },
+  {
+    "name": "buildSrc",
+    "path": "buildSrc",
+    "sha": "5df7f650b80fef281199e7d1c6bf53c6a5280802",
+    "size": 0,
+    "url": "https://api.github.com/repos/git/git/contents/dependencies?ref=main",
+    "html_url": "https://github.com/git/git/tree/main/dependencies",
+    "git_url": "https://api.github.com/repos/git/git/git/trees/5df7f650b80fef281199e7d1c6bf53c6a5280802",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/git/git/contents/dependencies?ref=main",
+      "git": "https://api.github.com/repos/git/git/git/trees/5df7f650b80fef281199e7d1c6bf53c6a5280802",
+      "html": "https://github.com/git/git/tree/main/dependencies"
+    }
+  }
+]

--- a/gradle/spec/fixtures/github/contents_java_with_buildsrc_and_settings.json
+++ b/gradle/spec/fixtures/github/contents_java_with_buildsrc_and_settings.json
@@ -1,0 +1,50 @@
+[
+  {
+    "name": "build.gradle",
+    "path": "build.gradle",
+    "sha": "f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+    "size": 2355,
+    "url": "https://api.github.com/repos/git/git/contents/build.gradle?ref=main",
+    "html_url": "https://github.com/git/git/blob/main/build.gradle",
+    "git_url": "https://api.github.com/repos/git/git/git/blobs/f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+    "download_url": "https://raw.githubusercontent.com/git/git/main/build.gradle",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/git/git/contents/build.gradle?ref=main",
+      "git": "https://api.github.com/repos/git/git/git/blobs/f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+      "html": "https://github.com/git/git/blob/main/build.gradle"
+    }
+  },
+  {
+    "name": "settings.gradle",
+    "path": "settings.gradle",
+    "sha": "f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+    "size": 2355,
+    "url": "https://api.github.com/repos/git/git/contents/build.gradle?ref=main",
+    "html_url": "https://github.com/git/git/blob/main/build.gradle",
+    "git_url": "https://api.github.com/repos/git/git/git/blobs/f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+    "download_url": "https://raw.githubusercontent.com/git/git/main/build.gradle",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/git/git/contents/build.gradle?ref=main",
+      "git": "https://api.github.com/repos/git/git/git/blobs/f036f9f0357a50b02a422923f0bb0c3719eaf8ae",
+      "html": "https://github.com/git/git/blob/main/build.gradle"
+    }
+  },
+  {
+    "name": "buildSrc",
+    "path": "buildSrc",
+    "sha": "5df7f650b80fef281199e7d1c6bf53c6a5280802",
+    "size": 0,
+    "url": "https://api.github.com/repos/git/git/contents/dependencies?ref=main",
+    "html_url": "https://github.com/git/git/tree/main/dependencies",
+    "git_url": "https://api.github.com/repos/git/git/git/trees/5df7f650b80fef281199e7d1c6bf53c6a5280802",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/git/git/contents/dependencies?ref=main",
+      "git": "https://api.github.com/repos/git/git/git/trees/5df7f650b80fef281199e7d1c6bf53c6a5280802",
+      "html": "https://github.com/git/git/tree/main/dependencies"
+    }
+  }
+]

--- a/gradle/spec/fixtures/settings_files/call_style_settings.gradle
+++ b/gradle/spec/fixtures/settings_files/call_style_settings.gradle
@@ -2,3 +2,9 @@ include(':function_without_space')
 include (':function_with_space')
 include ':implicit'
 include   ":implicit_with_many_spaces"
+
+includeBuild('without_space')
+includeBuild ('with_space')
+includeBuild 'implicit'
+includeBuild   "implicit_with_many_spaces"
+includeBuild './standard-path'

--- a/gradle/spec/fixtures/settings_files/comment_settings.gradle
+++ b/gradle/spec/fixtures/settings_files/comment_settings.gradle
@@ -5,3 +5,11 @@
 // include ':comment'
 
 include ':app'
+
+/*
+ * includeBuild './block_comment'
+ */
+
+// includeBuild('./comment')
+
+includeBuild './included'

--- a/gradle/spec/fixtures/settings_files/composite_build_settings.gradle
+++ b/gradle/spec/fixtures/settings_files/composite_build_settings.gradle
@@ -1,0 +1,6 @@
+pluginManagement {
+  includeBuild './plugins/settings-plugins'
+}
+
+includeBuild './plugins/lint-plugins'
+includeBuild './publishing'

--- a/gradle/spec/fixtures/settings_files/composite_build_simple_settings.gradle
+++ b/gradle/spec/fixtures/settings_files/composite_build_simple_settings.gradle
@@ -1,0 +1,2 @@
+include ':app'
+includeBuild './included'

--- a/gradle/spec/fixtures/settings_files/settings.gradle.kts
+++ b/gradle/spec/fixtures/settings_files/settings.gradle.kts
@@ -1,1 +1,8 @@
+pluginManagement {
+  includeBuild("./settings-plugins")
+}
+
+includeBuild("./project-plugins")
+
 include(":app")
+


### PR DESCRIPTION
Detect **already supported** Gradle dependency files inside included builds and `buildSrc`.

## Goal

Dependabot currently supports dependencies in `build.gradle` and other buildscripts in the _main build_. However, these files can be present in the same format in other builds part of the main one: included builds. They can be easily supported by the current file parsing and updating implementation, since they're in the same format, most changes being in fetching files in the additional folders.

- [Usual project `build.gradle`][1]
- [Similar `build.gradle` in an included build][2] (currently not fetched by Dependabot)

Closes #4375

### What are included builds?

In Gradle, a single build is composed of one root project with zero or more subprojects. A single build can also include other independent builds, each with its own settings file and root project (and maybe their own included builds):

```
main-build
\_settings.gradle
\_subproject
\_included-build
    \_settings.gradle
   \_build.gradle
   \_subproject
   \_nested-included-build
      \_settings.gradle
...
```

An included build is declared explicitly in `settings.gradle`:

```groovy
includeBuild './included'
include ':app'
// ...
```

`buildSrc` is a special case. [It's "treated as an included build"][3]. It's included in the build if the directory is named `buildSrc` regardless of being declared in `settings.gradle`. Not to be confused with the common pattern of declaring dependencies in code such as Kotlin classes inside buildSrc (#2180, [example][4]). That pattern is not supported and not a goal of this PR.

## Changes

- c6bf5388f Detect includeBuild in Gradle SettingsFileParser
- 0267202f7 Refactor FileFetcher to support transitive search. Supported files were always considered to be in the main build root project or main build subprojects. They should now be relative to the dir of current build being examined, the main one or included ones.
- c66e1e827 Fetch files of included builds in Gradle FileFetcher. Read includeBuild in every build's settings file and walk. Nothing changes if there's no included builds.
- 842c66a99 Support buildSrc as an included build. buildSrc is an implicit included build, check for it even if it's not manually declared.

### Dry run examples

In regards to finding the update of Kotlin 1.6.10 -> 1.6.21 in this [build.gradle.kts][5], which is inside an included build directory.

**Current behavior:** doesn't detect the Kotlin update because it doesn't detect and fetch files of included builds ([test branch][6])

<img width="876" alt="Screen Shot 2022-04-22 at 17 00 22" src="https://user-images.githubusercontent.com/25730717/164752336-76325695-a332-4fbe-a00f-c9fa38a04b77.png">

**New behavior:** detects the Kotlin update because it parses included build paths and fetches supported files inside (test branch [1][6] and [2][7])

<img width="1192" alt="Screen Shot 2022-04-22 at 17 04 20" src="https://user-images.githubusercontent.com/25730717/164752394-6540fb23-a9a7-4a50-a6a0-cb12399699a6.png">

<img width="1191" alt="Screen Shot 2022-04-22 at 17 05 32" src="https://user-images.githubusercontent.com/25730717/164752557-acda890d-deda-443c-bc04-648427d61bcf.png">

[1]: https://github.com/gabrielfeo/50-72/blob/bac65cf8133a107d1512b8e7d51d013228879327/cli/build.gradle.kts
[2]: https://github.com/gabrielfeo/50-72/blob/bac65cf8133a107d1512b8e7d51d013228879327/build-src/build.gradle.kts
[3]: https://docs.gradle.org/current/userguide/organizing_gradle_projects.html#sec:build_sources
[4]: https://github.com/sanogueralorenzo/Android-Kotlin-Clean-Architecture/blob/master/buildSrc/src/main/kotlin/Libs.kt
[5]: https://github.com/gabrielfeo/50-72/blob/bac65cf8133a107d1512b8e7d51d013228879327/build-src/build.gradle.kts#L14
[6]: https://github.com/gabrielfeo/50-72/tree/test/dependabot-included-build
[7]: https://github.com/gabrielfeo/50-72/tree/test/dependabot-buildSrc