### PR TITLE
Tweak bump-version script to just push the newly-created tag

### DIFF
--- a/bin/bump-version.rb
+++ b/bin/bump-version.rb
@@ -107,6 +107,6 @@ unless dry_run
   puts "# tag the approved release notes:"
   puts "git fetch"
   puts "git tag 'v#{new_version}' 'origin/v#{new_version}-release-notes'"
-  puts "git push --tags"
+  puts "git push origin v#{new_version}"
   puts
 end


### PR DESCRIPTION
Small nitpick, it makes me nervous to use `git push --tags` in the event I've accidentally created all release-like tags locally and accidentally push something to RubyGems, etc