### PR TITLE
Bump docker_registry2 to fix #3989

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-ecr", "~> 1.5"
   spec.add_dependency "bundler", ">= 1.16", "< 3.0.0"
   spec.add_dependency "commonmarker", ">= 0.20.1", "< 0.24.0"
-  spec.add_dependency "docker_registry2", "~> 1.7", ">= 1.7.1"
+  spec.add_dependency "docker_registry2", "~> 1.11", ">= 1.11.0"
   spec.add_dependency "excon", "~> 0.75"
   spec.add_dependency "faraday", "2.3.0"
   spec.add_dependency "gitlab", "4.19.0"


### PR DESCRIPTION
The latest version of docker_registry2 has the fix for #3989.