### PR TITLE
Allow diverged-commit pinned Actions to be updated

### DIFF
--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -130,8 +130,8 @@ module Dependabot
 
         # Update to the latest tag if pinned to a commit that has diverged
         if git_commit_checker.pinned_ref_looks_like_commit_sha? &&
-          !git_commit_checker.branch_or_ref_in_release?(latest_tag[:version])
-          return dependency_source_details.merge(ref: latest_tag[:tag])
+           !git_commit_checker.branch_or_ref_in_release?(latest_tag[:version])
+          return dependency_source_details.merge(ref: latest_tag.fetch(:commit_sha))
         end
 
         # Otherwise return the original source

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -121,16 +121,9 @@ module Dependabot
 
         latest_tag = git_commit_checker.local_tag_for_latest_version
 
-        # Update the git commit if updating a pinned commit
+        # Update the pinned git commit if one is available
         if git_commit_checker.pinned_ref_looks_like_commit_sha? &&
-           git_commit_checker.branch_or_ref_in_release?(latest_tag[:version]) &&
-           (latest_commit = latest_tag.fetch(:commit_sha)) != current_commit
-          return dependency_source_details.merge(ref: latest_commit)
-        end
-
-        # Update to the latest tag if pinned to a commit that has diverged
-        if git_commit_checker.pinned_ref_looks_like_commit_sha? &&
-           !git_commit_checker.branch_or_ref_in_release?(latest_tag[:version])
+           latest_tag.fetch(:commit_sha) != current_commit
           return dependency_source_details.merge(ref: latest_tag.fetch(:commit_sha))
         end
 

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -119,12 +119,19 @@ module Dependabot
           return dependency_source_details.merge(ref: new_tag.fetch(:tag))
         end
 
+        latest_tag = git_commit_checker.local_tag_for_latest_version
+
         # Update the git commit if updating a pinned commit
         if git_commit_checker.pinned_ref_looks_like_commit_sha? &&
-           (latest_tag = git_commit_checker.local_tag_for_latest_version) &&
            git_commit_checker.branch_or_ref_in_release?(latest_tag[:version]) &&
            (latest_commit = latest_tag.fetch(:commit_sha)) != current_commit
           return dependency_source_details.merge(ref: latest_commit)
+        end
+
+        # Update to the latest tag if pinned to a commit that has diverged
+        if git_commit_checker.pinned_ref_looks_like_commit_sha? &&
+          !git_commit_checker.branch_or_ref_in_release?(latest_tag[:version])
+          return dependency_source_details.merge(ref: latest_tag[:tag])
         end
 
         # Otherwise return the original source

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -70,13 +70,10 @@ module Dependabot
           return latest_version
         end
 
-        # If the dependency is pinned to a commit SHA and the latest
-        # version-like tag includes that commit then we want to update to that
-        # version-like tag. We return a version (not a commit SHA) so that we
-        # get nice behaviour in PullRequestCreator::MessageBuilder
-        if git_commit_checker.pinned_ref_looks_like_commit_sha? &&
-           (latest_tag = git_commit_checker.local_tag_for_latest_version) &&
-           git_commit_checker.branch_or_ref_in_release?(latest_tag[:version])
+        # If the dependency is pinned to a commit SHA, we return a *version* so
+        # that we get nice behaviour in PullRequestCreator::MessageBuilder
+        if git_commit_checker.pinned_ref_looks_like_commit_sha?
+          latest_tag = git_commit_checker.local_tag_for_latest_version
           return latest_tag.fetch(:version)
         end
 

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -143,11 +143,13 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
             )
         end
 
-        context "when the specified reference is not in the latest release" do
+        context "when the specified commit has diverged from the latest release" do
           let(:comparison_response) do
             fixture("github", "commit_compare_diverged.json")
           end
-          it { is_expected.to be_falsey }
+          it "can update to the latest version" do
+            expect(subject).to be_truthy
+          end
         end
 
         context "when the specified ref is included in the latest release" do
@@ -337,7 +339,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
           )
       end
 
-      context "when the specified reference is not in the latest release" do
+      context "when the specified commit has diverged from the latest release" do
         let(:comparison_response) do
           fixture("github", "commit_compare_diverged.json")
         end
@@ -403,7 +405,21 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         let(:comparison_response) do
           fixture("github", "commit_compare_diverged.json")
         end
-        it { is_expected.to eq(dependency.requirements) }
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: ".github/workflows/workflow.yml",
+            source: {
+              type: "git",
+              url: "https://github.com/actions/setup-node",
+              ref: "v1.1",
+              branch: nil
+            },
+            metadata: { declaration_string: "actions/setup-node@master" }
+          }]
+        end
+        it { is_expected.to eq(expected_requirements) }
       end
 
       context "when the specified ref is included in the latest release" do

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -341,7 +341,10 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         let(:comparison_response) do
           fixture("github", "commit_compare_diverged.json")
         end
-        it { is_expected.to be_nil }
+
+        it "updates to the latest version" do
+          expect(subject).to eq(Gem::Version.new("1.1.0"))
+        end
       end
 
       context "when the specified ref is included in the latest release" do

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -413,7 +413,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
             source: {
               type: "git",
               url: "https://github.com/actions/setup-node",
-              ref: "v1.1",
+              ref: "5273d0df9c603edc4284ac8402cf650b4f1f6686",
               branch: nil
             },
             metadata: { declaration_string: "actions/setup-node@master" }


### PR DESCRIPTION
The established wisdom for versioning actions is to syn major version
tags to the most recent corresponding release/tag (eg. v2 == v2.2.3).
However, there doesn't seem to be any recommendations for versioning via
commit SHA.

This commit makes the assumption that we should look up the _version_ of
diverged commits and make the update based on the version rather than
the commit. Until now, we've been bailing when commits have diverged
(aka no longer exist as part of a branch's lineage).