### PR TITLE
Log reasons why npm audit can't succeed

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -88,7 +88,7 @@ module Dependabot
 
         def viable_audit_result?(audit_result, security_advisories)
           validation_result = validate_audit_result(audit_result, security_advisories)
-          return true if validation_result == :valid
+          return true if validation_result == :viable
 
           Dependabot.logger.info("VulnerabilityAuditor: audit result not viable: #{validation_result}")
           false
@@ -100,7 +100,7 @@ module Dependabot
           return :dependency_still_vulnerable if dependency_still_vulnerable?(audit_result, security_advisories)
           return :downgrades_dependencies if downgrades_dependencies?(audit_result)
 
-          :valid
+          :viable
         end
 
         def vulnerable_dependency_removed?(audit_result)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -73,7 +73,7 @@ module Dependabot
               function: "npm:vulnerabilityAuditor",
               args: [Dir.pwd, vuln_versions]
             )
-            return fix_unavailable unless valid_audit_result?(audit_result, security_advisories)
+            return fix_unavailable unless viable_audit_result?(audit_result, security_advisories)
 
             audit_result
           end
@@ -86,15 +86,21 @@ module Dependabot
 
         attr_reader :dependency_files, :credentials
 
-        def valid_audit_result?(audit_result, security_advisories)
-          # we only need to check results that indicate a fix is available
-          return true unless audit_result["fix_available"]
+        def viable_audit_result?(audit_result, security_advisories)
+          validation_result = validate_audit_result(audit_result, security_advisories)
+          return true if validation_result == :valid
 
-          return false if vulnerable_dependency_removed?(audit_result)
-          return false if dependency_still_vulnerable?(audit_result, security_advisories)
-          return false if downgrades_dependencies?(audit_result)
+          Dependabot.logger.info("VulnerabilityAuditor: audit result not viable: #{validation_result}")
+          false
+        end
 
-          true
+        def validate_audit_result(audit_result, security_advisories)
+          return :fix_unavailable unless audit_result["fix_available"]
+          return :vulnerable_dependency_removed if vulnerable_dependency_removed?(audit_result)
+          return :dependency_still_vulnerable if dependency_still_vulnerable?(audit_result, security_advisories)
+          return :downgrades_dependencies if downgrades_dependencies?(audit_result)
+
+          :valid
         end
 
         def vulnerable_dependency_removed?(audit_result)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
           )
         ]
 
+        expect(Dependabot.logger).to receive(:info).with(/audit result not viable: vulnerable_dependency_removed/i)
         expect(subject.audit(dependency: dependency, security_advisories: security_advisories)).
           to include("fix_available" => false)
       end
@@ -104,6 +105,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
             "target_version" => "1.0.0"
           })
 
+        expect(Dependabot.logger).to receive(:info).with(/audit result not viable: dependency_still_vulnerable/i)
         expect(subject.audit(dependency: dependency, security_advisories: security_advisories)).
           to include("fix_available" => false)
       end
@@ -138,6 +140,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
             "top_level_ancestors" => ["@dependabot-fixtures/npm-parent-dependency"]
           })
 
+        expect(Dependabot.logger).to receive(:info).with(/audit result not viable: downgrades_dependencies/i)
         expect(subject.audit(dependency: dependency, security_advisories: security_advisories)).
           to include("fix_available" => false)
       end


### PR DESCRIPTION
This will make it easier to see why an update wasn't possible by viewing the job logs. Ideally we'd surface these in update error message but until then this is better than needing to reproduce the failure with the debugger.