### PR TITLE
Prioritize target dependency in transitive dependency updates

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -178,7 +178,9 @@ module Dependabot
           )
         end
 
-        updated_deps
+        # Target dependency should be first in the result to support rebases
+        updated_deps.select { |dep| dep.name == dependency.name } +
+          updated_deps.reject { |dep| dep.name == dependency.name }
       end
 
       def build_updated_dependency(update_details)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -142,18 +142,12 @@ module Dependabot
       end
 
       def conflicting_updated_dependencies
-        top_level_dependencies = FileParser.new(
-          dependency_files: dependency_files,
-          credentials: credentials,
-          source: nil
-        ).parse.select(&:top_level?)
-
-        top_level_dependency_lookup = top_level_dependencies.map { |dep| [dep.name, dep] }.to_h
+        top_level_dependencies = top_level_dependency_lookup
 
         updated_deps = []
         vulnerability_audit["fix_updates"].each do |update|
           dependency_name = update["dependency_name"]
-          requirements = top_level_dependency_lookup[dependency_name]&.requirements || []
+          requirements = top_level_dependencies[dependency_name]&.requirements || []
           conflicting_dep = Dependency.new(
             name: dependency_name,
             package_manager: "npm_and_yarn",
@@ -181,6 +175,16 @@ module Dependabot
         # Target dependency should be first in the result to support rebases
         updated_deps.select { |dep| dep.name == dependency.name } +
           updated_deps.reject { |dep| dep.name == dependency.name }
+      end
+
+      def top_level_dependency_lookup
+        top_level_dependencies = FileParser.new(
+          dependency_files: dependency_files,
+          credentials: credentials,
+          source: nil
+        ).parse.select(&:top_level?)
+
+        top_level_dependencies.map { |dep| [dep.name, dep] }.to_h
       end
 
       def build_updated_dependency(update_details)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -1306,6 +1306,14 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         expect(checker.send(:updated_dependencies_after_full_unlock)).
           to eq([
             Dependabot::Dependency.new(
+              name: "@dependabot-fixtures/npm-transitive-dependency",
+              version: "1.0.1",
+              package_manager: "npm_and_yarn",
+              previous_version: "1.0.0",
+              requirements: [],
+              previous_requirements: []
+            ),
+            Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-parent-dependency",
               version: "2.0.2",
               package_manager: "npm_and_yarn",
@@ -1325,14 +1333,6 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
                   url: "https://registry.npmjs.org"
                 }
               }]
-            ),
-            Dependabot::Dependency.new(
-              name: "@dependabot-fixtures/npm-transitive-dependency",
-              version: "1.0.1",
-              package_manager: "npm_and_yarn",
-              previous_version: "1.0.0",
-              requirements: [],
-              previous_requirements: []
             )
           ])
       end
@@ -1342,15 +1342,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         let(:registry_listing_url) { "https://registry.npmjs.org/transitive-dependency-locked-by-intermediate" }
 
         it "correctly updates the transitive dependency" do
-          expect(checker.send(:updated_dependencies_after_full_unlock)).to contain_exactly(
-            Dependabot::Dependency.new(
-              name: "@dependabot-fixtures/npm-intermediate-dependency",
-              package_manager: "npm_and_yarn",
-              previous_requirements: [],
-              previous_version: "0.0.1",
-              requirements: [],
-              version: "0.0.2"
-            ),
+          expect(checker.send(:updated_dependencies_after_full_unlock)).to eq([
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-transitive-dependency",
               package_manager: "npm_and_yarn",
@@ -1358,8 +1350,16 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
               previous_version: "1.0.0",
               requirements: [],
               version: "1.0.1"
+            ),
+            Dependabot::Dependency.new(
+              name: "@dependabot-fixtures/npm-intermediate-dependency",
+              package_manager: "npm_and_yarn",
+              previous_requirements: [],
+              previous_version: "0.0.1",
+              requirements: [],
+              version: "0.0.2"
             )
-          )
+          ])
         end
       end
 


### PR DESCRIPTION
When responding to rebase requests Dependabot will re-run the job using the first dependency in the PR. Since we aren't enforcing the target dependency is at the front of the list the rebase could run against a different dependency and produce a different result.

I only wanted to re-order the results with https://github.com/dependabot/dependabot-core/commit/7c2c02ae85762d8b7463feae5c098a34dd2c0374 but had to do a little bit more to satisfy Rubocop's complexity requirements.