### PR TITLE
Bump base image in docker push workflow to `20.04`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,6 @@
 name: Push docker images
 env:
-  BASE_IMAGE: "ubuntu:18.04"
+  BASE_IMAGE: "ubuntu:20.04"
   CORE_IMAGE: "dependabot/dependabot-core"
   CORE_IMAGE_MIRROR: "ghcr.io/dependabot/dependabot-core"
 on:


### PR DESCRIPTION
We've been running on `20.04` since https://github.com/dependabot/dependabot-core/pull/4394, I just didn't realize this actions workflow also pinned the version. So this bumps to our current base image.

Unfortunately, this will likely be outdated in the future again, once #5030 lands... and likely to be an ongoing issue of drift whenever we bump Ubuntu versions.

I wish there was an easy way to extract this value from the Dockerfile, but everything I come up with seems quite hacky/brittle.