### PR TITLE
Rollback RubyGems from 3.3.11 to 3.2.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
 RUN apt-add-repository ppa:brightbox/ruby-ng \
   && apt-get update \
   && apt-get install -y --no-install-recommends ruby2.7 ruby2.7-dev \
-  && gem update --system 3.3.11 --no-document \
+  && gem update --system 3.2.20 \
   && gem install bundler -v 1.17.3 --no-document \
   && gem install bundler -v 2.3.12 --no-document \
   && rm -rf /var/lib/gems/2.7.0/cache/* \


### PR DESCRIPTION
We attempted to resolve an issue around Bundler version detection for projects using Bundler 1.x in https://github.com/dependabot/dependabot-core/pull/5044, but this wasn't sufficient to fix the issue.

We've verified that the issue is resolved by reverting our recent RubyGems update so we're reverting #5035 to unblock releasing forward and we will reintroduce the RubyGems upgrade once we have determined root cause.