### PR TITLE
Fix implementation of `PackageName#library_name`

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_name.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_name.rb
@@ -3,13 +3,14 @@
 module Dependabot
   module NpmAndYarn
     class PackageName
-      PACKAGE_NAME_REGEX     = %r{
+      PACKAGE_NAME_REGEX = %r{
           \A                                         # beginning of string
           (?=.{1,214}\z)                             # enforce length (1 - 214)
           (@(?<scope>[a-z0-9\-~][a-z0-9\-\._~]*)\/)? # capture 'scope' if present
           (?<name>[a-z0-9\-~][a-z0-9\-._~]*)         # capture package name
           \z                                         # end of string
       }xi.freeze                                     # multi-line/case-insensitive
+
       TYPES_PACKAGE_NAME_REGEX = %r{
           \A                                         # beginning of string
           @#{DEFINITELY_TYPED_SCOPE}\/               # starts with @types/

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_name.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_name.rb
@@ -13,7 +13,7 @@ module Dependabot
 
       TYPES_PACKAGE_NAME_REGEX = %r{
           \A                                         # beginning of string
-          @#{DEFINITELY_TYPED_SCOPE}\/               # starts with @types/
+          @types\/                                   # starts with @types/
           ((?<scope>.+)__)?                          # capture scope
           (?<name>.+)                                # capture name
           \z                                         # end of string

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_name.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_name.rb
@@ -3,7 +3,6 @@
 module Dependabot
   module NpmAndYarn
     class PackageName
-      DEFINITELY_TYPED_SCOPE = /types/i.freeze
       PACKAGE_NAME_REGEX     = %r{
           \A                                         # beginning of string
           (?=.{1,214}\z)                             # enforce length (1 - 214)
@@ -81,7 +80,7 @@ module Dependabot
       end
 
       def types_package?
-        DEFINITELY_TYPED_SCOPE.match?(@scope)
+        "types".casecmp?(@scope)
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package_name_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package_name_spec.rb
@@ -67,11 +67,9 @@ RSpec.describe Dependabot::NpmAndYarn::PackageName do
 
   describe "#library_name" do
     it "returns nil if it is not a types package" do
-      jquery = "jquery"
-
-      library_name = described_class.new(jquery).library_name
-
-      expect(library_name).to be_nil
+      expect(described_class.new("jquery").library_name).to be_nil
+      expect(described_class.new("@babel/core").library_name).to be_nil
+      expect(described_class.new("@typescript-eslint/parser").library_name).to be_nil
     end
 
     it "returns the corresponding library for a types package" do


### PR DESCRIPTION
The current logic for determining whether a package has the Definitely Typed `@types` scope uses an unanchored regular expression, causing false positives on packages like `@typescript-eslint/parser`.

This PR replaces the check with the [`casecmp?`](https://apidock.com/ruby/v2_6_3/String/casecmp%3F) method, which performs a case-insensitive string equality check.