### PR TITLE
Update NPM package name validation rules

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_name.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_name.rb
@@ -4,20 +4,26 @@ module Dependabot
   module NpmAndYarn
     class PackageName
       PACKAGE_NAME_REGEX = %r{
-          \A                                         # beginning of string
-          (?=.{1,214}\z)                             # enforce length (1 - 214)
-          (@(?<scope>[a-z0-9\-~][a-z0-9\-\._~]*)\/)? # capture 'scope' if present
-          (?<name>[a-z0-9\-~][a-z0-9\-._~]*)         # capture package name
-          \z                                         # end of string
-      }xi.freeze                                     # multi-line/case-insensitive
+          \A                                          # beginning of string
+          (?=.{1,214}\z)                              # enforce length (1 - 214)
+          (@(?<scope>                                 # capture 'scope' if present
+            (?=[^\.])                                 # reject leading dot
+            [a-z0-9\-\_\.\!\~\*\'\(\)]+               # URL-safe characters
+          )\/)?
+          (?<name>                                    # capture package name
+            (?=[^\.\_])                               # reject leading dot or underscore
+            [a-z0-9\-\_\.\!\~\*\'\(\)]+               # URL-safe characters
+          )
+          \z                                          # end of string
+      }xi.freeze                                      # multi-line/case-insensitive
 
       TYPES_PACKAGE_NAME_REGEX = %r{
-          \A                                         # beginning of string
-          @types\/                                   # starts with @types/
-          ((?<scope>.+)__)?                          # capture scope
-          (?<name>.+)                                # capture name
-          \z                                         # end of string
-      }xi.freeze                                     # multi-line/case-insensitive
+          \A                                          # beginning of string
+          @types\/                                    # starts with @types/
+          ((?<scope>.+)__)?                           # capture scope
+          (?<name>.+)                                 # capture name
+          \z                                          # end of string
+      }xi.freeze                                      # multi-line/case-insensitive
 
       class InvalidPackageName < StandardError; end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package_name_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package_name_spec.rb
@@ -5,15 +5,41 @@ require "dependabot/npm_and_yarn/package_name"
 
 RSpec.describe Dependabot::NpmAndYarn::PackageName do
   describe "initialization" do
-    it "raises a meaningful error if the input is not a valid package name" do
+    it "allows valid package names" do
+      expect { described_class.new("some-package") }.not_to raise_error
+      expect { described_class.new("example.com") }.not_to raise_error
+      expect { described_class.new("under_score") }.not_to raise_error
+      expect { described_class.new("123numeric") }.not_to raise_error
+      expect { described_class.new("@npm/thingy") }.not_to raise_error
+      expect { described_class.new("@jane/foo.js") }.not_to raise_error
+      expect { described_class.new("@_foo/bar") }.not_to raise_error
+    end
+
+    # rubocop:disable Layout/LineLength
+    it "allows legacy package names" do
+      # Support
+      expect do
+        described_class.new("eLaBorAtE-paCkAgE-with-mixed-case-and-more-than-214-characters-----------------------------------------------------------------------------------------------------------------------------------------------------------")
+      end.not_to raise_error
+    end
+    # rubocop:enable Layout/LineLength
+
+    it "raises an error for invalid package names" do
+      expect { described_class.new("") }.to raise_error(described_class::InvalidPackageName)
+      expect { described_class.new(".leading-dot") }.to raise_error(described_class::InvalidPackageName)
+      expect { described_class.new("_leading-underscore") }.to raise_error(described_class::InvalidPackageName)
+
+      expect do
+        described_class.new(" leading-space:and:weirdchars")
+      end.to raise_error(described_class::InvalidPackageName)
+
+      expect { described_class.new("excited!") }.to raise_error(described_class::InvalidPackageName)
+      expect { described_class.new("mIxeD-CaSe-nAME") }.to raise_error(described_class::InvalidPackageName)
       expect { described_class.new("🤷") }.to raise_error(described_class::InvalidPackageName)
+
+      expect { described_class.new(nil) }.to raise_error(described_class::InvalidPackageName)
       expect { described_class.new([]) }.to raise_error(described_class::InvalidPackageName)
       expect { described_class.new({}) }.to raise_error(described_class::InvalidPackageName)
-      expect { described_class.new(nil) }.to raise_error(described_class::InvalidPackageName)
-      expect { described_class.new("") }.to raise_error(described_class::InvalidPackageName)
-      expect { described_class.new(" prefixed-with-a-space") }.to raise_error(described_class::InvalidPackageName)
-      expect { described_class.new(".prefixed-with-a-dot") }.to raise_error(described_class::InvalidPackageName)
-      expect { described_class.new("!invalid") }.to raise_error(described_class::InvalidPackageName)
     end
   end
 


### PR DESCRIPTION
Fixes #5246 

According to the [`npm-user-validate`](https://github.com/npm/npm-user-validate/) package, the requirement is that usernames contain only "URL-safe" characters (according to `encodeURIComponent`) and not have a leading dot (`.`):

https://github.com/npm/npm-user-validate/blob/dec282efeea3bb711a43ed5a7fdd509934f17410/npm-user-validate.js#L28-L30

However, in `Dependabot::NpmAndYarn::PackageName`, we allow underscores, but not in the first character.

https://github.com/dependabot/dependabot-core/blob/1bc65b5e1020c8eed70acfd01e172159fed6ea05/npm_and_yarn/lib/dependabot/npm_and_yarn/package_name.rb#L9

This PR updates `PACKAGE_NAME_REGEX` to allow URL-safe characters. This new version uses a positive lookahead to reject invalid leading characters, instead of defining two character classes (one with and one without the leading characters).