### PR TITLE
Upgrade pip inside of any newly created pyenv

### DIFF
--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -223,6 +223,7 @@ module Dependabot
           return if run_command("pyenv versions").include?("#{python_version}\n")
 
           run_command("pyenv install -s #{python_version}")
+          run_command("pyenv exec pip install --upgrade pip")
           run_command("pyenv exec pip install -r "\
                       "#{NativeHelpers.python_requirements_path}")
         end

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -178,6 +178,7 @@ module Dependabot
 
               if python_version && !pre_installed_python?(python_version)
                 run_poetry_command("pyenv install -s #{python_version}")
+                run_poetry_command("pyenv exec pip install --upgrade pip")
                 run_poetry_command("pyenv exec pip install -r"\
                                    "#{NativeHelpers.python_requirements_path}")
               end

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -313,6 +313,7 @@ module Dependabot
           return if run_command("pyenv versions").include?("#{python_version}\n")
 
           run_command("pyenv install -s #{python_version}")
+          run_command("pyenv exec pip install --upgrade pip")
           run_command("pyenv exec pip install -r"\
                       "#{NativeHelpers.python_requirements_path}")
         end

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -323,6 +323,7 @@ module Dependabot
 
           requirements_path = NativeHelpers.python_requirements_path
           run_command("pyenv install -s #{python_version}")
+          run_command("pyenv exec pip install --upgrade pip")
           run_command("pyenv exec pip install -r "\
                       "#{requirements_path}")
         end

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -79,6 +79,7 @@ module Dependabot
 
                 if python_version && !pre_installed_python?(python_version)
                   run_poetry_command("pyenv install -s #{python_version}")
+                  run_poetry_command("pyenv exec pip install --upgrade pip")
                   run_poetry_command(
                     "pyenv exec pip install -r "\
                     "#{NativeHelpers.python_requirements_path}"


### PR DESCRIPTION
As part of https://github.com/dependabot/dependabot-core/pull/5024 we identified an issue where newly created python versions installed via pyenv were not installing pre-compiled wheels but attempting to compile during pip installs.

This PR fixes the issue by updating pip before we attempt to install the python helper requirements.txt into a new pyenv as a newly installed pyenv will have a default pip version (python 3.6.9 has pip 18.0.1 for example).

This should speed up CI/tests, and will allow the above referenced work with earthly to move forward.