### PR TITLE
fix debase build errors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,15 +17,6 @@
       ]
     },
     {
-      "name": "Debug Tests",
-      "type": "Ruby",
-      "request": "launch",
-      "program": "${workspaceRoot}/${input:ecosystem}/.bundle/bin/rspec",
-      "cwd": "${workspaceRoot}/${input:ecosystem}",
-      "useBundler": true,
-      "args": ["${input:test_path}"],
-    },
-    {
       "type": "node",
       "name": "vscode-jest-tests",
       "request": "launch",

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "parser", ">= 2.5", "< 4.0"
   spec.add_dependency "toml-rb", ">= 1.1.2", "< 3.0"
 
-  spec.add_development_dependency "debase", "~> 0.2.4.1"
+  spec.add_development_dependency "debase", "~> 0.2.5.beta2"
   spec.add_development_dependency "debug", ">= 1.0.0"
   spec.add_development_dependency "gpgme", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13"

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "parser", ">= 2.5", "< 4.0"
   spec.add_dependency "toml-rb", ">= 1.1.2", "< 3.0"
 
-  spec.add_development_dependency "debase", "~> 0.2.5.beta2"
+  spec.add_development_dependency "debase", "= 0.2.2"
   spec.add_development_dependency "debug", ">= 1.0.0"
   spec.add_development_dependency "gpgme", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13"

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "parser", ">= 2.5", "< 4.0"
   spec.add_dependency "toml-rb", ">= 1.1.2", "< 3.0"
 
-  spec.add_development_dependency "debase", "= 0.2.2"
   spec.add_development_dependency "debug", ">= 1.0.0"
   spec.add_development_dependency "gpgme", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13"

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -41,7 +41,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_development_dependency "rspec-its", "~> 1.2"
   spec.add_development_dependency "rubocop", "~> 1.27.0"
-  spec.add_development_dependency "ruby-debug-ide", "~> 0.7.3"
   spec.add_development_dependency "simplecov", "~> 0.21.0"
   spec.add_development_dependency "simplecov-console", "~> 0.9.1"
   spec.add_development_dependency "stackprof", "~> 0.2.16"


### PR DESCRIPTION
Reverts #4971

@pavera Unfortunately debase started failing to build in Codespaces. 

I noticed this on my machine a couple weeks ago as well and managed to work around it by changing debase versions and ruby versions. It seems others are having this issue as well: https://github.com/ruby-debug/debase/issues/98

I tried a couple different versions of debase and they all failed, so I guess we should roll this back for now? Any ideas we can try before we do this?