### PR TITLE
cargo: handle patch with path that is a submodule

### DIFF
--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -84,7 +84,7 @@ module Dependabot
           next if previously_fetched_files.map(&:name).include?(path)
           next if file.name == path
 
-          fetched_file = fetch_file_from_host(path)
+          fetched_file = fetch_file_from_host(path, fetch_submodules: true)
           previously_fetched_files << fetched_file
           grandchild_requirement_files =
             fetch_workspace_files(

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -395,6 +395,13 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
         stub_request(:get, url + "lib/sub_crate/Cargo.toml?ref=sha").
           with(headers: { "Authorization" => "token token" }).
           to_return(status: 404, headers: json_header)
+        # additional requests due to submodule searching
+        stub_request(:get, url + "lib/sub_crate?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(status: 404, headers: json_header)
+        stub_request(:get, url + "lib?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(status: 404, headers: json_header)
       end
 
       it "raises a DependencyFileNotFound error" do

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -421,11 +421,12 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
           with(headers: { "Authorization" => "token token" }).
           to_return(status: 200, headers: json_header, body: fixture("github", "contents_cargo_submodule.json"))
         # Attempt to find the Cargo.toml in the submodule's repo.
-        stub_request(:get, "https://api.github.com/repos/runconduit/conduit/contents/?ref=453df4efd57f5e8958adf17d728520bd585c82c9").
+        submodule_root = "https://api.github.com/repos/runconduit/conduit"
+        stub_request(:get, submodule_root + "/contents/?ref=453df4efd57f5e8958adf17d728520bd585c82c9").
           with(headers: { "Authorization" => "token token" }).
           to_return(status: 200, headers: json_header, body: fixture("github", "contents_cargo_without_lockfile.json"))
         # Found it, so download it!
-        stub_request(:get, "https://api.github.com/repos/runconduit/conduit/contents/Cargo.toml?ref=453df4efd57f5e8958adf17d728520bd585c82c9 ").
+        stub_request(:get, submodule_root + "/contents/Cargo.toml?ref=453df4efd57f5e8958adf17d728520bd585c82c9 ").
           with(headers: { "Authorization" => "token token" }).
           to_return(status: 200, headers: json_header, body: fixture("github", "contents_cargo_manifest.json"))
       end

--- a/cargo/spec/fixtures/github/contents_cargo_submodule.json
+++ b/cargo/spec/fixtures/github/contents_cargo_submodule.json
@@ -1,0 +1,17 @@
+{
+  "name": "sub_crate",
+  "path": "lib/sub_crate",
+  "sha": "453df4efd57f5e8958adf17d728520bd585c82c9",
+  "size": 0,
+  "url": "https://api.github.com/repos/dsp-testing/updates-issue-2483/contents/deps/rusty_v8?ref=main",
+  "html_url": "https://github.com/denoland/rusty_v8/tree/453df4efd57f5e8958adf17d728520bd585c82c9",
+  "git_url": "https://api.github.com/repos/denoland/rusty_v8/git/trees/453df4efd57f5e8958adf17d728520bd585c82c9",
+  "download_url": null,
+  "type": "submodule",
+  "submodule_git_url": "git@github.com:runconduit/conduit.git",
+  "_links": {
+    "self": "https://api.github.com/repos/runconduit/conduit/contents/Cargo.toml?ref=master",
+    "git": "https://api.github.com/repos/runconduit/conduit/git/blobs/cb9ddc34d2c13ca51bd54ec7374d89cbad814d78",
+    "html": "https://github.com/runconduit/conduit/blob/master/Cargo.toml"
+  }
+}


### PR DESCRIPTION
In Cargo.toml a user can add this to override a dependency:

```
[patch.crates-io]
uuid = { path = './path/to/uuid' }
```

This doesn't work in Dependabot if `path/to/uuid` is a submodule since the file doesn't exist in this repository. So I've added the "fetch_submodules: true" flag which handles this case. 
