### PR TITLE
Fix for permission denied while building the image without base/cache.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -277,6 +277,8 @@ ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt" \
   PATH="$PATH:/opt/terraform/bin:/opt/python/bin:/opt/go_modules/bin" \
   MIX_HOME="/opt/hex/mix"
 
+RUN chown dependabot:dependabot /opt/*
+
 USER dependabot
 RUN bash /opt/bundler/helpers/v1/build
 RUN bash /opt/bundler/helpers/v2/build


### PR DESCRIPTION
The error I get without this change is this:

```
Step 67/78 : RUN bash /opt/bundler/helpers/v1/build
 ---> Running in 55a0cbf0e075
mkdir: cannot create directory ‘/opt/bundler/v1’: Permission denied
```
I don't consider this the best fix, but it works.