### PR TITLE
fix DependencyFileNotParseable due to 1MB file limit change

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -446,7 +446,13 @@ module Dependabot
           )
         end
 
-        Base64.decode64(tmp.content).force_encoding("UTF-8").encode
+        if tmp.content == ""
+          # The file may have exceeded the 1MB limit
+          # see https://github.blog/changelog/2022-05-03-increased-file-size-limit-when-retrieving-file-contents-via-rest-api/
+          tmp.content = github_client.contents(repo, path: path, ref: commit, accept: "application/vnd.github.v3.raw")
+        else
+          Base64.decode64(tmp.content).force_encoding("UTF-8").encode
+        end
       rescue Octokit::Forbidden => e
         raise unless e.message.include?("too_large")
 

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -449,7 +449,7 @@ module Dependabot
         if tmp.content == ""
           # The file may have exceeded the 1MB limit
           # see https://github.blog/changelog/2022-05-03-increased-file-size-limit-when-retrieving-file-contents-via-rest-api/
-          tmp.content = github_client.contents(repo, path: path, ref: commit, accept: "application/vnd.github.v3.raw")
+          github_client.contents(repo, path: path, ref: commit, accept: "application/vnd.github.v3.raw")
         else
           Base64.decode64(tmp.content).force_encoding("UTF-8").encode
         end


### PR DESCRIPTION
fix #5099

Due to a [recent file size limit change](https://github.blog/changelog/2022-05-03-increased-file-size-limit-when-retrieving-file-contents-via-rest-api/), the file contents may not be coming back from the query. 

Adding an additional explicit call when the contents is blank.