### PR TITLE
Bump underlying `ubuntu` to `22.04` LTS

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.source="https://github.com/dependabot/dependabot-core"
 
@@ -97,7 +97,7 @@ COPY --from=ruby:3.1.4-bullseye --chown=dependabot:dependabot /usr/local /usr/lo
 # This way other projects that import this library don't have to futz around with installing new / unexpected bundler versions.
 ARG BUNDLER_V2_VERSION=2.4.17
 
-# We had to explicitly bump this as the bundled version `0.2.2` in ubuntu 20.04 has a bug.
+# We had to explicitly bump this as the bundled version `0.2.2` in ubuntu 22.04 has a bug.
 # Once Ubuntu base image pulls in a new enough yaml version, we may not need to
 # explicitly manage this. However, if we do opt to pull it back out, see all changes
 # required in https://github.com/dependabot/dependabot-core/pull/7112

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -90,7 +90,7 @@ WORKDIR $DEPENDABOT_HOME/dependabot-updater
 
 # Install Ruby from official Docker image
 # When bumping Ruby minor, need to also add the previous version to `bundler/helpers/v{1,2}/monkey_patches/definition_ruby_version_patch.rb`
-COPY --from=ruby:3.1.4-bullseye --chown=dependabot:dependabot /usr/local /usr/local
+COPY --from=ruby:3.1.4-bookworm --chown=dependabot:dependabot /usr/local /usr/local
 
 # When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --lock --bundler`
 # Generally simplest to match the bundler version to the one that comes by default with whatever Ruby version we install.

--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -3,22 +3,29 @@ RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
     gnupg2
-# Install Erlang and Elixir
-ENV PATH="$PATH:/usr/local/elixir/bin"
+
+# Install Erlang
+# Note: Currently we install from Ubuntu PPA to unblock upgrading to Ubuntu 22.04, but we'd be happy to accept a PR
+# switching to a more up to date PPA. See also:
+#  * https://github.com/esl/packages/issues/15
+#  * https://github.com/dependabot/dependabot-core/pull/7865
+#  * https://erlangforums.com/t/erlang-solutions-apt-package-for-otp-25/1552/1
+#  * https://erlangforums.com/t/the-eef-is-looking-for-volunteers-to-take-over-esls-build-packages/2238/1
+ARG ERLANG_MAJOR_VERSION=24
+ARG ERLANG_VERSION=1:${ERLANG_MAJOR_VERSION}.2.1+dfsg-1ubuntu0.1
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    erlang=${ERLANG_VERSION}
+
+# Install Elixir
 # https://github.com/elixir-lang/elixir/releases
 ARG ELIXIR_VERSION=v1.14.4
 ARG ELIXIR_CHECKSUM=b5705275d62ce3dae172d25d7ea567fffdabb45458abeb29c0189923b907367c
-ARG ERLANG_MAJOR_VERSION=24
-ARG ERLANG_VERSION=1:${ERLANG_MAJOR_VERSION}.2.1-1
-RUN curl -sSLfO https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb \
-  && dpkg -i erlang-solutions_2.0_all.deb \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends esl-erlang=${ERLANG_VERSION} \
-  && curl -sSLfO https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
+RUN curl -sSLfO https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
   && echo "$ELIXIR_CHECKSUM  elixir-otp-${ERLANG_MAJOR_VERSION}.zip" | sha256sum -c - \
   && unzip -d /usr/local/elixir -x elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
-  && rm -f elixir-otp-${ERLANG_MAJOR_VERSION}.zip erlang-solutions_2.0_all.deb \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -f elixir-otp-${ERLANG_MAJOR_VERSION}.zip
+ENV PATH="$PATH:/usr/local/elixir/bin"
 
 USER dependabot
 

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -25,7 +25,7 @@ USER dependabot
 
 # https://www.swift.org/download/
 ARG SWIFT_VERSION=5.8.1
-ARG SWIFT_UBUNTU_VERSION=ubuntu20.04
+ARG SWIFT_UBUNTU_VERSION=ubuntu22.04
 
 RUN if [ "$TARGETARCH" = "arm64" ]; then SWIFT_UBUNTU_VERSION="${SWIFT_UBUNTU_VERSION}-aarch64"; fi \
   && SWIFT_SHORT_UBUNTU_VERSION=$(echo $SWIFT_UBUNTU_VERSION | tr -d .) \


### PR DESCRIPTION
`22.04` LTS dropped yesterday: https://ubuntu.com/blog/ubuntu-22-04-lts-released

I'm not sure of the GitHub internal infra, there may be security/infra reasons blocking
this upgrade that are not visible to external contributors, but thought I'd at least open
this PR to see what CI thinks.

For the Erlang issue, I had to install Erlang from Ubuntu Universe rather than Erlang Solutions.
Unfortunately that means we will probably lag on Erlang versions in the future.

While this isn't ideal from an Erlang perspective, this unblocks the
`22.04` upgrade, which is a bigger deal for the other ecosystems.

I'm hopeful this is only a temporary state of affairs and someone from
the community steps up to provide a PR switching to installing from
either the Erlang Solutions PPA or the RabbitMQ PPA.

Related:
* https://github.com/esl/packages/issues/15
* https://github.com/dependabot/dependabot-core/pull/7865
* https://erlangforums.com/t/erlang-solutions-apt-package-for-otp-25/1552/1
* https://erlangforums.com/t/the-eef-is-looking-for-volunteers-to-take-over-esls-build-packages/2238/1