### PR TITLE
Allow to mark files as executable

### DIFF
--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -5,7 +5,7 @@ require "pathname"
 module Dependabot
   class DependencyFile
     attr_accessor :name, :content, :directory, :type, :support_file,
-                  :symlink_target, :content_encoding, :operation
+                  :symlink_target, :content_encoding, :operation, :execute_filemode
 
     class ContentEncoding
       UTF_8 = "utf-8"
@@ -20,7 +20,8 @@ module Dependabot
 
     def initialize(name:, content:, directory: "/", type: "file",
                    support_file: false, symlink_target: nil,
-                   content_encoding: ContentEncoding::UTF_8, deleted: false, operation: Operation::UPDATE)
+                   content_encoding: ContentEncoding::UTF_8, deleted: false, operation: Operation::UPDATE,
+                   execute_filemode: false)
       @name = name
       @content = content
       @directory = clean_directory(directory)
@@ -28,6 +29,7 @@ module Dependabot
       @support_file = support_file
       @content_encoding = content_encoding
       @operation = operation
+      @execute_filemode = execute_filemode
 
       # Make deleted override the operation. Deleted is kept when operation
       # was introduced to keep compatibility with downstream dependants.
@@ -55,7 +57,8 @@ module Dependabot
         "support_file" => support_file,
         "content_encoding" => content_encoding,
         "deleted" => deleted,
-        "operation" => operation
+        "operation" => operation,
+        "execute_filemode" => execute_filemode
       }
 
       details["symlink_target"] = symlink_target if symlink_target
@@ -96,6 +99,10 @@ module Dependabot
 
     def deleted?
       deleted
+    end
+
+    def execute_filemode?
+      execute_filemode
     end
 
     def binary?

--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -193,7 +193,7 @@ module Dependabot
             {
               path: (file.symlink_target ||
                      file.path).sub(%r{^/}, ""),
-              mode: "100644",
+              mode: file.execute_filemode? ? "100755" : "100644",
               type: "blob"
             }.merge(content)
           end

--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -114,6 +114,14 @@ module Dependabot
           }
         end
 
+        files.select(&:execute_filemode?).each do |file|
+          actions << {
+            action: "chmod",
+            file_path: file.path,
+            execute_filemode: true
+          }
+        end
+
         gitlab_client_for_source.create_commit(
           source.repo,
           branch_name,

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -146,7 +146,7 @@ module Dependabot
             {
               path: (file.symlink_target ||
                      file.path).sub(%r{^/}, ""),
-              mode: "100644",
+              mode: file.execute_filemode? ? "100755" : "100644",
               type: "blob"
             }.merge(content)
           end

--- a/common/lib/dependabot/pull_request_updater/gitlab.rb
+++ b/common/lib/dependabot/pull_request_updater/gitlab.rb
@@ -83,6 +83,14 @@ module Dependabot
           }
         end
 
+        files.select(&:execute_filemode?).each do |file|
+          actions << {
+            action: "chmod",
+            file_path: file.path,
+            execute_filemode: true
+          }
+        end
+
         gitlab_client_for_source.create_commit(
           source.repo,
           merge_request.source_branch,

--- a/common/spec/dependabot/dependency_file_spec.rb
+++ b/common/spec/dependabot/dependency_file_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "file",
           "support_file" => false,
           "content_encoding" => "utf-8",
@@ -87,6 +88,11 @@ RSpec.describe Dependabot::DependencyFile do
         expect(file.deleted).to be_falsey
         expect(file.deleted?).to be_falsey
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::UPDATE
+      end
+
+      it "indicates the filemode correctly" do
+        expect(file.execute_filemode).to be_falsey
+        expect(file.execute_filemode?).to be_falsey
       end
     end
 
@@ -105,6 +111,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "symlink",
           "support_file" => false,
           "symlink_target" => "nested/Gemfile",
@@ -135,6 +142,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "file",
           "support_file" => false,
           "content_encoding" => "utf-8",
@@ -164,6 +172,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "file",
           "support_file" => false,
           "content_encoding" => "utf-8",
@@ -193,6 +202,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "file",
           "support_file" => false,
           "content_encoding" => "utf-8",
@@ -222,6 +232,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "file",
           "support_file" => false,
           "content_encoding" => "utf-8",
@@ -252,6 +263,7 @@ RSpec.describe Dependabot::DependencyFile do
           "name" => "Gemfile",
           "content" => "a",
           "directory" => "/",
+          "execute_filemode" => false,
           "type" => "file",
           "support_file" => false,
           "content_encoding" => "utf-8",
@@ -264,6 +276,36 @@ RSpec.describe Dependabot::DependencyFile do
         expect(file.deleted).to be_truthy
         expect(file.deleted?).to be_truthy
         expect(file.operation).to eq Dependabot::DependencyFile::Operation::DELETE
+      end
+    end
+
+    context "with an executable file" do
+      let(:file) do
+        described_class.new(
+          name: "Gemfile",
+          content: "a",
+          operation: Dependabot::DependencyFile::Operation::UPDATE,
+          execute_filemode: true
+        )
+      end
+
+      it "returns the correct array" do
+        expect(subject).to eq(
+          "name" => "Gemfile",
+          "content" => "a",
+          "directory" => "/",
+          "execute_filemode" => true,
+          "type" => "file",
+          "support_file" => false,
+          "content_encoding" => "utf-8",
+          "deleted" => false,
+          "operation" => Dependabot::DependencyFile::Operation::UPDATE
+        )
+      end
+
+      it "indicates the filemode correctly" do
+        expect(file.execute_filemode).to be_truthy
+        expect(file.execute_filemode?).to be_truthy
       end
     end
   end

--- a/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
       "password" => "token"
     }]
   end
-  let(:files) { [gemfile, gemfile_lock, created_file, deleted_file] }
+  let(:files) { [gemfile, gemfile_lock, created_file, created_executable, deleted_file] }
   let(:commit_message) { "Commit msg" }
   let(:pr_description) { "PR msg" }
   let(:pr_name) { "PR name" }
@@ -87,6 +87,14 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
       name: "created-file",
       content: "created",
       operation: Dependabot::DependencyFile::Operation::CREATE
+    )
+  end
+  let(:created_executable) do
+    Dependabot::DependencyFile.new(
+      name: "created-executable-file",
+      content: "created-executable",
+      operation: Dependabot::DependencyFile::Operation::CREATE,
+      execute_filemode: true
     )
   end
   let(:deleted_file) do
@@ -161,9 +169,19 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
                 content: created_file.content
               },
               {
+                action: "create",
+                file_path: created_executable.path,
+                content: created_executable.content
+              },
+              {
                 action: "delete",
                 file_path: deleted_file.path,
                 content: ""
+              },
+              {
+                action: "chmod",
+                file_path: created_executable.path,
+                execute_filemode: true
               }
             ]
           }

--- a/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
   let(:source) do
     Dependabot::Source.new(provider: "gitlab", repo: "gocardless/bump")
   end
-  let(:files) { [gemfile, gemfile_lock, created_file, deleted_file] }
+  let(:files) { [gemfile, gemfile_lock, created_file, created_executable, deleted_file] }
   let(:base_commit) { "basecommitsha" }
   let(:old_commit) { "oldcommitsha" }
   let(:merge_request_number) do
@@ -57,6 +57,14 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
       name: "created-file",
       content: "created",
       operation: Dependabot::DependencyFile::Operation::CREATE
+    )
+  end
+  let(:created_executable) do
+    Dependabot::DependencyFile.new(
+      name: "created-executable-file",
+      content: "created-executable",
+      operation: Dependabot::DependencyFile::Operation::CREATE,
+      execute_filemode: true
     )
   end
   let(:deleted_file) do
@@ -170,9 +178,19 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
                 content: created_file.content
               },
               {
+                action: "create",
+                file_path: created_executable.path,
+                content: created_executable.content
+              },
+              {
                 action: "delete",
                 file_path: deleted_file.path,
                 content: ""
+              },
+              {
+                action: "chmod",
+                file_path: created_executable.path,
+                execute_filemode: true
               }
             ],
             force: true,


### PR DESCRIPTION
So far all files have been assumed to be non-executable. For most dependencies this is fine, because only metadata files are being touched.

However, custom `FileUpdater` implementations may have the need to create files that are marked as executable.

### What's included?

This PR contains the necessary changes to `DependencyFile` to express the intent of marking a file as executable, as well as changes to the PR creators and updaters of GitHub and GitLab to act on those intentions.

### Limitations

The most notable limitation at this point is, that the support has not been added for all code hosting platforms. If that's required, I will go through them one-by-one and add support if possible as per docs. I will not be able to actually test the change on all related platforms though.

Also noteworthy is the fact, that for `GitLab` an extra action has to be added to determine the filemode of a file. This PR is keeping the list of actions smaller by only indicating a `chmod` action on executable files. Non-executable files receive no indication of a filemode. In case an updater wanted to _change_ the filemode of an existing file, this would not work. On the other hand it seemed like an unlikely use-case to me, so I thought it would be preferable to keep the requests shorter.
Alternatively I could implement it so that there is a `chmod` action for every created or updated file.

### Use case

We have an internal tool that helps keeping parts of our CI consistent. This includes adding/maintaining script files that are under version control. A custom `FileUpdater` for this tool allows us to update the tool version and regenerate files automatically within a pull request, however when creating a new script file this will eventually fail the CI, because the script is no executable.

The GitLab implementation has been tested on a local dependabot installation already through the help of monkey patching.