### PR TITLE
Disable potential script execution in arborist

### DIFF
--- a/npm_and_yarn/helpers/lib/npm/conflicting-dependency-parser.js
+++ b/npm_and_yarn/helpers/lib/npm/conflicting-dependency-parser.js
@@ -15,6 +15,8 @@ const semver = require("semver");
 async function findConflictingDependencies(directory, depName, targetVersion) {
   const arb = new Arborist({
     path: directory,
+    dryRun: true,
+    ignoreScripts: true,
   });
 
   return await arb.loadVirtual().then((tree) => {

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
@@ -43,6 +43,7 @@ async function findVulnerableDependencies(directory, advisories) {
     ca: caCerts,
     force: true,
     dryRun: true,
+    ignoreScripts: true,
     ...registryOpts,
     ...registryCreds,
   })


### PR DESCRIPTION
When executing updates via the npm clis we pass the `--ignore-scripts` flag to prevent dependencies from running untrusted code during dependency updates.

ex: https://github.com/dependabot/dependabot-core/blob/5574067c44c06042a352dbedd9b2b8b34a89eb77/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb#L177-L192

We should do the same for our usage of Arborist. This wasn't a documented option but I found this flag is honored in https://github.com/npm/cli/blob/5a50762faa37ae5964ae6f12595b20b367056c0a/workspaces/arborist/lib/arborist/rebuild.js#L50-L68