### PR TITLE
Stop skipping requirements with `original_link`

### DIFF
--- a/python/helpers/lib/parser.py
+++ b/python/helpers/lib/parser.py
@@ -37,9 +37,6 @@ def parse_requirements(directory):
             )
             for parsed_req in requirements:
                 install_req = install_req_from_parsed_requirement(parsed_req)
-                if install_req.original_link:
-                    continue
-
                 pattern = r"-[cr] (.*) \(line \d+\)"
                 abs_path = re.search(pattern, install_req.comes_from).group(1)
                 rel_path = os.path.relpath(abs_path, directory)


### PR DESCRIPTION
We had a user report that Dependabot wouldn't update Git dependencies.
I haven't been able to determine _why_ we were ignoring these yet, but
by removing the `continue`, Dependabot will attempt to handle the
dependency.