### PR TITLE
Add support for multi-level wildcard paths in composer

### DIFF
--- a/composer/lib/dependabot/composer/file_fetcher.rb
+++ b/composer/lib/dependabot/composer/file_fetcher.rb
@@ -103,9 +103,25 @@ module Dependabot
       end
 
       def expand_path(path)
-        repo_contents(dir: path.gsub(/\*$/, "")).
-          select { |file| file.type == "dir" }.
-          map { |f| path.gsub(/\*$/, f.name) }
+        wildcard_depth = 0
+        path = path.gsub(/\*$/, "")
+        while path.end_with?("*/")
+          path = path.gsub(/\*\/$/, "")
+          wildcard_depth += 1
+        end
+        directories = repo_contents(dir: path).
+                      select { |file| file.type == "dir" }.
+                      map { |f| File.join(path, f.name) }
+
+        while wildcard_depth > 0
+          directories.each do |dir|
+            directories += repo_contents(dir: dir).
+                           select { |file| file.type == "dir" }.
+                           map { |f| File.join(dir, f.name) }
+          end
+          wildcard_depth -= 1
+        end
+        directories
       rescue Octokit::NotFound, Gitlab::Error::NotFound
         lockfile_path_dependency_paths.
           select { |p| p.to_s.start_with?(path.gsub(/\*$/, "")) }

--- a/composer/lib/dependabot/composer/file_fetcher.rb
+++ b/composer/lib/dependabot/composer/file_fetcher.rb
@@ -106,14 +106,14 @@ module Dependabot
         wildcard_depth = 0
         path = path.gsub(/\*$/, "")
         while path.end_with?("*/")
-          path = path.gsub(/\*\/$/, "")
+          path = path.gsub(%r{\*/$}, "")
           wildcard_depth += 1
         end
         directories = repo_contents(dir: path).
                       select { |file| file.type == "dir" }.
                       map { |f| File.join(path, f.name) }
 
-        while wildcard_depth > 0
+        while wildcard_depth.positive?
           directories.each do |dir|
             directories += repo_contents(dir: dir).
                            select { |file| file.type == "dir" }.

--- a/composer/spec/dependabot/composer/file_fetcher_spec.rb
+++ b/composer/spec/dependabot/composer/file_fetcher_spec.rb
@@ -177,6 +177,73 @@ RSpec.describe Dependabot::Composer::FileFetcher do
         )
     end
 
+    context "with nested wildcards" do
+      before do
+        stub_request(:get, url + "composer.json?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "composer_json_with_nested_path_deps.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "components?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "contents_ruby_nested_path_top_level.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "components/vendor1?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "contents_ruby_nested_path_directory_one.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "components/vendor2?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "contents_ruby_nested_path_directory_two.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "components/vendor2/bump-core/composer.json?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "composer_json_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "components/vendor1/another-dep/composer.json?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "composer_json_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "components/vendor2/composer.json?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 404,
+            body: fixture("github", "composer_json_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "components/vendor1/composer.json?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 404,
+            body: fixture("github", "composer_json_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+      end
+      it "fetches the composer.json, composer.lock and the path dependencies" do
+        expect(file_fetcher_instance.files.map(&:name)).
+          to match_array(
+            %w(composer.json composer.lock components/vendor2/bump-core/composer.json
+               components/vendor1/another-dep/composer.json)
+          )
+      end
+    end
     context "specified as a hash" do
       before do
         stub_request(:get, url + "composer.json?ref=sha").

--- a/composer/spec/fixtures/github/composer_json_with_nested_path_deps.json
+++ b/composer/spec/fixtures/github/composer_json_with_nested_path_deps.json
@@ -1,0 +1,18 @@
+{
+  "name": "composer.json",
+  "path": "composer.json",
+  "sha": "5c7b3419e0056515122b981f1566ebe22c208251",
+  "size": 594,
+  "url": "https://api.github.com/repos/gocardless/bump/contents/composer.json?ref=master",
+  "html_url": "https://github.com/gocardless/bump/blob/master/composer.json",
+  "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+  "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/composer.json?token=ABMwe0apDiKCctWHnEHnszRBAebVHjQnks5WJWD9wA%3D%3D",
+  "type": "file",
+  "content": "ewogICAgInJlcG9zaXRvcmllcyI6IFsKICAgICAgICB7CiAgICAgICAgICAgICJ0eXBlIjogInBhdGgiLAogICAgICAgICAgICAidXJsIjogImNvbXBvbmVudHMvKi8qIiwKICAgICAgICAgICAgIm9wdGlvbnMiOiB7CiAgICAgICAgICAgICAgICAic3ltbGluayI6IGZhbHNlCiAgICAgICAgICAgIH0KICAgICAgICB9CiAgICBdLAogICAgInJlcXVpcmUiOiB7CiAgICAgICAgIm1vbm9sb2cvbW9ub2xvZyI6ICIxLjAuKiIsCiAgICAgICAgInN5bWZvbnkvcG9seWZpbGwtbWJzdHJpbmciOiAiMS4wLioiCiAgICB9Cn0K\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/gocardless/bump/contents/composer.json?ref=master",
+    "git": "https://api.github.com/repos/gocardless/bump/git/blobs/5c7b3419e0056515122b981f1566ebe22c208251",
+    "html": "https://github.com/gocardless/bump/blob/master/composer.json"
+  }
+}

--- a/composer/spec/fixtures/github/contents_ruby_nested_path_directory_one.json
+++ b/composer/spec/fixtures/github/contents_ruby_nested_path_directory_one.json
@@ -1,0 +1,18 @@
+[
+    {
+        "name": "another-dep",
+        "path": "another-dep",
+        "sha": "7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+        "size": 917,
+        "url": "https://api.github.com/repos/gocardless/business/contents/vendor1/another-dep?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/vendor1/another-dep",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/vendor1/another-dep",
+        "type": "dir",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/vendor1/another-dep?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+            "html": "https://github.com/gocardless/business/blob/master/vendor1/another-dep"
+        }
+    }
+]

--- a/composer/spec/fixtures/github/contents_ruby_nested_path_directory_two.json
+++ b/composer/spec/fixtures/github/contents_ruby_nested_path_directory_two.json
@@ -1,0 +1,18 @@
+[
+    {
+        "name": "bump-core",
+        "path": "bump-core",
+        "sha": "7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+        "size": 917,
+        "url": "https://api.github.com/repos/gocardless/business/contents/vendor2/bump-core?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/vendor2/bump-core",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/vendor2/bump-core",
+        "type": "dir",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/vendor2/bump-core?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+            "html": "https://github.com/gocardless/business/blob/master/vendor2/bump-core"
+        }
+    }
+]

--- a/composer/spec/fixtures/github/contents_ruby_nested_path_top_level.json
+++ b/composer/spec/fixtures/github/contents_ruby_nested_path_top_level.json
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "vendor1",
+        "path": "vendor1",
+        "sha": "7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+        "size": 917,
+        "url": "https://api.github.com/repos/gocardless/business/contents/vendor1?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/vendor1",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/vendor1",
+        "type": "dir",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/vendor1?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+            "html": "https://github.com/gocardless/business/blob/master/vendor1"
+        }
+    },
+    {
+        "name": "vendor2",
+        "path": "vendor2",
+        "sha": "7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+        "size": 917,
+        "url": "https://api.github.com/repos/gocardless/business/contents/vendor2?ref=master",
+        "html_url": "https://github.com/gocardless/business/blob/master/vendor2",
+        "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+        "download_url": "https://raw.githubusercontent.com/gocardless/business/master/vendor2",
+        "type": "dir",
+        "_links": {
+            "self": "https://api.github.com/repos/gocardless/business/contents/vendor2?ref=master",
+            "git": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+            "html": "https://github.com/gocardless/business/blob/master/vendor2"
+        }
+    }
+]


### PR DESCRIPTION
A customer reported that nested wildcard resolution fails in Dependabot.  Given a composer.json repository like:
```{
"repositories": [
   {
     "type": "path", 
     "url": "components/*/*", 
     "options": {"symlink": false}
   }
 ], 
 "require": {
   "monolog/monolog": "1.0.*", 
   "symfony/polyfill-mbstring": "1.0.*"
 }
}
```
We would fail to properly handle both `*` and would attempt to retrieve `components/*` from the source repository.  When this attempt returns an error we fail the update job.

This PR adds support to traverse the path and expand the directory list at each level of the path which is represented by a wildcard.  It also adds a test for this added path traversal support.