### PR TITLE
v0.207.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.207.0, 11 August 2022
+
+- Monkey patch bundler EndpointSpecification [#5510](https://github.com/dependabot/dependabot-core/pull/5510)
+- Log reasons why npm audit can't succeed [#5512](https://github.com/dependabot/dependabot-core/pull/5512)
+
 ## v0.206.0, 10 August 2022
 
 - Pin MessageBuilder cassette names [#5508](https://github.com/dependabot/dependabot-core/pull/5508)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.206.0"
+  VERSION = "0.207.0"
 end


### PR DESCRIPTION
## v0.207.0, 11 August 2022

- Monkey patch bundler EndpointSpecification [#5510](https://github.com/dependabot/dependabot-core/pull/5510)
- Log reasons why npm audit can't succeed [#5512](https://github.com/dependabot/dependabot-core/pull/5512)