### PR TITLE
Update psycopg2 test metadata to fix CodeQL alert about untrusted source code

### DIFF
--- a/python/spec/dependabot/python/metadata_finder_spec.rb
+++ b/python/spec/dependabot/python/metadata_finder_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Dependabot::Python::MetadataFinder do
       body: "Not GHES",
       headers: {}
     )
-    stub_request(:get, "https://initd.org/status").to_return(status: 404)
+    stub_request(:get, "https://www.psycopg.org/status").to_return(status: 404)
     stub_request(:get, "https://pypi.org/status").to_return(status: 404)
   end
 
@@ -218,7 +218,7 @@ RSpec.describe Dependabot::Python::MetadataFinder do
       let(:pypi_response) { fixture("pypi", "pypi_response_no_source.json") }
 
       before do
-        stub_request(:get, "http://initd.org/psycopg/").
+        stub_request(:get, "http://www.psycopg.org/").
           to_return(status: 200, body: "no details")
       end
 
@@ -232,19 +232,19 @@ RSpec.describe Dependabot::Python::MetadataFinder do
       it "caches the call to the homepage" do
         2.times { source_url }
         expect(WebMock).
-          to have_requested(:get, "http://initd.org/psycopg/").once
+          to have_requested(:get, "http://www.psycopg.org/").once
       end
 
       context "and the homepage does an infinite redirect" do
-        let(:redirect_url) { "http://initd.org/Psycopg/" }
+        let(:redirect_url) { "http://www.psycopg.org/fake-redirect/" }
 
         before do
-          stub_request(:get, "http://initd.org/psycopg/").
+          stub_request(:get, "http://www.psycopg.org/").
             to_return(status: 302, headers: { "Location" => redirect_url })
           stub_request(:get, redirect_url).
             to_return(
               status: 302,
-              headers: { "Location" => "http://initd.org/psycopg/" }
+              headers: { "Location" => "http://www.psycopg.org/" }
             )
         end
 
@@ -253,7 +253,7 @@ RSpec.describe Dependabot::Python::MetadataFinder do
 
       context "but there are details on the home page" do
         before do
-          stub_request(:get, "http://initd.org/psycopg/").
+          stub_request(:get, "http://psycopg.org/").
             to_return(
               status: 200,
               body: fixture("psycopg_homepage.html")
@@ -261,25 +261,25 @@ RSpec.describe Dependabot::Python::MetadataFinder do
         end
 
         context "for this dependency" do
-          let(:dependency_name) { "psycopg2" }
-          it { is_expected.to eq("https://github.com/psycopg/psycopg2") }
+          let(:dependency_name) { "psycopg" }
+          it { is_expected.to eq("https://github.com/psycopg/psycopg") }
 
           context "with an unexpected name" do
-            let(:dependency_name) { "python-psycopg2" }
+            let(:dependency_name) { "python-psycopg" }
             before do
-              stub_request(:get, "https://github.com/psycopg/psycopg2").
-                to_return(status: 200, body: "python-psycopg2")
+              stub_request(:get, "https://github.com/psycopg/psycopg").
+                to_return(status: 200, body: "python-psycopg")
             end
 
-            it { is_expected.to eq("https://github.com/psycopg/psycopg2") }
+            it { is_expected.to eq("https://github.com/psycopg/psycopg") }
           end
         end
 
         context "for another dependency" do
           let(:dependency_name) { "luigi" }
           before do
-            stub_request(:get, "https://github.com/psycopg/psycopg2").
-              to_return(status: 200, body: "python-psycopg2")
+            stub_request(:get, "https://github.com/psycopg/psycopg").
+              to_return(status: 200, body: "python-psycopg")
           end
 
           it { is_expected.to be_nil }
@@ -323,7 +323,7 @@ RSpec.describe Dependabot::Python::MetadataFinder do
       let(:pypi_response) { fixture("pypi", "pypi_response_no_source.json") }
 
       it "returns the specified homepage" do
-        expect(homepage_url).to eq("http://initd.org/psycopg/")
+        expect(homepage_url).to eq("http://www.psycopg.org/")
       end
     end
   end

--- a/python/spec/fixtures/psycopg_homepage.html
+++ b/python/spec/fixtures/psycopg_homepage.html
@@ -1,229 +1,319 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-  <title>PostgreSQL + Python | Psycopg</title>
-  <meta http-equiv="content-type" content="text/html;charset=utf-8" />
-  <meta http-equiv="content-language" content="en-us" />
-  <meta name="description" content="Python adapter for PostgreSQL" />
-  <meta name="keywords" content="python, postgresql, adapter, driver, psycopg, psycopg2, database" />
 
-  <link rel="stylesheet" type="text/css" href="/psycopg/media/css/psycopg.css" />
-  <link rel="stylesheet" type="text/css" href="/psycopg/media/css/syntax.css" />
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-19287248-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-19287248-2');
+    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="Python adapter for PostgreSQL" />
+    <meta name="keywords" content="python, postgresql, adapter, driver, psycopg, psycopg2, database" />
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="/css/syntax.css?h=8242465b">
+    <link rel="stylesheet" href="/css/psycopg.css?h=09ddafbb">
+    <title>PostgreSQL driver for Python — Psycopg</title>
+    <link rel="alternate" type="application/atom+xml" title="Psycopg news"
+      href="/news.xml" />
+    <link rel="alternate" type="application/atom+xml" title="Psycopg articles"
+      href="/articles.xml" />
+  </head>
+  <body>
+    <header>
+      <div id="logoContainer" class="container">
+        <div id="logo"><h1><a href="/">psycopg</a></h1></div>
+        <div style="clear: left"></div>
+      </div>
+  <nav id="menu" class="navbar navbar-expand-sm navbar-dark">
+    <button class="navbar-toggler" type="button" data-toggle="collapse"
+        data-target="#collapsibleNavbar">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="collapsibleNavbar">
+      <ul class="navbar-nav">
+          <li class="nav-item active">
+            <a class="nav-link" href="/">Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/features/">Features</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/install/">Install</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/articles/tag/news/">News</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/articles/tag/recipe/">Recipes</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/psycopg3/">psycopg3</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/sponsors/">Sponsors</a>
+          </li>
+      </ul>
+    </div>
+  </nav>
+    </header>
 
-
-  <link rel="alternate" type="application/atom+xml" title="Psycopg news"
-    href="/psycopg/articles/feeds/tag/news/atom/" />
-  <link rel="alternate" type="application/atom+xml" title="Psycopg articles"
-    href="/psycopg/articles/feeds/atom/" />
-  <script type="text/javascript">
-    /* <![CDATA[ */
-        (function() {
-          var s = document.createElement('script'), t = document.getElementsByTagName('script')[0];
-          s.type = 'text/javascript';
-          s.async = true;
-          s.src = 'http://api.flattr.com/js/0.6/load.js?mode=auto';
-          t.parentNode.insertBefore(s, t);
-        })();
-    /* ]]> */
-  </script>
-
-
-
-
-
-<script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-19287248-1']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-</script>
-
-
-
-</head>
-<body class="">
-
-<div id="header">
-  <div id="logoContainer">
-    <div id="logo"><h1><a href="/psycopg/">psycopg</a></h1></div>
-    <div class="clearLeft"></div>
-  </div>
-  <div id="menu">
-    <table cellpadding="0" cellspacing="0" border="0">
-      <tbody>
-        <tr>
-          <td>
-            <ul>
-              <li><a href="/psycopg/">Home</a></li>
-              <li><a href="/psycopg/download/">Download</a></li>
-              <li><a href="/psycopg/docs/install.html">Install</a></li>
-              <li><a href="/psycopg/docs/">Documentation</a></li>
-
-              <li><a href="/psycopg/articles/tag/news/">News</a></li>
-              <li><a href="/psycopg/articles/">Articles</a></li>
-              <li><a href="/psycopg/development/">Development</a></li>
-            </ul>
-            <div class="clearLeft"></div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
-
-<div id="site">
-  <div id="content">
+    <div id="site" class="container" style="margin-top:30px">
+      <div class="row">
+        <div id="content" class="col-sm-8 sidebar">
 
 <div class="teaser">
-<p><strong>Psycopg</strong> is the most popular <a class="reference external" href="http://www.postgresql.org/">PostgreSQL</a> adapter for the <a class="reference external" href="http://www.python.org/">Python programming language</a>.
-At its core it fully implements the <a class="reference external" href="http://www.python.org/dev/peps/pep-0249/">Python DB API 2.0</a> specifications. Several extensions allow access to many of the features offered by PostgreSQL.</p>
+<p><strong>Psycopg</strong> is the most popular <a class="reference external" href="http://www.postgresql.org/">PostgreSQL</a> adapter for the <a class="reference external" href="http://www.python.org/">Python programming
+language</a>. Its core is a complete implementation of the <a class="reference external" href="http://www.python.org/dev/peps/pep-0249/">Python DB API 2.0</a>
+specifications. Several extensions allow access to many of the features offered
+by PostgreSQL.</p>
 
 </div>
-<div style="margin-bottom: 1em">
-<p>Psycopg is released under the terms of the <a class="reference external" href="/psycopg/license/">GNU Lesser General Public License</a>, allowing use from both free and proprietary software.</p>
+
+<div class="sponsor">
+  <p>
+  <a href="/psycopg3/">Psycopg 3</a> was released in October 2021 and is currently in
+  <a href="https://www.psycopg.org/psycopg3/docs/" target="_blank"
+    >version 3.0 </a>.
+  </p>
+
+  <p><a href="https://www.psycopg.org/psycopg3/docs/news.html#psycopg-3-1-unreleased" target="_blank">Version 3.1</a> is about to be released, with new features and improvements.</p>
+
+  <p>
+    If you use Python and PostgreSQL, and you would like to support the
+    creation of the most advanced adapter between the two systems,
+    <a href="https://github.com/sponsors/dvarrazzo/" target="_blank"
+      >please consider becoming a sponsor</a>.
+  </p>
+
+  <p>
+  Sponsoring this project will help achieve swift completion and
+  ensure the maintenance of psycopg2, psycopg3 and other related
+  projects.
+  </p>
+
+  <p>If you are interested in contributing to the maintenance of the project, please reach out. Thank you!
+  </p>
+
+  <iframe src="https://github.com/sponsors/dvarrazzo/button"
+          title="Sponsor the project" style="border: 0"
+          width="116" height="35">
+  </iframe>
+
+  <div class="clear"></div>
+</div>
+
+<p>Psycopg is released under the terms of the <a class="reference external" href="/license/">GNU Lesser General Public
+License</a>, allowing use from both free and proprietary software.</p>
 <ul class="simple">
-<li>Check the <a class="reference external" href="/psycopg/features/">features list</a> to see what Psycopg offers</li>
-<li>Read the <a class="reference external" href="/psycopg/docs/">Psycopg documentation</a>. Be sure to check the <a class="reference external" href="/psycopg/docs/faq.html">Frequently Asked Questions</a></li>
-<li><a class="reference external" href="/psycopg/download/">Download Psycopg</a>!</li>
+<li>Check the <a class="reference external" href="/features/">features list</a> to see what Psycopg offers</li>
+<li>Read the <a class="reference external" href="/docs/">Psycopg documentation</a>. Be sure to check the <a class="reference external" href="/docs/faq.html">Frequently
+Asked Questions</a></li>
+<li><a class="reference external" href="/docs/install.html">Install Psycopg</a>!</li>
 </ul>
-
-</div>
-
-
-
-  <div class="clearbox">
-  <h2><a href="/psycopg/articles/">Latest articles</a></h2>
-
-    <div class="article">
-      <h3><a href="/psycopg/articles/2018/02/08/psycopg-274-released/">Psycopg 2.7.4 released</a></h3>
-
-<p class="header">
-  Posted by <a class="author" href="/psycopg/articles/author/piro/">Daniele Varrazzo</a>
-  on <span class="pub_date">February 8, 2018</span>
+<p>For help requests and development discussions please <a class="reference external" href="https://lists.postgresql.org/">subscribe to the mailing
+list</a> psycopg&#64;postgresql.org.</p>
 
 
-    <br />Tagged as
 
-    <a class="tag" href="/psycopg/articles/tag/news/">news</a>,
+<div class="dashed-top">
+  <h1>Latest articles</h1>
+  <div class="article">
 
-    <a class="tag" href="/psycopg/articles/tag/release/">release</a>
+    <h2><a href="/articles/2021/10/13/psycopg-30-released/">Psycopg 3.0 released</a></h2>
 
+  <p class="header">
+    Posted by Daniele Varrazzo on 2021-10-13
 
-</p>
-
-    </div>
-
-    <div class="article">
-      <h3><a href="/psycopg/articles/2017/10/24/psycopg-2732-released/">Psycopg 2.7.3.2 released</a></h3>
-
-<p class="header">
-  Posted by <a class="author" href="/psycopg/articles/author/piro/">Daniele Varrazzo</a>
-  on <span class="pub_date">October 24, 2017</span>
-
-
-    <br />Tagged as
-
-    <a class="tag" href="/psycopg/articles/tag/news/">news</a>,
-
-    <a class="tag" href="/psycopg/articles/tag/release/">release</a>
+      <br />
+      Tagged as
+      <a class="tag" href="/"
+          >news</a>,
+      <a class="tag" href="/"
+          >release</a>
 
 
-</p>
+  </p>
 
-    </div>
-
-    <div class="article">
-      <h3><a href="/psycopg/articles/2017/08/26/psycopg-2731-released/">Psycopg 2.7.3.1 released</a></h3>
-
-<p class="header">
-  Posted by <a class="author" href="/psycopg/articles/author/piro/">Daniele Varrazzo</a>
-  on <span class="pub_date">August 26, 2017</span>
+    <p>Hello,</p>
+<p>I am extremely excited to announce the first stable release of Psycopg 3!</p>
 
 
-</p>
-
-    </div>
-
-    <div class="article">
-      <h3><a href="/psycopg/articles/2017/07/24/psycopg-273-released/">Psycopg 2.7.3 released</a></h3>
-
-<p class="header">
-  Posted by <a class="author" href="/psycopg/articles/author/piro/">Daniele Varrazzo</a>
-  on <span class="pub_date">July 24, 2017</span>
-
-
-    <br />Tagged as
-
-    <a class="tag" href="/psycopg/articles/tag/news/">news</a>,
-
-    <a class="tag" href="/psycopg/articles/tag/release/">release</a>
-
-
-</p>
-
-    </div>
-
-    <div class="article">
-      <h3><a href="/psycopg/articles/2017/07/22/psycopg-272-released/">Psycopg 2.7.2 released</a></h3>
-
-<p class="header">
-  Posted by <a class="author" href="/psycopg/articles/author/piro/">Daniele Varrazzo</a>
-  on <span class="pub_date">July 22, 2017</span>
-
-
-    <br />Tagged as
-
-    <a class="tag" href="/psycopg/articles/tag/news/">news</a>,
-
-    <a class="tag" href="/psycopg/articles/tag/release/">release</a>
-
-
-</p>
-
-    </div>
-
-  </div>
-
+    <p class="read-more"><a href="/articles/2021/10/13/psycopg-30-released/">Read more...</a></p>
 
 
   </div>
 
-  <div id="sidebar">
+  <div class="article">
+
+    <h2><a href="/articles/2021/08/30/psycopg-30-beta1-released/">Psycopg 3.0 beta 1 released!</a></h2>
+
+  <p class="header">
+    Posted by Daniele Varrazzo on 2021-08-30
+
+      <br />
+      Tagged as
+      <a class="tag" href="/"
+          >news</a>,
+      <a class="tag" href="/"
+          >release</a>
 
 
-<div class="clearbox">
-  <h3>Donate</h3>
-  <a class="FlattrButton" style="display:none;" rev="flattr;button:compact;" href="http://www.psycopg.org/"></a>
-  <noscript><a href="http://flattr.com/thing/390575/psycopg" target="_blank">
-  <img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0" /></a></noscript>
+  </p>
+
+    <p>We are immensely proud to <a class="reference external" href="https://pypi.org/project/psycopg/3.0b1/">release on PyPI</a> the first beta package of Psycopg
+3!</p>
+
+
+    <p class="read-more"><a href="/articles/2021/08/30/psycopg-30-beta1-released/">Read more...</a></p>
+
+
+  </div>
+
+  <div class="article">
+
+    <h2><a href="/articles/2021/08/02/psycopg3-django-driver/">Building a Django driver for Psycopg 3</a></h2>
+
+  <p class="header">
+    Posted by Daniele Varrazzo on 2021-08-02
+
+      <br />
+      Tagged as
+      <a class="tag" href="/"
+          >psycopg3</a>,
+      <a class="tag" href="/"
+          >development</a>,
+      <a class="tag" href="/"
+          >recipe</a>
+
+
+  </p>
+
+    <p>One of the goals of the <a class="reference external" href="https://www.psycopg.org/psycopg3/">Psycopg 3 project</a> is to make easy to port code
+developed from Psycopg 2. For this reason the creation of a Django backend
+(the module you specify in the settings as your <a class="reference external" href="https://docs.djangoproject.com/en/3.2/ref/settings/#databases">database ENGINE</a>) was
+a project with a double goal:</p>
+<ul class="simple">
+<li>A Django driver is a way to make Psycopg 3 useful from the start, with the
+possibility of dropping it in a project transparently and have available,
+when needed the new features offered (for instance the superior <a class="reference external" href="https://www.psycopg.org/psycopg3/docs/basic/copy.html">COPY
+support</a>).</li>
+<li>The difficulty of introducing Psycopg 3 in the Django codebase and the type
+of changes required are indicative of the type of problems that could be
+found porting other projects.</li>
+</ul>
+<p>...and it's done! A few days ago, the new <a class="reference external" href="https://github.com/dvarrazzo/django-psycopg3-backend">Psycopg 3 Django backend</a> could
+pass the entire Django test suite!</p>
+
+
+    <p class="read-more"><a href="/articles/2021/08/02/psycopg3-django-driver/">Read more...</a></p>
+
+
+  </div>
+
+  <a href="/articles/">See all articles...</a>
 </div>
+        </div>
+        <div id="sidebar" class="col-sm-4">
 
-<div class="clearbox">
-  <h3>Quick links</h3>
-  <ul>
-    <li><a href="http://initd.org/psycopg/tarballs/PSYCOPG-2-7/psycopg2-2.7.4.tar.gz"
-      >Download stable release (2.7.4)</a></li>
 
-    <li><a href="http://www.stickpeople.com/projects/python/win-psycopg/">Windows download</a></li>
-    <li><a href="https://github.com/psycopg/psycopg2/issues">Report a bug</a></li>
-    <li><a href="https://lists.postgresql.org/">Mailing list</a></li>
+
+
+<div>
+
+  <h3>psycopg2</h3>
+
+  <ul class="fa-ul links">
+    <li>
+      <a href="/docs/">
+        <i class="fa-li fa-lg fa fa-book" aria-hidden="true"></i>
+        Documentation</a>
+    </li>
+    <li>
+      <a href="https://github.com/psycopg/psycopg2/">
+        <i class="fa-li fa-lg fa fa-github" aria-hidden="true"></i>
+        Source code</a>
+    </li>
+    <li>
+      <a href="https://github.com/psycopg/psycopg2/issues">
+        <i class="fa-li fa-lg fa fa-bug" aria-hidden="true"></i>
+        Bug tracker</a>
+    </li>
+    <li>
+      <a href="https://pypi.org/project/psycopg2/">
+        <i class="fa-li fa-lg fa fa-cloud-download" aria-hidden="true"></i>
+        Download</a>
+    </li>
   </ul>
 </div>
 
+<div class="dashed-top">
+  <h3>psycopg3</h3>
 
-  </div>
+  <ul class="fa-ul links">
+    <li>
+      <a href="/psycopg3/">
+        <i class="fa-li fa-lg fa fa-cogs" aria-hidden="true"></i>
+        The Project</a>
+    </li>
+    <li>
+      <a href="/psycopg3/docs/">
+        <i class="fa-li fa-lg fa fa-book" aria-hidden="true"></i>
+        Documentation</a>
+    </li>
+    <li>
+      <a href="https://github.com/psycopg/psycopg3/">
+        <i class="fa-li fa-lg fa fa-github" aria-hidden="true"></i>
+        Source code</a>
+    </li>
+    <li>
+      <a href="https://github.com/psycopg/psycopg3/issues">
+        <i class="fa-li fa-lg fa fa-bug" aria-hidden="true"></i>
+        Bug tracker</a>
+    </li>
+  </ul>
 </div>
 
-<div class="clearBoth"></div>
+<div class="dashed-top">
+  <h3>Mailing List</h3>
 
-<div id="footer">
-  <p>&#169; 2010&#8212;2017 &#8212; Daniele Varrazzo (at gmail.com)
+  <ul class="fa-ul links">
+    <li>
+      <a href="https://lists.postgresql.org/">
+        <i class="fa-li fa-lg fa fa-pencil" aria-hidden="true"></i>
+        Subscribe</a>
+    </li>
+    <li>
+      <a href="https://www.postgresql.org/list/psycopg/">
+        <i class="fa-li fa-lg fa fa-envelope-o" aria-hidden="true"></i>
+        Archives</a>
+    </li>
+  </ul>
 </div>
 
-</body>
+<div class="dashed-top">
+  <a class="twitter-timeline" data-width="300" data-height="600" data-dnt="true"
+    href="https://twitter.com/psycopg?ref_src=twsrc%5Etfw">Tweets by psycopg</a>
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+</div>
+
+        </div>
+
+      </div>
+    </div>
+
+    <footer>
+      <div style="margin-bottom:0">
+        <p>© Copyright 2010—2021 by Daniele Varrazzo (at gmail), The Psycopg Team.</p>
+      </div>
+    </footer>
+
+    <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"></script>
+  </body>
 </html>

--- a/python/spec/fixtures/pypi/pypi_response_no_source.json
+++ b/python/spec/fixtures/pypi/pypi_response_no_source.json
@@ -1,979 +1,882 @@
 {
     "info": {
-        "maintainer": null,
-        "docs_url": "http://pythonhosted.org/psycopg2/",
-        "requires_python": null,
-        "maintainer_email": null,
-        "cheesecake_code_kwalitee_id": null,
-        "keywords": null,
-        "package_url": "http://pypi.org/pypi/psycopg2",
-        "author": "Federico Di Gregorio",
-        "author_email": "fog@initd.org",
-        "download_url": "http://initd.org/psycopg/tarballs/PSYCOPG-2-6/psycopg2-2.6.2.tar.gz",
-        "platform": "any",
-        "version": "2.6.2",
-        "cheesecake_documentation_id": null,
-        "_pypi_hidden": false,
-        "description": "Psycopg is the most popular PostgreSQL database adapter for the Python\nprogramming language.  Its main features are the complete implementation of\nthe Python DB API 2.0 specification and the thread safety (several threads can\nshare the same connection).  It was designed for heavily multi-threaded\napplications that create and destroy lots of cursors and make a large number\nof concurrent \"INSERT\"s or \"UPDATE\"s.\n\nPsycopg 2 is mostly implemented in C as a libpq wrapper, resulting in being\nboth efficient and secure.  It features client-side and server-side cursors,\nasynchronous communication and notifications, \"COPY TO/COPY FROM\" support.\nMany Python types are supported out-of-the-box and adapted to matching\nPostgreSQL data types; adaptation can be extended and customized thanks to a\nflexible objects adaptation system.\n\nPsycopg 2 is both Unicode and Python 3 friendly.\n\n\nDocumentation\n-------------\n\nDocumentation is included in the 'doc' directory and is `available online`__.\n\n.. __: http://initd.org/psycopg/docs/\n\n\nInstallation\n------------\n\nIf all the dependencies are met (i.e. you have the Python and libpq\ndevelopment packages installed in your system) the standard::\n\n    python setup.py build\n    sudo python setup.py install\n\nshould work no problem.  In case you have any problem check the 'install' and\nthe 'faq' documents in the docs or online__.\n\n.. __: http://initd.org/psycopg/docs/install.html\n\nFor any other resource (source code repository, bug tracker, mailing list)\nplease check the `project homepage`__.\n\n.. __: http://initd.org/psycopg/",
-        "release_url": "http://pypi.org/pypi/psycopg2/2.6.2",
-        "downloads": {
-            "last_month": 0,
-            "last_week": 0,
-            "last_day": 0
-        },
-        "_pypi_ordering": 33,
+        "author": "Daniele Varrazzo",
+        "author_email": "daniele.varrazzo@gmail.com",
+        "bugtrack_url": null,
         "classifiers": [
             "Development Status :: 5 - Production/Stable",
             "Intended Audience :: Developers",
-            "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
-            "License :: OSI Approved :: Zope Public License",
+            "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
+            "Operating System :: MacOS :: MacOS X",
             "Operating System :: Microsoft :: Windows",
-            "Operating System :: Unix",
-            "Programming Language :: C",
-            "Programming Language :: Python",
-            "Programming Language :: Python :: 2.5",
-            "Programming Language :: Python :: 2.6",
-            "Programming Language :: Python :: 2.7",
+            "Operating System :: POSIX",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.1",
-            "Programming Language :: Python :: 3.2",
-            "Programming Language :: Python :: 3.3",
-            "Programming Language :: Python :: 3.4",
-            "Programming Language :: Python :: 3.5",
-            "Programming Language :: SQL",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
             "Topic :: Database",
             "Topic :: Database :: Front-Ends",
             "Topic :: Software Development",
             "Topic :: Software Development :: Libraries :: Python Modules"
         ],
-        "name": "psycopg2",
-        "bugtrack_url": null,
-        "license": "LGPL with exceptions or ZPL",
-        "summary": "psycopg2 - Python-PostgreSQL Database Adapter",
-        "home_page": "http://initd.org/psycopg/",
-        "cheesecake_installability_id": null
+        "description": "Psycopg 3: PostgreSQL database adapter for Python\n=================================================\n\nPsycopg 3 is a modern implementation of a PostgreSQL adapter for Python.\n\nThis distribution contains the pure Python package ``psycopg``.\n\n\nInstallation\n------------\n\nIn short, run the following::\n\n    pip install --upgrade pip           # to upgrade pip\n    pip install psycopg[binary,pool]    # to install package and dependencies\n\nIf something goes wrong, and for more information about installation, please\ncheck out the `Installation documentation`__.\n\n.. __: https://www.psycopg.org/psycopg3/docs/basic/install.html#\n\n\nHacking\n-------\n\nFor development information check out `the project readme`__.\n\n.. __: https://github.com/psycopg/psycopg#readme\n\n\nCopyright (C) 2020 The Psycopg Team\n\n\n",
+        "description_content_type": "text/x-rst",
+        "docs_url": null,
+        "download_url": "",
+        "downloads": {
+            "last_day": -1,
+            "last_month": -1,
+            "last_week": -1
+        },
+        "home_page": "https://psycopg.org/psycopg3/",
+        "keywords": "",
+        "license": "GNU Lesser General Public License v3 (LGPLv3)",
+        "maintainer": "",
+        "maintainer_email": "",
+        "name": "psycopg",
+        "package_url": "https://pypi.org/project/psycopg/",
+        "platform": null,
+        "project_url": "https://pypi.org/project/psycopg/",
+        "project_urls": {
+            "Code": "https://no-recognizable-source-for-testing-purposes.com/psycopg/psycopg",
+            "Download": "https://pypi.org/project/psycopg/",
+            "Homepage": "https://psycopg.org/",
+            "Issue Tracker": "https://no-recognizable-source-for-testing-purposes.com/psycopg/psycopg/issues"
+        },
+        "release_url": "https://pypi.org/project/psycopg/3.0.16/",
+        "requires_dist": [
+            "typing-extensions (>=3.10) ; python_version < \"3.8\"",
+            "backports.zoneinfo (>=0.2.0) ; python_version < \"3.9\"",
+            "tzdata ; sys_platform == \"win32\"",
+            "psycopg-binary (==3.0.16) ; extra == 'binary'",
+            "psycopg-c (==3.0.16) ; extra == 'c'",
+            "black (>=22.3.0) ; extra == 'dev'",
+            "dnspython (>=2.1) ; extra == 'dev'",
+            "flake8 (>=4.0) ; extra == 'dev'",
+            "mypy (!=0.930,!=0.931,>=0.920) ; extra == 'dev'",
+            "types-setuptools (>=57.4) ; extra == 'dev'",
+            "wheel (>=0.37) ; extra == 'dev'",
+            "Sphinx (>=5.0) ; extra == 'docs'",
+            "furo (==2022.6.21) ; extra == 'docs'",
+            "sphinx-autobuild (>=2021.3.14) ; extra == 'docs'",
+            "sphinx-autodoc-typehints (>=1.12) ; extra == 'docs'",
+            "psycopg-pool ; extra == 'pool'",
+            "mypy (!=0.930,!=0.931,>=0.920) ; extra == 'test'",
+            "pproxy (>=2.7) ; extra == 'test'",
+            "pytest (>=6.2.5) ; extra == 'test'",
+            "pytest-asyncio (<0.17,>=0.16) ; extra == 'test'",
+            "pytest-cov (>=3.0) ; extra == 'test'",
+            "pytest-randomly (>=3.10) ; extra == 'test'"
+        ],
+        "requires_python": ">=3.6",
+        "summary": "PostgreSQL database adapter for Python",
+        "version": "3.0.16",
+        "yanked": false,
+        "yanked_reason": null
     },
+    "last_serial": 14577467,
     "releases": {
-        "2.0.7": [],
-        "2.0.6": [],
-        "2.0.4": [],
-        "2.0.3": [],
-        "2.0.2": [],
-        "2.0.5.1": [],
-        "2.0.8": [],
-        "2.6": [
+        "1.1.21": [],
+        "3.0": [
             {
+                "comment_text": "",
+                "digests": {
+                    "md5": "d5df57ea1818dc606d08d952a95b47ea",
+                    "sha256": "65b9fb8838dae61040ad3e0cfc184d4ffd17f740ef4c0353d76050a6eb061a9c"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0-py3-none-any.whl",
                 "has_sig": true,
-                "upload_time": "2015-02-09T10:02:22",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/dd/c7/9016ff8ff69da269b1848276eebfb264af5badf6b38caad805426771f04d/psycopg2-2.6.tar.gz",
-                "md5_digest": "fbbb039a8765d561a1c04969bbae7c74",
-                "downloads": 1787225,
-                "filename": "psycopg2-2.6.tar.gz",
-                "packagetype": "sdist",
-                "path": "dd/c7/9016ff8ff69da269b1848276eebfb264af5badf6b38caad805426771f04d/psycopg2-2.6.tar.gz",
-                "size": 367972
-            }
-        ],
-        "2.2.1": [
+                "md5_digest": "d5df57ea1818dc606d08d952a95b47ea",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 140812,
+                "upload_time": "2021-10-12T16:20:12",
+                "upload_time_iso_8601": "2021-10-12T16:20:12.084578Z",
+                "url": "https://files.pythonhosted.org/packages/d8/31/9ce982570ebb20d092ba4d029ed2702634789bc0cc8deb0c09ba6e22e4db/psycopg-3.0-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
             {
-                "has_sig": false,
-                "upload_time": "2010-10-19T15:42:13",
                 "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/de/c4/fdfb801035bd7da9e1ce98169d48ca2d6dee5b4361e349afbba40b3d7a5d/psycopg2-2.2.1.tar.gz",
-                "md5_digest": "70b50773aefe5fb371ff4a018382012f",
-                "downloads": 44315,
-                "filename": "psycopg2-2.2.1.tar.gz",
-                "packagetype": "sdist",
-                "path": "de/c4/fdfb801035bd7da9e1ce98169d48ca2d6dee5b4361e349afbba40b3d7a5d/psycopg2-2.2.1.tar.gz",
-                "size": 529408
-            }
-        ],
-        "2.2.0": [
-            {
-                "has_sig": false,
-                "upload_time": "2010-10-19T15:41:50",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/32/0c/2f4da04ae2a66d71eff37f19fce67506ad28f887851cd1c1cca35ba08b36/psycopg2-2.2.0.tar.gz",
-                "md5_digest": "4a69436dc8efbfe2859ae3aeed85d03e",
-                "downloads": 5166,
-                "filename": "psycopg2-2.2.0.tar.gz",
-                "packagetype": "sdist",
-                "path": "32/0c/2f4da04ae2a66d71eff37f19fce67506ad28f887851cd1c1cca35ba08b36/psycopg2-2.2.0.tar.gz",
-                "size": 528718
-            }
-        ],
-        "2.2.2": [
-            {
-                "has_sig": false,
-                "upload_time": "2010-09-09T10:53:08",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/63/3e/a4a35761eb4595fff89e63347b4f8e79c2095782fa5bc016a6dfb18b21ac/psycopg2-2.2.2.tar.gz",
-                "md5_digest": "571af2ad9dfeb522ee5f8553278a4c38",
-                "downloads": 27853,
-                "filename": "psycopg2-2.2.2.tar.gz",
-                "packagetype": "sdist",
-                "path": "63/3e/a4a35761eb4595fff89e63347b4f8e79c2095782fa5bc016a6dfb18b21ac/psycopg2-2.2.2.tar.gz",
-                "size": 530021
-            }
-        ],
-        "2.5.4": [
-            {
+                "digests": {
+                    "md5": "88fd15e742aed8d1a0e9ce241f241010",
+                    "sha256": "82bce906431f44e81d72fbe0b924a71eebec09189bcf0dd16003e33960e36efa"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.tar.gz",
                 "has_sig": true,
-                "upload_time": "2014-08-30T18:04:42",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/63/c3/802668cb3cfc2880c2a8364623e7105a0257724a2612bb66ec733aaddb8c/psycopg2-2.5.4.tar.gz",
-                "md5_digest": "25216543a707eb33fd83aa8efb6e3f26",
-                "downloads": 1866067,
-                "filename": "psycopg2-2.5.4.tar.gz",
+                "md5_digest": "88fd15e742aed8d1a0e9ce241f241010",
                 "packagetype": "sdist",
-                "path": "63/c3/802668cb3cfc2880c2a8364623e7105a0257724a2612bb66ec733aaddb8c/psycopg2-2.5.4.tar.gz",
-                "size": 682578
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 115456,
+                "upload_time": "2021-10-12T16:23:56",
+                "upload_time_iso_8601": "2021-10-12T16:23:56.832410Z",
+                "url": "https://files.pythonhosted.org/packages/2a/1d/77fd95c963b8e066de8b49e592e7e912ae53a24275f04a4d5279f67e454a/psycopg-3.0.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
             }
         ],
-        "2.5": [
+        "3.0.1": [
             {
+                "comment_text": "",
+                "digests": {
+                    "md5": "1fc11f090012a084c00c54cd0e7b52c6",
+                    "sha256": "be91c7f793e13df2f314fb372fbae2c29d6dbed5ac14651c69e7b45cb876becf"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.1-py3-none-any.whl",
                 "has_sig": true,
-                "upload_time": "2013-04-07T18:18:13",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/84/7e/7256298bf7064238e63b9380cf424f776a4d2a87e387c9a9bd1bc5ea0fbc/psycopg2-2.5.tar.gz",
-                "md5_digest": "facd82faa067e99b80146a0ee2f842f6",
-                "downloads": 239430,
-                "filename": "psycopg2-2.5.tar.gz",
-                "packagetype": "sdist",
-                "path": "84/7e/7256298bf7064238e63b9380cf424f776a4d2a87e387c9a9bd1bc5ea0fbc/psycopg2-2.5.tar.gz",
-                "size": 703558
-            }
-        ],
-        "2.4": [
+                "md5_digest": "1fc11f090012a084c00c54cd0e7b52c6",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 140613,
+                "upload_time": "2021-10-14T11:37:08",
+                "upload_time_iso_8601": "2021-10-14T11:37:08.945474Z",
+                "url": "https://files.pythonhosted.org/packages/6e/6d/8ba973bb864fc873e866f77c6bd76516dab19f6e156ef497a9555b847efd/psycopg-3.0.1-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
             {
-                "has_sig": false,
-                "upload_time": "2011-02-27T16:52:11",
                 "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/ce/2d/e9e65ee32ef2657028109bd5a1c1ece97e409ebf790b6ee286aae2c6b890/psycopg2-2.4.tar.gz",
-                "md5_digest": "24f4368e2cfdc1a2b03282ddda814160",
-                "downloads": 78219,
-                "filename": "psycopg2-2.4.tar.gz",
-                "packagetype": "sdist",
-                "path": "ce/2d/e9e65ee32ef2657028109bd5a1c1ece97e409ebf790b6ee286aae2c6b890/psycopg2-2.4.tar.gz",
-                "size": 607925
-            }
-        ],
-        "2.4.6": [
-            {
+                "digests": {
+                    "md5": "b37f5c050394a349ca712b4fb8cbeb04",
+                    "sha256": "f509c236c7f08b5a46ca19efbe20b5b317876a8ed6823fefd1c3fb4a5d691fe3"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.1.tar.gz",
                 "has_sig": true,
-                "upload_time": "2012-12-12T10:51:33",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/59/aa/4d74a5dc32a89d622c1fa896a86683b488ef255f06d4b27231e12e6076f7/psycopg2-2.4.6.tar.gz",
-                "md5_digest": "79d7f05e67bf70a0ecc6e9103ccece5f",
-                "downloads": 464523,
-                "filename": "psycopg2-2.4.6.tar.gz",
+                "md5_digest": "b37f5c050394a349ca712b4fb8cbeb04",
                 "packagetype": "sdist",
-                "path": "59/aa/4d74a5dc32a89d622c1fa896a86683b488ef255f06d4b27231e12e6076f7/psycopg2-2.4.6.tar.gz",
-                "size": 667783
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 115151,
+                "upload_time": "2021-10-14T11:40:11",
+                "upload_time_iso_8601": "2021-10-14T11:40:11.406939Z",
+                "url": "https://files.pythonhosted.org/packages/ca/18/013477dd26878919381c71824efeeb63dd443b2ee667ae7d2af2384defff/psycopg-3.0.1.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
             }
         ],
-        "2.5.1": [
+        "3.0.10": [
             {
+                "comment_text": "",
+                "digests": {
+                    "md5": "a91ac568d049f16af5d09a0640fd35d4",
+                    "sha256": "8cf07019035f4933c522ccdae1954f458743a98a43aa3a731937869fe3857eaa"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.10-py3-none-any.whl",
                 "has_sig": true,
-                "upload_time": "2013-06-23T19:24:08",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/22/09/63d5da7375c267e208bbadf56b51699d85cb7b3a9096817eeea500a27b3b/psycopg2-2.5.1.tar.gz",
-                "md5_digest": "1b433f83d50d1bc61e09026e906d84c7",
-                "downloads": 1488696,
-                "filename": "psycopg2-2.5.1.tar.gz",
-                "packagetype": "sdist",
-                "path": "22/09/63d5da7375c267e208bbadf56b51699d85cb7b3a9096817eeea500a27b3b/psycopg2-2.5.1.tar.gz",
-                "size": 684504
-            }
-        ],
-        "2.3.0": [
+                "md5_digest": "a91ac568d049f16af5d09a0640fd35d4",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 142110,
+                "upload_time": "2022-03-12T14:28:00",
+                "upload_time_iso_8601": "2022-03-12T14:28:00.609559Z",
+                "url": "https://files.pythonhosted.org/packages/a2/40/04f9825e6b8f37754baa83aee46d70dfaf88bbc850d14253bba6b191f1ee/psycopg-3.0.10-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
             {
-                "has_sig": false,
-                "upload_time": "2010-12-02T00:53:24",
                 "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/68/0a/459df8dcbcc118ca435e9567abceaab919706908d52139e503f6396c4935/psycopg2-2.3.0.tar.gz",
-                "md5_digest": "0b52101b47f1e73001c6412d9a476222",
-                "downloads": 6552,
-                "filename": "psycopg2-2.3.0.tar.gz",
-                "packagetype": "sdist",
-                "path": "68/0a/459df8dcbcc118ca435e9567abceaab919706908d52139e503f6396c4935/psycopg2-2.3.0.tar.gz",
-                "size": 588979
-            }
-        ],
-        "2.3.1": [
-            {
-                "has_sig": false,
-                "upload_time": "2010-12-04T22:24:29",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/cd/7c/6acf5aacd347f3dc1398eca0e2123c35a48efb07617d4d9578e9cd79a1a7/psycopg2-2.3.1.tar.gz",
-                "md5_digest": "15d1c7f821f3a0306955d6cde3e762af",
-                "downloads": 20602,
-                "filename": "psycopg2-2.3.1.tar.gz",
-                "packagetype": "sdist",
-                "path": "cd/7c/6acf5aacd347f3dc1398eca0e2123c35a48efb07617d4d9578e9cd79a1a7/psycopg2-2.3.1.tar.gz",
-                "size": 567191
-            }
-        ],
-        "2.3.2": [
-            {
-                "has_sig": false,
-                "upload_time": "2011-02-18T12:33:34",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/50/48/32927cbc99633613704950be5013fc144aa0f451a5e0616635a934d94a62/psycopg2-2.3.2.tar.gz",
-                "md5_digest": "11e8021a4fda49faa15495f8bea65f4d",
-                "downloads": 11128,
-                "filename": "psycopg2-2.3.2.tar.gz",
-                "packagetype": "sdist",
-                "path": "50/48/32927cbc99633613704950be5013fc144aa0f451a5e0616635a934d94a62/psycopg2-2.3.2.tar.gz",
-                "size": 568029
-            }
-        ],
-        "2.4.3": [
-            {
-                "has_sig": false,
-                "upload_time": "2011-12-12T12:15:35",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/1e/71/8929172068cbc3d3c7288bf888a7df5862a28d67ed61ad9b4c7aa5cf8be8/psycopg2-2.4.3.tar.gz",
-                "md5_digest": "5f67ca0c8b6c1ac5c4afd82811e0facc",
-                "downloads": 16990,
-                "filename": "psycopg2-2.4.3.tar.gz",
-                "packagetype": "sdist",
-                "path": "1e/71/8929172068cbc3d3c7288bf888a7df5862a28d67ed61ad9b4c7aa5cf8be8/psycopg2-2.4.3.tar.gz",
-                "size": 647008
-            }
-        ],
-        "2.4.2": [
-            {
-                "has_sig": false,
-                "upload_time": "2011-06-17T15:15:38",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/70/91/345f8eb32dc333331510e1adad858f7a1478d3a1e4aae05ee188985c6b17/psycopg2-2.4.2.tar.gz",
-                "md5_digest": "58cfd294d28b7e8ef059d72085d71ac2",
-                "downloads": 105108,
-                "filename": "psycopg2-2.4.2.tar.gz",
-                "packagetype": "sdist",
-                "path": "70/91/345f8eb32dc333331510e1adad858f7a1478d3a1e4aae05ee188985c6b17/psycopg2-2.4.2.tar.gz",
-                "size": 667192
-            }
-        ],
-        "2.4.1": [
-            {
-                "has_sig": false,
-                "upload_time": "2011-05-11T12:56:53",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/82/f8/6c80beb1b58f01f52dcdfa52bc1668caa4e3fc4927e9230edc40afa98c05/psycopg2-2.4.1.tar.gz",
-                "md5_digest": "4e79c822ab75dd89d931ee627c66032f",
-                "downloads": 219576,
-                "filename": "psycopg2-2.4.1.tar.gz",
-                "packagetype": "sdist",
-                "path": "82/f8/6c80beb1b58f01f52dcdfa52bc1668caa4e3fc4927e9230edc40afa98c05/psycopg2-2.4.1.tar.gz",
-                "size": 398200
-            }
-        ],
-        "2.5.5": [
-            {
+                "digests": {
+                    "md5": "cea7cd24d9e724cabaf5c7ca1d729bd6",
+                    "sha256": "9c2ba4b3253af8cd1a31ba365cd8bfae7818cc917e409930abc5571ba66c12d8"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.10.tar.gz",
                 "has_sig": true,
-                "upload_time": "2015-02-09T09:59:31",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/9b/60/f4c79e73a69ded145880bcf4f98eeed741af12c62c5ddc89b754602b1807/psycopg2-2.5.5.tar.gz",
-                "md5_digest": "1404a6cc0108eed5d7dd0c1dc9a1c074",
-                "downloads": 64048,
-                "filename": "psycopg2-2.5.5.tar.gz",
+                "md5_digest": "cea7cd24d9e724cabaf5c7ca1d729bd6",
                 "packagetype": "sdist",
-                "path": "9b/60/f4c79e73a69ded145880bcf4f98eeed741af12c62c5ddc89b754602b1807/psycopg2-2.5.5.tar.gz",
-                "size": 779757
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 116673,
+                "upload_time": "2022-03-12T14:31:53",
+                "upload_time_iso_8601": "2022-03-12T14:31:53.294962Z",
+                "url": "https://files.pythonhosted.org/packages/16/82/6a7b7870dde0cdcc267a0c8cbc65b1f3e2b1fea68bbd733d3f42a771a985/psycopg-3.0.10.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
             }
         ],
-        "2.5.2": [
+        "3.0.11": [
             {
+                "comment_text": "",
+                "digests": {
+                    "md5": "b7fed4e11f5a9c04dc0c173a981ddae9",
+                    "sha256": "8fcbac023ef84922e107645fa8e21b7dc3b0fec0ca49c4270b53d7e64fb08e5f"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.11-py3-none-any.whl",
                 "has_sig": true,
-                "upload_time": "2014-01-07T12:25:11",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/c3/f3/5519551f02ae70fc51f4e608e7b44d59a408fe3264fec4afeea37b8ea317/psycopg2-2.5.2.tar.gz",
-                "md5_digest": "53d81793fbab8fee6e732a0425d50047",
-                "downloads": 1030601,
-                "filename": "psycopg2-2.5.2.tar.gz",
-                "packagetype": "sdist",
-                "path": "c3/f3/5519551f02ae70fc51f4e608e7b44d59a408fe3264fec4afeea37b8ea317/psycopg2-2.5.2.tar.gz",
-                "size": 685762
-            }
-        ],
-        "2.5.3": [
+                "md5_digest": "b7fed4e11f5a9c04dc0c173a981ddae9",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 143002,
+                "upload_time": "2022-03-29T22:09:39",
+                "upload_time_iso_8601": "2022-03-29T22:09:39.634351Z",
+                "url": "https://files.pythonhosted.org/packages/b5/88/07fa91bb791506ff7a05df99b47796cdb03e4cc3f9f026a5a6c77ef22147/psycopg-3.0.11-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
             {
+                "comment_text": "",
+                "digests": {
+                    "md5": "772b8cf21f19231716c7525a19b32b7f",
+                    "sha256": "5dfe409eefc91890602dff18ee17b3815e803d48f87de48f3fa8587653a5a2fb"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.11.tar.gz",
                 "has_sig": true,
-                "upload_time": "2014-05-13T16:51:38",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/22/fa/5ddcafc7387c1534c59eb3ffcdb9ab2af106fd3b104e6df191b6c55718af/psycopg2-2.5.3.tar.gz",
-                "md5_digest": "09dcec70f623a9ef774f1aef75690995",
-                "downloads": 1114861,
-                "filename": "psycopg2-2.5.3.tar.gz",
+                "md5_digest": "772b8cf21f19231716c7525a19b32b7f",
                 "packagetype": "sdist",
-                "path": "22/fa/5ddcafc7387c1534c59eb3ffcdb9ab2af106fd3b104e6df191b6c55718af/psycopg2-2.5.3.tar.gz",
-                "size": 690689
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 117506,
+                "upload_time": "2022-03-29T22:14:07",
+                "upload_time_iso_8601": "2022-03-29T22:14:07.813450Z",
+                "url": "https://files.pythonhosted.org/packages/b9/ed/b4a17a02ca1cdccd88a87e964d4eb0625070518c81b7e940d3b9be6bec0a/psycopg-3.0.11.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
             }
         ],
-        "2.4.5": [
+        "3.0.12": [
             {
+                "comment_text": "",
+                "digests": {
+                    "md5": "ad99091e2a13956e85567e06db7e6fa4",
+                    "sha256": "57c3b208fbe1a8b7dd1a6db1389cf3ecede06998692ce98240e5fbe41d87e75c"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.12-py3-none-any.whl",
                 "has_sig": true,
-                "upload_time": "2012-03-29T11:42:27",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/36/77/894a5dd9f3f55cfc85682d3e6473ee5103d8d418b95baf4019fad3ffa026/psycopg2-2.4.5.tar.gz",
-                "md5_digest": "075e4df465e9a863f288d5bdf6e6887e",
-                "downloads": 7212996,
-                "filename": "psycopg2-2.4.5.tar.gz",
-                "packagetype": "sdist",
-                "path": "36/77/894a5dd9f3f55cfc85682d3e6473ee5103d8d418b95baf4019fad3ffa026/psycopg2-2.4.5.tar.gz",
-                "size": 719343
-            }
-        ],
-        "2.4.4": [
-            {
-                "has_sig": false,
-                "upload_time": "2011-12-19T13:38:39",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/6f/91/890c6f954e2d09d26b266a24468570c6227de61ac6f64926c48000db0a6e/psycopg2-2.4.4.tar.gz",
-                "md5_digest": "639e014ea9ce3aa3306724f12d16d79b",
-                "downloads": 102479,
-                "filename": "psycopg2-2.4.4.tar.gz",
-                "packagetype": "sdist",
-                "path": "6f/91/890c6f954e2d09d26b266a24468570c6227de61ac6f64926c48000db0a6e/psycopg2-2.4.4.tar.gz",
-                "size": 648954
-            }
-        ],
-        "2.6.1": [
-            {
-                "has_sig": false,
-                "upload_time": "2015-11-06T21:07:04",
-                "comment_text": "",
-                "python_version": "cp26",
-                "url": "https://pypi.org/packages/47/ed/5bd02bf1a7f78823f8a708beb3656f7c3ad935fb013c7063ff5f67848a52/psycopg2-2.6.1-cp26-none-win32.whl",
-                "md5_digest": "a849b57608acf6ae26db67cf6b7667b5",
-                "downloads": 1109,
-                "filename": "psycopg2-2.6.1-cp26-none-win32.whl",
+                "md5_digest": "ad99091e2a13956e85567e06db7e6fa4",
                 "packagetype": "bdist_wheel",
-                "path": "47/ed/5bd02bf1a7f78823f8a708beb3656f7c3ad935fb013c7063ff5f67848a52/psycopg2-2.6.1-cp26-none-win32.whl",
-                "size": 814523
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 143090,
+                "upload_time": "2022-04-30T00:14:40",
+                "upload_time_iso_8601": "2022-04-30T00:14:40.190473Z",
+                "url": "https://files.pythonhosted.org/packages/63/c3/e8d4468a4957ef8634b1a35cf4f6ff8f9688c3046cb191c2b09a81dee535/psycopg-3.0.12-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
             },
             {
-                "has_sig": false,
-                "upload_time": "2015-11-06T21:07:14",
                 "comment_text": "",
-                "python_version": "cp26",
-                "url": "https://pypi.org/packages/2e/40/8ab9a8d99b7abd2b95858872fee6894a3eb4fc361692abc02e94091aa54b/psycopg2-2.6.1-cp26-none-win_amd64.whl",
-                "md5_digest": "66fda625af6267f020abc06a66afe75b",
-                "downloads": 921,
-                "filename": "psycopg2-2.6.1-cp26-none-win_amd64.whl",
-                "packagetype": "bdist_wheel",
-                "path": "2e/40/8ab9a8d99b7abd2b95858872fee6894a3eb4fc361692abc02e94091aa54b/psycopg2-2.6.1-cp26-none-win_amd64.whl",
-                "size": 1162332
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2015-11-06T21:07:21",
-                "comment_text": "",
-                "python_version": "cp27",
-                "url": "https://pypi.org/packages/1f/84/a2fffb87348bc688d70bcdc24e761b06f48d958e1c1adfc3fa9eb3f4379c/psycopg2-2.6.1-cp27-none-win32.whl",
-                "md5_digest": "089acf7f1a8349c6308106bec896c762",
-                "downloads": 13199,
-                "filename": "psycopg2-2.6.1-cp27-none-win32.whl",
-                "packagetype": "bdist_wheel",
-                "path": "1f/84/a2fffb87348bc688d70bcdc24e761b06f48d958e1c1adfc3fa9eb3f4379c/psycopg2-2.6.1-cp27-none-win32.whl",
-                "size": 814322
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2015-11-06T21:07:28",
-                "comment_text": "",
-                "python_version": "cp27",
-                "url": "https://pypi.org/packages/b5/37/b6e759f1f6a0fd32ad0e1b2576bf94cfa252710cad66e155f47fc04ba744/psycopg2-2.6.1-cp27-none-win_amd64.whl",
-                "md5_digest": "a8d7808e7c67e5bc0b6088a56045d2d2",
-                "downloads": 5864,
-                "filename": "psycopg2-2.6.1-cp27-none-win_amd64.whl",
-                "packagetype": "bdist_wheel",
-                "path": "b5/37/b6e759f1f6a0fd32ad0e1b2576bf94cfa252710cad66e155f47fc04ba744/psycopg2-2.6.1-cp27-none-win_amd64.whl",
-                "size": 1162753
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2015-11-06T21:07:36",
-                "comment_text": "",
-                "python_version": "cp32",
-                "url": "https://pypi.org/packages/20/84/aaaf44c339a3b51196b8b1d0928899cbc02e1583ec455b6777011fdb63b0/psycopg2-2.6.1-cp32-none-win32.whl",
-                "md5_digest": "c8a704a73f0ea6369ea74a5a24e8f8db",
-                "downloads": 610,
-                "filename": "psycopg2-2.6.1-cp32-none-win32.whl",
-                "packagetype": "bdist_wheel",
-                "path": "20/84/aaaf44c339a3b51196b8b1d0928899cbc02e1583ec455b6777011fdb63b0/psycopg2-2.6.1-cp32-none-win32.whl",
-                "size": 815145
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2015-11-06T21:07:44",
-                "comment_text": "",
-                "python_version": "cp32",
-                "url": "https://pypi.org/packages/84/50/ff71daf3e32a8bff56ac661eff9226d035abaf45fe1af007cfb2134970b3/psycopg2-2.6.1-cp32-none-win_amd64.whl",
-                "md5_digest": "e29046e7095483ecacac9e3390318254",
-                "downloads": 620,
-                "filename": "psycopg2-2.6.1-cp32-none-win_amd64.whl",
-                "packagetype": "bdist_wheel",
-                "path": "84/50/ff71daf3e32a8bff56ac661eff9226d035abaf45fe1af007cfb2134970b3/psycopg2-2.6.1-cp32-none-win_amd64.whl",
-                "size": 1163315
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2015-11-06T19:48:39",
-                "comment_text": "",
-                "python_version": "cp33",
-                "url": "https://pypi.org/packages/2c/5a/8334a55459289cf8d7485a42bcb2dbe0dab5162973ef66a96baee5107593/psycopg2-2.6.1-cp33-none-win32.whl",
-                "md5_digest": "f438d2c01fbaa8f9d0cb150154448a9f",
-                "downloads": 769,
-                "filename": "psycopg2-2.6.1-cp33-none-win32.whl",
-                "packagetype": "bdist_wheel",
-                "path": "2c/5a/8334a55459289cf8d7485a42bcb2dbe0dab5162973ef66a96baee5107593/psycopg2-2.6.1-cp33-none-win32.whl",
-                "size": 818485
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2015-11-06T19:48:52",
-                "comment_text": "",
-                "python_version": "cp33",
-                "url": "https://pypi.org/packages/7b/ed/82f31122dcc502d8f43c208a74eaa2b9ff39421aaab1ff8d61547639a474/psycopg2-2.6.1-cp33-none-win_amd64.whl",
-                "md5_digest": "632ab3d538a8239b619d434c5e17baf5",
-                "downloads": 875,
-                "filename": "psycopg2-2.6.1-cp33-none-win_amd64.whl",
-                "packagetype": "bdist_wheel",
-                "path": "7b/ed/82f31122dcc502d8f43c208a74eaa2b9ff39421aaab1ff8d61547639a474/psycopg2-2.6.1-cp33-none-win_amd64.whl",
-                "size": 1160268
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2015-11-06T19:49:07",
-                "comment_text": "",
-                "python_version": "cp34",
-                "url": "https://pypi.org/packages/f0/34/894f8f486196fdb15d376f77a0102b25628ec0ac71538ed019b3ea93b907/psycopg2-2.6.1-cp34-none-win32.whl",
-                "md5_digest": "9d90c554f68cfabed7fdb90107e9d464",
-                "downloads": 2628,
-                "filename": "psycopg2-2.6.1-cp34-none-win32.whl",
-                "packagetype": "bdist_wheel",
-                "path": "f0/34/894f8f486196fdb15d376f77a0102b25628ec0ac71538ed019b3ea93b907/psycopg2-2.6.1-cp34-none-win32.whl",
-                "size": 818452
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2015-11-06T19:49:19",
-                "comment_text": "",
-                "python_version": "cp34",
-                "url": "https://pypi.org/packages/b7/90/23af1a90f06dfa012a4ae829821b3161344a9e447358841779d027f14bd7/psycopg2-2.6.1-cp34-none-win_amd64.whl",
-                "md5_digest": "4c95328c20e00efc66f0046823f6d1d0",
-                "downloads": 3142,
-                "filename": "psycopg2-2.6.1-cp34-none-win_amd64.whl",
-                "packagetype": "bdist_wheel",
-                "path": "b7/90/23af1a90f06dfa012a4ae829821b3161344a9e447358841779d027f14bd7/psycopg2-2.6.1-cp34-none-win_amd64.whl",
-                "size": 1160261
-            },
-            {
+                "digests": {
+                    "md5": "196e896d12b8cdb59d89d6066f187a5f",
+                    "sha256": "cede6d073a73ace182e6f14dd7410cdfe049a7655ab3f338447fe1a293a3a2cb"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.12.tar.gz",
                 "has_sig": true,
-                "upload_time": "2015-06-15T09:50:35",
-                "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/86/fd/cc8315be63a41fe000cce20482a917e874cdc1151e62cb0141f5e55f711e/psycopg2-2.6.1.tar.gz",
-                "md5_digest": "842b44f8c95517ed5b792081a2370da1",
-                "downloads": 3521176,
-                "filename": "psycopg2-2.6.1.tar.gz",
+                "md5_digest": "196e896d12b8cdb59d89d6066f187a5f",
                 "packagetype": "sdist",
-                "path": "86/fd/cc8315be63a41fe000cce20482a917e874cdc1151e62cb0141f5e55f711e/psycopg2-2.6.1.tar.gz",
-                "size": 371373
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 117634,
+                "upload_time": "2022-04-30T00:18:28",
+                "upload_time_iso_8601": "2022-04-30T00:18:28.688935Z",
+                "url": "https://files.pythonhosted.org/packages/4c/60/12ca1783f49f91f97e1ac2e42dc5187332a8ee0f3ecfbd4786189782ae79/psycopg-3.0.12.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
             }
         ],
-        "2.6.2": [
+        "3.0.13": [
             {
-                "has_sig": false,
-                "upload_time": "2016-07-08T03:12:31",
                 "comment_text": "",
-                "python_version": "cp26",
-                "url": "https://pypi.org/packages/49/fe/edd5a96ece520bf6522e27360f0aa66305e8cafa177c3bf5d5418a6b0741/psycopg2-2.6.2-cp26-none-win32.whl",
-                "md5_digest": "24ece1e5ea08083289e564b2b864a5a6",
-                "downloads": 465,
-                "filename": "psycopg2-2.6.2-cp26-none-win32.whl",
-                "packagetype": "bdist_wheel",
-                "path": "49/fe/edd5a96ece520bf6522e27360f0aa66305e8cafa177c3bf5d5418a6b0741/psycopg2-2.6.2-cp26-none-win32.whl",
-                "size": 807955
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2016-07-08T03:12:41",
-                "comment_text": "",
-                "python_version": "cp26",
-                "url": "https://pypi.org/packages/14/04/c449c231d35b1d26ebd902aea4f9237da744cd3a0bd9ff89caf616a6e6fc/psycopg2-2.6.2-cp26-none-win_amd64.whl",
-                "md5_digest": "3ee8bcfeefb573b7a68000bd25f73f43",
-                "downloads": 568,
-                "filename": "psycopg2-2.6.2-cp26-none-win_amd64.whl",
-                "packagetype": "bdist_wheel",
-                "path": "14/04/c449c231d35b1d26ebd902aea4f9237da744cd3a0bd9ff89caf616a6e6fc/psycopg2-2.6.2-cp26-none-win_amd64.whl",
-                "size": 1157090
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2016-07-08T03:12:48",
-                "comment_text": "",
-                "python_version": "cp27",
-                "url": "https://pypi.org/packages/30/b9/629418a0fdc84506cfb9005ac066bb409b40661d2bfde6fc083d93237b27/psycopg2-2.6.2-cp27-none-win32.whl",
-                "md5_digest": "be33931d712a47275c3f4a373059f7ea",
-                "downloads": 4658,
-                "filename": "psycopg2-2.6.2-cp27-none-win32.whl",
-                "packagetype": "bdist_wheel",
-                "path": "30/b9/629418a0fdc84506cfb9005ac066bb409b40661d2bfde6fc083d93237b27/psycopg2-2.6.2-cp27-none-win32.whl",
-                "size": 807955
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2016-07-08T03:12:57",
-                "comment_text": "",
-                "python_version": "cp27",
-                "url": "https://pypi.org/packages/a4/0e/29d29dceca6e465804ae612bc711a4741599ac849cf0a99acdbf53838581/psycopg2-2.6.2-cp27-none-win_amd64.whl",
-                "md5_digest": "08d618f1c5a4db211481e59102cc16f8",
-                "downloads": 4240,
-                "filename": "psycopg2-2.6.2-cp27-none-win_amd64.whl",
-                "packagetype": "bdist_wheel",
-                "path": "a4/0e/29d29dceca6e465804ae612bc711a4741599ac849cf0a99acdbf53838581/psycopg2-2.6.2-cp27-none-win_amd64.whl",
-                "size": 1157086
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2016-07-08T03:13:07",
-                "comment_text": "",
-                "python_version": "cp32",
-                "url": "https://pypi.org/packages/ba/29/bb6c465a38f6ba070ad4f4b17797ccc345dcd2cd42eb2f262aa75d86fa52/psycopg2-2.6.2-cp32-none-win32.whl",
-                "md5_digest": "0e9dca689b2395dea2498b3b82923b37",
-                "downloads": 333,
-                "filename": "psycopg2-2.6.2-cp32-none-win32.whl",
-                "packagetype": "bdist_wheel",
-                "path": "ba/29/bb6c465a38f6ba070ad4f4b17797ccc345dcd2cd42eb2f262aa75d86fa52/psycopg2-2.6.2-cp32-none-win32.whl",
-                "size": 808593
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2016-07-08T03:13:16",
-                "comment_text": "",
-                "python_version": "cp32",
-                "url": "https://pypi.org/packages/d3/bd/f989a3be8cd9fa696471ca399c005c903c3a4b840c419784fb27c0c62ae8/psycopg2-2.6.2-cp32-none-win_amd64.whl",
-                "md5_digest": "66243f1c0a3f0365489d84d0e9111e63",
-                "downloads": 339,
-                "filename": "psycopg2-2.6.2-cp32-none-win_amd64.whl",
-                "packagetype": "bdist_wheel",
-                "path": "d3/bd/f989a3be8cd9fa696471ca399c005c903c3a4b840c419784fb27c0c62ae8/psycopg2-2.6.2-cp32-none-win_amd64.whl",
-                "size": 1158092
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2016-07-08T03:11:48",
-                "comment_text": "",
-                "python_version": "cp33",
-                "url": "https://pypi.org/packages/6c/b4/d5bf17145954a3c8e80e3601d8eaf486f058ae09688910f1f0a22cb6b1d2/psycopg2-2.6.2-cp33-none-win32.whl",
-                "md5_digest": "7d7dbd8e6203e2e757b46d77fcb30eee",
-                "downloads": 358,
-                "filename": "psycopg2-2.6.2-cp33-none-win32.whl",
-                "packagetype": "bdist_wheel",
-                "path": "6c/b4/d5bf17145954a3c8e80e3601d8eaf486f058ae09688910f1f0a22cb6b1d2/psycopg2-2.6.2-cp33-none-win32.whl",
-                "size": 812530
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2016-07-08T03:11:56",
-                "comment_text": "",
-                "python_version": "cp33",
-                "url": "https://pypi.org/packages/2a/34/849e0491130bf2f67d72826ad64cfe8d9dc4e322b42ba99ab77dd96d970f/psycopg2-2.6.2-cp33-none-win_amd64.whl",
-                "md5_digest": "60816e4ffadd258f3bd1b5c3da62ecfe",
-                "downloads": 366,
-                "filename": "psycopg2-2.6.2-cp33-none-win_amd64.whl",
-                "packagetype": "bdist_wheel",
-                "path": "2a/34/849e0491130bf2f67d72826ad64cfe8d9dc4e322b42ba99ab77dd96d970f/psycopg2-2.6.2-cp33-none-win_amd64.whl",
-                "size": 1154446
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2016-07-08T03:12:04",
-                "comment_text": "",
-                "python_version": "cp34",
-                "url": "https://pypi.org/packages/8f/80/20bdb48cfccaf31be57f7ae4b5165d7bb669cfaae5a42eaf00d55b2bf39b/psycopg2-2.6.2-cp34-none-win32.whl",
-                "md5_digest": "819bcec9a26fb1877090cf60faf5bfc4",
-                "downloads": 1040,
-                "filename": "psycopg2-2.6.2-cp34-none-win32.whl",
-                "packagetype": "bdist_wheel",
-                "path": "8f/80/20bdb48cfccaf31be57f7ae4b5165d7bb669cfaae5a42eaf00d55b2bf39b/psycopg2-2.6.2-cp34-none-win32.whl",
-                "size": 812387
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2016-07-08T03:12:13",
-                "comment_text": "",
-                "python_version": "cp34",
-                "url": "https://pypi.org/packages/fe/23/c67030ab4a43655d10b62acc658829054a97a147819a81094b1e9673e592/psycopg2-2.6.2-cp34-none-win_amd64.whl",
-                "md5_digest": "26ca03d4f4f65c75a530824981a60df6",
-                "downloads": 1204,
-                "filename": "psycopg2-2.6.2-cp34-none-win_amd64.whl",
-                "packagetype": "bdist_wheel",
-                "path": "fe/23/c67030ab4a43655d10b62acc658829054a97a147819a81094b1e9673e592/psycopg2-2.6.2-cp34-none-win_amd64.whl",
-                "size": 1154539
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2016-07-08T03:13:21",
-                "comment_text": "",
-                "python_version": "cp35",
-                "url": "https://pypi.org/packages/85/bb/7ab5d5b040d6c8a26180acb864f50c1887f27e02e9fb4e94f1f730a4e01b/psycopg2-2.6.2-cp35-none-win32.whl",
-                "md5_digest": "9355dc0c57491e4e42bc610428570994",
-                "downloads": 2932,
-                "filename": "psycopg2-2.6.2-cp35-none-win32.whl",
-                "packagetype": "bdist_wheel",
-                "path": "85/bb/7ab5d5b040d6c8a26180acb864f50c1887f27e02e9fb4e94f1f730a4e01b/psycopg2-2.6.2-cp35-none-win32.whl",
-                "size": 801274
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2016-07-08T03:13:26",
-                "comment_text": "",
-                "python_version": "cp35",
-                "url": "https://pypi.org/packages/5e/45/de485228f46a2487da8e774fa2dbd772e7e03e65a3c31a322a224806e734/psycopg2-2.6.2-cp35-none-win_amd64.whl",
-                "md5_digest": "c8101dfc2a2c2e6eb7e2054c8c0208b2",
-                "downloads": 3340,
-                "filename": "psycopg2-2.6.2-cp35-none-win_amd64.whl",
-                "packagetype": "bdist_wheel",
-                "path": "5e/45/de485228f46a2487da8e774fa2dbd772e7e03e65a3c31a322a224806e734/psycopg2-2.6.2-cp35-none-win_amd64.whl",
-                "size": 1159852
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2016-12-23T16:50:51",
-                "comment_text": "",
-                "python_version": "cp36",
-                "url": "https://pypi.org/packages/66/97/e8922a18a142195cfdbdfc9ec84a8d1a46b09edae24a150d79ea90e6b55b/psycopg2-2.6.2-cp36-cp36m-win32.whl",
-                "md5_digest": "be2016ebc0a83ef40d068baa25ee4f3f",
-                "downloads": 493,
-                "filename": "psycopg2-2.6.2-cp36-cp36m-win32.whl",
-                "packagetype": "bdist_wheel",
-                "path": "66/97/e8922a18a142195cfdbdfc9ec84a8d1a46b09edae24a150d79ea90e6b55b/psycopg2-2.6.2-cp36-cp36m-win32.whl",
-                "size": 802352
-            },
-            {
-                "has_sig": false,
-                "upload_time": "2016-12-23T16:50:54",
-                "comment_text": "",
-                "python_version": "cp36",
-                "url": "https://pypi.org/packages/b6/cb/b7ad5008df09b8392942db9a262435bda778457be4aaba5fc79ead1444b4/psycopg2-2.6.2-cp36-cp36m-win_amd64.whl",
-                "md5_digest": "a1cc2cbb0d9a9191c64640d5129402c3",
-                "downloads": 582,
-                "filename": "psycopg2-2.6.2-cp36-cp36m-win_amd64.whl",
-                "packagetype": "bdist_wheel",
-                "path": "b6/cb/b7ad5008df09b8392942db9a262435bda778457be4aaba5fc79ead1444b4/psycopg2-2.6.2-cp36-cp36m-win_amd64.whl",
-                "size": 1162079
-            },
-            {
+                "digests": {
+                    "md5": "1918c469b21d131ab163f2eb06a09984",
+                    "sha256": "d38f3d87c9e0f1d95595066d24b2d62f84f7fe3d385a9c483e6d8170e75026e5"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.13-py3-none-any.whl",
                 "has_sig": true,
-                "upload_time": "2016-07-07T02:23:58",
+                "md5_digest": "1918c469b21d131ab163f2eb06a09984",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 142967,
+                "upload_time": "2022-05-10T10:28:06",
+                "upload_time_iso_8601": "2022-05-10T10:28:06.093568Z",
+                "url": "https://files.pythonhosted.org/packages/2a/be/4dcf9ce5db1144935d6f9920900cb6d09525075e1688b998952cac11aeb2/psycopg-3.0.13-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
+            {
                 "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/7b/a8/dc2d50a6f37c157459cd18bab381c8e6134b9381b50fbe969997b2ae7dbc/psycopg2-2.6.2.tar.gz",
-                "md5_digest": "4a392949ba31a378a18ed3e775a4693f",
-                "downloads": 1545062,
-                "filename": "psycopg2-2.6.2.tar.gz",
+                "digests": {
+                    "md5": "00b96749e890c1072997d20b39a77930",
+                    "sha256": "78287732c9f9d86d669dd675c1faae9b692ef951ec04d91b928a3bf165a77dce"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.13.tar.gz",
+                "has_sig": true,
+                "md5_digest": "00b96749e890c1072997d20b39a77930",
                 "packagetype": "sdist",
-                "path": "7b/a8/dc2d50a6f37c157459cd18bab381c8e6134b9381b50fbe969997b2ae7dbc/psycopg2-2.6.2.tar.gz",
-                "size": 376348
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 117549,
+                "upload_time": "2022-05-10T10:31:57",
+                "upload_time_iso_8601": "2022-05-10T10:31:57.517958Z",
+                "url": "https://files.pythonhosted.org/packages/3e/bb/8e6438576cd6a64ae4b9490706d20720e0be992ce3ea60b27c872a6f589f/psycopg-3.0.13.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
             }
         ],
-        "2.0.14": [
+        "3.0.14": [
             {
-                "has_sig": false,
-                "upload_time": "2010-10-19T15:29:17",
                 "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/e0/1c/f0843f50a69fba3db880e9b267d36f6709bbf31a36fc46b82f75e8975ede/psycopg2-2.0.14.tar.gz",
-                "md5_digest": "30136c7753acc9cbdc36cc5c2448fdee",
-                "downloads": 19521,
-                "filename": "psycopg2-2.0.14.tar.gz",
+                "digests": {
+                    "md5": "4ede995fdcfaa585471ddd07823b3dd8",
+                    "sha256": "6d7099b7dd940341d8e9e52e346d194fc94e39faa19d91b36110ca8215c3bf36"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.14-py3-none-any.whl",
+                "has_sig": true,
+                "md5_digest": "4ede995fdcfaa585471ddd07823b3dd8",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 143504,
+                "upload_time": "2022-05-16T02:20:28",
+                "upload_time_iso_8601": "2022-05-16T02:20:28.463439Z",
+                "url": "https://files.pythonhosted.org/packages/de/d1/bd783c0924ef5227db8af744a58b385e31859c9d6b28612100f4f6d50a4b/psycopg-3.0.14-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "67b65b19fd5350505464210deddb463e",
+                    "sha256": "9da6b46170dd78e2c5e072ac380a7c89b2af3381c20383118ef5bc66610e77f8"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.14.tar.gz",
+                "has_sig": true,
+                "md5_digest": "67b65b19fd5350505464210deddb463e",
                 "packagetype": "sdist",
-                "path": "e0/1c/f0843f50a69fba3db880e9b267d36f6709bbf31a36fc46b82f75e8975ede/psycopg2-2.0.14.tar.gz",
-                "size": 491362
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 118030,
+                "upload_time": "2022-05-16T02:24:22",
+                "upload_time_iso_8601": "2022-05-16T02:24:22.282210Z",
+                "url": "https://files.pythonhosted.org/packages/4b/28/2fde0bfe6c528a93268d6691e7af21547c773f0d19497b8aa7911d01aae9/psycopg-3.0.14.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
             }
         ],
-        "2.0.13": [
+        "3.0.15": [
             {
-                "has_sig": false,
-                "upload_time": "2010-10-19T15:31:38",
                 "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/3a/7a/968afcb86b1958ae963a3aaa42c561e3ed2c2d4a8b773622b03856a16248/psycopg2-2.0.13.tar.gz",
-                "md5_digest": "f520260595f4fcf035d26cfd57a75f19",
-                "downloads": 14083,
-                "filename": "psycopg2-2.0.13.tar.gz",
+                "digests": {
+                    "md5": "fcf3a5aa8f6380d6744900e3dde8c3d8",
+                    "sha256": "9e9beaf38ace6bdf5a5ad969130339d69d61e6ad41114d166779e591bfe40076"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.15-py3-none-any.whl",
+                "has_sig": true,
+                "md5_digest": "fcf3a5aa8f6380d6744900e3dde8c3d8",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 144144,
+                "upload_time": "2022-06-15T07:08:47",
+                "upload_time_iso_8601": "2022-06-15T07:08:47.180735Z",
+                "url": "https://files.pythonhosted.org/packages/9b/95/0ee469cb2756ba1b32f10d6fe50914ddc859b3c617ca42e53fa28f78373a/psycopg-3.0.15-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "a6c06dfcc417e70a21b29abe9e021722",
+                    "sha256": "1c5637f47e9a4d9b742a0b101f39189bebae0f625bfdfb0cf8a54dd5fe677610"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.15.tar.gz",
+                "has_sig": true,
+                "md5_digest": "a6c06dfcc417e70a21b29abe9e021722",
                 "packagetype": "sdist",
-                "path": "3a/7a/968afcb86b1958ae963a3aaa42c561e3ed2c2d4a8b773622b03856a16248/psycopg2-2.0.13.tar.gz",
-                "size": 258399
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 118560,
+                "upload_time": "2022-06-15T07:17:51",
+                "upload_time_iso_8601": "2022-06-15T07:17:51.697635Z",
+                "url": "https://files.pythonhosted.org/packages/fd/e2/57c6e30dd5be63445653cc05e0b2889347f4d4a0d44c7ada2c404c0b683e/psycopg-3.0.15.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
             }
         ],
-        "2.0.12": [
+        "3.0.16": [
             {
-                "has_sig": false,
-                "upload_time": "2010-10-19T15:33:16",
                 "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/6a/8d/ee5c330823d527a5cd14c833063f825211d7b5de6e4897f72e250c107d85/psycopg2-2.0.12.tar.gz",
-                "md5_digest": "5c8080d0d0568479f041bb8534caf1f8",
-                "downloads": 4001,
-                "filename": "psycopg2-2.0.12.tar.gz",
+                "digests": {
+                    "md5": "97d31f921845f9ae8988e7e8a3fd89b4",
+                    "sha256": "0f5e18920ed978f5063e48acc5ca4389225db7d06a03090d2bbb7a0ec7a640b2"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.16-py3-none-any.whl",
+                "has_sig": true,
+                "md5_digest": "97d31f921845f9ae8988e7e8a3fd89b4",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 143225,
+                "upload_time": "2022-07-28T13:32:58",
+                "upload_time_iso_8601": "2022-07-28T13:32:58.590489Z",
+                "url": "https://files.pythonhosted.org/packages/b6/d6/3b74d0662006df825f2d426291260550ff659bc315b1f86311687b0cffa4/psycopg-3.0.16-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "10ed2b5b290d5bf4f007303d135aec17",
+                    "sha256": "44ca63373c33957ca852fefa1940f8cc5d4c11493b7f6710b0ab250ff5abc50c"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.16.tar.gz",
+                "has_sig": true,
+                "md5_digest": "10ed2b5b290d5bf4f007303d135aec17",
                 "packagetype": "sdist",
-                "path": "6a/8d/ee5c330823d527a5cd14c833063f825211d7b5de6e4897f72e250c107d85/psycopg2-2.0.12.tar.gz",
-                "size": 256169
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 117836,
+                "upload_time": "2022-07-28T13:36:41",
+                "upload_time_iso_8601": "2022-07-28T13:36:41.148055Z",
+                "url": "https://files.pythonhosted.org/packages/da/43/ea5a5580c73051f37842a84e471315d38ee4d1277ceb9716c66cd6ae288a/psycopg-3.0.16.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
             }
         ],
-        "2.0.11": [
+        "3.0.2": [
             {
-                "has_sig": false,
-                "upload_time": "2010-10-19T15:35:04",
                 "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/2d/d7/496da11d7c81971870ddd36800419c4f84e8f6208aac5eabedf9f7748729/psycopg2-2.0.11.tar.gz",
-                "md5_digest": "eec2a45bcea75a00cbf20a15ab1b8bae",
-                "downloads": 4052,
-                "filename": "psycopg2-2.0.11.tar.gz",
+                "digests": {
+                    "md5": "ce3f6cdb63251a1b481eef339cc5eb5f",
+                    "sha256": "a4766afcb25f253fd70d39a3ed123a32beb3f0b853cb99a0a05ce19cb7e0b331"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.2-py3-none-any.whl",
+                "has_sig": true,
+                "md5_digest": "ce3f6cdb63251a1b481eef339cc5eb5f",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 140869,
+                "upload_time": "2021-11-08T16:01:35",
+                "upload_time_iso_8601": "2021-11-08T16:01:35.508129Z",
+                "url": "https://files.pythonhosted.org/packages/a0/2a/cb322d72935aec744ad3e54889f0bd6d65819ab0dedf5955bf556362ad76/psycopg-3.0.2-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "864a8c8d0df7cad1c2be0d0dac4b411a",
+                    "sha256": "91e6658b3583e3f3dec06985a08f94ad4f76d93e7b6197add914c66d4cde355f"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.2.tar.gz",
+                "has_sig": true,
+                "md5_digest": "864a8c8d0df7cad1c2be0d0dac4b411a",
                 "packagetype": "sdist",
-                "path": "2d/d7/496da11d7c81971870ddd36800419c4f84e8f6208aac5eabedf9f7748729/psycopg2-2.0.11.tar.gz",
-                "size": 255260
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 115455,
+                "upload_time": "2021-11-08T16:07:53",
+                "upload_time_iso_8601": "2021-11-08T16:07:53.660015Z",
+                "url": "https://files.pythonhosted.org/packages/b9/1f/4c706b6c8383fe0d2f5869751a6391563d6061b4ca208e5cdb08875a8177/psycopg-3.0.2.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
             }
         ],
-        "2.0.10": [
+        "3.0.3": [
             {
-                "has_sig": false,
-                "upload_time": "2010-10-19T15:36:38",
                 "comment_text": "",
-                "python_version": "source",
-                "url": "https://pypi.org/packages/19/79/35c7596bab4456f3610c12ec542a94d51c6781ced587d1d85127210b879b/psycopg2-2.0.10.tar.gz",
-                "md5_digest": "2dc60d0fd90ad681e1e9106edef34e97",
-                "downloads": 5027,
-                "filename": "psycopg2-2.0.10.tar.gz",
+                "digests": {
+                    "md5": "115f9a1dff766071f6da4b422c9209df",
+                    "sha256": "fa8a01310178a912e9ad81b3cd1574e9da1105fff23b7ecdb81597844ddd6d29"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.3-py3-none-any.whl",
+                "has_sig": true,
+                "md5_digest": "115f9a1dff766071f6da4b422c9209df",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 140969,
+                "upload_time": "2021-11-10T16:17:50",
+                "upload_time_iso_8601": "2021-11-10T16:17:50.239307Z",
+                "url": "https://files.pythonhosted.org/packages/83/0b/589e2a6345e93b37db29a3429c16af1a7002209436643da4a0d4a1eceaa2/psycopg-3.0.3-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "c52a867106e28c63ebdc6596963cbe48",
+                    "sha256": "e9a0aa02a94f355844746a9d343789af035437e63a036eeb12ab795916c7a157"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.3.tar.gz",
+                "has_sig": true,
+                "md5_digest": "c52a867106e28c63ebdc6596963cbe48",
                 "packagetype": "sdist",
-                "path": "19/79/35c7596bab4456f3610c12ec542a94d51c6781ced587d1d85127210b879b/psycopg2-2.0.10.tar.gz",
-                "size": 255995
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 115491,
+                "upload_time": "2021-11-10T16:22:15",
+                "upload_time_iso_8601": "2021-11-10T16:22:15.593407Z",
+                "url": "https://files.pythonhosted.org/packages/8d/f0/94b567553673e4bfe3d4806bc859a314cea423f75e94c4206396e314e7e9/psycopg-3.0.3.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
+            }
+        ],
+        "3.0.4": [
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "e22f8d1188cf86bb02a1c190338a592e",
+                    "sha256": "6907b49f3f6c24e5f652f069e3c18e3a44f446d0ce3a5e9f0bb54febd636ff36"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.4-py3-none-any.whl",
+                "has_sig": true,
+                "md5_digest": "e22f8d1188cf86bb02a1c190338a592e",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 140870,
+                "upload_time": "2021-11-14T23:20:16",
+                "upload_time_iso_8601": "2021-11-14T23:20:16.444087Z",
+                "url": "https://files.pythonhosted.org/packages/77/a2/7d376e4df9362debc0ef5d63d61812a86e50ce15aad5650c8302566f280b/psycopg-3.0.4-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "68aa91fb57b6defe6fde40ee847f3a2b",
+                    "sha256": "f784a50754978f9d39ba544e4527a274b682b212b2ee99d0516738fa9e6abd65"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.4.tar.gz",
+                "has_sig": true,
+                "md5_digest": "68aa91fb57b6defe6fde40ee847f3a2b",
+                "packagetype": "sdist",
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 115331,
+                "upload_time": "2021-11-14T23:25:39",
+                "upload_time_iso_8601": "2021-11-14T23:25:39.201838Z",
+                "url": "https://files.pythonhosted.org/packages/ea/5b/11ba86711afc7b2123434e801efc13415697a6a548ccd3ae74bad32ad745/psycopg-3.0.4.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
+            }
+        ],
+        "3.0.5": [
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "c11620064830212b0c8f2fd79e98fb55",
+                    "sha256": "134d5a6085dd50d8d0fc49a697ea6bfa223bcfbb865cd51887be2dfebbd9f795"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.5-py3-none-any.whl",
+                "has_sig": true,
+                "md5_digest": "c11620064830212b0c8f2fd79e98fb55",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 141094,
+                "upload_time": "2021-11-28T19:12:45",
+                "upload_time_iso_8601": "2021-11-28T19:12:45.604892Z",
+                "url": "https://files.pythonhosted.org/packages/f8/d3/7e5e193a187002a13f649cffb9254c778f32a9dedb38ca7ff3497d687cc8/psycopg-3.0.5-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "dad1e485ebdaf1dc27ae3c29952a0a63",
+                    "sha256": "3d8815ad90bf2ae4a18caa684032417ae1c80e3a78ed2f8213c6acead52586ab"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.5.tar.gz",
+                "has_sig": true,
+                "md5_digest": "dad1e485ebdaf1dc27ae3c29952a0a63",
+                "packagetype": "sdist",
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 115575,
+                "upload_time": "2021-11-28T19:18:00",
+                "upload_time_iso_8601": "2021-11-28T19:18:00.310864Z",
+                "url": "https://files.pythonhosted.org/packages/a9/21/9b74ed2b38b27bac3c845b8be319439748114bf106e96a37672f446e2761/psycopg-3.0.5.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
+            }
+        ],
+        "3.0.6": [
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "b919533e59424c987f1ff7fadeebed18",
+                    "sha256": "d3393887802ee6fd771ca76836d64de7de0d76108f6e51ef220d55a06552f8ba"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.6-py3-none-any.whl",
+                "has_sig": true,
+                "md5_digest": "b919533e59424c987f1ff7fadeebed18",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 141742,
+                "upload_time": "2021-12-13T15:14:49",
+                "upload_time_iso_8601": "2021-12-13T15:14:49.050913Z",
+                "url": "https://files.pythonhosted.org/packages/72/0c/3d2f1f11a9ad65ad873fff082438a0670746f73ab26339ca0be41ba595fd/psycopg-3.0.6-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "4d06f5e14799f1772e6f87a85e3de4e8",
+                    "sha256": "733ed84ea062c69ebafa1fd6b7f7bc76e4c7a1e74439e339e6c86593f3119fa0"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.6.tar.gz",
+                "has_sig": true,
+                "md5_digest": "4d06f5e14799f1772e6f87a85e3de4e8",
+                "packagetype": "sdist",
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 116259,
+                "upload_time": "2021-12-13T15:20:27",
+                "upload_time_iso_8601": "2021-12-13T15:20:27.538863Z",
+                "url": "https://files.pythonhosted.org/packages/d7/63/023d6faddedaeb2e257b95c829b53ee0f53df5f15ae1945ea34594f0ce24/psycopg-3.0.6.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
+            }
+        ],
+        "3.0.7": [
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "d73a46e7d089a5c833a7a68ad2464f73",
+                    "sha256": "9a0e89937ad08e1e0af6ec97a5030ee02273bd651d4fb682e7d8facd80973fda"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.7-py3-none-any.whl",
+                "has_sig": true,
+                "md5_digest": "d73a46e7d089a5c833a7a68ad2464f73",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 141740,
+                "upload_time": "2021-12-15T00:35:41",
+                "upload_time_iso_8601": "2021-12-15T00:35:41.882969Z",
+                "url": "https://files.pythonhosted.org/packages/d4/f1/c3925adee57cfa21730db7877a0df98604ab9b4c16fcd6961912b0906f68/psycopg-3.0.7-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "a278ebc194b88614725cab51eb953a60",
+                    "sha256": "54f3bbcb7ece702d0141a1669e4e46e6cd3b0635813fc8ad4887ce085902e354"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.7.tar.gz",
+                "has_sig": true,
+                "md5_digest": "a278ebc194b88614725cab51eb953a60",
+                "packagetype": "sdist",
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 116236,
+                "upload_time": "2021-12-15T00:40:18",
+                "upload_time_iso_8601": "2021-12-15T00:40:18.142933Z",
+                "url": "https://files.pythonhosted.org/packages/26/6d/836360c3d462c8e04c3f4c783e0c30913deda2b50137ce2e5779567133a2/psycopg-3.0.7.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
+            }
+        ],
+        "3.0.8": [
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "08f7b983551023e3a43b27e9d04872b8",
+                    "sha256": "c2e4afbe71b77b101523b06707f2e2edf1ed801504dd6175efda11da31af8f12"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.8-py3-none-any.whl",
+                "has_sig": true,
+                "md5_digest": "08f7b983551023e3a43b27e9d04872b8",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 142155,
+                "upload_time": "2022-01-08T20:08:32",
+                "upload_time_iso_8601": "2022-01-08T20:08:32.295234Z",
+                "url": "https://files.pythonhosted.org/packages/79/95/f2585610699180d1f4634e54962fe30c70596f8a40a344c9157c21f5b0ac/psycopg-3.0.8-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "69744cbeb6004cdeac7b9d6fb86087f6",
+                    "sha256": "d803be0de54c26ee8c06fd73b6391f809efbcde6a5bbdc118a1a66c2fb4cf944"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.8.tar.gz",
+                "has_sig": true,
+                "md5_digest": "69744cbeb6004cdeac7b9d6fb86087f6",
+                "packagetype": "sdist",
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 116723,
+                "upload_time": "2022-01-08T20:14:11",
+                "upload_time_iso_8601": "2022-01-08T20:14:11.276886Z",
+                "url": "https://files.pythonhosted.org/packages/7b/eb/1fc30f2179d9ea6298cc58d255bd2c28641056dcd65b0bd235dc46b0d36b/psycopg-3.0.8.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
+            }
+        ],
+        "3.0.9": [
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "6e84f572445b20957c0fa7bb86bc59df",
+                    "sha256": "801ea3fa3ea7f562506dce6f0121d652b2525073294c7c08ce1d4250f6614405"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.9-py3-none-any.whl",
+                "has_sig": true,
+                "md5_digest": "6e84f572445b20957c0fa7bb86bc59df",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 141759,
+                "upload_time": "2022-02-19T22:12:49",
+                "upload_time_iso_8601": "2022-02-19T22:12:49.558606Z",
+                "url": "https://files.pythonhosted.org/packages/0b/b2/09e4172e6fba3b71185fa4bd76483cf04a21f98853b22f46e04270ba5c08/psycopg-3.0.9-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "70e41535ce46b53f1d02348f161eb560",
+                    "sha256": "9f72c6bdccfdab405c654ea2e9ed2293a3e9f993f66a37621f796732ce8e1855"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0.9.tar.gz",
+                "has_sig": true,
+                "md5_digest": "70e41535ce46b53f1d02348f161eb560",
+                "packagetype": "sdist",
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 116462,
+                "upload_time": "2022-02-19T22:16:30",
+                "upload_time_iso_8601": "2022-02-19T22:16:30.151363Z",
+                "url": "https://files.pythonhosted.org/packages/d2/87/26daa600f2728156845932931262af9b1684b25b4d8132ec9dbecf21ea73/psycopg-3.0.9.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
+            }
+        ],
+        "3.0b1": [
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "0e4b1ddecc1ae935bddd20bf2c56fd92",
+                    "sha256": "fd510caaaa90aec11781c0581a8a03f847e35925db6de293404db87d625a44e8"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0b1-py3-none-any.whl",
+                "has_sig": false,
+                "md5_digest": "0e4b1ddecc1ae935bddd20bf2c56fd92",
+                "packagetype": "bdist_wheel",
+                "python_version": "py3",
+                "requires_python": ">=3.6",
+                "size": 131830,
+                "upload_time": "2021-09-03T21:34:46",
+                "upload_time_iso_8601": "2021-09-03T21:34:46.638478Z",
+                "url": "https://files.pythonhosted.org/packages/4f/09/82c50c58aa2916d0bb1f46e1c4523ab34dd0513623576d1eb2aff2107d43/psycopg-3.0b1-py3-none-any.whl",
+                "yanked": false,
+                "yanked_reason": null
+            },
+            {
+                "comment_text": "",
+                "digests": {
+                    "md5": "a9c5b7172dc340dc8d7f60c3a8b5766b",
+                    "sha256": "90188a415f2132eabccfa58ae41330d3bfc1c5c410add4d6194e783521478189"
+                },
+                "downloads": -1,
+                "filename": "psycopg-3.0b1.tar.gz",
+                "has_sig": true,
+                "md5_digest": "a9c5b7172dc340dc8d7f60c3a8b5766b",
+                "packagetype": "sdist",
+                "python_version": "source",
+                "requires_python": ">=3.6",
+                "size": 108312,
+                "upload_time": "2021-08-30T04:25:06",
+                "upload_time_iso_8601": "2021-08-30T04:25:06.027667Z",
+                "url": "https://files.pythonhosted.org/packages/00/9a/6a9736d77056057ff9329d02499b6f3fd71d3fa0e6ef06e35331e5082254/psycopg-3.0b1.tar.gz",
+                "yanked": false,
+                "yanked_reason": null
             }
         ]
     },
     "urls": [
         {
-            "has_sig": false,
-            "upload_time": "2016-07-08T03:12:31",
             "comment_text": "",
-            "python_version": "cp26",
-            "url": "https://pypi.org/packages/49/fe/edd5a96ece520bf6522e27360f0aa66305e8cafa177c3bf5d5418a6b0741/psycopg2-2.6.2-cp26-none-win32.whl",
-            "md5_digest": "24ece1e5ea08083289e564b2b864a5a6",
-            "downloads": 465,
-            "filename": "psycopg2-2.6.2-cp26-none-win32.whl",
-            "packagetype": "bdist_wheel",
-            "path": "49/fe/edd5a96ece520bf6522e27360f0aa66305e8cafa177c3bf5d5418a6b0741/psycopg2-2.6.2-cp26-none-win32.whl",
-            "size": 807955
-        },
-        {
-            "has_sig": false,
-            "upload_time": "2016-07-08T03:12:41",
-            "comment_text": "",
-            "python_version": "cp26",
-            "url": "https://pypi.org/packages/14/04/c449c231d35b1d26ebd902aea4f9237da744cd3a0bd9ff89caf616a6e6fc/psycopg2-2.6.2-cp26-none-win_amd64.whl",
-            "md5_digest": "3ee8bcfeefb573b7a68000bd25f73f43",
-            "downloads": 568,
-            "filename": "psycopg2-2.6.2-cp26-none-win_amd64.whl",
-            "packagetype": "bdist_wheel",
-            "path": "14/04/c449c231d35b1d26ebd902aea4f9237da744cd3a0bd9ff89caf616a6e6fc/psycopg2-2.6.2-cp26-none-win_amd64.whl",
-            "size": 1157090
-        },
-        {
-            "has_sig": false,
-            "upload_time": "2016-07-08T03:12:48",
-            "comment_text": "",
-            "python_version": "cp27",
-            "url": "https://pypi.org/packages/30/b9/629418a0fdc84506cfb9005ac066bb409b40661d2bfde6fc083d93237b27/psycopg2-2.6.2-cp27-none-win32.whl",
-            "md5_digest": "be33931d712a47275c3f4a373059f7ea",
-            "downloads": 4658,
-            "filename": "psycopg2-2.6.2-cp27-none-win32.whl",
-            "packagetype": "bdist_wheel",
-            "path": "30/b9/629418a0fdc84506cfb9005ac066bb409b40661d2bfde6fc083d93237b27/psycopg2-2.6.2-cp27-none-win32.whl",
-            "size": 807955
-        },
-        {
-            "has_sig": false,
-            "upload_time": "2016-07-08T03:12:57",
-            "comment_text": "",
-            "python_version": "cp27",
-            "url": "https://pypi.org/packages/a4/0e/29d29dceca6e465804ae612bc711a4741599ac849cf0a99acdbf53838581/psycopg2-2.6.2-cp27-none-win_amd64.whl",
-            "md5_digest": "08d618f1c5a4db211481e59102cc16f8",
-            "downloads": 4240,
-            "filename": "psycopg2-2.6.2-cp27-none-win_amd64.whl",
-            "packagetype": "bdist_wheel",
-            "path": "a4/0e/29d29dceca6e465804ae612bc711a4741599ac849cf0a99acdbf53838581/psycopg2-2.6.2-cp27-none-win_amd64.whl",
-            "size": 1157086
-        },
-        {
-            "has_sig": false,
-            "upload_time": "2016-07-08T03:13:07",
-            "comment_text": "",
-            "python_version": "cp32",
-            "url": "https://pypi.org/packages/ba/29/bb6c465a38f6ba070ad4f4b17797ccc345dcd2cd42eb2f262aa75d86fa52/psycopg2-2.6.2-cp32-none-win32.whl",
-            "md5_digest": "0e9dca689b2395dea2498b3b82923b37",
-            "downloads": 333,
-            "filename": "psycopg2-2.6.2-cp32-none-win32.whl",
-            "packagetype": "bdist_wheel",
-            "path": "ba/29/bb6c465a38f6ba070ad4f4b17797ccc345dcd2cd42eb2f262aa75d86fa52/psycopg2-2.6.2-cp32-none-win32.whl",
-            "size": 808593
-        },
-        {
-            "has_sig": false,
-            "upload_time": "2016-07-08T03:13:16",
-            "comment_text": "",
-            "python_version": "cp32",
-            "url": "https://pypi.org/packages/d3/bd/f989a3be8cd9fa696471ca399c005c903c3a4b840c419784fb27c0c62ae8/psycopg2-2.6.2-cp32-none-win_amd64.whl",
-            "md5_digest": "66243f1c0a3f0365489d84d0e9111e63",
-            "downloads": 339,
-            "filename": "psycopg2-2.6.2-cp32-none-win_amd64.whl",
-            "packagetype": "bdist_wheel",
-            "path": "d3/bd/f989a3be8cd9fa696471ca399c005c903c3a4b840c419784fb27c0c62ae8/psycopg2-2.6.2-cp32-none-win_amd64.whl",
-            "size": 1158092
-        },
-        {
-            "has_sig": false,
-            "upload_time": "2016-07-08T03:11:48",
-            "comment_text": "",
-            "python_version": "cp33",
-            "url": "https://pypi.org/packages/6c/b4/d5bf17145954a3c8e80e3601d8eaf486f058ae09688910f1f0a22cb6b1d2/psycopg2-2.6.2-cp33-none-win32.whl",
-            "md5_digest": "7d7dbd8e6203e2e757b46d77fcb30eee",
-            "downloads": 358,
-            "filename": "psycopg2-2.6.2-cp33-none-win32.whl",
-            "packagetype": "bdist_wheel",
-            "path": "6c/b4/d5bf17145954a3c8e80e3601d8eaf486f058ae09688910f1f0a22cb6b1d2/psycopg2-2.6.2-cp33-none-win32.whl",
-            "size": 812530
-        },
-        {
-            "has_sig": false,
-            "upload_time": "2016-07-08T03:11:56",
-            "comment_text": "",
-            "python_version": "cp33",
-            "url": "https://pypi.org/packages/2a/34/849e0491130bf2f67d72826ad64cfe8d9dc4e322b42ba99ab77dd96d970f/psycopg2-2.6.2-cp33-none-win_amd64.whl",
-            "md5_digest": "60816e4ffadd258f3bd1b5c3da62ecfe",
-            "downloads": 366,
-            "filename": "psycopg2-2.6.2-cp33-none-win_amd64.whl",
-            "packagetype": "bdist_wheel",
-            "path": "2a/34/849e0491130bf2f67d72826ad64cfe8d9dc4e322b42ba99ab77dd96d970f/psycopg2-2.6.2-cp33-none-win_amd64.whl",
-            "size": 1154446
-        },
-        {
-            "has_sig": false,
-            "upload_time": "2016-07-08T03:12:04",
-            "comment_text": "",
-            "python_version": "cp34",
-            "url": "https://pypi.org/packages/8f/80/20bdb48cfccaf31be57f7ae4b5165d7bb669cfaae5a42eaf00d55b2bf39b/psycopg2-2.6.2-cp34-none-win32.whl",
-            "md5_digest": "819bcec9a26fb1877090cf60faf5bfc4",
-            "downloads": 1040,
-            "filename": "psycopg2-2.6.2-cp34-none-win32.whl",
-            "packagetype": "bdist_wheel",
-            "path": "8f/80/20bdb48cfccaf31be57f7ae4b5165d7bb669cfaae5a42eaf00d55b2bf39b/psycopg2-2.6.2-cp34-none-win32.whl",
-            "size": 812387
-        },
-        {
-            "has_sig": false,
-            "upload_time": "2016-07-08T03:12:13",
-            "comment_text": "",
-            "python_version": "cp34",
-            "url": "https://pypi.org/packages/fe/23/c67030ab4a43655d10b62acc658829054a97a147819a81094b1e9673e592/psycopg2-2.6.2-cp34-none-win_amd64.whl",
-            "md5_digest": "26ca03d4f4f65c75a530824981a60df6",
-            "downloads": 1204,
-            "filename": "psycopg2-2.6.2-cp34-none-win_amd64.whl",
-            "packagetype": "bdist_wheel",
-            "path": "fe/23/c67030ab4a43655d10b62acc658829054a97a147819a81094b1e9673e592/psycopg2-2.6.2-cp34-none-win_amd64.whl",
-            "size": 1154539
-        },
-        {
-            "has_sig": false,
-            "upload_time": "2016-07-08T03:13:21",
-            "comment_text": "",
-            "python_version": "cp35",
-            "url": "https://pypi.org/packages/85/bb/7ab5d5b040d6c8a26180acb864f50c1887f27e02e9fb4e94f1f730a4e01b/psycopg2-2.6.2-cp35-none-win32.whl",
-            "md5_digest": "9355dc0c57491e4e42bc610428570994",
-            "downloads": 2932,
-            "filename": "psycopg2-2.6.2-cp35-none-win32.whl",
-            "packagetype": "bdist_wheel",
-            "path": "85/bb/7ab5d5b040d6c8a26180acb864f50c1887f27e02e9fb4e94f1f730a4e01b/psycopg2-2.6.2-cp35-none-win32.whl",
-            "size": 801274
-        },
-        {
-            "has_sig": false,
-            "upload_time": "2016-07-08T03:13:26",
-            "comment_text": "",
-            "python_version": "cp35",
-            "url": "https://pypi.org/packages/5e/45/de485228f46a2487da8e774fa2dbd772e7e03e65a3c31a322a224806e734/psycopg2-2.6.2-cp35-none-win_amd64.whl",
-            "md5_digest": "c8101dfc2a2c2e6eb7e2054c8c0208b2",
-            "downloads": 3340,
-            "filename": "psycopg2-2.6.2-cp35-none-win_amd64.whl",
-            "packagetype": "bdist_wheel",
-            "path": "5e/45/de485228f46a2487da8e774fa2dbd772e7e03e65a3c31a322a224806e734/psycopg2-2.6.2-cp35-none-win_amd64.whl",
-            "size": 1159852
-        },
-        {
-            "has_sig": false,
-            "upload_time": "2016-12-23T16:50:51",
-            "comment_text": "",
-            "python_version": "cp36",
-            "url": "https://pypi.org/packages/66/97/e8922a18a142195cfdbdfc9ec84a8d1a46b09edae24a150d79ea90e6b55b/psycopg2-2.6.2-cp36-cp36m-win32.whl",
-            "md5_digest": "be2016ebc0a83ef40d068baa25ee4f3f",
-            "downloads": 493,
-            "filename": "psycopg2-2.6.2-cp36-cp36m-win32.whl",
-            "packagetype": "bdist_wheel",
-            "path": "66/97/e8922a18a142195cfdbdfc9ec84a8d1a46b09edae24a150d79ea90e6b55b/psycopg2-2.6.2-cp36-cp36m-win32.whl",
-            "size": 802352
-        },
-        {
-            "has_sig": false,
-            "upload_time": "2016-12-23T16:50:54",
-            "comment_text": "",
-            "python_version": "cp36",
-            "url": "https://pypi.org/packages/b6/cb/b7ad5008df09b8392942db9a262435bda778457be4aaba5fc79ead1444b4/psycopg2-2.6.2-cp36-cp36m-win_amd64.whl",
-            "md5_digest": "a1cc2cbb0d9a9191c64640d5129402c3",
-            "downloads": 582,
-            "filename": "psycopg2-2.6.2-cp36-cp36m-win_amd64.whl",
-            "packagetype": "bdist_wheel",
-            "path": "b6/cb/b7ad5008df09b8392942db9a262435bda778457be4aaba5fc79ead1444b4/psycopg2-2.6.2-cp36-cp36m-win_amd64.whl",
-            "size": 1162079
-        },
-        {
+            "digests": {
+                "md5": "97d31f921845f9ae8988e7e8a3fd89b4",
+                "sha256": "0f5e18920ed978f5063e48acc5ca4389225db7d06a03090d2bbb7a0ec7a640b2"
+            },
+            "downloads": -1,
+            "filename": "psycopg-3.0.16-py3-none-any.whl",
             "has_sig": true,
-            "upload_time": "2016-07-07T02:23:58",
+            "md5_digest": "97d31f921845f9ae8988e7e8a3fd89b4",
+            "packagetype": "bdist_wheel",
+            "python_version": "py3",
+            "requires_python": ">=3.6",
+            "size": 143225,
+            "upload_time": "2022-07-28T13:32:58",
+            "upload_time_iso_8601": "2022-07-28T13:32:58.590489Z",
+            "url": "https://files.pythonhosted.org/packages/b6/d6/3b74d0662006df825f2d426291260550ff659bc315b1f86311687b0cffa4/psycopg-3.0.16-py3-none-any.whl",
+            "yanked": false,
+            "yanked_reason": null
+        },
+        {
             "comment_text": "",
-            "python_version": "source",
-            "url": "https://pypi.org/packages/7b/a8/dc2d50a6f37c157459cd18bab381c8e6134b9381b50fbe969997b2ae7dbc/psycopg2-2.6.2.tar.gz",
-            "md5_digest": "4a392949ba31a378a18ed3e775a4693f",
-            "downloads": 1545062,
-            "filename": "psycopg2-2.6.2.tar.gz",
+            "digests": {
+                "md5": "10ed2b5b290d5bf4f007303d135aec17",
+                "sha256": "44ca63373c33957ca852fefa1940f8cc5d4c11493b7f6710b0ab250ff5abc50c"
+            },
+            "downloads": -1,
+            "filename": "psycopg-3.0.16.tar.gz",
+            "has_sig": true,
+            "md5_digest": "10ed2b5b290d5bf4f007303d135aec17",
             "packagetype": "sdist",
-            "path": "7b/a8/dc2d50a6f37c157459cd18bab381c8e6134b9381b50fbe969997b2ae7dbc/psycopg2-2.6.2.tar.gz",
-            "size": 376348
+            "python_version": "source",
+            "requires_python": ">=3.6",
+            "size": 117836,
+            "upload_time": "2022-07-28T13:36:41",
+            "upload_time_iso_8601": "2022-07-28T13:36:41.148055Z",
+            "url": "https://files.pythonhosted.org/packages/da/43/ea5a5580c73051f37842a84e471315d38ee4d1277ceb9716c66cd6ae288a/psycopg-3.0.16.tar.gz",
+            "yanked": false,
+            "yanked_reason": null
         }
-    ]
+    ],
+    "vulnerabilities": []
 }


### PR DESCRIPTION
I originally started on this task to address a CodeQL alert about
untrusted source code being pulled in. That turned out to be a trivial
issue--a test spec copies the source HTML of the homepage of the
`psycopg2` project... and that source HTML pulled in
`http://api.flattr.com/js/0.6/load.js?mode=auto`.

I considered marking the alert as not relevant, but instead took the
opportunity to update the test metadata...

For those unfamiliar with `psycopg2` and the broader Python ecosystem,
three changes happened recently:
1. The old PyPI backend was replaced by a new implementation called
   warehouse. Along the way, a bunch of stuff was modernised, including
   the APIs, some of the metadata tags, etc.
2. The psycopg project moved its homepage to `www.psycopg.org`
3. The `psycopg2` project was deprecated in favor of the rewritten
   psycopg3, which is now called `psycopg`.

So I did a couple of things:
1. I updated the homepage references of psycopg to point to the new page
2. I switched the `psycopg2` project references to `psycopg`
2. I used the new warehouse JSON API to grab the current metadata for
   `psycopg`.

This particular test spec is trying to replicate the scenario where none
of the project URLs include a "source"... aka, a link to the source code
of the project.

Unfortunately for us, the `psycopg` project updated it's PyPI
description to include links to the source code on GitHub, as well as
the issue tracker:
```
"project_urls": {
    "Code": "https://github.com/psycopg/psycopg",
    "Download": "https://pypi.org/project/psycopg/",
    "Homepage": "https://psycopg.org/",
    "Issue Tracker": "https://github.com/psycopg/psycopg/issues"
},
```

I considered trying to find another Python package that doesn't currently include source,
but decided that was more trouble than it was worth. Besides, even if I did that,
later on _that_ package might start shipping valid source URLs and we'd be back to
square one.

Instead I switched those two URLs in order to
retain the existing fixture behavior... since JSON doesn't support
inline comments, I simply made the domain name my inline comment 😁:
```
"project_urls": {
    "Code": "https://no-recognizable-source-for-testing-purposes.com/psycopg/psycopg",
    "Download": "https://pypi.org/project/psycopg/",
    "Homepage": "https://psycopg.org/",
    "Issue Tracker": "https://no-recognizable-source-for-testing-purposes.com/psycopg/psycopg/issues"
},
```

I also noticed we should probably update a bunch of the other python
spec fixtures to ensure they're representative of the current warehouse
API responses. But that is out of scope for this PR, so will handle in a
follow-on PR.

Fix https://github.com/dependabot/dependabot-core/security/code-scanning/5