### PR TITLE
Decouple Bundler versions

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -3,6 +3,7 @@
 set -e
 
 shellcheck \
+  --source-path=SCRIPTDIR \
   ./bin/ci-test \
   ./bin/docker-dev-shell \
   ./bin/lint \

--- a/bundler/helpers/v1/build
+++ b/bundler/helpers/v1/build
@@ -2,21 +2,21 @@
 
 set -e
 
-if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
-  echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
-  exit 1
-fi
-
-install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/bundler/v1"
-mkdir -p "$install_dir"
-
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
-cp -r \
-  "$helpers_dir/lib" \
-  "$helpers_dir/monkey_patches" \
-  "$helpers_dir/run.rb" \
-  "$helpers_dir/Gemfile" \
-  "$install_dir"
+
+if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
+  install_dir="$helpers_dir"
+else
+  install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/bundler/v1"
+  mkdir -p "$install_dir"
+
+  cp -r \
+    "$helpers_dir/lib" \
+    "$helpers_dir/monkey_patches" \
+    "$helpers_dir/run.rb" \
+    "$helpers_dir/Gemfile" \
+    "$install_dir"
+fi
 
 cd "$install_dir"
 
@@ -25,7 +25,10 @@ export GEM_HOME=$install_dir/.bundle
 gem install bundler -v 1.17.3 --no-document
 
 BUNDLER_VERSION=1.17.3 bundle config --local path.system true
-BUNDLER_VERSION=1.17.3 bundle config --local without "test"
+
+if [ -n "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
+  BUNDLER_VERSION=1.17.3 bundle config --local without "test"
+fi
 
 # NOTE: Sets `BUNDLED WITH` to match the installed v1 version in Gemfile.lock
 # forcing native helpers to run with the same version

--- a/bundler/helpers/v1/build
+++ b/bundler/helpers/v1/build
@@ -2,7 +2,7 @@
 
 set -e
 
-helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
+helpers_dir=$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
   install_dir="$helpers_dir"

--- a/bundler/helpers/v1/build
+++ b/bundler/helpers/v1/build
@@ -20,8 +20,13 @@ cp -r \
 
 cd "$install_dir"
 
+export GEM_HOME=$install_dir/.bundle
+
+gem install bundler -v 1.17.3 --no-document
+
+BUNDLER_VERSION=1.17.3 bundle config --local path.system true
+BUNDLER_VERSION=1.17.3 bundle config --local without "test"
+
 # NOTE: Sets `BUNDLED WITH` to match the installed v1 version in Gemfile.lock
 # forcing native helpers to run with the same version
-BUNDLER_VERSION=1.17.3 bundle config --local path ".bundle"
-BUNDLER_VERSION=1.17.3 bundle config --local without "test"
 BUNDLER_VERSION=1.17.3 bundle install

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -20,6 +20,12 @@ cp -r \
 
 cd "$install_dir"
 
-bundle config --local path ".bundle"
+export GEM_HOME=$install_dir/.bundle
+
+default_version=$(ruby -rbundler -e'print Bundler::VERSION')
+
+gem install bundler -v "$default_version" --no-document
+
+bundle config --local path.system true
 bundle config --local without "test"
 bundle install

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -2,30 +2,34 @@
 
 set -e
 
-if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
-  echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
-  exit 1
-fi
-
-install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/bundler/v2"
-mkdir -p "$install_dir"
-
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
-cp -r \
-  "$helpers_dir/lib" \
-  "$helpers_dir/monkey_patches" \
-  "$helpers_dir/run.rb" \
-  "$helpers_dir/Gemfile" \
-  "$install_dir"
+
+if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
+  install_dir="$helpers_dir"
+else
+  install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/bundler/v2"
+  mkdir -p "$install_dir"
+
+  cp -r \
+    "$helpers_dir/lib" \
+    "$helpers_dir/monkey_patches" \
+    "$helpers_dir/run.rb" \
+    "$helpers_dir/Gemfile" \
+    "$install_dir"
+fi
 
 cd "$install_dir"
 
-export GEM_HOME=$install_dir/.bundle
-
 default_version=$(ruby -rbundler -e'print Bundler::VERSION')
+
+export GEM_HOME=$install_dir/.bundle
 
 gem install bundler -v "$default_version" --no-document
 
 bundle config --local path.system true
-bundle config --local without "test"
+
+if [ -n "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
+  bundle config --local without "test"
+fi
+
 bundle install

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -2,7 +2,7 @@
 
 set -e
 
-helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
+helpers_dir=$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
   install_dir="$helpers_dir"

--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -11,13 +11,13 @@ bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX
 
 # Should we only run these on one of the CI_NODE_INDEX's?
 if [[ "$SUITE_NAME" == "bundler1" ]]; then
-  cd helpers/v1 \
-    && BUNDLER_VERSION=1.17.3 bundle install \
+  # shellcheck source=../helpers/v1/build
+  DEPENDABOT_NATIVE_HELPERS_PATH="" source helpers/v1/build \
     && BUNDLER_VERSION=1.17.3 bundle exec rspec spec\
     && cd -
 else
-  cd helpers/v2 \
-    && bundle install \
+  # shellcheck source=../helpers/v2/build
+  DEPENDABOT_NATIVE_HELPERS_PATH="" source helpers/v2/build \
     && bundle exec rspec spec \
     && cd -
 fi


### PR DESCRIPTION
### Problem

When upgrading RubyGems to 3.3+, RubyGems gets confused about which Bundler version to use when shelling out to native helpers.

### Context 

There's two different instances of Bundler during a dependabot run/update. There's the version that runs Dependabot itself and that activates the different `dependabot-*` gems, and there's the version of Bundler that runs native helpers.

The version of Bundler that runs dependabot itself can be anything really. It defaults to the highest version globally installed, but may be restricted by manifest files (`Gemfile` and `Gemfile.lock`) present when Dependabot is run.

The version of Bundler that runs native helpers is more tricky, because it needs to respect (up to a certain point) the version of Bundler the manifest files being updated work best with.

With RubyGems 3.3+, some Bundler magic is activated, where Bundler will choose and switch to the version in the `BUNDLED WITH` section in the lockfile. There's more information about it here: https://bundler.io/blog/2022/01/23/bundler-v2-3.html. This respects `BUNDLE_PATH` too.

#### What does this mean for Dependabot setup? 🤔 

With RubyGems 3.3, if `dependabot` is run through `bundle exec` with a `BUNDLE_PATH` configured, then Bundler will automatically re-exec to the proper version of itself installed at `BUNDLE_PATH`, and with `GEM_HOME` and `GEM_PATH` set to that isolated location. Then, when re-execing (again) to native helpers,, even if we properly use `Bundler.with_original_env` before re-execing, the original env has `GEM_HOME` and `GEM_PATH` pointing to the isolated `BUNDLE_PATH` location, where the blessed Bundler 1.x version (1.17.3), and Bundler 2.x version (2.3.14, as of now) are not available, since they are installed globally in the Dockerfile.

So, we fail to shell out to native helpers.

### Solution 💡 

My solution is to decouple the different Bundler versions. For example, Bundler 1.x is only useful for updating lockfiles with `BUNDLED WITH` set to Bundler 1.x. So we only install that version to the `GEM_HOME` specific to Bundler 1 native helpers, which we set specifically when shelling out:

https://github.com/dependabot/dependabot-core/blob/d0e5145348eeb88cc82d74cab20e548da674682e/bundler/lib/dependabot/bundler/native_helpers.rb#L50

That way, we can be 100% sure it will be found.

And similarly with Bundler 2.x.