### PR TITLE
Fix rubocop configuration error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   - "*/spec/fixtures/**/*"
   TargetRubyVersion: 2.7
   SuggestExtensions: false
-Gemspec/DateAssignment:
+Gemspec/DeprecatedAttributeAssignment:
   Enabled: true
 Layout/DotPosition:
   EnforcedStyle: trailing


### PR DESCRIPTION
Rubocop for the omnibus started failing today. This does what it asks in an attempt to fix it.

```
Error: The `Gemspec/DateAssignment` cop has been removed. Please use `Gemspec/DeprecatedAttributeAssignment` instead.
(obsolete configuration found in /home/dependabot/dependabot-core/.rubocop.yml, please update it)
```