### PR TITLE
[npm] Refactor with top-down traversal

### DIFF
--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
@@ -28,7 +28,7 @@
 
 const Arborist = require('@npmcli/arborist')
 const nock = require('nock')
-const { inspect, promisify } = require('util');
+const { promisify } = require('util');
 const exec = promisify(require('child_process').exec)
 
 async function findVulnerableDependencies(directory, advisories) {

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
@@ -76,21 +76,22 @@ async function findVulnerableDependencies(directory, advisories) {
 
     const chains = buildDependencyChains(auditReport, name)
 
-    // In order to consider the vuln dependency in question fixable,
+    // In order for the vuln dependency in question to be considered fixable,
     // all dependency chains originating from it must be fixable.
     if (chains.some((chain) => !Boolean(chain.fixAvailable))) {
       response.fix_available = false
       return response
     }
 
-    for (const chain of chains) {
-      const topMost = chain.items[0]
-      if (topMost.name === name) {
-        continue
-      }
+    const fixUpdateChains = chains.filter((chain) => chain.nodes[0].name !== name)
+    const groupedFixUpdateChains = groupBy(fixUpdateChains, (chain) => chain.nodes[0].pkgid)
+
+    for (const group of groupedFixUpdateChains.values()) {
+      const fixUpdateNode = group[0].nodes[0]
+
       response.fix_updates.push({
-        dependency_name: topMost.name,
-        current_version: topMost.version,
+        dependency_name: fixUpdateNode.name,
+        current_version: fixUpdateNode.version,
       })
     }
 
@@ -135,75 +136,60 @@ function convertAdvisoriesToRegistryBulkFormat(advisories) {
   }, {})
 }
 
-/* Traverses all effects originating from the named dependency in the
- * audit report and returns an array of dependency chains rooted in the named
- * dependency,
+/* Returns an array of dependency chains rooted in the named dependency,
  *   [
  *    {
  *      fixAvailable: true | false | object,
- *      items: [
- *        { name: 'foo', version: '1.0.0' },
+ *      nodes: [
+ *        ArboristNode {
+ *          name: 'foo',
+ *          version: '1.0.0',
+ *          ...
+ *        },
  *        ...
  *      ]
  *    },
  *    ...
  *   ]
  *
- * The first item in the chain is always the top-most dependency affected by
- * the vulnerable dependency in question. The `fixAvailable` field
- * applies to the first item in the chain (if that item is fixable, then
- * every item after it must be fixable, too).
+ * The first node in each chain is the innermost dependency affected by the vuln;
+ * the `fixAvailable` field applies to this dependency. The last node in each
+ * chain is always a top-level dependency.
  */
 function buildDependencyChains(auditReport, name) {
-  const helper = (name, chain, visited) => {
-    // The vuln for this dependency.
-    const vuln = auditReport.get(name)
-
-    // The current version of this dependency.
-    const version = [...vuln.nodes][0].version
-
-    // The item that will represent this dependency in this chain.
-    const item = { name, version }
-
-    // Array of effects, excluding cycles.
-    const effects = [...vuln.effects]
-
-    if (visited.has(name)) {
-      // We've already visited this dependency in this chain, so we've detected a cycle.
-      // We currently throw when this happens. Ultimately we want to gracefully handle
-      // cycles and still return the recommended fix updates.
-      const source = chain.items[chain.items.length-1]
-      const message = `Cycle detected while traversing effects from ` +
-        `${source.name}@${source.version}: ` +
-        inspect([name, ...visited], {
-          breakLength: Infinity,
-          depth: 1,
-          maxStringLength: 255,
-        })
-      throw new Error(message)
+  const helper = (node, chain, visited) => {
+    if (!node) {
+      return []
     }
-
-    if (!effects.length) {
-      // If the current vuln has no effects, we've reached the end of this chain.
-      return [{ fixAvailable: vuln.fixAvailable, items: [item, ...chain.items] }]
+    if (visited.has(node.name)) {
+      // We've already seen this node; end path.
+      return []
     }
-
-    return effects.reduce((chains, effect) => {
-      return chains.concat(
-        helper(effect.name, { items: [item, ...chain.items] }, new Set([name, ...visited])))
+    if (auditReport.has(node.name)) {
+      const vuln = auditReport.get(node.name)
+      return [{ fixAvailable: vuln.fixAvailable, nodes: [node, ...chain.nodes] }]
+    }
+    if (!node.edgesOut.size) {
+      // This is a leaf node that is unaffected by the vuln; end path.
+      return []
+    }
+    return [...node.edgesOut.values()].reduce((chains, { to }) => {
+      // Only prepend current node to chain/visited if it's not the project root.
+      const newChain = node.isProjectRoot ? chain : { nodes: [node, ...chain.nodes] }
+      const newVisited = node.isProjectRoot ? visited : new Set([node.name, ...visited])
+      return chains.concat(helper(to, newChain, newVisited))
     }, [])
   }
+  return helper(auditReport.tree, { nodes: [] }, new Set())
+}
 
-  const chains = helper(name, { items: [] }, new Set())
-  const seen = new Set()
-  return chains.filter(chain => {
-    const head = chain.items[0]
-    if (seen.has(head.name)) {
-      return false
-    }
-    seen.add(head.name)
-    return true
-  })
+function groupBy(elems, fn) {
+  const groups = new Map()
+  for (const [index, elem] of [...elems].entries()) {
+    const key = fn(elem, index, elems)
+    groups.set(key, (groups.get(key) || []).concat([elem]))
+  }
+  return groups
 }
 
 async function loadNpmConfig() {

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
@@ -92,8 +92,7 @@ async function findVulnerableDependencies(directory, advisories) {
       return response
     }
 
-    const fixUpdateChains = chains.filter((chain) => chain.nodes[0].name !== name)
-    const groupedFixUpdateChains = groupBy(fixUpdateChains, (chain) => chain.nodes[0].pkgid)
+    const groupedFixUpdateChains = groupBy(chains, (chain) => chain.nodes[0].pkgid)
     let topLevelAncestors = new Set()
 
     for (const group of groupedFixUpdateChains.values()) {

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
@@ -68,6 +68,7 @@ async function findVulnerableDependencies(directory, advisories) {
       current_version: version,
       fix_available: Boolean(fixAvailable),
       fix_updates: [],
+      top_level_ancestors: [],
     }
 
     if (!Boolean(fixAvailable)) {
@@ -85,15 +86,32 @@ async function findVulnerableDependencies(directory, advisories) {
 
     const fixUpdateChains = chains.filter((chain) => chain.nodes[0].name !== name)
     const groupedFixUpdateChains = groupBy(fixUpdateChains, (chain) => chain.nodes[0].pkgid)
+    let topLevelAncestors = new Set()
 
     for (const group of groupedFixUpdateChains.values()) {
       const fixUpdateNode = group[0].nodes[0]
+      const groupTopLevelAncestors = group.reduce((anc, chain) => {
+        const topLevelNode = chain.nodes[chain.nodes.length - 1]
+        return anc.add(topLevelNode.name)
+      }, new Set())
+
+      // Add group's top-level ancestors to the set of all top-level ancestors of
+      // the vuln dependency in question.
+      topLevelAncestors = new Set([...topLevelAncestors, ...groupTopLevelAncestors])
+
+      // If a chain consists of only one node, chain.nodes[0].name == chain.nodes[chain.nodes.length-1].name.
+      // In such cases, don't include the fix update node as an ancestor of itself.
+      const fixUpdateNodeTopLevelAncestors =
+        [...groupTopLevelAncestors].filter((nodeName) => nodeName !== fixUpdateNode.name).sort()
 
       response.fix_updates.push({
         dependency_name: fixUpdateNode.name,
         current_version: fixUpdateNode.version,
+        top_level_ancestors: fixUpdateNodeTopLevelAncestors,
       })
     }
+
+    response.top_level_ancestors = [...topLevelAncestors].sort()
 
     const fixTree = await arb.audit({
       fix: true,

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
@@ -59,17 +59,25 @@ async function findVulnerableDependencies(directory, advisories) {
 
   try {
     const name = advisories[0].dependency_name
-    const auditReport = await arb.audit()
-    const vuln = auditReport.get(name)
-    const version = [...vuln.nodes][0].version
-    const fixAvailable = vuln.fixAvailable
     const response = {
       dependency_name: name,
-      current_version: version,
-      fix_available: Boolean(fixAvailable),
       fix_updates: [],
       top_level_ancestors: [],
     }
+    const auditReport = await arb.audit()
+    if (!auditReport.has(name)) {
+      if (auditReport.tree.children.has(name)) {
+        response.current_version = auditReport.tree.children.get(name).version
+      }
+      response.fix_available = false
+      return response
+    }
+    const vuln = auditReport.get(name)
+    const version = [...vuln.nodes][0].version
+    const fixAvailable = vuln.fixAvailable
+
+    response.current_version = version
+    response.fix_available = Boolean(fixAvailable)
 
     if (!Boolean(fixAvailable)) {
       return response

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -36,11 +36,16 @@ module Dependabot
         #     * :dependency_name [String] the name of the blocking dependency
         #     * :current_version [String] the current version of the blocking dependency
         #     * :target_version [String] the target version of the blocking dependency
+        #     * :top_level_ancestors [Array<String>] the names of top-level dependencies with a transitive
+        #       dependency on the blocking dependency
+        #   * :top_level_ancestors [Array<String>] the names of all top-level dependencies with a transitive
+        #     dependency on the dependency
         def audit(dependency:, security_advisories:)
           fix_unavailable = {
             "dependency_name" => dependency.name,
             "fix_available" => false,
-            "fix_updates" => []
+            "fix_updates" => [],
+            "top_level_ancestors" => []
           }
 
           SharedHelpers.in_a_temporary_directory do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
     context "when the native helper detects a vuln effects cycle" do
       let(:dependency_files) { project_dependency_files("npm8/transitive_dependency_effects_cycle") }
 
-      it "returns fix_available => false and logs the error raised by the helper" do
+      it "returns a hash with the target version and transitive updates to make" do
         security_advisories = [
           Dependabot::SecurityAdvisory.new(
             dependency_name: dependency.name,
@@ -177,9 +177,18 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
           )
         ]
 
-        expect(Dependabot.logger).to receive(:info).with(/cycle detected/i)
         expect(subject.audit(dependency: dependency, security_advisories: security_advisories)).
-          to include("fix_available" => false)
+          to include(
+            "dependency_name" => dependency.name,
+            "current_version" => "1.0.0",
+            "target_version" => "1.0.1",
+            "fix_available" => true,
+            "fix_updates" => [{
+              "dependency_name" => "@dependabot-fixtures/npm-parent-dependency-4",
+              "current_version" => "1.0.0",
+              "target_version" => "2.0.0"
+            }]
+          )
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
     end
 
     context "when a fix is available" do
-      let(:dependency_files) { project_dependency_files("npm8/locked_transitive_dependency") }
+      let(:dependency_files) { project_dependency_files("npm8/transitive_dependency_locked_by_intermediate") }
 
-      it "returns a hash with the target version and transitive updates to make" do
+      it "returns a hash with the top-level ancestors, target version, and transitive updates to make" do
         security_advisories = [
           Dependabot::SecurityAdvisory.new(
             dependency_name: dependency.name,
@@ -56,10 +56,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
             "target_version" => "1.0.1",
             "fix_available" => true,
             "fix_updates" => [{
-              "dependency_name" => "@dependabot-fixtures/npm-parent-dependency",
-              "current_version" => "2.0.0",
-              "target_version" => "2.0.2",
-              "top_level_ancestors" => []
+              "dependency_name" => "@dependabot-fixtures/npm-intermediate-dependency",
+              "current_version" => "0.0.1",
+              "target_version" => "0.0.2",
+              "top_level_ancestors" => ["@dependabot-fixtures/npm-parent-dependency"]
             }],
             "top_level_ancestors" => ["@dependabot-fixtures/npm-parent-dependency"]
           )

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
       end
     end
 
-    context "when the native helper detects a vuln effects cycle" do
+    context "when the audit report contains a vuln effects cycle" do
       let(:dependency_files) { project_dependency_files("npm8/transitive_dependency_effects_cycle") }
 
       it "returns a hash with the target version and transitive updates to make" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -58,8 +58,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
             "fix_updates" => [{
               "dependency_name" => "@dependabot-fixtures/npm-parent-dependency",
               "current_version" => "2.0.0",
-              "target_version" => "2.0.2"
-            }]
+              "target_version" => "2.0.2",
+              "top_level_ancestors" => []
+            }],
+            "top_level_ancestors" => ["@dependabot-fixtures/npm-parent-dependency"]
           )
       end
     end
@@ -130,8 +132,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
             "fix_updates" => [{
               "dependency_name" => "@dependabot-fixtures/npm-parent-dependency",
               "current_version" => "2.0.0",
-              "target_version" => "1.0.2"
-            }]
+              "target_version" => "1.0.2",
+              "top_level_ancestors" => []
+            }],
+            "top_level_ancestors" => ["@dependabot-fixtures/npm-parent-dependency"]
           })
 
         expect(subject.audit(dependency: dependency, security_advisories: security_advisories)).
@@ -186,8 +190,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
             "fix_updates" => [{
               "dependency_name" => "@dependabot-fixtures/npm-parent-dependency-4",
               "current_version" => "1.0.0",
-              "target_version" => "2.0.0"
-            }]
+              "target_version" => "2.0.0",
+              "top_level_ancestors" => []
+            }],
+            "top_level_ancestors" => ["@dependabot-fixtures/npm-parent-dependency-4"]
           )
       end
     end


### PR DESCRIPTION
### Background

The `npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js` script leverages the library code that powers `npm audit` in order to determine if a vulnerable transitive dependency can be fixed and, if it can, the updates necessary to fix it.

The audit report is essentially a map of packages affected by the vulnerable transitive dependency. Each entry in the map has an array of effects, which are the names of other packages—keys in the same map—affected by it.

Originally the script would start at the vulnerable transitive dependency and walk up the "tree of effects" until it encountered entries with no effects, signaling the earliest ancestors of the vulnerable transitive dependency that have known fixability. A problem arose when we realized that the effects tree may contain cycles, which manifested as a stack overflow error in our recursive algorithm. Detecting a cycle is trivial, but determining _which_ node along the path before the cycle was detected is the one to read the `fixAvailable` attribute from (when a node may have multiple parents) is not.

### Changes

This PR does two things.

First, it sidesteps the issue of cycles in the effects described above. Instead of starting at the vulnerable dependency and walking up the effects tree in the audit report, the script now walks the dependency graph starting with the project's direct dependencies, does some bookkeeping at each visited node using the audit report, and collects all dependency chains that terminate at a node that is affected by the vulnerable dependency (i.e., ones that are in the audit report map). The downside of this approach is that it requires visiting every node in the dependency graph, but in my testing this hasn't resulted in alarming performance. A benefit of this approach is that by starting with the direct dependencies, it's trivial to track how each dependency to be updated is related to a direct dependency, which segues to the second thing.

Since we have the complete dependency chain from each fix update to a direct dependency, the script's response now includes the list of direct dependencies. Here's what that looks like for our [node-forge-intermediate example](https://github.com/dsp-testing/dependabot-reproduce-update-not-possible/tree/master/node-forge-intermediate):

```
react-scripts (direct)
└ webpack-dev-server (unlock/update)
  └ selfsigned
    └ node-forge (vuln)
```

```json
{
  "dependency_name": "node-forge",
  "current_version": "0.10.0",
  "fix_available": true,
  "fix_updates": [
    {
      "dependency_name": "webpack-dev-server",
      "current_version": "4.7.2",
      "top_level_ancestors": ["react-scripts"],
      "target_version": "4.9.3"
    }
  ],
  "top_level_ancestors": ["react-scripts"],
  "target_version": "1.3.1"
}
```

This will prove useful if we decide to surface more information about transitive dependency updates in PR descriptions per https://github.com/github/dependabot-updates/issues/2629. Currently only the list of direct dependencies is returned. It would be trivial to return the full dependency chains with intermediate dependencies and versions, but it felt premature to introduce that now.