### PR TITLE
[npm] Prefer setting `process.exitCode` to `process.exit()` with pending writes

### DIFF
--- a/npm_and_yarn/helpers/run.js
+++ b/npm_and_yarn/helpers/run.js
@@ -25,6 +25,6 @@ process.stdin.on("end", () => {
     })
     .catch((error) => {
       output({ error: error.message });
-      process.exit(1);
+      process.exitCode = 1;
     });
 });


### PR DESCRIPTION
Writes to `process.stdout` may happen asynchronously, during the next tick (or several) of the event loop. Calling `process.exit()` immediately after calling `process.stdout.write()` may result in lost writes to stdout.

See: https://nodejs.org/api/process.html#processexitcode