### PR TITLE
Option to install gems for only target ecosystem in dev shell

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -41,7 +41,7 @@ RUN GREEN='\033[0;32m'; NC='\033[0m'; \
   for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
     -not -path "${CODE_DIR}/common/Gemfile" \
     -name 'Gemfile' | xargs dirname`; do \
-    if [ -z $TARGET_ECOSYSTEM ] || [ "$d" = "${CODE_DIR}/$TARGET_ECOSYSTEM" ]; then \
+    if [ -z "$TARGET_ECOSYSTEM" ] || [ "$d" = "${CODE_DIR}/$TARGET_ECOSYSTEM" ]; then \
       echo && \
       echo "---------------------------------------------------------------------------" && \
       echo "Installing gems for ${GREEN}$(realpath --relative-to=${CODE_DIR} $d)${NC}..." && \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -36,15 +36,18 @@ COPY --chown=dependabot:dependabot nuget/Gemfile nuget/dependabot-nuget.gemspec 
 COPY --chown=dependabot:dependabot python/Gemfile python/dependabot-python.gemspec ${CODE_DIR}/python/
 COPY --chown=dependabot:dependabot pub/Gemfile pub/dependabot-pub.gemspec ${CODE_DIR}/pub/
 COPY --chown=dependabot:dependabot terraform/Gemfile terraform/dependabot-terraform.gemspec ${CODE_DIR}/terraform/
+ARG TARGET_ECOSYSTEM=
 RUN GREEN='\033[0;32m'; NC='\033[0m'; \
   for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
     -not -path "${CODE_DIR}/common/Gemfile" \
     -name 'Gemfile' | xargs dirname`; do \
-    echo && \
-    echo "---------------------------------------------------------------------------" && \
-    echo "Installing gems for ${GREEN}$(realpath --relative-to=${CODE_DIR} $d)${NC}..." && \
-    echo "---------------------------------------------------------------------------" && \
-    cd $d && bundle install; \
+    if [ -z $TARGET_ECOSYSTEM ] || [ "$d" = "${CODE_DIR}/$TARGET_ECOSYSTEM" ]; then \
+      echo && \
+      echo "---------------------------------------------------------------------------" && \
+      echo "Installing gems for ${GREEN}$(realpath --relative-to=${CODE_DIR} $d)${NC}..." && \
+      echo "---------------------------------------------------------------------------" && \
+      cd $d && bundle install; \
+    fi; \
   done
 
 COPY --chown=dependabot:dependabot omnibus/Gemfile omnibus/dependabot-omnibus.gemspec ${CODE_DIR}/omnibus/

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -53,7 +53,11 @@ build_image() {
     --cache-from "dependabot/dependabot-core:latest" \
     -t dependabot/dependabot-core .
   echo "$(tput setaf 2)=> building image from $DOCKERFILE$(tput sgr0)"
-  docker build --build-arg BUILDKIT_INLINE_CACHE=1 -t "$IMAGE_NAME" -f "$DOCKERFILE" .
+  docker build \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --build-arg "TARGET_ECOSYSTEM=${TARGET_ECOSYSTEM}" \
+    -t "$IMAGE_NAME" \
+    -f "$DOCKERFILE" .
 }
 
 IMAGE_ID=$(docker inspect --type=image -f '{{.Id}}' "$IMAGE_NAME" 2> /dev/null || true)


### PR DESCRIPTION
This speeds up build time of the dev shell if you only need to work with a particular ecosystem. Installing gems for all ecosystems takes a long time so this flag allows you to only install them for a particular ecosystem. You'll be able to dry-run/test the target ecosystem but you'll need to rebuild or manually install gems to work with others.

```
TARGET_ECOSYSTEM=go_modules ./bin/docker-dev-shell --rebuild
```

My bash skills are a bit rusty so open to any tips on improving this as well!