### PR TITLE
[Maven] Fix some malformed memoizations

### DIFF
--- a/maven/lib/dependabot/maven/update_checker/property_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/property_updater.rb
@@ -23,8 +23,9 @@ module Dependabot
 
         def update_possible?
           return false unless target_version
+          return @update_possible if defined?(@update_possible)
 
-          @update_possible ||=
+          @update_possible =
             dependencies_using_property.all? do |dep|
               next false if includes_property_reference?(updated_version(dep))
 

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -156,7 +156,7 @@ module Dependabot
 
         def dependency_metadata(repository_details)
           repository_key = repository_details.hash
-          return @dependency_metadata[repository_key] if @dependency_metadata.has_key?(repository_key)
+          return @dependency_metadata[repository_key] if @dependency_metadata.key?(repository_key)
 
           @dependency_metadata[repository_key] = fetch_dependency_metadata(repository_details)
         end
@@ -173,7 +173,7 @@ module Dependabot
         rescue URI::InvalidURIError
           Nokogiri::XML("")
         rescue Excon::Error::Socket, Excon::Error::Timeout,
-                Excon::Error::TooManyRedirects
+               Excon::Error::TooManyRedirects
           raise if central_repo_urls.include?(repository_details["url"])
 
           Nokogiri::XML("")

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -25,6 +25,7 @@ module Dependabot
           @raise_on_ignored    = raise_on_ignored
           @security_advisories = security_advisories
           @forbidden_urls      = []
+          @dependency_metadata = {}
         end
 
         def latest_version_details
@@ -154,25 +155,28 @@ module Dependabot
         end
 
         def dependency_metadata(repository_details)
-          @dependency_metadata ||= {}
-          @dependency_metadata[repository_details.hash] ||=
-            begin
-              response = Excon.get(
-                dependency_metadata_url(repository_details.fetch("url")),
-                idempotent: true,
-                **Dependabot::SharedHelpers.excon_defaults(headers: repository_details.fetch("auth_headers"))
-              )
-              check_response(response, repository_details.fetch("url"))
+          repository_key = repository_details.hash
+          return @dependency_metadata[repository_key] if @dependency_metadata.has_key?(repository_key)
 
-              Nokogiri::XML(response.body)
-            rescue URI::InvalidURIError
-              Nokogiri::XML("")
-            rescue Excon::Error::Socket, Excon::Error::Timeout,
-                   Excon::Error::TooManyRedirects
-              raise if central_repo_urls.include?(repository_details["url"])
+          @dependency_metadata[repository_key] = fetch_dependency_metadata(repository_details)
+        end
 
-              Nokogiri::XML("")
-            end
+        def fetch_dependency_metadata(repository_details)
+          response = Excon.get(
+            dependency_metadata_url(repository_details.fetch("url")),
+            idempotent: true,
+            **Dependabot::SharedHelpers.excon_defaults(headers: repository_details.fetch("auth_headers"))
+          )
+          check_response(response, repository_details.fetch("url"))
+
+          Nokogiri::XML(response.body)
+        rescue URI::InvalidURIError
+          Nokogiri::XML("")
+        rescue Excon::Error::Socket, Excon::Error::Timeout,
+                Excon::Error::TooManyRedirects
+          raise if central_repo_urls.include?(repository_details["url"])
+
+          Nokogiri::XML("")
         end
 
         def check_response(response, repository_url)
@@ -184,7 +188,7 @@ module Dependabot
         end
 
         def repositories
-          return @repositories if @repositories
+          return @repositories if defined?(@repositories)
 
           details = pom_repository_details + credentials_repository_details
 


### PR DESCRIPTION
This PR collects up a pass on any methods that make `Excon.get` calls which attempt to memoize the outcome of requests.

I found a couple of cases where the pattern used wouldn't correctly memoize falsy values and fall through to making the request a second time.

From walking through the code I don't think these will have any performance implications unfortunately, I don't believe these methods are called more than once in any of our runtimes, but it could catch us out in future.