### PR TITLE
Make failures in Bundler 1 native helper specs actually fail CI

### DIFF
--- a/bundler/helpers/v1/Gemfile
+++ b/bundler/helpers/v1/Gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 # NOTE: Used to run native helper specs
 group :test do
-  gem "debug", ">= 1.0.0"
   gem "rspec", "~> 3.8"
   gem "rspec-its", "~> 1.2"
   gem "vcr", "6.1.0"

--- a/bundler/helpers/v1/spec/native_spec_helper.rb
+++ b/bundler/helpers/v1/spec/native_spec_helper.rb
@@ -2,7 +2,6 @@
 
 require "rspec/its"
 require "webmock/rspec"
-require "debug"
 require "tmpdir"
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))

--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -6,14 +6,15 @@ bundle install
 bundle exec rubocop .
 bundle exec rspec spec
 
+# NOTE: Don't use `if` branches without `else` part, since the code in some of
+# then seems to not abort the script regardless of `set -e`
+
 if [[ "$SUITE_NAME" == "bundler1" ]]; then
   cd helpers/v1 \
     && BUNDLER_VERSION=1.17.3 bundle install \
     && BUNDLER_VERSION=1.17.3 bundle exec rspec spec\
     && cd -
-fi
-
-if [[ "$SUITE_NAME" == "bundler2" ]]; then
+else
   cd helpers/v2 \
     && bundle install \
     && bundle exec rspec spec \


### PR DESCRIPTION
This is a fun one.

Consider the following script

```bash
#!/bin/bash

set -e

true

if [[ "$SUITE_NAME" == "bundler1" ]]; then
  cd helpers/v1 \
    && false \
    && cd -
fi

if [[ "$SUITE_NAME" == "bundler2" ]]; then
  cd helpers/v2 \
    && false \
    && cd -
fi
```

Believe or not, this is what you get when you run it

```
$ SUITE_NAME=bundler1 ./script/ci-test-dummy; echo $?
=> 0

$ SUITE_NAME=bundler2 ./script/ci-test-dummy; echo $?
=> 1
```

You can read more about here here:
http://mywiki.wooledge.org/BashFAQ/105, but the conclusion is that `set
-e` is brittle.

Yet I think adding `|| exit 1` to all commands is painful.

As an alternative, I added a full if-else construct that works as expected, with a note on top. I'm not fully sold on this solution, but it's simple and it also lets the script default to Bundler 2 when run without `SUITE_NAME` set, which seems handy.