### PR TITLE
[Cargo] Correctly handle unused subdependencies of path dependencies

### DIFF
--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -29,7 +29,9 @@ module Dependabot
         end
 
         def latest_resolvable_version
-          @latest_resolvable_version ||= fetch_latest_resolvable_version
+          return @latest_resolvable_version if defined?(@latest_resolvable_version)
+
+          @latest_resolvable_version = fetch_latest_resolvable_version
         end
 
         private
@@ -72,6 +74,8 @@ module Dependabot
             else
               versions.min_by { |p| version_class.new(p.fetch("version")) }
             end
+
+          return unless updated_version
 
           if git_dependency?
             updated_version.fetch("source").split("#").last

--- a/cargo/spec/fixtures/manifests/bare_version_specified_as_optional
+++ b/cargo/spec/fixtures/manifests/bare_version_specified_as_optional
@@ -1,0 +1,8 @@
+[package]
+name = "dependabot" # the name of the package
+version = "0.1.0"    # the current version, obeying semver
+authors = ["support@dependabot.com"]
+
+[dependencies]
+time = "0.1.12"
+regex = { version = "0.1.41", optional = true }

--- a/cargo/spec/fixtures/manifests/cargo-registry-s3-ssl-optional
+++ b/cargo/spec/fixtures/manifests/cargo-registry-s3-ssl-optional
@@ -1,0 +1,25 @@
+
+[package]
+
+name = "cargo-registry-s3"
+version = "0.2.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang/crates.io"
+description = "Interaction between crates.io and S3 for storing crate files"
+
+[lib]
+
+name = "s3"
+path = "lib.rs"
+
+[features]
+default = ["not_safe"]
+safe = ["openssl"]
+not_safe = []
+
+[dependencies]
+chrono = "0.4"
+curl = "0.4"
+base64 = "0.9"
+openssl = { version = "0.10", optional = true }

--- a/cargo/spec/fixtures/manifests/path_dependency_feature_enabled
+++ b/cargo/spec/fixtures/manifests/path_dependency_feature_enabled
@@ -1,0 +1,8 @@
+[package]
+name = "dependabot" # the name of the package
+version = "0.1.0"    # the current version, obeying semver
+authors = ["support@dependabot.com"]
+
+[dependencies]
+cargo-registry-s3 = { path = "src/s3", version = "0.2.0", features = ["safe"] }
+regex = "=0.1.38"


### PR DESCRIPTION
This change fixes an unexpected nil error when a project has a path dependency which includes one or more optional sub-dependencies that are not included by default.

I believe this behaviour is the most correct as we rely on Cargo to generate a lockfile from which to determine the latest version; for a disabled optional sub-dependency it won't be present in the generated lockfile, so we should treat it as unused and return nil.