### PR TITLE
Yarn: support recursive paths expansion

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -1174,6 +1174,92 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         end
       end
 
+      context "specified using 'packages/*/*'" do
+        before do
+          stub_request(:get, File.join(url, "package.json?ref=sha")).
+            with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body:
+                fixture("github", "package_json_with_nested_glob_workspaces.json"),
+              headers: json_header
+            )
+          stub_request(
+            :get,
+            File.join(url, "packages/package1?ref=sha")
+          ).with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "packages_files_nested2.json"),
+              headers: json_header
+            )
+          stub_request(
+            :get,
+            File.join(url, "packages/package2?ref=sha")
+          ).with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "packages_files_nested3.json"),
+              headers: json_header
+            )
+          stub_request(
+            :get,
+            File.join(url, "packages/package1/package1/package.json?ref=sha")
+          ).with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "package_json_content.json"),
+              headers: json_header
+            )
+          stub_request(
+            :get,
+            File.join(url, "packages/package1/package2/package.json?ref=sha")
+          ).with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "package_json_content.json"),
+              headers: json_header
+            )
+          stub_request(
+            :get,
+            File.join(url, "packages/package2/package21/package.json?ref=sha")
+          ).with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "package_json_content.json"),
+              headers: json_header
+            )
+          stub_request(
+            :get,
+            File.join(url, "packages/package2/package22/package.json?ref=sha")
+          ).with(headers: { "Authorization" => "token token" }).
+            to_return(
+              status: 200,
+              body: fixture("github", "package_json_content.json"),
+              headers: json_header
+            )
+        end
+
+        it "fetches package.json from the workspace dependencies" do
+          expect(file_fetcher_instance.files.map(&:name)).
+            to match_array(
+              %w(
+                package.json
+                package-lock.json
+                packages/package1/package1/package.json
+                packages/package1/package2/package.json
+                packages/package2/package21/package.json
+                packages/package2/package22/package.json
+              )
+            )
+
+          workspace_dep =
+            file_fetcher_instance.files.
+            find { |f| f.name == "packages/package1/package1/package.json" }
+          expect(workspace_dep.type).to eq("file")
+        end
+      end
+
       context "specified using a hash" do
         before do
           stub_request(:get, File.join(url, "package.json?ref=sha")).

--- a/npm_and_yarn/spec/fixtures/github/package_json_with_nested_glob_workspaces.json
+++ b/npm_and_yarn/spec/fixtures/github/package_json_with_nested_glob_workspaces.json
@@ -1,0 +1,18 @@
+{
+  "name": "package.json",
+  "path": "package.json",
+  "sha": "5c7b3419e0056515122b981f1566ebe22c208251",
+  "size": 594,
+  "url": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+  "html_url": "https://github.com/gocardless/bump/blob/master/package.json",
+  "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+  "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/package.json?token=ABMwe0apDiKCctWHnEHnszRBAebVHjQnks5WJWD9wA%3D%3D",
+  "type": "file",
+  "content": "ewogICJuYW1lIjogImJ1bXAtdGVzdCIsCiAgInZlcnNpb24iOiAiMC4wLjEiLAogICJkZXNjcmlwdGlvbiI6ICIiLAogICJtYWluIjogImluZGV4LmpzIiwKICAicmVwb3NpdG9yeSI6IHsKICAgICJ0eXBlIjogImdpdCIsCiAgICAidXJsIjogImdpdCtodHRwczovL2dpdGh1Yi5jb20vZ29jYXJkbGVzcy9idW1wLXRlc3QuZ2l0IgogIH0sCiAgImF1dGhvciI6ICIiLAogICJsaWNlbnNlIjogIklTQyIsCiAgImJ1Z3MiOiB7CiAgICAidXJsIjogImh0dHBzOi8vZ2l0aHViLmNvbS9nb2NhcmRsZXNzL2J1bXAtdGVzdC9pc3N1ZXMiCiAgfSwKICAiaG9tZXBhZ2UiOiAiaHR0cHM6Ly9naXRodWIuY29tL2dvY2FyZGxlc3MvYnVtcC10ZXN0I3JlYWRtZSIsCiAgImRlcGVuZGVuY2llcyI6IHsKICAgICJsb2Rhc2giOiAiXjEuMy4xIiwKICAgICJjaGFsayI6ICIwLjQuMCIsCiAgICAic3RvcHdvcmRzIjogIjAuMC4xIgogIH0sCiAgImRldkRlcGVuZGVuY2llcyI6IHsKICAgICJldGFnIjogIl4xLjAuMCIKICB9LAogICJ3b3Jrc3BhY2VzIjogWyJwYWNrYWdlcy8qLyoiXQp9",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/gocardless/bump/contents/package.json?ref=master",
+    "git": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+    "html": "https://github.com/gocardless/bump/blob/master/package.json"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/github/packages_files_nested3.json
+++ b/npm_and_yarn/spec/fixtures/github/packages_files_nested3.json
@@ -1,0 +1,50 @@
+[
+    {
+        "name": "README.md",
+        "path": "README.md",
+        "sha": "f3b764a5099ffa9f52a7e1799e85bd8171036cbb",
+        "size": 4187,
+        "url": "https://api.github.com/repos/gocardless/business/contents/README.md?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/README.md",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/f3b764a5099ffa9f52a7e1799e85bd8171036cbb",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/README.md",
+        "type": "file",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/README.md?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/f3b764a5099ffa9f52a7e1799e85bd8171036cbb",
+            "html": "https://github.com/gocardless/business/blob/master/README.md"
+        }
+    },
+    {
+        "name": "package21",
+        "path": "packages/package2/package21",
+        "sha": "9a243198d483ad8407f8ee38d8e5bb1b18564d8f",
+        "size": 0,
+        "url": "https://api.github.com/repos/gocardless/business/contents/lib?ref=master",
+        "html_url": "https://github.com/gocardless/business/tree/master/lib",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/trees/9a243198d483ad8407f8ee38d8e5bb1b18564d8f",
+        "download_url": null,
+        "type": "dir",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/lib?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/trees/9a243198d483ad8407f8ee38d8e5bb1b18564d8f",
+            "html": "https://github.com/gocardless/business/tree/master/lib"
+        }
+    },
+    {
+        "name": "package22",
+        "path": "packages/package2/package22",
+        "sha": "ddaa472673172f2407888ec366282a08b23f681c",
+        "size": 0,
+        "url": "https://api.github.com/repos/gocardless/business/contents/spec?ref=master",
+        "html_url": "https://github.com/gocardless/business/tree/master/spec",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/trees/ddaa472673172f2407888ec366282a08b23f681c",
+        "download_url": null,
+        "type": "dir",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/spec?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/trees/ddaa472673172f2407888ec366282a08b23f681c",
+            "html": "https://github.com/gocardless/business/tree/master/spec"
+        }
+    }
+]


### PR DESCRIPTION
So now it can successfully expand a glob like `packages/*/*`.
Resolves https://github.com/dependabot/dependabot-core/issues/1777

~~**NOTE**: this PR is based on top of https://github.com/dependabot/dependabot-core/pull/5220~~

**UPDATE**: the previously mentioned PR is already merged, so this one is rebased now.