### PR TITLE
Allow Python projects that only have a ``setup.py``

### DIFF
--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -290,7 +290,7 @@ module Dependabot
               fetch_submodules: true
             ).tap { |f| f.support_file = true }
           rescue Dependabot::DependencyFileNotFound
-            raise unless allow_pyproject
+            raise unless allow_pyproject || setup_cfg_file
 
             fetch_file_from_host(
               path.gsub("setup.py", "pyproject.toml"),


### PR DESCRIPTION
Closes https://github.com/dependabot/dependabot-core/issues/4483
Based on the solution provided by @jurre in https://github.com/dependabot/dependabot-core/issues/4483#issuecomment-1035199337.

As I said in https://github.com/dependabot/dependabot-core/issues/4483#issuecomment-1078832206 if I could get some guidance I'd happily provide tests or additional information, but I have no experience with Ruby so I don't really know how to.

However, as the Python ecosystem is moving away from `setup.py` I really think this change should be landed. Hopefully by providing the PR we can get some traction on the issue. If this is not the preferred way to do so, please feel free to close.