### PR TITLE
[npm] Ensure 'fix_updates' field in `VulnerabilityAuditor#audit` response

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -39,7 +39,8 @@ module Dependabot
         def audit(dependency:, security_advisories:)
           fix_unavailable = {
             "dependency_name" => dependency.name,
-            "fix_available" => false
+            "fix_available" => false,
+            "fix_updates" => []
           }
 
           SharedHelpers.in_a_temporary_directory do


### PR DESCRIPTION
The underlying JavaScript helper invoked by the vulnerability auditor consistently returns a JSON object with predictable fields, including a `fix_updates` JSON array. If the vulnerability auditor reaches an exceptional code path, or if the helper raises an exception, it should also similarly return a hash with the same fields, including `fix_updates`, so that downstream code can safely rely on this.