### PR TITLE
Add TODO note about removing parser warning

### DIFF
--- a/common/spec/warning_monkey_patch.rb
+++ b/common/spec/warning_monkey_patch.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 ALLOW_PATTERNS = [
+  # TODO: Pin the parser version to the Ruby version--details: https://github.com/dependabot/dependabot-core/issues/5461
   # Ignore parser warnings for ruby 2.7 minor version mismatches.
   # This is a recurring issue that occurs whenever the parser gets
   # ahead of our installed ruby version.


### PR DESCRIPTION
I originally thought we were only hitting this warning due to Rubocop,
and tried removing it, but it turns out we pull in this library for
other code. I don't have time to dig deeper right now, so I filed
https://github.com/dependabot/dependabot-core/issues/5461 explaining
what I learned so far and this PR adds a TODO note in the code so the
information doesn't get lost in the issue tracker.