### PR TITLE
Validate before creating version objects in `Dependabot::NpmAndYarn::UpdateChecker::VersionResolver`

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -252,7 +252,9 @@ module Dependabot
 
           return false unless latest_allowable_version.backwards_compatible_with?(latest_types_package_version)
 
+          return false unless version_class.correct?(types_package.version)
           current_types_package_version = version_class.new(types_package.version)
+
           return false unless current_types_package_version < latest_types_package_version
 
           true
@@ -261,8 +263,10 @@ module Dependabot
         def original_package_update_available?
           return false if original_package.nil?
 
-          latest_version = latest_version_finder(original_package).latest_version_from_registry
+          return false unless version_class.correct?(original_package.version)
           original_package_version = version_class.new(original_package.version)
+
+          latest_version = latest_version_finder(original_package).latest_version_from_registry
 
           original_package_version < latest_version
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -253,6 +253,7 @@ module Dependabot
           return false unless latest_allowable_version.backwards_compatible_with?(latest_types_package_version)
 
           return false unless version_class.correct?(types_package.version)
+
           current_types_package_version = version_class.new(types_package.version)
 
           return false unless current_types_package_version < latest_types_package_version
@@ -264,6 +265,7 @@ module Dependabot
           return false if original_package.nil?
 
           return false unless version_class.correct?(original_package.version)
+
           original_package_version = version_class.new(original_package.version)
 
           latest_version = latest_version_finder(original_package).latest_version_from_registry


### PR DESCRIPTION
The current implementation of `original_package_update_available?` and `types_update_available?` in `Dependabot::NpmAndYarn::UpdateChecker::VersionResolver` calls `Version.new` without first validating, which raises an exception.

This PR adds missing calls to `Version.correct?` and returns from these methods early.