### PR TITLE
Rebuild dependabot-core image in CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Build dependabot-core image
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker build \
+            -t "dependabot/dependabot-core:latest" \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --cache-from ghcr.io/dependabot/dependabot-core \
+            .
       - name: Build dependabot-core-ci image
         env:
           DOCKER_BUILDKIT: 1
@@ -51,7 +60,6 @@ jobs:
             -f Dockerfile.ci \
             -t "dependabot-core-ci:latest" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from ghcr.io/dependabot/dependabot-core \
             .
       - name: Run ${{ matrix.suite.name }} tests
         run: |


### PR DESCRIPTION
With our changes in #5295, we inadvertently removed a step that rebuilds `dependabot/dependabot-core` before using it as a base image in `Dockerfile.ci`. This would cause any changes to system libraries or native helpers in a branch to be missing from CI runs for PRs for that branch.

This PR adds a step to the CI workflow to rebuild `dependabot/dependabot-core`.