### PR TITLE
[Maven] Cache client-side timeouts when a remote host is unreachable

### DIFF
--- a/maven/lib/dependabot/maven.rb
+++ b/maven/lib/dependabot/maven.rb
@@ -9,6 +9,7 @@ require "dependabot/maven/file_updater"
 require "dependabot/maven/metadata_finder"
 require "dependabot/maven/requirement"
 require "dependabot/maven/version"
+require "dependabot/maven/registry_client"
 
 require "dependabot/pull_request_creator/labeler"
 Dependabot::PullRequestCreator::Labeler.

--- a/maven/lib/dependabot/maven/file_parser/property_value_finder.rb
+++ b/maven/lib/dependabot/maven/file_parser/property_value_finder.rb
@@ -4,7 +4,6 @@ require "nokogiri"
 
 require "dependabot/dependency_file"
 require "dependabot/maven/file_parser"
-require "dependabot/shared_helpers"
 
 # For documentation, see:
 # - http://maven.apache.org/guides/introduction/introduction-to-the-pom.html
@@ -128,11 +127,7 @@ module Dependabot
             url = remote_pom_url(group_id, artifact_id, version, base_url)
 
             @maven_responses ||= {}
-            @maven_responses[url] ||= Excon.get(
-              url,
-              idempotent: true,
-              **SharedHelpers.excon_defaults
-            )
+            @maven_responses[url] ||= RegistryClient.get(url: url)
             next unless @maven_responses[url].status == 200
             next unless pom?(@maven_responses[url].body)
 

--- a/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
+++ b/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
@@ -4,7 +4,6 @@ require "nokogiri"
 
 require "dependabot/dependency_file"
 require "dependabot/maven/file_parser"
-require "dependabot/shared_helpers"
 require "dependabot/errors"
 
 # For documentation, see:
@@ -110,15 +109,13 @@ module Dependabot
             url = remote_pom_url(group_id, artifact_id, version, base_url)
 
             @maven_responses ||= {}
-            @maven_responses[url] ||= Excon.get(
-              url,
-              idempotent: true,
+            @maven_responses[url] ||= RegistryClient.get(
+              url: url,
               # We attempt to find dependencies in private repos before failing over to the CENTRAL_REPO_URL,
               # but this can burn a lot of a job's time against slow servers due to our `read_timeout` being 20 seconds.
               #
               # In order to avoid the overall job timing out, we only make one retry attempt
-              retry_limit: 1,
-              **SharedHelpers.excon_defaults
+              options: { retry_limit: 1 }
             )
             next unless @maven_responses[url].status == 200
             next unless pom?(@maven_responses[url].body)

--- a/maven/lib/dependabot/maven/metadata_finder.rb
+++ b/maven/lib/dependabot/maven/metadata_finder.rb
@@ -104,12 +104,9 @@ module Dependabot
       def dependency_pom_file
         return @dependency_pom_file unless @dependency_pom_file.nil?
 
-        response = Excon.get(
-          "#{maven_repo_dependency_url}/"\
-          "#{dependency.version}/"\
-          "#{dependency_artifact_id}-#{dependency.version}.pom",
-          idempotent: true,
-          **SharedHelpers.excon_defaults(headers: auth_headers)
+        response = RegistryClient.get(
+          url: "#{maven_repo_dependency_url}/#{dependency.version}/#{dependency_artifact_id}-#{dependency.version}.pom",
+          headers: auth_headers
         )
 
         @dependency_pom_file = Nokogiri::XML(response.body)
@@ -137,10 +134,9 @@ module Dependabot
               "#{version}/"\
               "#{artifact_id}-#{version}.pom"
 
-        response = Excon.get(
-          substitute_properties_in_source_url(url, pom),
-          idempotent: true,
-          **SharedHelpers.excon_defaults(headers: auth_headers)
+        response = RegistryClient.get(
+          url: substitute_properties_in_source_url(url, pom),
+          headers: auth_headers
         )
 
         Nokogiri::XML(response.body)

--- a/maven/lib/dependabot/maven/registry_client.rb
+++ b/maven/lib/dependabot/maven/registry_client.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "dependabot/shared_helpers"
+
+# This class provides a thin wrapper around our normal usage of Excon as a simple HTTP client in order to
+# provide some minor caching functionality.
+#
+# This is not used to support full response caching currently, we just use it to ensure we detect unreachable
+# hosts and fast-fail on any subsequent requests to them to avoid excessive use of retries and connect- or
+# read-timeouts as Maven jobs tend to be sensitive to exceeding our overall 45 minute timeout.
+module Dependabot
+  module Maven
+    class RegistryClient
+      def self.get(url:, headers: {}, options: {})
+        Excon.get(
+          url,
+          idempotent: true,
+          **SharedHelpers.excon_defaults({ headers: headers }.merge(options))
+        )
+      end
+
+      def self.head(url:, headers: {}, options: {})
+        Excon.head(
+          url,
+          idempotent: true,
+          **SharedHelpers.excon_defaults({ headers: headers }.merge(options))
+        )
+      end
+    end
+  end
+end

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "nokogiri"
-require "dependabot/shared_helpers"
 require "dependabot/update_checkers/version_filters"
 require "dependabot/maven/file_parser/repositories_finder"
 require "dependabot/maven/update_checker"
@@ -139,10 +138,9 @@ module Dependabot
           @released_check[version] =
             repositories.any? do |repository_details|
               url = repository_details.fetch("url")
-              response = Excon.head(
-                dependency_files_url(url, version),
-                idempotent: true,
-                **SharedHelpers.excon_defaults(headers: repository_details.fetch("auth_headers"))
+              response = RegistryClient.head(
+                url: dependency_files_url(url, version),
+                headers: repository_details.fetch("auth_headers")
               )
 
               response.status < 400
@@ -162,10 +160,9 @@ module Dependabot
         end
 
         def fetch_dependency_metadata(repository_details)
-          response = Excon.get(
-            dependency_metadata_url(repository_details.fetch("url")),
-            idempotent: true,
-            **Dependabot::SharedHelpers.excon_defaults(headers: repository_details.fetch("auth_headers"))
+          response = RegistryClient.get(
+            url: dependency_metadata_url(repository_details.fetch("url")),
+            headers: repository_details.fetch("auth_headers")
           )
           check_response(response, repository_details.fetch("url"))
 

--- a/maven/spec/dependabot/maven/registry_client_spec.rb
+++ b/maven/spec/dependabot/maven/registry_client_spec.rb
@@ -118,4 +118,64 @@ RSpec.describe Dependabot::Maven::RegistryClient do
       end
     end
   end
+
+  describe "exception caching" do
+    let(:unreachable_url) { "https://example.local" }
+
+    before do
+      described_class.clear_cache!
+      allow(Excon).to receive(:get).with(/#{unreachable_url}/, anything).and_raise(error)
+      allow(Excon).to receive(:head).with(/#{unreachable_url}/, anything).and_raise(error)
+    end
+
+    describe "when Excon times out internally" do
+      let(:error) { Excon::Error::Timeout.new("read timeout reached") }
+
+      it "only attempts to reach it once and then plays back the first error without calling the internet" do
+        expect(Excon).to receive(:get).with(unreachable_url, anything).once
+
+        expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Timeout)
+        expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Timeout)
+        expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Timeout)
+      end
+
+      it "replays the first error for the host on any request path" do
+        expect(Excon).to receive(:get).with(unreachable_url, anything).once
+
+        expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Timeout)
+        expect { described_class.get(url: "#{unreachable_url}/foos") }.to raise_error(Excon::Error::Timeout)
+        expect { described_class.get(url: "#{unreachable_url}/foos/bars") }.to raise_error(Excon::Error::Timeout)
+      end
+    end
+
+    describe "with an HTTP status error" do
+      Excon::Error.status_errors.each do |status_code, error_details|
+        context "with [#{status_code}] - #{error_details.last}" do
+          let(:error_class) { error_details.first }
+          let(:error_message) { error_details.last }
+          let(:error) { error_class.new(error_message) }
+
+          it "does not cache anything" do
+            expect(Excon).to receive(:get).with(/#{unreachable_url}/, anything)
+
+            expect { described_class.get(url: unreachable_url) }.to raise_error(error_class)
+            expect { described_class.get(url: "#{unreachable_url}/foos") }.to raise_error(error_class)
+            expect { described_class.get(url: "#{unreachable_url}/foos/bars") }.to raise_error(error_class)
+          end
+        end
+      end
+    end
+
+    describe "with a non-specific Excon error" do
+      let(:error) { Excon::Error.new("Boom!") }
+
+      it "does not cache anything" do
+        expect(Excon).to receive(:get).with(/#{unreachable_url}/, anything)
+
+        expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error)
+        expect { described_class.get(url: "#{unreachable_url}/foos") }.to raise_error(Excon::Error)
+        expect { described_class.get(url: "#{unreachable_url}/foos/bars") }.to raise_error(Excon::Error)
+      end
+    end
+  end
 end

--- a/maven/spec/dependabot/maven/registry_client_spec.rb
+++ b/maven/spec/dependabot/maven/registry_client_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/maven/registry_client"
+
+RSpec.describe Dependabot::Maven::RegistryClient do
+  let(:url) { "https://example.com" }
+  let(:maven_defaults) do
+    { idempotent: true }
+  end
+  let(:dependabot_defaults) do
+    Dependabot::SharedHelpers.excon_defaults
+  end
+
+  before do
+    allow(Excon).to receive(:get)
+    allow(Excon).to receive(:head)
+  end
+
+  describe "delegation to Excon" do
+    describe "::get" do
+      it "delegates requests using Dependabot defaults" do
+        expect(Excon).to receive(:get).with(url, **maven_defaults, **dependabot_defaults)
+
+        described_class.get(url: url)
+      end
+
+      it "delegates headers correctly" do
+        headers = { "Foo" => "Bar" }
+        expect(Excon).to receive(:get).with(url, **maven_defaults, **dependabot_defaults.merge(headers: {
+          "Foo" => "Bar",
+          "User-Agent" => anything
+        }))
+
+        described_class.get(url: url, headers: headers)
+      end
+
+      it "delegates options correctly" do
+        options = { foo: "bar" }
+        expect(Excon).to receive(:get).with(url, **maven_defaults, **dependabot_defaults.merge(options))
+
+        described_class.get(url: url, options: options)
+      end
+
+      it "delegates with headers and options merged correctly" do
+        headers = { "Foo" => "Bar" }
+        options = { bar: "baaz" }
+        expect(Excon).to receive(:get).with(url, **maven_defaults, **dependabot_defaults.merge(
+          headers: {
+            "Foo" => "Bar",
+            "User-Agent" => anything
+          },
+          bar: "baaz"
+        ))
+
+        described_class.get(url: url, headers: headers, options: options)
+      end
+
+      it "ignores headers that are passed as options" do
+        headers = { "Foo" => "Bar" }
+        options = { headers: headers }
+        expect(Excon).to receive(:get).with(url, **maven_defaults, **dependabot_defaults.merge(headers: {
+          "Foo" => "Bar",
+          "User-Agent" => anything
+        }))
+
+        described_class.get(url: url, options: options)
+      end
+    end
+
+    describe "::head" do
+      it "delegates requests using Dependabot defaults" do
+        expect(Excon).to receive(:head).with(url, **maven_defaults, **dependabot_defaults)
+
+        described_class.head(url: url)
+      end
+
+      it "delegates headers correctly" do
+        headers = { "Foo" => "Bar" }
+        expect(Excon).to receive(:head).with(url, **maven_defaults, **dependabot_defaults.merge(headers: {
+          "Foo" => "Bar",
+          "User-Agent" => anything
+        }))
+
+        described_class.head(url: url, headers: headers)
+      end
+
+      it "delegates options correctly" do
+        options = { foo: "bar" }
+        expect(Excon).to receive(:head).with(url, **maven_defaults, **dependabot_defaults.merge(options))
+
+        described_class.head(url: url, options: options)
+      end
+
+      it "delegates with headers and options merged correctly" do
+        headers = { "Foo" => "Bar" }
+        options = { bar: "baaz" }
+        expect(Excon).to receive(:head).with(url, **maven_defaults, **dependabot_defaults.merge(
+          headers: {
+            "Foo" => "Bar",
+            "User-Agent" => anything
+          },
+          bar: "baaz"
+        ))
+
+        described_class.head(url: url, headers: headers, options: options)
+      end
+
+      it "ignores headers that are passed as options" do
+        headers = { "Foo" => "Bar" }
+        options = { headers: headers }
+        expect(Excon).to receive(:head).with(url, **maven_defaults, **dependabot_defaults.merge(headers: {
+          "Foo" => "Bar",
+          "User-Agent" => anything
+        }))
+
+        described_class.head(url: url, options: options)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Maven projects tend to be fairly heavy on network activity as Dependabot attempts to recursively walk up the directory structure looking for parent `pom.xml` files when compiling a list of all maven registry hosts it should poll for version update data.

Once it has compiled this list, it will generally query these hosts _three times per dependency_. There may be some gains to be made in fully incorporating response caching for some very large projects but the issue that is causing most problems is that due to Dependabot's greedy registry detection if we find a registry that is behind a VPN, we will:
- [wait 5 seconds](https://github.com/dependabot/dependabot-core/blob/667b42d564a51cf819073e6f45c4626a557e537a/common/lib/dependabot/shared_helpers.rb#L155) for a `connect_timeout` if running standlone
- [wait 20 seconds](https://github.com/dependabot/dependabot-core/blob/667b42d564a51cf819073e6f45c4626a557e537a/common/lib/dependabot/shared_helpers.rb#L157) for a `read_timeout` if running behind a proxy, depending on it's implementation/configuration

The overall result is that detecting a VPN registry anywhere in the directory hierarchy of a project delay each Dependency update by:
> ( [Attempts](https://github.com/dependabot/dependabot-core/blob/667b42d564a51cf819073e6f45c4626a557e537a/common/lib/dependabot/shared_helpers.rb#L158) x Timeout ) x 3 seconds

This amounts to up to ~1 minute per dependency standalone and ~6 minutes per dependency behind a proxy.

#### The Change

Dependabot uses [Excon](https://github.com/excon/excon) as a simple HTTP client and generally uses bare `Excon.get` calls using a set of defaults that are [centrally maintained](https://github.com/dependabot/dependabot-core/blob/667b42d564a51cf819073e6f45c4626a557e537a/common/lib/dependabot/shared_helpers.rb#L150-L163) across all Ecosystems.

This PR introduces `Dependabot::Maven::RegistryClient` as a point of change local to our Maven support as:
- I don't believe other ecosystems are likely to encounter the 'bystander' VPN registries
- I don't want to introduce a RegistryClient pattern to core more generally (yet) [^1]

It **only** caches `Excon::Error::Timeout` as the specific signal of an unreachable host, there may be other responses that indicate an unhealthy host we should consider caching but I'm reluctant to do that in a first pass.

I choose this approach instead of an Excon middleware as I felt injecting it just for Maven was fairly indirect. If we decide this behaviour is something we should apply more generally, that might be a better approach. 

[^1]: While looking at this I do wonder if it would be of benefit to materialise specific named clients for registries that are low tolerance vs high tolerance and introduce some general best practice behaviours for fault tolerance - consider; it is less of an issue failing to fetch release notes than failing to fetch an actual dependency.