### PR TITLE
Run shellcheck on all native helper build scripts

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -6,6 +6,7 @@ shellcheck \
   ./bin/ci-test \
   ./bin/docker-dev-shell \
   ./bin/lint \
+  ./*/helpers/*/build \
   ./*/helpers/build \
   ./*/script/* \
   "$@"

--- a/bundler/helpers/v1/build
+++ b/bundler/helpers/v1/build
@@ -2,13 +2,13 @@
 
 set -e
 
-if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
   echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/bundler/v1"
-mkdir -p $install_dir
+mkdir -p "$install_dir"
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \

--- a/bundler/helpers/v2/build
+++ b/bundler/helpers/v2/build
@@ -2,13 +2,13 @@
 
 set -e
 
-if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
   echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/bundler/v2"
-mkdir -p $install_dir
+mkdir -p "$install_dir"
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \

--- a/composer/helpers/v1/build
+++ b/composer/helpers/v1/build
@@ -2,13 +2,13 @@
 
 set -e
 
-if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
   echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/composer/v1"
-mkdir -p $install_dir
+mkdir -p "$install_dir"
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \

--- a/composer/helpers/v2/build
+++ b/composer/helpers/v2/build
@@ -2,13 +2,13 @@
 
 set -e
 
-if [ -z $DEPENDABOT_NATIVE_HELPERS_PATH ]; then
+if [ -z "$DEPENDABOT_NATIVE_HELPERS_PATH" ]; then
   echo "Unable to build, DEPENDABOT_NATIVE_HELPERS_PATH is not set"
   exit 1
 fi
 
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/composer/v2"
-mkdir -p $install_dir
+mkdir -p "$install_dir"
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \


### PR DESCRIPTION
It was not being run for Bundler and Composer due to having a slightly different structure.