### PR TITLE
Migrate from `actions/setup-ruby` to `ruby/setup-ruby`

### DIFF
--- a/.github/workflows/gems.yml
+++ b/.github/workflows/gems.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
       - run: |
           [ -d ~/.gem ] || mkdir ~/.gem
           echo "---" > ~/.gem/credentials


### PR DESCRIPTION
The `actions/setup-ruby` action [was deprecated in favor of `ruby/setup-ruby`](https://github.com/actions/setup-ruby/commit/e932e7af67fc4a8fc77bd86b744acd4e42fe3543#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9).

So this switches to that.

Reading the docs for `ruby/setup-ruby`, all the examples include the
following params:
```
with:
        ruby-version: '3.0' # Not needed with a .ruby-version file
        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
```

However, the `ruby-version` looked like it needed to be specified for
`actions/setup-ruby` as well, and it wasn't, so maybe there's a default
that suffices?

And I suspect the `bundler-cache` arg is only relevant for repeated calls to ruby/bundler
within a single CI run... whereas we only call this action once for the following ruby call:
```
gem install rake && rake gems:release
```

So I doubt that caching adds value. 
Happy to be proved wrong if someone more familiar with Ruby knows more.