### PR TITLE
skip CI workflow when creating release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - "main"
   pull_request:
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'common/lib/dependabot/version.rb'
     branches:
       - "main"
   schedule:


### PR DESCRIPTION
The release process is already pretty lengthy, so this allows us to skip the CI step when cutting release notes. We could use admin powers to merge before CI is complete but that is a bad habit.