### PR TITLE
[go_mod] Stub failed response for initial go get call

### DIFF
--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
 
       before do
         allow(Open3).to receive(:capture3).and_call_original
-        allow(Open3).to receive(:capture3).with(anything, "go get").and_return(["", stderr, exit_status])
+        allow(Open3).to receive(:capture3).with(anything, "go get github.com/spf13/viper@v1.7.1").and_return(["", stderr, exit_status])
       end
 
       it { expect { subject }.to raise_error(Dependabot::DependencyFileNotResolvable, /The remote end hung up/) }

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -362,7 +362,9 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
 
       before do
         allow(Open3).to receive(:capture3).and_call_original
-        allow(Open3).to receive(:capture3).with(anything, "go get github.com/spf13/viper@v1.7.1").and_return(["", stderr, exit_status])
+        allow(Open3).to receive(:capture3).with(anything,
+                                                "go get github.com/spf13/viper@v1.7.1").and_return(["", stderr,
+                                                                                                    exit_status])
       end
 
       it { expect { subject }.to raise_error(Dependabot::DependencyFileNotResolvable, /The remote end hung up/) }


### PR DESCRIPTION
We've seen flakiness with this particular test. It's stubbing out a response to execution of `go get` but only captures our [2nd call](https://github.com/dependabot/dependabot-core/blob/e44578d99d6c925de2823ea52712dc78149f83cb/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb#L96-L99) to it. Our initial call to `go get github.com/spf13/viper@v1.7.1` is unstubbed so can fail if there's issues resolving the update for that external dependency. I've adjusted the test to stub the initial usage of `go get` instead. The failure that it returns will prevent the 2nd call to `go get`.