### PR TITLE
[Maven] Avoid an infinite loop if the default branch for a dependency 404s

### DIFF
--- a/maven/lib/dependabot/maven/metadata_finder.rb
+++ b/maven/lib/dependabot/maven/metadata_finder.rb
@@ -40,8 +40,12 @@ module Dependabot
           select { |f| f.type == "dir" }.
           any? { |f| dependency_artifact_id.end_with?(f.name) }
       rescue Dependabot::BranchNotFound
-        tmp_source.branch = nil
-        retry
+        # If we are attempting to find a branch, we should fail over to the default branch and retry once only
+        if tmp_source.branch.present?
+          tmp_source.branch = nil
+          retry
+        end
+        @repo_has_subdir_for_dep[tmp_source] = false
       rescue Dependabot::RepoNotFound
         @repo_has_subdir_for_dep[tmp_source] = false
       end

--- a/maven/spec/dependabot/maven/metadata_finder_spec.rb
+++ b/maven/spec/dependabot/maven/metadata_finder_spec.rb
@@ -194,6 +194,49 @@ RSpec.describe Dependabot::Maven::MetadataFinder do
 
             it { is_expected.to eq("https://github.com/square/unrelated_name") }
           end
+
+          context "neither the branch nor default branch can be found" do
+            before do
+              allow_any_instance_of(Dependabot::FileFetchers::Base).
+                to receive(:commit).and_call_original
+              stub_request(:get, parent_url).
+                to_return(
+                  status: 200,
+                  body: fixture("poms", "parent-unrelated-branch-3.10.0.xml")
+                )
+              stub_request(:get, url).
+                with(headers: { "Authorization" => "token token" }).
+                to_return(status: 200,
+                          body: fixture("github", "bump_repo.json"),
+                          headers: { "content-type" => "application/json" })
+              stub_request(:get, url + "/contents/my-dir?ref=aa218f56b14c9653891f9e74264a383fa43fefbd").
+                with(headers: { "Authorization" => "token token" }).
+                to_return(
+                  status: 200,
+                  body: fixture("github", repo_contents_fixture_nm),
+                  headers: { "content-type" => "application/json" }
+                )
+
+              # We should try the branch first, and get a 404
+              stub_request(:get, url + "/git/refs/heads/missing-branch").
+                with(headers: { "Authorization" => "token token" }).
+                to_return(
+                  status: 404,
+                  headers: { "content-type" => "application/json" }
+                )
+
+              # And this will failover to the default, but we could get a 404 as well
+              stub_request(:get, url + "/git/refs/heads/master").
+                with(headers: { "Authorization" => "token token" }).
+                to_return(
+                  status: 404,
+                  headers: { "content-type" => "application/json" }
+                )
+            end
+            let(:repo_contents_fixture_nm) { "contents_java_with_subdir.json" }
+
+            it { is_expected.to be_nil }
+          end
         end
       end
 


### PR DESCRIPTION
We currently have an unbounded `retry` in `Dependabot::Maven::MetadataFinder` which assumed that if we get a 404 attempting to look up a branch-dependency we should fail over to using the default branch of the project.

In the event we get a 404 on the default branch, we go into an infinite retry loop until the job times out.

The test case I've added recreates the infinite loop problem without adding the fix.

This is fairly unlikely to happen under most circumstances as it would require the repository's default branch settings to be out of sync with the contents of the repository, but it is conceivable, as is an interstitial 404 from somewhere else in the stack from non-GitHub providers.