### PR TITLE
Set version range for pipenv to maintain python 3.6 support

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -2,7 +2,7 @@ pip>=21.3.1,<22.2.3  # Allow earlier versions to retain python 3.6 support
 pip-tools>=6.4.0,<6.8.1  # Allow earlier versions to retain python 3.6 support
 flake8==5.0.4
 hashin==0.17.0
-pipenv==2022.4.8
+pipenv>=2022.4.8,<=22.8.5  # Allow earlier versions to retain python 3.6 support
 pipfile==0.0.2
 poetry==1.1.14
 wheel==0.37.1

--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -2,7 +2,7 @@ pip>=21.3.1,<22.2.3  # Allow earlier versions to retain python 3.6 support
 pip-tools>=6.4.0,<6.8.1  # Allow earlier versions to retain python 3.6 support
 flake8==5.0.4
 hashin==0.17.0
-pipenv>=2022.4.8,<=22.8.5  # Allow earlier versions to retain python 3.6 support
+pipenv>=2022.4.8,<=2022.8.5  # Allow earlier versions to retain python 3.6 support
 pipfile==0.0.2
 poetry==1.1.14
 wheel==0.37.1

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -30,7 +30,7 @@ module Dependabot
       # still better than nothing, though.
       class PipenvVersionResolver
         GIT_DEPENDENCY_UNREACHABLE_REGEX =
-          /git clone -q (?<url>[^\s]+).* /.freeze
+          /git clone -q | --filter=blob:none (?<url>[^\s]+).* /.freeze
         GIT_REFERENCE_NOT_FOUND_REGEX =
           %r{git checkout -q (?<tag>[^\n"]+)\n?[^\n]*/(?<name>.*?)(\\n'\]|$)}m.
           freeze
@@ -238,7 +238,7 @@ module Dependabot
             raise DependencyFileNotResolvable, msg
           end
 
-          # NOTE: Pipenv masks the actualy error, see this issue for updates:
+          # NOTE: Pipenv masks the actual error, see this issue for updates:
           # https://github.com/pypa/pipenv/issues/2791
           handle_pipenv_installation_error(error.message) if error.message.match?(PIPENV_INSTALLATION_ERROR_REGEX)
 

--- a/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipenvVersionResolver do
         expect { subject }.
           to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
             expect(error.message).to start_with(
-              "CRITICAL:pipenv.patched.notpip._internal.resolution.resolvelib.factory:"\
+              "CRITICAL:pipenv.patched.pip._internal.resolution.resolvelib.factory:"\
               "Could not find a version that satisfies the requirement "\
               "pytest==10.4.0"
             )


### PR DESCRIPTION
A dependabot update attempt is failing CI due in part to pipenv removing python 3.6 support.  This PR will maintain that support and resolve any other issues with the latest pipenv version.