### PR TITLE
Clarify comment and remove TODO

### DIFF
--- a/common/spec/warning_monkey_patch.rb
+++ b/common/spec/warning_monkey_patch.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 ALLOW_PATTERNS = [
-  # Ignore parser warnings for ruby 2.7 minor version mismatches
-  # TODO: Fix these by upgrading to ruby 2.7.3 (requires ubuntu upgrade)
+  # Ignore parser warnings for ruby 2.7 minor version mismatches.
+  # This is a recurring issue that occurs whenever the parser gets
+  # ahead of our installed ruby version.
   %r{parser/current is loading parser/ruby27},
   /2.7.\d-compliant syntax, but you are running 2.7.\d/,
   %r{whitequark/parser}


### PR DESCRIPTION
The current version of the warning:
```
warning: parser/current is loading parser/ruby27, which recognizes2.7.6-compliant syntax, but you are running 2.7.5.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
```

So I removed the TODO comment because it's outdated. 
But I left the actual exclusion in because it will be a recurring issue from time to time because https://ppa.launchpadcontent.net/brightbox/ruby-ng/ubuntu can be a little slow to update...
for example see various discussions on the mailing list that sometimes get no response from
the maintainers: https://groups.google.com/g/brightbox-ruby-ubuntu-packaging