### PR TITLE
Strip UTF-8 BOM from file contents

### DIFF
--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -4,6 +4,9 @@ require "pathname"
 
 module Dependabot
   class DependencyFile
+    # See https://www.unicode.org/faq/utf_bom.html#BOM
+    UTF_8_BOM = [0xEF, 0xBB, 0xBF].pack("C*").force_encoding("UTF-8").freeze
+
     attr_accessor :name, :content, :directory, :type, :support_file,
                   :symlink_target, :content_encoding, :operation
 
@@ -21,6 +24,9 @@ module Dependabot
     def initialize(name:, content:, directory: "/", type: "file",
                    support_file: false, symlink_target: nil,
                    content_encoding: ContentEncoding::UTF_8, deleted: false, operation: Operation::UPDATE)
+      # Remove UTF-8 byte order mark (BOM) from content, if present
+      content = content.sub(UTF_8_BOM, "") if content && content_encoding == ContentEncoding::UTF_8
+
       @name = name
       @content = content
       @directory = clean_directory(directory)

--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -25,7 +25,7 @@ module Dependabot
                    support_file: false, symlink_target: nil,
                    content_encoding: ContentEncoding::UTF_8, deleted: false, operation: Operation::UPDATE)
       # Remove UTF-8 byte order mark (BOM) from content, if present
-      content = content.sub(UTF_8_BOM, "") if content && content_encoding == ContentEncoding::UTF_8
+      content = content.delete_prefix(UTF_8_BOM) if content && content_encoding == ContentEncoding::UTF_8
 
       @name = name
       @content = content

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -293,6 +293,22 @@ RSpec.describe Dependabot::DependencyFile do
     end
   end
 
+  describe "#content" do
+    context "for utf-8 encoded content containing a BOM" do
+      let(:file) do
+        described_class.new(
+          name: "example.txt",
+          content_encoding: described_class::ContentEncoding::UTF_8,
+          content: "\xEF\xBB\xBFabc"
+        )
+      end
+
+      it "removes the BOM" do
+        expect(file.content).to eq("abc")
+      end
+    end
+  end
+
   describe "#decoded_content" do
     context "for base64 encoded content" do
       let(:file) do

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -101,6 +101,29 @@ RSpec.describe Dependabot::Docker::FileParser do
       end
     end
 
+    context "with a FROM line starting with a BOM" do
+      let(:dockerfile_fixture_name) { "bom" }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: { tag: "17.04" }
+          }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("ubuntu")
+          expect(dependency.version).to eq("17.04")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+    end
+
     context "with a FROM line written by a nutcase" do
       let(:dockerfile_fixture_name) { "case" }
 

--- a/docker/spec/fixtures/docker/dockerfiles/bom
+++ b/docker/spec/fixtures/docker/dockerfiles/bom
@@ -1,0 +1,21 @@
+﻿FROM ubuntu:17.04
+# This file starts with a UTF-8 BOM
+# See https://www.unicode.org/faq/utf_bom.html#BOM
+
+### SYSTEM DEPENDENCIES
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+      build-essential \
+      dirmngr \
+      git \
+
+
+### RUBY
+
+# Install Ruby 2.4
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3173AA6 \
+    && echo "deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu zesty main" > /etc/apt/sources.list.d/brightbox.list \
+    && apt-get update
+RUN apt-get install -y ruby2.4 ruby2.4-dev


### PR DESCRIPTION
Resolves #5118

From the [Unicode FAQ about BOM](https://www.unicode.org/faq/utf_bom.html#BOM) (emphasis added):

> Q: What is a BOM?
> A: A byte order mark (BOM) consists of the character code U+FEFF at the beginning of a data stream, where it can be used as a signature defining the byte order and encoding form, primarily of unmarked plaintext files. Under some higher level protocols, use of a BOM may be mandatory (or prohibited) in the Unicode data stream defined in that protocol.

> Q: Can a UTF-8 data stream contain the BOM character (in UTF-8 form)? If yes, then can I still assume the remaining UTF-8 bytes are in big-endian order?
> A: Yes, UTF-8 can contain a BOM. However, it makes no difference as to the endianness of the byte stream. UTF-8 always has the same byte order. An initial BOM is only used as a signature — an indication that an otherwise unmarked text file is in UTF-8. Note that some recipients of UTF-8 encoded data do not expect a BOM. **Where UTF-8 is used transparently in 8-bit environments, the use of a BOM will interfere with any protocol or file format that expects specific ASCII characters at the beginning, such as the use of "#!" of at the beginning of Unix shell scripts**.

...as well as `FROM` statements on the first line of a `Dockerfile`.

https://github.com/dependabot/dependabot-core/blob/49b0e89be4ba273ed842df8b8297c7dc55a3b8fa/docker/lib/dependabot/docker/file_parser.rb#L31-L33

This PR updates the `Dependabot::DependencyFile` initializer to proactively remove the UTF-8 BOM from content when the file encoding is UTF-8. It also adds a test case and fixture for a Dockerfile containing a BOM.

⚠️ This change touches all ecosystems, so it carries an outsized risk. Theoretically, this may fix a bunch of unreported issues for folks where Dependabot isn't doing the right thing (there are hundreds of regexes in `dependabot-core` that include a `^` anchor, any of which could break with a BOM).