### PR TITLE
Skip installing docs when installing Ruby

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN mkdir -p /tmp/ruby-install \
  && tar -xzvf ruby-install-$RUBY_INSTALL_VERSION.tar.gz \
  && cd ruby-install-$RUBY_INSTALL_VERSION/ \
  && make \
- && ./bin/ruby-install --system ruby $RUBY_VERSION \
+ && ./bin/ruby-install --system ruby $RUBY_VERSION -- --disable-install-doc \
  && gem update --system $RUBYGEMS_SYSTEM_VERSION --no-document \
  && gem install bundler -v $BUNDLER_V1_VERSION --no-document \
  && gem install bundler -v $BUNDLER_V2_VERSION --no-document \


### PR DESCRIPTION
I noticed that our Ruby installs included generating docs, which takes
~30 seconds:
https://github.com/dependabot/dependabot-core/runs/7646741836?check_suite_focus=true#step:3:5996

But we don't need docs in our docker images--humans can always look them
up online.

So skip installing docs and cut 30s off our CI times.

Thanks to @deivid-rodriguez for the tip on [how to pass the arg through
`ruby-install` to the underlying `ruby`](https://github.com/dependabot/dependabot-core/issues/5475#issuecomment-1204742884).

Fix #5475