### PR TITLE
Tweak comment now that `pip` has a resolver

### DIFF
--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -107,10 +107,7 @@ module Dependabot
       private
 
       def latest_version_resolvable_with_full_unlock?
-        # Full unlock checks aren't implemented for pip because they're not
-        # relevant (pip doesn't have a resolver). This method always returns
-        # false to ensure `updated_dependencies_after_full_unlock` is never
-        # called.
+        # Full unlock checks aren't implemented for Python (yet)
         false
       end
 


### PR DESCRIPTION
`pip` has a [new resolver that's enabled by default](https://blog.python.org/2020/11/pip-20-3-release-new-resolver.html).

So let's update this comment to reduce the confusion.

I copied the text from other ecosystems where we use this exact wording:
* [`hex`](https://github.com/dependabot/dependabot-core/blob/c2adf22e99192547ee5cd597b9c572ccd3419972/hex/lib/dependabot/hex/update_checker.rb#L56)
* [`go`](https://github.com/dependabot/dependabot-core/blob/c2adf22e99192547ee5cd597b9c572ccd3419972/go_modules/lib/dependabot/go_modules/update_checker.rb#L80)