### PR TITLE
Bump pub revision to fix error without lockfile

### DIFF
--- a/pub/helpers/pubspec.lock
+++ b/pub/helpers/pubspec.lock
@@ -138,8 +138,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "0ad17e8424e9989722f272e012636d9f43bb5205"
-      resolved-ref: "0ad17e8424e9989722f272e012636d9f43bb5205"
+      ref: "6f20a94b074a1c2dc82d429fa04d365b4bcf65b6"
+      resolved-ref: "6f20a94b074a1c2dc82d429fa04d365b4bcf65b6"
       url: "https://github.com/dart-lang/pub"
     source: git
     version: "0.0.0"

--- a/pub/helpers/pubspec.yaml
+++ b/pub/helpers/pubspec.yaml
@@ -12,4 +12,4 @@ dependencies:
   pub:
     git:
      url: https://github.com/dart-lang/pub
-     ref: 0ad17e8424e9989722f272e012636d9f43bb5205
+     ref: 6f20a94b074a1c2dc82d429fa04d365b4bcf65b6


### PR DESCRIPTION
Based on @sigurdm's [suggestion](https://github.com/dependabot/dependabot-core/issues/5199#issuecomment-1154825560) this bumps the revision of Pub used to match the previous version used in https://github.com/dependabot/dependabot-core/pull/5203. This fixed an [issue](https://github.com/dependabot/dependabot-core/issues/5199) with projects without lockfiles failing to update. 

In https://github.com/dependabot/dependabot-core/pull/5207 the method of pinning to the Pub revision changed and we accidentally pinned to an older version of Pub without the fix.