### PR TITLE
Suppress "detached head" advice during `git clone`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ ENV PYENV_ROOT=/usr/local/.pyenv \
   PATH="/usr/local/.pyenv/bin:$PATH"
 RUN mkdir -p "$PYENV_ROOT" && chown dependabot:dependabot "$PYENV_ROOT"
 USER dependabot
-RUN git clone https://github.com/pyenv/pyenv.git --branch v2.3.2 --single-branch --depth=1 /usr/local/.pyenv \
+RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch v2.3.2 --single-branch --depth=1 /usr/local/.pyenv \
   # This is the version of CPython that gets installed
   && pyenv install 3.10.5 \
   && pyenv global 3.10.5 \


### PR DESCRIPTION
I noticed the [following logs during the docker build](https://github.com/dependabot/dependabot-core/runs/7646741836?check_suite_focus=true#step:3:5062):
```
0.906 You are in 'detached HEAD' state. You can look around, make experimental
0.906 changes and commit them, and you can discard any commits you make in this
0.906 state without impacting any branches by switching back to a branch.
0.906
0.906 If you want to create a new branch to retain commits you create, you may
0.906 do so (now or later) by using -c with the switch command. Example:
0.906
0.906   git switch -c <new-branch-name>
0.906
0.906 Or undo this operation with:
0.906
0.906   git switch -
0.906
0.906 Turn off this advice by setting config variable advice.detachedHead to false
```

Passing the config this way sets it _only_ for this command (we don't
want to set it globally).

Details: https://stackoverflow.com/a/72588008/770425