### PR TITLE
Only report conflicting dependencies when update is not possible

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -674,16 +674,6 @@ dependencies.each do |dep|
                            end
   puts " => latest allowed version is #{latest_allowed_version || dep.version}"
 
-  conflicting_dependencies = checker.conflicting_dependencies
-  if conflicting_dependencies.any?
-    puts " => The update is not possible because of the following conflicting "\
-      "dependencies:"
-
-    conflicting_dependencies.each do |conflicting_dep|
-      puts "   #{conflicting_dep['explanation']}"
-    end
-  end
-
   if checker.up_to_date?
     puts "    (no update needed as it's already up-to-date)"
     next
@@ -712,6 +702,17 @@ dependencies.each do |dep|
     else
       puts "    (no update possible 🙅‍♀️)"
     end
+
+    conflicting_dependencies = checker.conflicting_dependencies
+    if conflicting_dependencies.any?
+      puts " => The update is not possible because of the following conflicting "\
+        "dependencies:"
+
+      conflicting_dependencies.each do |conflicting_dep|
+        puts "   #{conflicting_dep['explanation']}"
+      end
+    end
+
     next
   end
 


### PR DESCRIPTION
I extracted this commit from https://github.com/dependabot/dependabot-core/pull/5221, because it's also useful for me to (fix) #4867.

If I understand correctly, both https://github.com/rubygems/rubygems/pull/5520 and #5221 are fixing the same issue but for different ecosystems, and we both run into the same issue where the dependency is properly updated but `bin/dry-run.rb` still reports conflicts.