### PR TITLE
Print package manager version instrumentation events in the dry runner

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -469,11 +469,9 @@ ActiveSupport::Notifications.subscribe(/excon.request/) do |*args|
   puts "🌍 #{payload[:scheme]}//#{payload[:host]}:#{payload[:port]}#{payload[:path]}"
 end
 
-$package_manager_version_events_count = 0
+$package_manager_version_log = []
 Dependabot.subscribe(Dependabot::Notifications::FILE_PARSER_PACKAGE_MANAGER_VERSION_PARSED) do |*args|
-  $package_manager_version_events_count += 1
-  payload = args.last
-  puts "🎈 #{payload}"
+  $package_manager_version_log << args.last
 end
 
 $source = Dependabot::Source.new(
@@ -790,7 +788,7 @@ StackProf.stop if $options[:profile]
 StackProf.results("tmp/stackprof-#{Time.now.strftime('%Y-%m-%d-%H:%M')}.dump") if $options[:profile]
 
 puts "🌍 Total requests made: '#{$network_trace_count}'"
-puts "🎈 Total package manager version logs made: '#{$package_manager_version_events_count}'"
+puts "🎈 Package manager version log: #{$package_manager_version_log.join('\n')}" if $package_manager_version_log.any?
 
 # rubocop:enable Metrics/BlockLength
 

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -469,6 +469,13 @@ ActiveSupport::Notifications.subscribe(/excon.request/) do |*args|
   puts "🌍 #{payload[:scheme]}//#{payload[:host]}:#{payload[:port]}#{payload[:path]}"
 end
 
+$package_manager_version_events_count = 0
+Dependabot.subscribe(Dependabot::Notifications::FILE_PARSER_PACKAGE_MANAGER_VERSION_PARSED) do |*args|
+  $package_manager_version_events_count += 1
+  payload = args.last
+  puts "🎈 #{payload}"
+end
+
 $source = Dependabot::Source.new(
   provider: $options[:provider],
   repo: $repo_name,
@@ -783,6 +790,7 @@ StackProf.stop if $options[:profile]
 StackProf.results("tmp/stackprof-#{Time.now.strftime('%Y-%m-%d-%H:%M')}.dump") if $options[:profile]
 
 puts "🌍 Total requests made: '#{$network_trace_count}'"
+puts "🎈 Total package manager version logs made: '#{$package_manager_version_events_count}'"
 
 # rubocop:enable Metrics/BlockLength
 


### PR DESCRIPTION
Follow up to https://github.com/dependabot/dependabot-core/pull/5187

Prints package manager version instrumentation events in the dry runner

Previously in this PR, the dry runner would print out the package manager version log when the notification event occurred, but really it should only be logged once per ecosystem. 

Since the additional logging was polluting, I modified the dry runner to instead print out the logging event(s) at the end of the run.

The dry runner will still show all the package manager version log events in case it really is logged more than once per ecosystem

```
🌍 Total requests made: '7'
🎈 Package manager version log: {:ecosystem=>"npm", :package_managers=>{"npm"=>8, "yarn"=>1}}
```