### PR TITLE
Update test cases with new hashes returned from npm registry

### DIFF
--- a/npm_and_yarn/helpers/test/npm6/fixtures/updater/updated/package-lock.json
+++ b/npm_and_yarn/helpers/test/npm6/fixtures/updater/updated/package-lock.json
@@ -10,7 +10,7 @@
     "left-pad": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.1.3.tgz",
-      "integrity": "sha1-YS9hwDPzqeCOk58crr7qQbbzGZo="
+      "integrity": "sha512-m3z9QHpSXmd2H8Z5jnSXbGONPty4dFQfH1QpGgivzrEzICgsi50j9S+aGc77EaLoHpbw0BzP5+k1pp2UajTRuw=="
     }
   }
 }

--- a/npm_and_yarn/helpers/test/yarn/fixtures/updater/updated/yarn.lock
+++ b/npm_and_yarn/helpers/test/yarn/fixtures/updater/updated/yarn.lock
@@ -9,4 +9,4 @@ is-positive@^3.1.0:
 left-pad@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.1.3.tgz#612f61c033f3a9e08e939f1caebeea41b6f3199a"
-  integrity sha1-YS9hwDPzqeCOk58crr7qQbbzGZo=
+  integrity sha512-m3z9QHpSXmd2H8Z5jnSXbGONPty4dFQfH1QpGgivzrEzICgsi50j9S+aGc77EaLoHpbw0BzP5+k1pp2UajTRuw==

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm6/simple/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm6/simple/package-lock.json
@@ -15,7 +15,7 @@
 		"es6-promise": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-			"integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+			"integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -26,7 +26,7 @@
 		"fetch-factory": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.2.tgz",
-			"integrity": "sha1-7h380QJIZAv+MOXD2Jiie3Ysh6w=",
+			"integrity": "sha512-4G9zr4/vs97MlQRMTqr6HzCVCCnzUy6VdfJldIyweecAdrRJs3DjV1duugymtHexXMne48i+pRArN+zTsBpXSw==",
 			"requires": {
 				"es6-promise": "^3.0.2",
 				"isomorphic-fetch": "^2.1.1",
@@ -44,12 +44,12 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
 		},
 		"isomorphic-fetch": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
 			"requires": {
 				"node-fetch": "^1.0.1",
 				"whatwg-fetch": ">=0.10.0"
@@ -58,7 +58,7 @@
 		"lodash": {
 			"version": "3.10.1",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-			"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+			"integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="
 		},
 		"node-fetch": {
 			"version": "1.7.3",

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm6/subdependency_update_tab_indentation/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm6/subdependency_update_tab_indentation/package-lock.json
@@ -7,7 +7,7 @@
 				"extend": {
 						"version": "1.3.0",
 						"resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-						"integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
+						"integrity": "sha512-hT3PRBs1qm4P8g2keUBZ9bPaFHAcS78o5aCd9WhFTluHZZgBEkI08R+zYrpRpImyRTH+dw7IlqxrOp9iartTkw=="
 				},
 				"test-old-npm-sub-dependency": {
 						"version": "github:dependabot-fixtures/test-old-npm-sub-dependency#3022e23aa7dac4d134d176ad2feaed72457946b4",

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm8/packages_name_missing/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm8/packages_name_missing/package-lock.json
@@ -13,7 +13,7 @@
         "node_modules/etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -23,7 +23,7 @@
         "etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
         }
     }
 }

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm8/packages_name_outdated/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm8/packages_name_outdated/package-lock.json
@@ -14,7 +14,7 @@
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -24,7 +24,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     }
   }
 }

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm8/simple/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm8/simple/package-lock.json
@@ -40,7 +40,7 @@
         "node_modules/fetch-factory": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.2.tgz",
-            "integrity": "sha1-7h380QJIZAv+MOXD2Jiie3Ysh6w=",
+            "integrity": "sha512-4G9zr4/vs97MlQRMTqr6HzCVCCnzUy6VdfJldIyweecAdrRJs3DjV1duugymtHexXMne48i+pRArN+zTsBpXSw==",
             "dependencies": {
                 "es6-promise": "^3.0.2",
                 "isomorphic-fetch": "^2.1.1",
@@ -115,7 +115,7 @@
         "fetch-factory": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.2.tgz",
-            "integrity": "sha1-7h380QJIZAv+MOXD2Jiie3Ysh6w=",
+            "integrity": "sha512-4G9zr4/vs97MlQRMTqr6HzCVCCnzUy6VdfJldIyweecAdrRJs3DjV1duugymtHexXMne48i+pRArN+zTsBpXSw==",
             "requires": {
                 "es6-promise": "^3.0.2",
                 "isomorphic-fetch": "^2.1.1",

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm8/simple_no_indentation/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm8/simple_no_indentation/package-lock.json
@@ -40,7 +40,7 @@
     "node_modules/fetch-factory": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.2.tgz",
-      "integrity": "sha1-7h380QJIZAv+MOXD2Jiie3Ysh6w=",
+      "integrity": "sha512-4G9zr4/vs97MlQRMTqr6HzCVCCnzUy6VdfJldIyweecAdrRJs3DjV1duugymtHexXMne48i+pRArN+zTsBpXSw==",
       "dependencies": {
         "es6-promise": "^3.0.2",
         "isomorphic-fetch": "^2.1.1",
@@ -115,7 +115,7 @@
     "fetch-factory": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.2.tgz",
-      "integrity": "sha1-7h380QJIZAv+MOXD2Jiie3Ysh6w=",
+      "integrity": "sha512-4G9zr4/vs97MlQRMTqr6HzCVCCnzUy6VdfJldIyweecAdrRJs3DjV1duugymtHexXMne48i+pRArN+zTsBpXSw==",
       "requires": {
         "es6-promise": "^3.0.2",
         "isomorphic-fetch": "^2.1.1",

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm8/subdependency_update_tab_indentation/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm8/subdependency_update_tab_indentation/package-lock.json
@@ -14,7 +14,7 @@
 				"node_modules/extend": {
 						"version": "1.3.0",
 						"resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-						"integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
+						"integrity": "sha512-hT3PRBs1qm4P8g2keUBZ9bPaFHAcS78o5aCd9WhFTluHZZgBEkI08R+zYrpRpImyRTH+dw7IlqxrOp9iartTkw=="
 				},
 				"node_modules/test-old-npm-sub-dependency": {
 						"version": "1.0.0",
@@ -30,7 +30,7 @@
 				"extend": {
 						"version": "1.3.0",
 						"resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-						"integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
+						"integrity": "sha512-hT3PRBs1qm4P8g2keUBZ9bPaFHAcS78o5aCd9WhFTluHZZgBEkI08R+zYrpRpImyRTH+dw7IlqxrOp9iartTkw=="
 				},
 				"test-old-npm-sub-dependency": {
 						"version": "git+ssh://git@github.com/dependabot-fixtures/test-old-npm-sub-dependency.git#3022e23aa7dac4d134d176ad2feaed72457946b4",

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm8/workspaces_dev/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm8/workspaces_dev/package-lock.json
@@ -39,7 +39,7 @@
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -128,7 +128,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true
     },
     "has-color": {


### PR DESCRIPTION
We are getting some [npm ci failures](https://github.com/dependabot/dependabot-core/runs/6665124687?check_suite_focus=true) from tests that run against the actual npm registry. Some dependencies have been returning sha512 hashes instead of sha1. This updates the failing test cases to expect the sha512 hashes.