### PR TITLE
Disable `pip` latest version check when building `python` native helper

### DIFF
--- a/python/helpers/build
+++ b/python/helpers/build
@@ -18,7 +18,7 @@ cp -r \
   "$install_dir"
 
 cd "$install_dir"
-PYENV_VERSION=3.10.5 pyenv exec pip install -r "requirements.txt"
+PYENV_VERSION=3.10.5 pyenv exec pip --disable-pip-version-check install -r "requirements.txt"
 
 # Workaround of https://github.com/python-poetry/poetry/issues/3010
 # By default poetry config file is stored under ~/.config/pypoetry


### PR DESCRIPTION
This python helper is being run during the build of `Dependabot-core`
docker image, triggering the following warning:
```
You are using pip version 22.0.4; however, version 22.2.2 is available.
You should consider upgrading via the '/usr/local/.pyenv/versions/3.10.5/bin/python3.10 -m pip install --upgrade pip' command.
```

Beyond the annoyance of the warning message, this means that `pip` is
making an unnecessary call to a remote server to check the version.
This won't be a huge savings, a blogger [benchmarked this as costing ~0.2s](https://pythonspeed.com/articles/faster-pip-installs/), but still might as well disable it.

This option can also be set globally using a config file or env var:
* https://stackoverflow.com/a/46288945
* https://stackoverflow.com/a/60270281

However, we have a number of different use cases for calling `pip`, and
in some cases we _may_ end up wanting the version check... for example
it feels wrong/unpredictable to simultaneously disable the version check
while we are [upgrading to the latest version](https://github.com/dependabot/dependabot-core/pull/5195).