### PR TITLE
Fix Dependabot ignoring scoped registries if the lockfile resolved uri contains a port number

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -194,12 +194,7 @@ module Dependabot
           # Registry used for unscoped packages
           return if scopes.include?(nil)
 
-          # TODO: Remove this line
-          #
-          # We do not require the trailing slash for scopes, but we are currently added one
-          # by accident. This avoids us having to churn the tests to ensure the bug fix passes
-          registry_with_trailing_slash = registry.sub(%r{\/?$}, "/")
-          scopes.map { |scope| "@#{scope}:registry=https://#{registry_with_trailing_slash}" }
+          scopes.map { |scope| "@#{scope}:registry=https://#{registry}" }
         end
         # rubocop:enable Metrics/PerceivedComplexity
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -48,7 +48,9 @@ module Dependabot
         end
 
         def global_registry # rubocop:disable Metrics/PerceivedComplexity
-          @global_registry ||=
+          return @global_registry if defined?(@global_registry)
+
+          @global_registry =
             registry_credentials.find do |cred|
               next false if CENTRAL_REGISTRIES.include?(cred["registry"])
 
@@ -132,21 +134,24 @@ module Dependabot
         def credential_lines_for_npmrc
           lines = []
           registry_credentials.each do |cred|
-            registry = cred.fetch("registry").sub(%r{\/?$}, "/")
+            registry = cred.fetch("registry")
 
             lines += registry_scopes(registry) if registry_scopes(registry)
 
             token = cred.fetch("token", nil)
             next unless token
 
+            # We need to ensure the registry uri ends with a trailing slash in the npmrc file
+            # but we do not want to add one if it already exists
+            registry_with_trailing_slash = registry.sub(%r{\/?$}, "/")
             if token.include?(":")
               encoded_token = Base64.encode64(token).delete("\n")
-              lines << "//#{registry}:_auth=#{encoded_token}"
+              lines << "//#{registry_with_trailing_slash}:_auth=#{encoded_token}"
             elsif Base64.decode64(token).ascii_only? &&
                   Base64.decode64(token).include?(":")
-              lines << %(//#{registry}:_auth=#{token.delete("\n")})
+              lines << %(//#{registry_with_trailing_slash}:_auth=#{token.delete("\n")})
             else
-              lines << "//#{registry}:_authToken=#{token}"
+              lines << "//#{registry_with_trailing_slash}:_authToken=#{token}"
             end
           end
 
@@ -169,7 +174,6 @@ module Dependabot
         def registry_scopes(registry)
           # Central registries don't just apply to scopes
           return if CENTRAL_REGISTRIES.include?(registry)
-
           return unless dependency_urls
 
           other_regs =
@@ -190,7 +194,12 @@ module Dependabot
           # Registry used for unscoped packages
           return if scopes.include?(nil)
 
-          scopes.map { |scope| "@#{scope}:registry=https://#{registry}" }
+          # TODO: Remove this line
+          #
+          # We do not require the trailing slash for scopes, but we are currently added one
+          # by accident. This avoids us having to churn the tests to ensure the bug fix passes
+          registry_with_trailing_slash = registry.sub(%r{\/?$}, "/")
+          scopes.map { |scope| "@#{scope}:registry=https://#{registry_with_trailing_slash}" }
         end
         # rubocop:enable Metrics/PerceivedComplexity
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npmrc_builder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npmrc_builder_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
 
             it "adds auth details, and scopes them correctly" do
               expect(npmrc_content).
-                to eq("@dependabot:registry=https://npm.fury.io/dependabot/\n"\
+                to eq("@dependabot:registry=https://npm.fury.io/dependabot\n"\
                       "//npm.fury.io/dependabot/:_authToken=my_token\n"\
                       "//npm.fury.io/dep/:_authToken=my_other_token")
             end
@@ -217,7 +217,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
                 expect(npmrc_content).
                   to eq(
                     "@dependabot:registry=https://api.bintray.com/npm/"\
-                    "dependabot/npm-private/\n"\
+                    "dependabot/npm-private\n"\
                     "//api.bintray.com/npm/dependabot/"\
                     "npm-private/:_authToken=my_token"
                   )
@@ -258,7 +258,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
               it "adds auth details, and scopes them correctly" do
                 expect(npmrc_content).
                   to eq(
-                    "@dependabot:registry=https://npm.fury.io/dependabot/\n"\
+                    "@dependabot:registry=https://npm.fury.io/dependabot\n"\
                     "//npm.fury.io/dependabot/:_authToken=my_token\n"\
                     "//npm.fury.io/dep/:_authToken=my_other_token"
                   )
@@ -299,7 +299,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
           end
           it "adds auth details, and scopes them correctly" do
             expect(npmrc_content).
-              to eq("@dependabot:registry=https://npm.fury.io/dependabot/")
+              to eq("@dependabot:registry=https://npm.fury.io/dependabot")
           end
         end
       end
@@ -570,7 +570,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
             end
             it "adds auth details, and scopes them correctly" do
               expect(npmrc_content).
-                to eq("@dependabot:registry=https://npm.fury.io/dependabot/\n"\
+                to eq("@dependabot:registry=https://npm.fury.io/dependabot\n"\
                       "//npm.fury.io/dependabot/:_authToken=my_token")
             end
           end
@@ -634,7 +634,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
             end
             it "adds auth details, and scopes them correctly" do
               expect(npmrc_content).
-                to eq("@dependabot:registry=https://npm.fury.io/dependabot/")
+                to eq("@dependabot:registry=https://npm.fury.io/dependabot")
             end
           end
 
@@ -651,7 +651,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
             end
             it "adds auth details, and scopes them correctly" do
               expect(npmrc_content).
-                to eq("@dependabot:registry=https://npm.fury.io/dependabot/")
+                to eq("@dependabot:registry=https://npm.fury.io/dependabot")
             end
           end
         end
@@ -863,7 +863,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
               registry = https://npm.pkg.github.com
               _authToken = my_token
               always-auth = true
-              @dsp-testing:registry=https://npm.pkg.github.com/
+              @dsp-testing:registry=https://npm.pkg.github.com
               //npm.pkg.github.com/:_authToken=my_token
             NPMRC
         end
@@ -877,7 +877,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
         it "adds the scoped registry and token auth details" do
           expect(npmrc_content).
             to eq(<<~NPMRC.chomp)
-              @dsp-testing:registry=https://npm.pkg.github.com/
+              @dsp-testing:registry=https://npm.pkg.github.com
               //npm.pkg.github.com/:_authToken=my_token
             NPMRC
         end
@@ -891,7 +891,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
         it "adds the scoped registry and token auth details" do
           expect(npmrc_content).
             to eq(<<~NPMRC.chomp)
-              @dsp-testing:registry=https://npm.pkg.github.com/
+              @dsp-testing:registry=https://npm.pkg.github.com
               //npm.pkg.github.com/:_authToken=my_token
             NPMRC
         end

--- a/npm_and_yarn/spec/fixtures/projects/npm8/private_registry_ghpr_and_npm/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/private_registry_ghpr_and_npm/package-lock.json
@@ -1,0 +1,40 @@
+{
+  "name": "dependabot-consume-private-registries",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dependabot-consume-private-registries",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@dsp-testing/inner-source-top-secret-npm-2": "1.0.3",
+        "lodash": "^4.17.20"
+      }
+    },
+    "node_modules/@dsp-testing/inner-source-top-secret-npm-2": {
+      "version": "1.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@dsp-testing/inner-source-top-secret-npm-2/1.0.3/0a19a66110450848d0a88b1be211cadae740a86f0c1c1658ed89c9f391b8f605",
+      "integrity": "sha512-5Kt5AHgt2qE9YFlRnqizh36k1lcuTdGQP3UsxJgxVUo1Uxh4Z7vDgr7wDBm2hp4PjZ6soE4zupSyfaCbYguQqg==",
+      "license": "ISC"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    }
+  },
+  "dependencies": {
+    "@dsp-testing/inner-source-top-secret-npm-2": {
+      "version": "1.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@dsp-testing/inner-source-top-secret-npm-2/1.0.3/0a19a66110450848d0a88b1be211cadae740a86f0c1c1658ed89c9f391b8f605",
+      "integrity": "sha512-5Kt5AHgt2qE9YFlRnqizh36k1lcuTdGQP3UsxJgxVUo1Uxh4Z7vDgr7wDBm2hp4PjZ6soE4zupSyfaCbYguQqg=="
+    },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm8/private_registry_ghpr_and_npm/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/private_registry_ghpr_and_npm/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "dependabot-consume-private-registries",
+  "version": "1.0.0",
+  "description": "Used by [#dependabot-updates-team](https://app.slack.com/client/T0CA8C346/C01BKB7EVQX) to test [support for private registries](https://github.com/github/dsp/issues/167).",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dsp-testing/dependabot-consume-private-registries.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/dsp-testing/dependabot-consume-private-registries/issues"
+  },
+  "homepage": "https://github.com/dsp-testing/dependabot-consume-private-registries#readme",
+  "dependencies": {
+    "@dsp-testing/inner-source-top-secret-npm-2": "1.0.3",
+    "lodash": "^4.17.20"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm8/private_registry_ghpr_only/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/private_registry_ghpr_only/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "dependabot-consume-private-registries",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dependabot-consume-private-registries",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@dsp-testing/inner-source-top-secret-npm-2": "1.0.3"
+      }
+    },
+    "node_modules/@dsp-testing/inner-source-top-secret-npm-2": {
+      "version": "1.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@dsp-testing/inner-source-top-secret-npm-2/1.0.3/0a19a66110450848d0a88b1be211cadae740a86f0c1c1658ed89c9f391b8f605",
+      "integrity": "sha512-5Kt5AHgt2qE9YFlRnqizh36k1lcuTdGQP3UsxJgxVUo1Uxh4Z7vDgr7wDBm2hp4PjZ6soE4zupSyfaCbYguQqg==",
+      "license": "ISC"
+    }
+  },
+  "dependencies": {
+    "@dsp-testing/inner-source-top-secret-npm-2": {
+      "version": "1.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@dsp-testing/inner-source-top-secret-npm-2/1.0.3/0a19a66110450848d0a88b1be211cadae740a86f0c1c1658ed89c9f391b8f605",
+      "integrity": "sha512-5Kt5AHgt2qE9YFlRnqizh36k1lcuTdGQP3UsxJgxVUo1Uxh4Z7vDgr7wDBm2hp4PjZ6soE4zupSyfaCbYguQqg=="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm8/private_registry_ghpr_only/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/private_registry_ghpr_only/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "dependabot-consume-private-registries",
+  "version": "1.0.0",
+  "description": "Used by [#dependabot-updates-team](https://app.slack.com/client/T0CA8C346/C01BKB7EVQX) to test [support for private registries](https://github.com/github/dsp/issues/167).",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dsp-testing/dependabot-consume-private-registries.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/dsp-testing/dependabot-consume-private-registries/issues"
+  },
+  "homepage": "https://github.com/dsp-testing/dependabot-consume-private-registries#readme",
+  "dependencies": {
+    "@dsp-testing/inner-source-top-secret-npm-2": "1.0.3"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm8/private_registry_ghpr_with_ports/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/private_registry_ghpr_with_ports/package-lock.json
@@ -1,0 +1,40 @@
+{
+  "name": "dependabot-consume-private-registries",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dependabot-consume-private-registries",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@dsp-testing/inner-source-top-secret-npm-2": "1.0.3",
+        "lodash": "^4.17.20"
+      }
+    },
+    "node_modules/@dsp-testing/inner-source-top-secret-npm-2": {
+      "version": "1.0.3",
+      "resolved": "https://npm.pkg.github.com:443/download/@dsp-testing/inner-source-top-secret-npm-2/1.0.3/0a19a66110450848d0a88b1be211cadae740a86f0c1c1658ed89c9f391b8f605",
+      "integrity": "sha512-5Kt5AHgt2qE9YFlRnqizh36k1lcuTdGQP3UsxJgxVUo1Uxh4Z7vDgr7wDBm2hp4PjZ6soE4zupSyfaCbYguQqg==",
+      "license": "ISC"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    }
+  },
+  "dependencies": {
+    "@dsp-testing/inner-source-top-secret-npm-2": {
+      "version": "1.0.3",
+      "resolved": "https://npm.pkg.github.com:443/download/@dsp-testing/inner-source-top-secret-npm-2/1.0.3/0a19a66110450848d0a88b1be211cadae740a86f0c1c1658ed89c9f391b8f605",
+      "integrity": "sha512-5Kt5AHgt2qE9YFlRnqizh36k1lcuTdGQP3UsxJgxVUo1Uxh4Z7vDgr7wDBm2hp4PjZ6soE4zupSyfaCbYguQqg=="
+    },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm8/private_registry_ghpr_with_ports/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/private_registry_ghpr_with_ports/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "dependabot-consume-private-registries",
+  "version": "1.0.0",
+  "description": "Used by [#dependabot-updates-team](https://app.slack.com/client/T0CA8C346/C01BKB7EVQX) to test [support for private registries](https://github.com/github/dsp/issues/167).",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dsp-testing/dependabot-consume-private-registries.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/dsp-testing/dependabot-consume-private-registries/issues"
+  },
+  "homepage": "https://github.com/dsp-testing/dependabot-consume-private-registries#readme",
+  "dependencies": {
+    "@dsp-testing/inner-source-top-secret-npm-2": "1.0.3",
+    "lodash": "^4.17.20"
+  }
+}


### PR DESCRIPTION
Assuming a project has the following config:

**dependabot.yml**
```yml
version: 2
registries:
  private-npm:
    type: npm-registry
    url: example.com/artifactory/api/npm/example
    username: ${{secrets.USER}}
    password: ${{secrets.PASS}}
updates:
  - package-ecosystem: "npm"
    registries:
      - private-npm
    schedule:
      interval: "daily"
```

In their package.json they have a dependency from their private registry, which has a `resolved` URL in the form:

```
https://example.com:443/artifactory/api/npm/example/@example/example-client/-/@example-corp/example-client-1.0.0.tgz
```

This will result in confusing behaviour where we will correctly find the latest version in the private registry but fail to actually update the package with a `private_source_authentication_failure`.

### The problem

The `private_source_authentication_failure` is actually a misdirection, using the debugger I was able to output the raw error which was coming from npm [here](https://github.com/dependabot/dependabot-core/blob/main/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb#L57-L63)

```
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/@example%2fexample-client - Not found
npm ERR! 404 
npm ERR! 404  '@example/example-client@1.0.1' is not in this registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
```

This indicates that **we are actually calling the _public_ npm registry** and getting a 404 but then assume that it's a private registry problem [here](https://github.com/dependabot/dependabot-core/blob/main/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb#L409-L426) as this line is false:

```
UpdateChecker::RegistryFinder.central_registry?(reg)
```

### The fix

After investigating I discovered that no 'scoped registry' line was being added to the `.npmrc` file we generate on the fly when performing the update.

It should have had a line like so:
```
@example=https://example.com/artifactory/api/npm/example
```

The reason this wasn't being added is that due to a fix for a duplicate trailing slash in the past (https://github.com/dependabot/dependabot-core/pull/1013/files), we started adding a trailing slash to the `registry` value used in this method unintentionally:
https://github.com/dependabot/dependabot-core/blob/3428ef7720a4b68e5238f4299a1d096f59da81e6/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb#L174-L198

The fix was to add the compulsory trailing slash later in the method, I've added test cases that verify this resolves the issue.

### Unrelated changes

I fixed the bug in fd4fb97 to make the red/green pass as clear as possible. The final commit cleans up some test churn where we expected the scoped registry lines to have the trailing `/` - this isn't necessary and we tolerate it as a side-effect of the original bug fix.