### PR TITLE
Refactor CI Workflow for cache re-use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,19 +5,18 @@ on:
       - "main"
   pull_request:
     paths-ignore:
-      - 'CHANGELOG.md'
-      - 'common/lib/dependabot/version.rb'
+      - "CHANGELOG.md"
+      - "common/lib/dependabot/version.rb"
     branches:
       - "main"
   schedule:
     - cron: "0 0 * * *"
-permissions:
-  contents: read
-  packages: write
+
 jobs:
-  ci:
-    name: CI
+  test:
+    name: Test
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
@@ -42,57 +41,20 @@ jobs:
           - { path: python, name: python_slow }
           - { path: pub, name: pub }
           - { path: terraform, name: terraform }
-    env:
-      BASE_IMAGE: ubuntu:18.04
-      CORE_IMAGE: dependabot/dependabot-core
-      CORE_BRANCH_IMAGE: ghcr.io/dependabot/dependabot-core-branch
-      CORE_CI_IMAGE: ghcr.io/dependabot/dependabot-core-ci
-      CODE_DIR: /home/dependabot/dependabot-core
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Prepare BRANCH_REF environment variable
-        run: echo "BRANCH_REF=$(echo '${{ github.ref }}' | sed -E 's/[^A-Za-z0-9]+/-/g')" >> $GITHUB_ENV
-      - name: Log in to GHCR
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build dependabot-core image for branch
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -t "$CORE_IMAGE:latest" \
-            -t "$CORE_BRANCH_IMAGE:$BRANCH_REF" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from "$BASE_IMAGE" \
-            --cache-from "$CORE_IMAGE:latest" \
-            --cache-from "$CORE_BRANCH_IMAGE:$BRANCH_REF" \
-            .
-      - name: Push dependabot-core-branch image to GHCR
-        env:
-          ACCESS_CANARY: ${{ secrets.ACCESS_CANARY }}
-        if: env.ACCESS_CANARY != ''
-        run: |
-          docker push "$CORE_BRANCH_IMAGE:$BRANCH_REF"
+
       - name: Build dependabot-core-ci image
         env:
           DOCKER_BUILDKIT: 1
         run: |
           docker build \
-            -t "$CORE_CI_IMAGE:latest" \
-            -t "$CORE_CI_IMAGE:branch--$BRANCH_REF" \
             -f Dockerfile.ci \
+            -t "dependabot-core-ci:latest" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from "$CORE_CI_IMAGE:latest" \
-            --cache-from "$CORE_CI_IMAGE:branch--$BRANCH_REF" \
+            --cache-from ghcr.io/dependabot/dependabot-core \
             .
-      - name: Push dependabot-core-ci image to GHCR
-        env:
-          ACCESS_CANARY: ${{ secrets.ACCESS_CANARY }}
-        if: env.ACCESS_CANARY != ''
-        run: |
-          docker push "$CORE_CI_IMAGE:latest"
-          docker push "$CORE_CI_IMAGE:branch--$BRANCH_REF"
       - name: Run ${{ matrix.suite.name }} tests
         run: |
           docker run \
@@ -100,12 +62,13 @@ jobs:
             --env "RAISE_ON_WARNINGS=true" \
             --env "DEPENDABOT_TEST_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }}" \
             --env "SUITE_NAME=${{ matrix.suite.name }}" \
-            --rm "$CORE_CI_IMAGE:branch--$BRANCH_REF" bash -c \
+            --rm dependabot-core-ci bash -c \
             "cd /home/dependabot/dependabot-core/${{ matrix.suite.path }} && ./script/ci-test"
+
   lint:
-    name: lint
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt-get update -y && sudo apt-get install --no-install-recommends shellcheck
       - run: ./bin/lint
+        continue-on-error: true


### PR DESCRIPTION
Our current CI workflow attempts to build and push multiple images in parallel before running tests. Not only does this create extra work, but we have reason to believe that it's creating race conditions that result in unpredictable runs.  

This PR makes the following changes:

- [x] Moves the build and push steps into a new `build` job
- [x] Moves the subsequent test steps into a [dependent](https://docs.github.com/en/actions/using-workflows/about-workflows#creating-dependent-jobs) `test` job
- [x] Stops tagging branch image as `dependabot/dependabot-core:latest` (this isn't currently pushed anyway)
- [x] Derives CI container images from `github.repository`, so that forks can run CI  