### PR TITLE
remove multiplicative retries to improve system health

### DIFF
--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -90,12 +90,6 @@ module Dependabot
           )
 
           @crates_listing = JSON.parse(response.body)
-        rescue Excon::Error::Timeout
-          retrying ||= false
-          raise if retrying
-
-          retrying = true
-          sleep(rand(1.0..5.0)) && retry
         end
 
         def wants_prerelease?

--- a/common/lib/dependabot/clients/bitbucket.rb
+++ b/common/lib/dependabot/clients/bitbucket.rb
@@ -160,7 +160,8 @@ module Dependabot
           url,
           user: credentials&.fetch("username", nil),
           password: credentials&.fetch("password", nil),
-          idempotent: true,
+          # Setting to false to prevent Excon retries, use BitbucketWithRetries for retries.
+          idempotent: false,
           **Dependabot::SharedHelpers.excon_defaults(
             headers: auth_header
           )

--- a/common/lib/dependabot/git_metadata_fetcher.rb
+++ b/common/lib/dependabot/git_metadata_fetcher.rb
@@ -48,7 +48,6 @@ module Dependabot
 
     attr_reader :url, :credentials
 
-    # rubocop:disable Metrics/PerceivedComplexity
     def fetch_upload_pack_for(uri)
       response = fetch_raw_upload_pack_for(uri)
       return response.body if response.status == 200
@@ -70,15 +69,10 @@ module Dependabot
 
       raise Dependabot::GitDependenciesNotReachable, [uri]
     rescue Excon::Error::Socket, Excon::Error::Timeout
-      retry_count ||= 0
-      retry_count += 1
-
-      sleep(rand(0.9)) && retry if retry_count <= 2 && uri.match?(KNOWN_HOSTS)
       raise if uri.match?(KNOWN_HOSTS)
 
       raise Dependabot::GitDependenciesNotReachable, [uri]
     end
-    # rubocop:enable Metrics/PerceivedComplexity
 
     def fetch_raw_upload_pack_for(uri)
       url = service_pack_uri(uri)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -285,10 +285,7 @@ module Dependabot
               if git_dependency?
                 nil
               else
-                retry_count ||= 0
-                retry_count += 1
-                raise_npm_details_error(e) if retry_count > 2
-                sleep(rand(3.0..10.0)) && retry
+                raise_npm_details_error(e)
               end
             end
         end


### PR DESCRIPTION
Excon has a builtin retry of 4 when using idempotent: true. The retries removed by this PR were multiplying the total retries done. So for NPM, with 2 retries a total of 12 retries are made.

We think 4 retries are probably enough! This will probably make some jobs succeed that were hitting the maximum wait limit since doing 12 retries can take quite a while. 

*Implementation note:*
BitBucketWIthRetries delegates to BitBucket and it seems like the intent was to not retry using BitBucket, so there I set idempotent to false with a note as to why. The other option is to remove BitBucketWithRetries entirely which I am not opposed to. Any opinions there?