### PR TITLE
Cache client-side timeouts when a remote host is unreachable for remaining ecosystems

### DIFF
--- a/elm/lib/dependabot/elm/update_checker.rb
+++ b/elm/lib/dependabot/elm/update_checker.rb
@@ -3,7 +3,7 @@
 require "excon"
 require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
-require "dependabot/shared_helpers"
+require "dependabot/registry_client"
 require "dependabot/errors"
 
 module Dependabot
@@ -98,11 +98,8 @@ module Dependabot
 
         @version_lookup_attempted = true
 
-        response = Excon.get(
-          "https://package.elm-lang.org/packages/#{dependency.name}/"\
-          "releases.json",
-          idempotent: true,
-          **Dependabot::SharedHelpers.excon_defaults
+        response = Dependabot::RegistryClient.get(
+          url: "https://package.elm-lang.org/packages/#{dependency.name}/releases.json"
         )
 
         return @all_versions = [] unless response.status == 200

--- a/gradle/lib/dependabot/gradle/metadata_finder.rb
+++ b/gradle/lib/dependabot/gradle/metadata_finder.rb
@@ -6,6 +6,7 @@ require "dependabot/metadata_finders/base"
 require "dependabot/file_fetchers/base"
 require "dependabot/gradle/file_parser/repositories_finder"
 require "dependabot/maven/utils/auth_headers_finder"
+require "dependabot/registry_client"
 
 module Dependabot
   module Gradle
@@ -109,12 +110,9 @@ module Dependabot
             dependency.name.split(":").last
           end
 
-        response = Excon.get(
-          "#{maven_repo_dependency_url}/"\
-          "#{dependency.version}/"\
-          "#{artifact_id}-#{dependency.version}.pom",
-          idempotent: true,
-          **SharedHelpers.excon_defaults(headers: auth_headers)
+        response = Dependabot::RegistryClient.get(
+          url: "#{maven_repo_dependency_url}/#{dependency.version}/#{artifact_id}-#{dependency.version}.pom",
+          headers: auth_headers
         )
 
         @dependency_pom_file = Nokogiri::XML(response.body)
@@ -132,12 +130,9 @@ module Dependabot
 
         return unless artifact_id && group_id && version
 
-        response = Excon.get(
-          "#{maven_repo_url}/#{group_id.tr('.', '/')}/#{artifact_id}/"\
-          "#{version}/"\
-          "#{artifact_id}-#{version}.pom",
-          idempotent: true,
-          **SharedHelpers.excon_defaults(headers: auth_headers)
+        response = Dependabot::RegistryClient.get(
+          url: "#{maven_repo_url}/#{group_id.tr('.', '/')}/#{artifact_id}/#{version}/#{artifact_id}-#{version}.pom",
+          headers: auth_headers
         )
 
         Nokogiri::XML(response.body)

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -143,11 +143,7 @@ module Dependabot
 
           @google_version_details ||=
             begin
-              response = Excon.get(
-                dependency_metadata_url,
-                idempotent: true,
-                **SharedHelpers.excon_defaults
-              )
+              response = Dependabot::RegistryClient.get(url: dependency_metadata_url)
               Nokogiri::XML(response.body)
             end
 
@@ -168,10 +164,9 @@ module Dependabot
           @dependency_metadata ||= {}
           @dependency_metadata[repository_details.hash] ||=
             begin
-              response = Excon.get(
-                dependency_metadata_url(repository_details.fetch("url")),
-                idempotent: true,
-                **Dependabot::SharedHelpers.excon_defaults(headers: repository_details.fetch("auth_headers"))
+              response = Dependabot::RegistryClient.get(
+                url: dependency_metadata_url(repository_details.fetch("url")),
+                headers: repository_details.fetch("auth_headers")
               )
               check_response(response, repository_details.fetch("url"))
               Nokogiri::XML(response.body)

--- a/hex/lib/dependabot/hex/metadata_finder.rb
+++ b/hex/lib/dependabot/hex/metadata_finder.rb
@@ -3,7 +3,7 @@
 require "excon"
 require "dependabot/metadata_finders"
 require "dependabot/metadata_finders/base"
-require "dependabot/shared_helpers"
+require "dependabot/registry_client"
 
 module Dependabot
   module Hex
@@ -55,12 +55,7 @@ module Dependabot
       def hex_listing
         return @hex_listing unless @hex_listing.nil?
 
-        response = Excon.get(
-          "https://hex.pm/api/packages/#{dependency.name}",
-          idempotent: true,
-          **SharedHelpers.excon_defaults
-        )
-
+        response = Dependabot::RegistryClient.get(url: "https://hex.pm/api/packages/#{dependency.name}")
         @hex_listing = JSON.parse(response.body)
       end
     end

--- a/hex/lib/dependabot/hex/update_checker.rb
+++ b/hex/lib/dependabot/hex/update_checker.rb
@@ -4,7 +4,7 @@ require "excon"
 require "dependabot/git_commit_checker"
 require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
-require "dependabot/shared_helpers"
+require "dependabot/registry_client"
 
 require "json"
 
@@ -243,12 +243,7 @@ module Dependabot
 
         @hex_registry_requested = true
 
-        response = Excon.get(
-          dependency_url,
-          idempotent: true,
-          **SharedHelpers.excon_defaults
-        )
-
+        response = Dependabot::RegistryClient.get(url: dependency_url)
         return unless response.status == 200
 
         @hex_registry_response = JSON.parse(response.body)

--- a/pub/lib/dependabot/pub/metadata_finder.rb
+++ b/pub/lib/dependabot/pub/metadata_finder.rb
@@ -3,7 +3,7 @@
 require "excon"
 require "dependabot/metadata_finders"
 require "dependabot/metadata_finders/base"
-require "dependabot/shared_helpers"
+require "dependabot/registry_client"
 
 module Dependabot
   module Pub
@@ -31,12 +31,7 @@ module Dependabot
       end
 
       def repository_listing(repository_url)
-        response = Excon.get(
-          "#{repository_url}/api/packages/#{dependency.name}",
-          idempotent: true,
-          **SharedHelpers.excon_defaults
-        )
-
+        response = Dependabot::RegistryClient.get(url: "#{repository_url}/api/packages/#{dependency.name}")
         JSON.parse(response.body)
       end
     end


### PR DESCRIPTION
Follows up on https://github.com/dependabot/dependabot-core/pull/5142

This PR collects up the final swap over from using `Excon` directly to using `Dependabot::RegistryClient` to cache unreachable hosts and provide an interface to start adding more logging/caching behaviour in future.