### PR TITLE
Monkey patch bundler EndpointSpecification

### DIFF
--- a/bundler/helpers/v2/lib/functions.rb
+++ b/bundler/helpers/v2/lib/functions.rb
@@ -143,7 +143,7 @@ module Functions
 
       Bundler.settings.set_command_option(
         cred.fetch("host"),
-        token.gsub("@", "%40F").gsub("?", "%3F")
+        token.gsub("@", "%40").gsub("?", "%3F")
       )
     end
 

--- a/bundler/helpers/v2/monkey_patches/endpoint_specification_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/endpoint_specification_patch.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "bundler/endpoint_specification"
+
+module EndpointSpecificationPatch
+  def required_ruby_version
+    @required_ruby_version ||= Gem::Requirement.default
+  end
+
+  def required_rubygems_version
+    @required_rubygems_version ||= Gem::Requirement.default
+  end
+end
+
+Bundler::EndpointSpecification.prepend(EndpointSpecificationPatch)

--- a/bundler/helpers/v2/run.rb
+++ b/bundler/helpers/v2/run.rb
@@ -15,6 +15,7 @@ end
 # Bundler monkey patches
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"
+require "endpoint_specification_patch"
 require "git_source_patch"
 
 require "functions"


### PR DESCRIPTION
We have had a number of customer escalations reporting timeouts and excessive requests to private gem servers.

This is a known performance regression in bundler documented here: https://github.com/rubygems/rubygems/issues/5385

Through discussions with @deivid-rodriguez he is working on an upstream fix, but in the meantime we can patch the EndpointSpecification class so that it no longer retrieves gemspec.rz files from private servers.

I've confirmed through manual tests against a private gem server and a repo that consumes said registry that this patch greatly improves performance (~10 minutes to run dry-run.rb down to 30-45s)