### PR TITLE
Document why the link needs to be unescaped

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -232,6 +232,9 @@ module Dependabot
 
           if (link_href = fetch_v2_next_link_href(response.body))
             url_details = url_details.dup
+            # Some Nuget repositories, such as JFrog's Artifactory, URL encode the "next" href
+            # link in the paged results. If the href is not URL decoded, the paging parameters
+            # are ignored and the first page is always returned. 
             url_details[:versions_url] = CGI.unescape(link_href)
             fetch_paginated_v2_nuget_listings(url_details, results)
           end

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -234,7 +234,7 @@ module Dependabot
             url_details = url_details.dup
             # Some Nuget repositories, such as JFrog's Artifactory, URL encode the "next" href
             # link in the paged results. If the href is not URL decoded, the paging parameters
-            # are ignored and the first page is always returned. 
+            # are ignored and the first page is always returned.
             url_details[:versions_url] = CGI.unescape(link_href)
             fetch_paginated_v2_nuget_listings(url_details, results)
           end


### PR DESCRIPTION
Since this link will always work on GitHub regardless of whether escaped or not,
I added an inline code comment with the commit message from 62366e46fea1b0c9e56d55a9aca8b1bbeb86b43b.

That way someone doesn't accidentally pull this out and think they're okay just
because everything continues to work on GitHub.

I meant to tag this onto #5174 but then forgot before I clicked the merge button.