### PR TITLE
Add --network-trace to dry-run

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -236,11 +236,6 @@ option_parse = OptionParser.new do |opts|
     $options[:profile] = true
   end
 
-  opts.on("--network-tracing",
-          "Enable Excon instrumentation to log requests made to remote hosts.") do
-    $options[:network_tracing] = true
-  end
-
   opts.on("--pull-request",
           "Output pull request information: title, description") do
     $options[:pull_request] = true
@@ -466,13 +461,12 @@ end
 
 StackProf.start(raw: true) if $options[:profile]
 
-if $options[:network_tracing]
-  $network_trace_count = 0
-  ActiveSupport::Notifications.subscribe(/excon.request/) do |*args|
-    $network_trace_count += 1
-    payload = args.last
-    puts "🌍 #{payload[:scheme]}//#{payload[:host]}:#{payload[:port]}#{payload[:path]}"
-  end
+
+$network_trace_count = 0
+ActiveSupport::Notifications.subscribe(/excon.request/) do |*args|
+  $network_trace_count += 1
+  payload = args.last
+  puts "🌍 #{payload[:scheme]}//#{payload[:host]}:#{payload[:port]}#{payload[:path]}"
 end
 
 $source = Dependabot::Source.new(
@@ -788,9 +782,7 @@ end
 StackProf.stop if $options[:profile]
 StackProf.results("tmp/stackprof-#{Time.now.strftime('%Y-%m-%d-%H:%M')}.dump") if $options[:profile]
 
-if $options[:network_tracing]
-  puts "🌍 Total requests made: '#{$network_trace_count}'"
-end
+puts "🌍 Total requests made: '#{$network_trace_count}'"
 
 # rubocop:enable Metrics/BlockLength
 

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/notifications"
 require "digest"
 require "English"
 require "excon"
@@ -150,6 +151,7 @@ module Dependabot
       options ||= {}
       headers = options.delete(:headers)
       {
+        instrumentor: ActiveSupport::Notifications,
         connect_timeout: 5,
         write_timeout: 5,
         read_timeout: 20,

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -301,6 +301,7 @@ RSpec.describe Dependabot::SharedHelpers do
 
     it "includes the defaults" do
       expect(subject).to eq(
+        instrumentor: ActiveSupport::Notifications,
         connect_timeout: 5,
         write_timeout: 5,
         read_timeout: 20,


### PR DESCRIPTION
We are currently investigating some slow running jobs and one thing that is noticeable is that some ecosystem implementations tend to make excessive network calls within core's code.

This change does two things:
- Adds `ActiveSupport::Notification` as a generic instrumentor for `Excon`, per the [docs](https://github.com/excon/excon#instrumentation)
- Adds a `--network-trace` argument to the dry-run script that optionally prints out every request made during the run along with a total count at the end of the job

Example:
```log
$ bin/dry-run.rb maven "apache/avro" --dir="/lang/java" --cache=files --dep "org.eclipse.jetty:jetty-server" --network-tracing
warning: parser/current is loading parser/ruby27, which recognizes2.7.6-compliant syntax, but you are running 2.7.5.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> reading dependency files from cache manifest: ./dry-run/apache/avro/lang/java/cache-manifest-maven.json
=> parsing dependency files
=> updating 1 dependencies: org.eclipse.jetty:jetty-server

=== org.eclipse.jetty:jetty-server (9.4.44.v20210927)
 => checking for updates 1/1
🌍 https//repo.maven.apache.org:443/maven2/org/apache/apache/23/apache-23.pom
🌍 https//repository.apache.org:443/snapshots/org/eclipse/jetty/jetty-server/maven-metadata.xml
🌍 https//repo.maven.apache.org:443/maven2/org/eclipse/jetty/jetty-server/maven-metadata.xml
🌍 https//repository.apache.org:443/snapshots/org/eclipse/jetty/jetty-server/11.0.9/jetty-server-11.0.9.jar
🌍 https//repository.apache.org:443/snapshots/org/eclipse/jetty/jetty-server/11.0.9/jetty-server-11.0.9.jar
🌍 https//repo.maven.apache.org:443/maven2/org/eclipse/jetty/jetty-server/11.0.9/jetty-server-11.0.9.jar
 => latest available version is 11.0.9
 => latest allowed version is 9.4.44.v20210927
🌍 https//repo.maven.apache.org:443/maven2/org/apache/apache/23/apache-23.pom
🌍 https//repository.apache.org:443/snapshots/org/eclipse/jetty/jetty-server/maven-metadata.xml
🌍 https//repo.maven.apache.org:443/maven2/org/eclipse/jetty/jetty-server/maven-metadata.xml
🌍 https//repo.maven.apache.org:443/maven2/org/apache/apache/23/apache-23.pom
🌍 https//repository.apache.org:443/snapshots/org/eclipse/jetty/jetty-servlet/maven-metadata.xml
🌍 https//repo.maven.apache.org:443/maven2/org/eclipse/jetty/jetty-servlet/maven-metadata.xml
🌍 https//repo.maven.apache.org:443/maven2/org/apache/apache/23/apache-23.pom
🌍 https//repository.apache.org:443/snapshots/org/eclipse/jetty/jetty-util/maven-metadata.xml
🌍 https//repo.maven.apache.org:443/maven2/org/eclipse/jetty/jetty-util/maven-metadata.xml
 => requirements to unlock: all
 => requirements update strategy: 
🌍 https//repo.maven.apache.org:443/maven2/org/apache/apache/23/apache-23.pom
🌍 https//repository.apache.org:443/snapshots/org/eclipse/jetty/jetty-servlet/maven-metadata.xml
🌍 https//repo.maven.apache.org:443/maven2/org/eclipse/jetty/jetty-servlet/maven-metadata.xml
🌍 https//repository.apache.org:443/snapshots/org/eclipse/jetty/jetty-servlet/11.0.9/jetty-servlet-11.0.9.jar
🌍 https//repository.apache.org:443/snapshots/org/eclipse/jetty/jetty-servlet/11.0.9/jetty-servlet-11.0.9.jar
🌍 https//repo.maven.apache.org:443/maven2/org/eclipse/jetty/jetty-servlet/11.0.9/jetty-servlet-11.0.9.jar
🌍 https//repo.maven.apache.org:443/maven2/org/apache/apache/23/apache-23.pom
🌍 https//repository.apache.org:443/snapshots/org/eclipse/jetty/jetty-util/maven-metadata.xml
🌍 https//repo.maven.apache.org:443/maven2/org/eclipse/jetty/jetty-util/maven-metadata.xml
🌍 https//repository.apache.org:443/snapshots/org/eclipse/jetty/jetty-util/11.0.9/jetty-util-11.0.9.jar
🌍 https//repository.apache.org:443/snapshots/org/eclipse/jetty/jetty-util/11.0.9/jetty-util-11.0.9.jar
🌍 https//repo.maven.apache.org:443/maven2/org/eclipse/jetty/jetty-util/11.0.9/jetty-util-11.0.9.jar
 => updating org.eclipse.jetty:jetty-server, org.eclipse.jetty:jetty-servlet, org.eclipse.jetty:jetty-util

    ± pom.xml
    ~~~
    43c43
    <     <jetty.version>9.4.44.v20210927</jetty.version>
    ---
    >     <jetty.version>11.0.9</jetty.version>
    ~~~
🌍 Total requests made: '27'
```

### Potential follow-ups

The use of ActiveSupport notification may pave the way for attaching a metric service to core in future.
