### PR TITLE
Optional options arg for FileFetcher

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -489,7 +489,8 @@ $repo_contents_path = File.expand_path(File.join("tmp", $repo_name.split("/"))) 
 fetcher_args = {
   source: $source,
   credentials: $options[:credentials],
-  repo_contents_path: $repo_contents_path
+  repo_contents_path: $repo_contents_path,
+  options: $options[:updater_options]
 }
 $config_file = begin
   cfg_file = Dependabot::Config::FileFetcher.new(**fetcher_args).config_file

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -15,7 +15,7 @@ require "dependabot/shared_helpers"
 module Dependabot
   module FileFetchers
     class Base
-      attr_reader :source, :credentials, :repo_contents_path
+      attr_reader :source, :credentials, :repo_contents_path, :options
 
       CLIENT_NOT_FOUND_ERRORS = [
         Octokit::NotFound,
@@ -42,11 +42,14 @@ module Dependabot
       # If provided, file _data_ will be loaded from the clone.
       # Submodules and directory listings are _not_ currently supported
       # by repo_contents_path and still use an API trip.
-      def initialize(source:, credentials:, repo_contents_path: nil)
+      #
+      # options supports custom feature enablement
+      def initialize(source:, credentials:, repo_contents_path: nil, options: {})
         @source = source
         @credentials = credentials
         @repo_contents_path = repo_contents_path
         @linked_paths = {}
+        @options = options
       end
 
       def repo


### PR DESCRIPTION
Originally introduced by @brendandburns in
https://github.com/dependabot/dependabot-core/pull/5348,

This allows our FileFetcher to accept an optional `options` hash, that
we can use for feature-flagging, like we do in the
FileUpdater/UpdateChecker etc.

This does not make use of the functionality yet, but it will enable us
to start passing the argument in our internal systems.

No tests are added or changed, because right now the behavior is not
altered, as long as the existing tests keep working, we're good!