### PR TITLE
Update ruby gems using the `--no-document` flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ RUN mkdir -p /tmp/ruby-install \
  && cd ruby-install-$RUBY_INSTALL_VERSION/ \
  && make \
  && ./bin/ruby-install --system ruby $RUBY_VERSION \
- && gem update --system $RUBYGEMS_SYSTEM_VERSION \
+ && gem update --system $RUBYGEMS_SYSTEM_VERSION --no-document \
  && gem install bundler -v $BUNDLER_V1_VERSION --no-document \
  && gem install bundler -v $BUNDLER_V2_VERSION --no-document \
  && rm -rf /var/lib/gems/*/cache/* \


### PR DESCRIPTION
The `--no-document` flag [skips installing documentation](https://guides.rubygems.org/command-reference/#installupdate-options), so is faster.

This was originally proposed by @deivid-rodriguez as part of
https://github.com/dependabot/dependabot-core/pull/5035, but was lost when https://github.com/dependabot/dependabot-core/pull/5048 reverted the version bump.

So this adds back only the `--no-document` flag, but doesn't touch the
version.