### PR TITLE
v0.192.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.192.1, 14 June 2022
+
+- Bump pub revision to fix error without lockfile [#5263](https://github.com/dependabot/dependabot-core/pull/5263)
+
 ## v0.192.0, 13 June 2022
 
 - Use inferred flutter version (@sigurdm) [#5207](https://github.com/dependabot/dependabot-core/pull/5207)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.192.0"
+  VERSION = "0.192.1"
 end


### PR DESCRIPTION
Diff: https://github.com/dependabot/dependabot-core/compare/v0.192.0...v0.192.1-release-notes

## v0.192.1, 14 June 2022

- Bump pub revision to fix error without lockfile [#5263](https://github.com/dependabot/dependabot-core/pull/5263)