### PR TITLE
fix required checks not run during a release

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,38 @@
+name: CI
+on:
+  pull_request:
+    paths:
+      - 'CHANGELOG.md'
+      - 'common/lib/dependabot/version.rb'
+    branches:
+      - "main"
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - { path: bundler, name: bundler1 }
+          - { path: bundler, name: bundler2 }
+          - { path: cargo, name: cargo }
+          - { path: common, name: common }
+          - { path: composer, name: composer }
+          - { path: docker, name: docker }
+          - { path: elm, name: elm }
+          - { path: git_submodules, name: git_submodules }
+          - { path: github_actions, name: github_actions }
+          - { path: go_modules, name: go_modules }
+          - { path: gradle, name: gradle }
+          - { path: hex, name: hex }
+          - { path: maven, name: maven }
+          - { path: npm_and_yarn, name: npm_and_yarn }
+          - { path: nuget, name: nuget }
+          - { path: omnibus, name: omnibus }
+          - { path: python, name: python }
+          - { path: python, name: python_slow }
+          - { path: pub, name: pub }
+          - { path: terraform, name: terraform }
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,8 @@ on:
     branches: [ main ]
     paths-ignore:
       - '*/spec/fixtures/**'
+      - 'CHANGELOG.md'
+      - 'common/lib/dependabot/version.rb'
   schedule:
     - cron: '41 4 * * 3'
 


### PR DESCRIPTION
We have "required checks" configured for the CI, and so if the CI never runs then the build will never pass. So this creates a workflow which runs during a release with identical names to the real CI workflow, but doesn't run the real tests.

We also thought it would be a good idea to skip the CodeQL step during a release since it probably won't detect any issues. The CodeQL isn't currently required so no codeql-analysis-release.yml required yet!

See https://github.com/dependabot/dependabot-core/pull/5143