### PR TITLE
Update logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-<p align="center">
-  <img src="https://s3.eu-west-2.amazonaws.com/dependabot-images/logo-with-name-horizontal.svg?v5" alt="Dependabot" width="336">
-</p>
-
-# Dependabot
+<h1 align="center">
+    <picture>
+        <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/7659/174594540-5e29e523-396a-465b-9a6e-6cab5b15a568.svg">
+        <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/7659/174594559-0b3ddaa7-e75b-4f10-9dee-b51431a9fd4c.svg">
+        <img src="https://user-images.githubusercontent.com/7659/174594540-5e29e523-396a-465b-9a6e-6cab5b15a568.svg" alt="Dependabot" width="336">
+    </picture>
+</h1>
 
 Welcome to the public home of Dependabot. This repository serves 2 purposes:
 


### PR DESCRIPTION
The logo used in the current README hardcodes the `fill` value for its text to `#24292E`. This causes the text to have a contrast ratio of 1.02:1 against its background color (`#22272E`) when viewed in dark mode.

<img width="829" alt="README before" src="https://user-images.githubusercontent.com/7659/175090537-afcd87b8-2ea6-405d-98fb-76ed430aad87.png">

This PR updates the README to replace the `<img>` element with a `<picture>` containing image sources with light and dark media queries. [^1]

```html
<h1 align="center">
    <picture>
        <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/7659/174594540-5e29e523-396a-465b-9a6e-6cab5b15a568.svg">
        <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/7659/174594559-0b3ddaa7-e75b-4f10-9dee-b51431a9fd4c.svg">
        <img src="https://user-images.githubusercontent.com/7659/174594540-5e29e523-396a-465b-9a6e-6cab5b15a568.svg" alt="Dependabot" width="336">
    </picture>
</h1>
```

The embedded SVGs are uploaded directly to GitHub, whereas the previous was hot-linked from our AWS bucket.

Here's how the README looks after applying these changes:

<img width="833" alt="README after" src="https://user-images.githubusercontent.com/7659/175090630-fd624819-8ba7-45a0-b246-3e2f0703fd54.png">


[^1]: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to

