### PR TITLE
Check if updated file exists before adding to list of updated files

### DIFF
--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -29,7 +29,9 @@ module Dependabot
 
           raise "Content didn't change!" if updated_content == file.content
 
-          updated_files << updated_file(file: file, content: updated_content)
+          updated_file = updated_file(file: file, content: updated_content)
+
+          updated_files << updated_file unless updated_files.include?(updated_file)
         end
         updated_lockfile_content = update_lockfile_declaration(updated_files)
 


### PR DESCRIPTION
Fixes #5167 by not adding duplicate files to the updated files list