### PR TITLE
Allow Actions to be fetched from non-GitHub source

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -55,7 +55,7 @@ module Dependabot
       def build_github_dependency(file, string)
         details = string.match(GITHUB_REPO_REFERENCE).named_captures
         name = "#{details.fetch('owner')}/#{details.fetch('repo')}"
-        url = "https://github.com/#{name}"
+        url = "https://#{source.hostname}/#{name}"
 
         ref = details.fetch("ref")
         version = version_class.new(ref).to_s if version_class.correct?(ref)

--- a/github_actions/spec/fixtures/workflow_files/non_github_source.yml
+++ b/github_actions/spec/fixtures/workflow_files/non_github_source.yml
@@ -1,0 +1,7 @@
+on: [push]
+
+name: Integration
+jobs:
+  chore:
+    steps:
+    - uses: inactions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81


### PR DESCRIPTION
I don't think we realized that we lacked the ability to fetch Actions
from non-GitHub.com sources. With this change, we're now able to fetch
Actions from GitHub Enterprise Server instances.