### PR TITLE
Update Ruby to version 2.7.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN if ! getent group "$USER_GID"; then groupadd --gid "$USER_GID" dependabot ; 
 
 ### RUBY
 
-ARG RUBY_VERSION=2.7.5
+ARG RUBY_VERSION=2.7.6
 ARG RUBY_INSTALL_VERSION=0.8.3
 
 ARG RUBYGEMS_SYSTEM_VERSION=3.2.20


### PR DESCRIPTION
Following up on #5356, this PR uses `ruby-install` to install [Ruby 2.7.6](https://www.ruby-lang.org/en/news/2022/04/12/ruby-2-7-6-released/), which is the most up-to-date 2.7 release.