### PR TITLE
Fix incomplete regular expression for hostnames

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -32,7 +32,7 @@ module Dependabot
         %r{^#{FROM}\s+(#{PLATFORM}\s+)?(#{REGISTRY}/)?
           #{IMAGE}#{TAG}?#{DIGEST}?#{NAME}?}x.freeze
 
-      AWS_ECR_URL = /dkr\.ecr\.(?<region>[^.]+).amazonaws\.com/.freeze
+      AWS_ECR_URL = /dkr\.ecr\.(?<region>[^.]+)\.amazonaws\.com/.freeze
 
       def parse
         dependency_set = DependencySet.new

--- a/docker/lib/dependabot/docker/utils/credentials_finder.rb
+++ b/docker/lib/dependabot/docker/utils/credentials_finder.rb
@@ -9,7 +9,7 @@ module Dependabot
   module Docker
     module Utils
       class CredentialsFinder
-        AWS_ECR_URL = /dkr\.ecr\.(?<region>[^.]+).amazonaws\.com/.freeze
+        AWS_ECR_URL = /dkr\.ecr\.(?<region>[^.]+)\.amazonaws\.com/.freeze
 
         def initialize(credentials)
           @credentials = credentials


### PR DESCRIPTION
The unescaped '.' before 'amazonaws.com' could match more hosts than
expected.

Discovered via CodeQL.

Fix https://github.com/dependabot/dependabot-core/security/code-scanning/6
Fix https://github.com/dependabot/dependabot-core/security/code-scanning/7