### PR TITLE
Move comment to relevant section of code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ ENV DEBIAN_FRONTEND="noninteractive" \
   LC_ALL="en_US.UTF-8" \
   LANG="en_US.UTF-8"
 
-# Everything from `make` onwards in apt-get install is only installed to ensure
-# Python support works with all packages (which may require specific libraries
-# at install time).
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
@@ -36,6 +33,9 @@ RUN apt-get update \
     locales \
     openssh-client \
     software-properties-common \
+    # Everything from here onwards is only installed to ensure
+    # Python support works with all packages (which may require
+    # specific libraries at install time).
     make \
     libpq-dev \
     libssl-dev \


### PR DESCRIPTION
Previously, it was easy to lose track of this comment because it's
located quite a ways from the code. Moving it makes it less likely that
packages will listed in the wrong category.

Although I'd happily bet an ice cream cone that the comment is
partially incorrect and some of the listed packages are not just for
python.