### PR TITLE
[cargo] Cache client-side timeouts when a remote host is unreachable

### DIFF
--- a/cargo/lib/dependabot/cargo/metadata_finder.rb
+++ b/cargo/lib/dependabot/cargo/metadata_finder.rb
@@ -3,7 +3,7 @@
 require "excon"
 require "dependabot/metadata_finders"
 require "dependabot/metadata_finders/base"
-require "dependabot/shared_helpers"
+require "dependabot/registry_client"
 
 module Dependabot
   module Cargo
@@ -50,12 +50,7 @@ module Dependabot
       def crates_listing
         return @crates_listing unless @crates_listing.nil?
 
-        response = Excon.get(
-          "https://crates.io/api/v1/crates/#{dependency.name}",
-          idempotent: true,
-          **SharedHelpers.excon_defaults
-        )
-
+        response = Dependabot::RegistryClient.get(url: "https://crates.io/api/v1/crates/#{dependency.name}")
         @crates_listing = JSON.parse(response.body)
       end
     end

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -3,6 +3,7 @@
 require "excon"
 require "dependabot/cargo/update_checker"
 require "dependabot/update_checkers/version_filters"
+require "dependabot/registry_client"
 
 module Dependabot
   module Cargo
@@ -83,12 +84,7 @@ module Dependabot
         def crates_listing
           return @crates_listing unless @crates_listing.nil?
 
-          response = Excon.get(
-            "https://crates.io/api/v1/crates/#{dependency.name}",
-            idempotent: true,
-            **SharedHelpers.excon_defaults
-          )
-
+          response = Dependabot::RegistryClient.get(url: "https://crates.io/api/v1/crates/#{dependency.name}")
           @crates_listing = JSON.parse(response.body)
         end
 


### PR DESCRIPTION
Follows up on https://github.com/dependabot/dependabot-core/pull/5142

This PR switches cargo over to use the `Dependabot::RegistryClient` so it benefits from caching of unreachable hosts.