### PR TITLE
Add fixtures to `paths-ignore` for CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+    paths-ignore:
+      - '*/spec/fixtures/**'
   schedule:
     - cron: '41 4 * * 3'
 


### PR DESCRIPTION
Related to #5108 

14 of the 30 code scanning alerts triggered for test fixtures with "Dependency download using unencrypted communication channel". This behavior is intentional, and should be ignored. For example:

https://github.com/dependabot/dependabot-core/blob/bef818879143045aec43af0c46b9c6019dba3358/bundler/spec/fixtures/projects/bundler2/includes_requires_gemfile/Gemfile#L1-L1

This PR updates our CodeQL workflow to ignore anything in a spec/fixture subdirectory from future analysis.