### PR TITLE
[Composer] Cache client-side timeouts when a remote host is unreachable

### DIFF
--- a/composer/lib/dependabot/composer/metadata_finder.rb
+++ b/composer/lib/dependabot/composer/metadata_finder.rb
@@ -3,7 +3,7 @@
 require "excon"
 require "dependabot/metadata_finders"
 require "dependabot/metadata_finders/base"
-require "dependabot/shared_helpers"
+require "dependabot/registry_client"
 require "dependabot/composer/version"
 
 module Dependabot
@@ -48,11 +48,7 @@ module Dependabot
       def packagist_listing
         return @packagist_listing unless @packagist_listing.nil?
 
-        response = Excon.get(
-          "https://packagist.org/p/#{dependency.name.downcase}.json",
-          idempotent: true,
-          **SharedHelpers.excon_defaults
-        )
+        response = Dependabot::RegistryClient.get(url: "https://packagist.org/p/#{dependency.name.downcase}.json")
 
         return nil unless response.status == 200
 

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -121,12 +121,12 @@ module Dependabot
         def fetch_registry_versions_from_url(url)
           cred = registry_credentials.find { |c| url.include?(c["registry"]) }
 
-          response = Excon.get(
-            url,
-            idempotent: true,
-            user: cred&.fetch("username", nil),
-            password: cred&.fetch("password", nil),
-            **SharedHelpers.excon_defaults
+          response = Dependabot::RegistryClient.get(
+            url: url,
+            options: {
+              user: cred&.fetch("username", nil),
+              password: cred&.fetch("password", nil)
+            }
           )
 
           parse_registry_response(response, url)


### PR DESCRIPTION
Follows up on https://github.com/dependabot/dependabot-core/pull/5142

This PR switches Composer over to use the `Dependabot::RegistryClient` so it benefits from caching of unreachable hosts.