### PR TITLE
[Maven] Avoid retrying requests to repos excessively

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -153,6 +153,7 @@ module Dependabot
         connect_timeout: 5,
         write_timeout: 5,
         read_timeout: 20,
+        retry_limit: 4, # Excon defaults to four retries, but let's set it explicitly for clarity
         omit_default_port: true,
         middlewares: excon_middleware,
         headers: excon_headers(headers)

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -304,6 +304,7 @@ RSpec.describe Dependabot::SharedHelpers do
         connect_timeout: 5,
         write_timeout: 5,
         read_timeout: 20,
+        retry_limit: 4,
         omit_default_port: true,
         middlewares: described_class.excon_middleware,
         headers: described_class.excon_headers

--- a/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
+++ b/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
@@ -113,6 +113,11 @@ module Dependabot
             @maven_responses[url] ||= Excon.get(
               url,
               idempotent: true,
+              # We attempt to find dependencies in private repos before failing over to the CENTRAL_REPO_URL,
+              # but this can burn a lot of a job's time against slow servers due to our `read_timeout` being 20 seconds.
+              #
+              # In order to avoid the overall job timing out, we only make one retry attempt
+              retry_limit: 1,
               **SharedHelpers.excon_defaults
             )
             next unless @maven_responses[url].status == 200


### PR DESCRIPTION
Excon has a default retry strategy of `4` requests.

As part of Maven updates, we attempt to find a list of repository URLs to lookup in "parent" pom files, but generally treat a non-200 response as a nil return. In the case a parent URL points to a host that is unreachable, we can spend up to 100 seconds attempting a single this with the current configuration.

We should tolerate network weather, but 5 attempts is fairly excessive, so let's drop to a single retry for 2 attempts overall.