### PR TITLE
[Nuget] Cache client-side timeouts when a remote host is unreachable

### DIFF
--- a/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb
@@ -4,7 +4,7 @@ require "excon"
 require "nokogiri"
 require "dependabot/errors"
 require "dependabot/nuget/update_checker"
-require "dependabot/shared_helpers"
+require "dependabot/registry_client"
 
 module Dependabot
   module Nuget
@@ -69,12 +69,9 @@ module Dependabot
         end
 
         def get_repo_metadata(repo_details)
-          Excon.get(
-            repo_details.fetch(:url),
-            idempotent: true,
-            **SharedHelpers.excon_defaults(
-              headers: auth_header_for_token(repo_details.fetch(:token))
-            )
+          Dependabot::RegistryClient.get(
+            url: repo_details.fetch(:url),
+            headers: auth_header_for_token(repo_details.fetch(:token))
           )
         end
 

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -219,10 +219,9 @@ module Dependabot
         end
 
         def fetch_paginated_v2_nuget_listings(url_details, results = {})
-          response = Excon.get(
-            url_details[:versions_url],
-            idempotent: true,
-            **SharedHelpers.excon_defaults(excon_options.merge(headers: url_details[:auth_header]))
+          response = Dependabot::RegistryClient.get(
+            url: url_details[:versions_url],
+            headers: url_details[:auth_header]
           )
 
           # NOTE: Short circuit if we get a circular next link
@@ -261,12 +260,9 @@ module Dependabot
             fetch_versions_from_search_url(repository_details)
           # Otherwise, use the versions URL
           elsif repository_details[:versions_url]
-            response = Excon.get(
-              repository_details[:versions_url],
-              idempotent: true,
-              **SharedHelpers.excon_defaults(
-                excon_options.merge(headers: repository_details[:auth_header])
-              )
+            response = Dependabot::RegistryClient.get(
+              url: repository_details[:versions_url],
+              headers: repository_details[:auth_header]
             )
             return unless response.status == 200
 
@@ -276,12 +272,9 @@ module Dependabot
         end
 
         def fetch_versions_from_search_url(repository_details)
-          response = Excon.get(
-            repository_details[:search_url],
-            idempotent: true,
-            **SharedHelpers.excon_defaults(
-              excon_options.merge(headers: repository_details[:auth_header])
-            )
+          response = Dependabot::RegistryClient.get(
+            url: repository_details[:search_url],
+            headers: repository_details[:auth_header]
           )
           return unless response.status == 200
 


### PR DESCRIPTION
Follows up on https://github.com/dependabot/dependabot-core/pull/5142

This PR switches Nuget over to use the `Dependabot::RegistryClient` so it benefits from caching of unreachable hosts.