### PR TITLE
fix cargo errors in dependencies that have submodules

### DIFF
--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -352,7 +352,7 @@ module Dependabot
           FileUtils.mkdir_p(".cargo")
           # Use git for git operations instead of the built-in libgit
           # so that it picks up our configuration.
-          File.write("[net]\ngit-fetch-with-cli = true")
+          File.write(".cargo/config.toml", "[net]\ngit-fetch-with-cli = true")
         end
 
         def git_dependency_version

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -152,7 +152,7 @@ module Dependabot
 
         def write_temporary_dependency_files(prepared: true)
           write_manifest_files(prepared: prepared)
-          write_cargo_config
+
           File.write(lockfile.name, lockfile.content) if lockfile
           File.write(toolchain.name, toolchain.content) if toolchain
         end
@@ -346,13 +346,6 @@ module Dependabot
             File.write(File.join(dir, "src/lib.rs"), dummy_app_content)
             File.write(File.join(dir, "src/main.rs"), dummy_app_content)
           end
-        end
-
-        def write_cargo_config
-          FileUtils.mkdir_p(".cargo")
-          # Use git for git operations instead of the built-in libgit
-          # so that it picks up our configuration.
-          File.write(".cargo/config.toml", "[net]\ngit-fetch-with-cli = true")
         end
 
         def git_dependency_version

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -152,7 +152,7 @@ module Dependabot
 
         def write_temporary_dependency_files(prepared: true)
           write_manifest_files(prepared: prepared)
-
+          write_cargo_config
           File.write(lockfile.name, lockfile.content) if lockfile
           File.write(toolchain.name, toolchain.content) if toolchain
         end
@@ -346,6 +346,13 @@ module Dependabot
             File.write(File.join(dir, "src/lib.rs"), dummy_app_content)
             File.write(File.join(dir, "src/main.rs"), dummy_app_content)
           end
+        end
+
+        def write_cargo_config
+          FileUtils.mkdir_p(".cargo")
+          # Use git for git operations instead of the built-in libgit
+          # so that it picks up our configuration.
+          File.write("[net]\ngit-fetch-with-cli = true")
         end
 
         def git_dependency_version

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -210,6 +210,8 @@ module Dependabot
         github_credentials.find { |c| !c["password"]&.start_with?("v1.") } ||
         github_credentials.first
 
+      configure_git_to_use_https
+
       deduped_credentials = credentials -
                             github_credentials +
                             [github_credential].compact
@@ -225,7 +227,6 @@ module Dependabot
           "@#{cred.fetch('host')}"
 
         git_store_content += authenticated_url + "\n"
-        configure_git_to_use_https
       end
 
       # Save the file

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -210,9 +210,6 @@ module Dependabot
         github_credentials.find { |c| !c["password"]&.start_with?("v1.") } ||
         github_credentials.first
 
-      # Make sure we always have https alternatives for github.com.
-      configure_git_to_use_https("github.com") if github_credential.nil?
-
       deduped_credentials = credentials -
                             github_credentials +
                             [github_credential].compact
@@ -228,7 +225,7 @@ module Dependabot
           "@#{cred.fetch('host')}"
 
         git_store_content += authenticated_url + "\n"
-        configure_git_to_use_https(cred.fetch("host"))
+        configure_git_to_use_https
       end
 
       # Save the file
@@ -237,29 +234,12 @@ module Dependabot
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/PerceivedComplexity
 
-    def self.configure_git_to_use_https(host)
+    def self.configure_git_to_use_https
       # NOTE: we use --global here (rather than --system) so that Dependabot
       # can be run without privileged access
-      run_shell_command(
-        "git config --global --replace-all url.https://#{host}/."\
-        "insteadOf ssh://git@#{host}/"
-      )
-      run_shell_command(
-        "git config --global --add url.https://#{host}/."\
-        "insteadOf ssh://git@#{host}:"
-      )
-      run_shell_command(
-        "git config --global --add url.https://#{host}/."\
-        "insteadOf git@#{host}:"
-      )
-      run_shell_command(
-        "git config --global --add url.https://#{host}/."\
-        "insteadOf git@#{host}/"
-      )
-      run_shell_command(
-        "git config --global --add url.https://#{host}/."\
-        "insteadOf git://#{host}/"
-      )
+      run_shell_command("git config --global --add url.https://.insteadOf ssh://git@")
+      run_shell_command("git config --global --add url.https://.insteadOf git@")
+      run_shell_command("git config --global --add url.https://.insteadOf git://")
     end
 
     def self.reset_git_repo(path)

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -342,14 +342,12 @@ RSpec.describe Dependabot::SharedHelpers do
       	helper = !#{Dependabot::SharedHelpers.credential_helper_path} --file #{Dir.pwd}/git.store
     CONFIG
 
-    def alternatives(host)
+    def alternatives
       <<~CONFIG.chomp
-        [url "https://#{host}/"]
-        	insteadOf = ssh://git@#{host}/
-        	insteadOf = ssh://git@#{host}:
-        	insteadOf = git@#{host}:
-        	insteadOf = git@#{host}/
-        	insteadOf = git://#{host}/
+        [url "https://"]
+        	insteadOf = ssh://git@
+        	insteadOf = git@
+        	insteadOf = git://
       CONFIG
     end
 
@@ -400,8 +398,8 @@ RSpec.describe Dependabot::SharedHelpers do
         expect(configured_git_config).to include(credentials_helper)
       end
 
-      it "creates a .gitconfig that contains the github.com alternatives" do
-        expect(configured_git_config).to include(alternatives("github.com"))
+      it "creates a .gitconfig that contains alternatives" do
+        expect(configured_git_config).to include(alternatives)
       end
 
       it "creates a git credentials store that is empty" do
@@ -430,7 +428,7 @@ RSpec.describe Dependabot::SharedHelpers do
       end
 
       it "creates a .gitconfig that contains the github.com alternatives" do
-        expect(configured_git_config).to include(alternatives("github.com"))
+        expect(configured_git_config).to include(alternatives)
       end
 
       it "creates a git credentials store that contains github.com credentials" do
@@ -481,12 +479,8 @@ RSpec.describe Dependabot::SharedHelpers do
         expect(configured_git_config).to include(credentials_helper)
       end
 
-      it "creates a .gitconfig that contains the github.com alternatives" do
-        expect(configured_git_config).to include(alternatives("github.com"))
-      end
-
-      it "creates a .gitconfig that contains the private.com alternatives" do
-        expect(configured_git_config).to include(alternatives("private.com"))
+      it "creates a .gitconfig that contains alternatives" do
+        expect(configured_git_config).to include(alternatives)
       end
 
       it "creates a git credentials store that contains private git credentials" do


### PR DESCRIPTION
## Problem

When using a dependency that has a submodule such as this:

```
glommio = { git = "ssh://git@github.com/DataDog/glommio.git", tag = "v0.6.0" }
```

We see strange DNS-related errors in the Dependabot logs:

```
Updating crates.io index
    Updating git repository `https://github.com/DataDog/glommio.git`
    Updating git submodule `git://git.kernel.dk/liburing`
warning: spurious network error (2 tries remaining): failed to resolve address for git.kernel.dk: Temporary failure in name resolution; class=Net (12)
warning: spurious network error (1 tries remaining): failed to resolve address for git.kernel.dk: Temporary failure in name resolution; class=Net (12)
error: failed to get `glommio` as a dependency of package `git-submodule-unresolvable v0.1.0 (/home/dependabot/dependabot-core/dependabot_tmp_dir)`

Caused by:
  failed to load source for dependency `glommio`

Caused by:
  Unable to update https://github.com/DataDog/glommio.git?tag=v0.6.0

Caused by:
  failed to update submodule `glommio/liburing`

Caused by:
  failed to fetch submodule `glommio/liburing` from git://git.kernel.dk/liburing

Caused by:
  network failure seems to have happened
  if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
 failed to resolve address for git.kernel.dk: Temporary failure in name resolution; class=Net (12)
```

I found that the issue was that `cargo` uses git (or rather a git library) to get the submodule like so: `git fetch --tags --force --update-head-ok 'git://git.kernel.dk/liburing' '+refs/heads/*:refs/remotes/origin/*' '+HEAD:refs/remotes/origin/HEAD'` which uses the git protocol and not https.

Normally we'd configure git to use the https protocol for each host, but here since the host isn't known to Dependabot at this point it isn't configured.

## Solution

I thought the simplest solution is to make a more general git configuration that isn't dependent on knowing every host ahead of time. So now no matter which host is present, git will be able to clone it. 

This is a wider reaching change than I would want to make but it seems like it might be ok! Let me know if you think of any downsides to this approach as I couldn't think of any. 