### PR TITLE
Update RubyGems and use `--no-document` for updating it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
 RUN apt-add-repository ppa:brightbox/ruby-ng \
   && apt-get update \
   && apt-get install -y --no-install-recommends ruby2.7 ruby2.7-dev \
-  && gem update --system 3.3.11 \
+  && gem update --system 3.3.11 --no-document \
   && gem install bundler -v 1.17.3 --no-document \
   && gem install bundler -v 2.3.12 --no-document \
   && rm -rf /var/lib/gems/2.7.0/cache/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
 RUN apt-add-repository ppa:brightbox/ruby-ng \
   && apt-get update \
   && apt-get install -y --no-install-recommends ruby2.7 ruby2.7-dev \
-  && gem update --system 3.2.20 \
+  && gem update --system 3.3.11 \
   && gem install bundler -v 1.17.3 --no-document \
   && gem install bundler -v 2.3.12 --no-document \
   && rm -rf /var/lib/gems/2.7.0/cache/* \


### PR DESCRIPTION
The RubyGems version had fallen a bit behind. I didn't update all the way to the latest 3.3.12 because there's a bug in 3.3.12 that might affect Dependabot (I don't think so, but just in case). Also I think it makes sense to use `--no-document` for updating it because it's faster.