### PR TITLE
Configure arborist registries from npm config

### DIFF
--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
@@ -193,7 +193,7 @@ const credKeys = ['token', '_authToken', '_auth']
 
 function loadNpmConfigCredentials(projectDir) {
   const projectNpmrc = maybeReadFile(path.join(projectDir, '.npmrc'))
-  if (projectNpmrc == null) {
+  if (!projectNpmrc) {
     return {}
   }
 

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
@@ -35,6 +35,7 @@ async function findVulnerableDependencies(directory, advisories) {
   const npmConfig = await loadNpmConfig()
   const caCerts = loadCACerts(npmConfig)
   const registryOpts = extractRegistryOptions(npmConfig)
+  const registryCreds = loadNpmConfigCredentials(directory)
 
   const arb = new Arborist({
     path: directory,
@@ -43,6 +44,7 @@ async function findVulnerableDependencies(directory, advisories) {
     force: true,
     dryRun: true,
     ...registryOpts,
+    ...registryCreds,
   })
 
   const scope = nock('http://localhost:9999')
@@ -180,6 +182,29 @@ function extractRegistryOptions(npmConfig) {
     }
   }
   return Object.fromEntries(opts)
+}
+
+// loadNpmConfig doesn't return registry credentials so we need to manually extract them. If available,
+// Dependabot will have written them to the project's .npmrc file.
+const ini = require('ini')
+const path = require('path')
+
+const credKeys = ['token', '_authToken', '_auth']
+
+function loadNpmConfigCredentials(projectDir) {
+  const projectNpmrc = maybeReadFile(path.join(projectDir, '.npmrc'))
+  if (projectNpmrc == null) {
+    return {}
+  }
+
+  const credentials = []
+  const config = ini.parse(projectNpmrc)
+  for (const [key, value] of Object.entries(config)) {
+    if (credKeys.includes(key) || credKeys.some((credKey) => key.endsWith(':' + credKey))) {
+      credentials.push([key, value])
+    }
+  }
+  return Object.fromEntries(credentials)
 }
 
 // sourced from npm's cli/lib/utils/config/definitions.js for reading certs from the cafile option

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
@@ -34,6 +34,7 @@ const exec = promisify(require('child_process').exec)
 async function findVulnerableDependencies(directory, advisories) {
   const npmConfig = await loadNpmConfig()
   const caCerts = loadCACerts(npmConfig)
+  const registryOpts = extractRegistryOptions(npmConfig)
 
   const arb = new Arborist({
     path: directory,
@@ -41,6 +42,7 @@ async function findVulnerableDependencies(directory, advisories) {
     ca: caCerts,
     force: true,
     dryRun: true,
+    ...registryOpts,
   })
 
   const scope = nock('http://localhost:9999')
@@ -168,6 +170,16 @@ function buildDependencyChains(auditReport, name, chain = { items: [] }) {
 async function loadNpmConfig() {
   const configOutput = await exec('npm config ls --json')
   return JSON.parse(configOutput.stdout)
+}
+
+function extractRegistryOptions(npmConfig) {
+  const opts = []
+  for (const [key, value] of Object.entries(npmConfig)) {
+    if (key == "registry" || key.endsWith(":registry")) {
+      opts.push([key, value])
+    }
+  }
+  return Object.fromEntries(opts)
 }
 
 // sourced from npm's cli/lib/utils/config/definitions.js for reading certs from the cafile option


### PR DESCRIPTION
To support dependencies in private registries we need to forward the credentials we've passed to npm along to arborist.

I was able to extract registry scopes from the existing npm config we parse from the `npm config list --json` command. Unfortunately that doesn't return credentials so I needed to do a second pass to read them directly from the project's `.npmrc` file.

In the future we hope to be able to replace this with a npm maintained library to load the configuration.