### PR TITLE
Instrument npm version

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -53,14 +53,7 @@ module Dependabot
       def instrument_package_manager_version
         package_managers = {}
 
-        if [package_lock].any?
-          [package_lock].each do |lockfile|
-            versions = [package_managers["npm"]]
-            versions << Helpers.npm_version_numeric(lockfile.content)
-            package_managers["npm"] = versions.compact.min
-          end
-        end
-
+        package_managers["npm"] =  Helpers.npm_version_numeric(package_lock.content) if package_lock
         package_managers["yarn"] = 1 if yarn_lock
         package_managers["shrinkwrap"] = 1 if shrinkwrap
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -61,8 +61,8 @@ module Dependabot
           end
         end
 
-        package_managers["yarn"] = 1 if [yarn_lock].any?
-        package_managers["shrinkwrap"] = 1 if [shrinkwrap].any?
+        package_managers["yarn"] = 1 if yarn_lock
+        package_managers["shrinkwrap"] = 1 if shrinkwrap
 
         Dependabot.instrument(
           Notifications::FILE_PARSER_PACKAGE_MANAGER_VERSION_PARSED,

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -3,7 +3,9 @@
 require "json"
 require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
+require "dependabot/npm_and_yarn/helpers"
 require "dependabot/npm_and_yarn/file_parser"
+require "dependabot/npm_and_yarn/file_parser/lockfile_parser"
 
 module Dependabot
   module NpmAndYarn
@@ -43,8 +45,30 @@ module Dependabot
         fetched_files += workspace_package_jsons
         fetched_files += lerna_packages
         fetched_files += path_dependencies(fetched_files)
+        instrument_package_manager_version
 
         fetched_files.uniq
+      end
+
+      def instrument_package_manager_version
+        package_managers = {}
+
+        if [package_lock].any?
+          [package_lock].each do |lockfile|
+            versions = [package_managers["npm"]]
+            versions << Helpers.npm_version_numeric(lockfile.content)
+            package_managers["npm"] = versions.compact.min
+          end
+        end
+
+        package_managers["yarn"] = 1 if [yarn_lock].any?
+        package_managers["shrinkwrap"] = 1 if [shrinkwrap].any?
+
+        Dependabot.instrument(
+          Notifications::FILE_PARSER_PACKAGE_MANAGER_VERSION_PARSED,
+          ecosystem: "npm",
+          package_managers: package_managers
+        )
       end
 
       def package_json

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -4,12 +4,17 @@ module Dependabot
   module NpmAndYarn
     module Helpers
       def self.npm_version(lockfile_content)
-        return "npm8" unless lockfile_content
-        return "npm8" if JSON.parse(lockfile_content)["lockfileVersion"] >= 2
+        return "npm#{ npm_version_numeric(lockfile_content) }"
+      end
 
-        "npm6"
+
+      def self.npm_version_numeric(lockfile_content)
+        return 8 unless lockfile_content
+        return 8 if JSON.parse(lockfile_content)["lockfileVersion"] >= 2
+
+        6
       rescue JSON::ParserError
-        "npm6"
+        6
       end
     end
   end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -4,9 +4,8 @@ module Dependabot
   module NpmAndYarn
     module Helpers
       def self.npm_version(lockfile_content)
-        return "npm#{ npm_version_numeric(lockfile_content) }"
+        "npm#{npm_version_numeric(lockfile_content)}"
       end
-
 
       def self.npm_version_numeric(lockfile_content)
         return 8 unless lockfile_content


### PR DESCRIPTION
Instruments the package manager version for npm and yarn similar to [how we instrument bundler versions](https://github.com/dependabot/dependabot-core/blob/e96b546e8d6bbe723732ba9657f9008c75c0424a/bundler/lib/dependabot/bundler/file_parser.rb#L46-L55)

Note: 
This PR instruments in the FileFetcher step so it should only run once.
The dry-runner shows this too


```shell
[dependabot-core-dev] ~/dependabot-core $ SECURITY_ADVISORIES='[{"dependency-name":"node-forge","patched-versions":[],"unaffected-versions":[],"affected-versions":["< 0.10.0"]},{"dependency-name":"node-forge","patched-versions":[],"unaffected-versions":[],"affected-versions":["< 1.0.0"]},{"dependency-name":"node-forge","patched-versions":[],"unaffected-versions":[],"affected-versions":["< 1.3.0"]}]' bin/dry-run.rb npm_and_yarn <redacted> --dir=/node-forge-npm8 --dep=node-forge --security-updates-only
warning: parser/current is loading parser/ruby27, which recognizes2.7.6-compliant syntax, but you are running 2.7.5.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> fetching dependency files
{:ecosystem=>"npm", :package_managers=>{"npm"=>8}} # <----- This is the only time the instrumentation is called
=> dumping fetched dependency files: ./dry-run/<redacted>
=> parsing dependency files
=> updating 1 dependencies: node-forge

=== node-forge (0.10.0) (vulnerable 🚨)
 => checking for updates 1/1
🌍 https//registry.npmjs.org:443/node-forge
🌍 https//registry.npmjs.org:443/node-forge/1.3.1
 => latest available version is 1.3.1
🌍 https//registry.npmjs.org:443/node-forge/1.3.0
 => earliest available non-vulnerable version is 1.3.0
 => latest allowed version is 0.10.0
 => The update is not possible because of the following conflicting dependencies:
   webpack-dev-server@3.11.3 requires node-forge@^0.10.0 via selfsigned@1.10.14
 => requirements to unlock: update_not_possible
🌍 https//registry.npmjs.org:443/forge-npm8
 => requirements update strategy: bump_versions
    (no security update possible 🙅‍♀️)
🌍 Total requests made: '4'
🎈 Package manager version log: {:ecosystem=>"npm", :package_managers=>{"npm"=>8}}

```