### PR TITLE
[gomod] Cache client-side timeouts when a remote host is unreachable

### DIFF
--- a/go_modules/lib/dependabot/go_modules/path_converter.rb
+++ b/go_modules/lib/dependabot/go_modules/path_converter.rb
@@ -3,7 +3,7 @@
 require "excon"
 require "nokogiri"
 
-require "dependabot/shared_helpers"
+require "dependabot/registry_client"
 require "dependabot/source"
 require "dependabot/go_modules/native_helpers"
 
@@ -58,11 +58,7 @@ module Dependabot
       def self.fetch_path_metadata(path)
         # TODO: This is not robust! Instead, we should shell out to Go and
         # use https://github.com/Masterminds/vcs.
-        response = Excon.get(
-          "https://#{path}?go-get=1",
-          idempotent: true,
-          **SharedHelpers.excon_defaults
-        )
+        response = Dependabot::RegistryClient.get(url: "https://#{path}?go-get=1")
 
         return unless response.status == 200
 


### PR DESCRIPTION
Follows up on https://github.com/dependabot/dependabot-core/pull/5142

This PR switches gomod over to use the Dependabot::RegistryClient so it benefits from caching of unreachable hosts.