### PR TITLE
Add dependabot updates for Dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     directory: "/composer/helpers/v2"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
I was surprised I had to manually open #5030 until I realized
that the docker ecosystem was never enabled for Dependabot.

So this fixes that.