### PR TITLE
Do not attribute `maintainers` in release notes

### DIFF
--- a/bin/bump-version.rb
+++ b/bin/bump-version.rb
@@ -22,7 +22,7 @@ CHANGELOG_PATH = File.join(__dir__, "..", "CHANGELOG.md")
 CHANGELOG_CONTENTS = File.read(CHANGELOG_PATH)
 
 def proposed_changes(version, _new_version)
-  dependabot_team = `gh api -X GET 'orgs/dependabot/teams/reviewers/members' --jq '.[].login'`
+  dependabot_team = `gh api -X GET 'orgs/dependabot/teams/maintainers/members' --jq '.[].login'`
   dependabot_team = dependabot_team.split("\n").map(&:strip) + ["dependabot"]
 
   commit_subjects = `git log --pretty="%s" v#{version}..HEAD`.lines


### PR DESCRIPTION
Historically we've not attributed the core team in release notes, as the
mentions can be a bit noisy and I guess because it's our job to
contribute to Dependabot :smile:

To do so, we used to pull the `reviewers` team, but that team is no
more, and is now called `maintainers`, so I've updated our
`bump-version` script to pull in that team instead.