### PR TITLE
Set BUNDLER_VERSION to the specific installed version in native helpers

### DIFF
--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -36,7 +36,7 @@ module Dependabot
       def self.run_bundler_subprocess(function:, args:, bundler_version:, options: {})
         # Run helper suprocess with all bundler-related ENV variables removed
         bundler_major_version = bundler_version.split(".").first
-        helpers_path = versioned_helper_path(bundler_version: bundler_major_version)
+        helpers_path = versioned_helper_path(bundler_major_version)
         ::Bundler.with_original_env do
           command = BundleCommand.
                     new(options[:timeout_per_operation_seconds]).
@@ -47,7 +47,7 @@ module Dependabot
             args: args,
             env: {
               # Bundler will pick the matching installed major version
-              "BUNDLER_VERSION" => bundler_version,
+              "BUNDLER_VERSION" => installed_bundler_version(major_bundler_version),
               "BUNDLE_GEMFILE" => File.join(helpers_path, "Gemfile"),
               # Prevent the GEM_HOME from being set to a folder owned by root
               "GEM_HOME" => File.join(helpers_path, ".bundle")
@@ -61,8 +61,15 @@ module Dependabot
         end
       end
 
-      def self.versioned_helper_path(bundler_version:)
-        File.join(native_helpers_root, "v#{bundler_version}")
+      def self.versioned_helper_path(bundler_major_version)
+        File.join(native_helpers_root, "v#{bundler_major_version}")
+      end
+
+      # Maps the major version unto the specific version we have installed
+      def self.installed_bundler_version(bundler_major_version)
+        return Helpers::V1 if bundler_major_version == '1'
+
+        Helpers::V2
       end
 
       def self.native_helpers_root

--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -67,7 +67,7 @@ module Dependabot
 
       # Maps the major version unto the specific version we have installed
       def self.installed_bundler_version(bundler_major_version)
-        return Helpers::V1 if bundler_major_version == '1'
+        return Helpers::V1 if bundler_major_version == "1"
 
         Helpers::V2
       end

--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -47,7 +47,7 @@ module Dependabot
             args: args,
             env: {
               # Bundler will pick the matching installed major version
-              "BUNDLER_VERSION" => installed_bundler_version(major_bundler_version),
+              "BUNDLER_VERSION" => installed_bundler_version(bundler_major_version),
               "BUNDLE_GEMFILE" => File.join(helpers_path, "Gemfile"),
               # Prevent the GEM_HOME from being set to a folder owned by root
               "GEM_HOME" => File.join(helpers_path, ".bundle")


### PR DESCRIPTION
We've encountered an issue in the move forward to bundler 2.3.12 where our approach to setting the `BUNDLER_VERSION` in native helpers now behaves differently.

Using `v0.182.0`, you can observe the behaviour like so:

```
$ cd bundler/helpers/v1
$ bundle install
$ BUNDLER_VERSION=1.14.6 bundler -v
> Bundler version 1.17.3
```

On main the behaviour is like so:

```
$ cd bundler/helpers/v1
$ bundle install
$ BUNDLER_VERSION=1.14.6 bundler -v
> Bundler version 2.3.12
```

We updated this behaviour in https://github.com/dependabot/dependabot-core/pull/4132 when we noted that passing in just the major version, i.e. `BUNDLER_VERSION=1` no longer worked and we started using the _detected_ version instead, which bundler would previously 'guess' at a near match.

### The change

This modifies our `native_helper` function to set the BUNDLER_VERSION to the actual version of v1.x or v2.x we have installed according to the detected major version.

In retrospect, this feels a little bit like it was working by accident and we were relying on bundler doing some magic for us, so I think this is a more correct approach.