### PR TITLE
Update pub revision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -251,7 +251,7 @@ RUN DART_ARCH=${TARGETARCH} \
 # We pull the dependency_services from the dart-lang/pub repo as it is not
 # exposed from the Dart SDK (yet...).
 RUN git clone https://github.com/dart-lang/pub.git /opt/dart/pub \
-  && git -C /opt/dart/pub checkout 1e3c17ea871e6a80c720aa998f37cbd3913bc287 \
+  && git -C /opt/dart/pub checkout 6f20a94b074a1c2dc82d429fa04d365b4bcf65b6 \
   && dart pub global activate --source path /opt/dart/pub \
   && chmod -R o+r "/opt/dart/pub" \
   && chown -R dependabot:dependabot "$PUB_CACHE" \


### PR DESCRIPTION
This pulls in a fix of https://github.com/dependabot/dependabot-core/issues/5199

New commits:
```
> git -C ~/projects/pub log --format="%C(auto) %h %s" 1e3c17ea871e6a80c720aa998f37cbd3913bc287..6f20a94b074a1c2dc82d429fa04d365b4bcf65b6
 6f20a94b Handle missing pubspec.lock in dependency_services list (#3439)
 0ad17e84 Handle broken response from userinfo_endpoint (#3427)
 153ef061 `pub add` create top-level attribute in block-style if possible. (#3423)
 3b96f910 Handle error code 183 on windows (#3426)
 9eb6428c Ignore `pubspec_overrides.yaml` for `publish` command (#3419)
 51435efc Reland "Add flag controlling creation of `.packages` file." (#3413)
```
For dependabot the only one relevant is
```
 6f20a94b Handle missing pubspec.lock in dependency_services list (#3439)
```