### PR TITLE
[Python] Cache client-side timeouts when a remote host is unreachable

### DIFF
--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -6,7 +6,7 @@ require "toml-rb"
 require "dependabot/dependency"
 require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
-require "dependabot/shared_helpers"
+require "dependabot/registry_client"
 require "dependabot/errors"
 require "dependabot/python/requirement"
 require "dependabot/python/requirement_parser"
@@ -274,10 +274,8 @@ module Dependabot
         details = TomlRB.parse(pyproject.content).dig("tool", "poetry")
         return false unless details
 
-        index_response = Excon.get(
-          "https://pypi.org/pypi/#{normalised_name(details['name'])}/json/",
-          idempotent: true,
-          **SharedHelpers.excon_defaults
+        index_response = Dependabot::RegistryClient.get(
+          url: "https://pypi.org/pypi/#{normalised_name(details['name'])}/json/"
         )
 
         return false unless index_response.status == 200

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -7,7 +7,7 @@ require "nokogiri"
 require "dependabot/dependency"
 require "dependabot/python/update_checker"
 require "dependabot/update_checkers/version_filters"
-require "dependabot/shared_helpers"
+require "dependabot/registry_client"
 require "dependabot/python/authed_url_builder"
 require "dependabot/python/name_normaliser"
 
@@ -214,18 +214,16 @@ module Dependabot
         end
 
         def registry_response_for_dependency(index_url)
-          Excon.get(
-            index_url + normalised_name + "/",
-            idempotent: true,
-            **SharedHelpers.excon_defaults(headers: { "Accept" => "text/html" })
+          Dependabot::RegistryClient.get(
+            url: index_url + normalised_name + "/",
+            headers: { "Accept" => "text/html" }
           )
         end
 
         def registry_index_response(index_url)
-          Excon.get(
-            index_url,
-            idempotent: true,
-            **SharedHelpers.excon_defaults(headers: { "Accept" => "text/html" })
+          Dependabot::RegistryClient.get(
+            url: index_url,
+            headers: { "Accept" => "text/html" }
           )
         end
 


### PR DESCRIPTION
Follows up on https://github.com/dependabot/dependabot-core/pull/5142
See: https://github.com/dependabot/dependabot-core/pull/5373

This PR modifies the timeout caching strategy we used for Maven into a generic 'Dependabot::RegistryClient' and then applies it to the `python` gem to ship this strategy for another ecosystem.

Python is currently in the two three ecosystems experiencing this issue, but it's a little lower frequency than NPM so it might be worth shipping this first.