### PR TITLE
URL decode Nuget API v2 "next" link when paging version results

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -232,7 +232,7 @@ module Dependabot
 
           if (link_href = fetch_v2_next_link_href(response.body))
             url_details = url_details.dup
-            url_details[:versions_url] = link_href
+            url_details[:versions_url] = CGI::unescape(link_href)
             fetch_paginated_v2_nuget_listings(url_details, results)
           end
 

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -232,7 +232,7 @@ module Dependabot
 
           if (link_href = fetch_v2_next_link_href(response.body))
             url_details = url_details.dup
-            url_details[:versions_url] = CGI::unescape(link_href)
+            url_details[:versions_url] = CGI.unescape(link_href)
             fetch_paginated_v2_nuget_listings(url_details, results)
           end
 


### PR DESCRIPTION
Fixes #5166

Some Nuget repositories, such as JFrog's Artifactory, URL encode the "next" href link in the paged results. If the href is not URL decoded, the paging parameters are ignored and the first page is always returned. This change URL decodes the href before fetching the next page of version results.