### PR TITLE
Prevent KeyError when checking search results

### DIFF
--- a/nuget/lib/dependabot/nuget/metadata_finder.rb
+++ b/nuget/lib/dependabot/nuget/metadata_finder.rb
@@ -59,11 +59,11 @@ module Dependabot
         JSON.parse(body).fetch("data", []).each do |search_result|
           next unless search_result["id"].downcase == dependency.name.downcase
 
-          if search_result.fetch("projectUrl")
+          if search_result.key?("projectUrl")
             source = Source.from_url(search_result.fetch("projectUrl"))
             return source unless source.repo.nil?
           end
-          if search_result.fetch("licenseUrl")
+          if search_result.key?("licenseUrl")
             source = Source.from_url(search_result.fetch("licenseUrl"))
             return source unless source.repo.nil?
           end


### PR DESCRIPTION
Bug fix on #5002, we noticed a trace on this due to the use of `fetch` without a default I missed in review.