### PR TITLE
DRY up CI workflow and make it easier to run locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,56 +20,40 @@ jobs:
       fail-fast: false
       matrix:
         suite:
-          - { path: bundler, name: bundler1 }
-          - { path: bundler, name: bundler2 }
-          - { path: cargo, name: cargo }
-          - { path: common, name: common }
-          - { path: composer, name: composer }
-          - { path: docker, name: docker }
-          - { path: elm, name: elm }
-          - { path: git_submodules, name: git_submodules }
-          - { path: github_actions, name: github_actions }
-          - { path: go_modules, name: go_modules }
-          - { path: gradle, name: gradle }
-          - { path: hex, name: hex }
-          - { path: maven, name: maven }
-          - { path: npm_and_yarn, name: npm_and_yarn }
-          - { path: nuget, name: nuget }
-          - { path: omnibus, name: omnibus }
-          - { path: python, name: python }
-          - { path: python, name: python_slow }
-          - { path: pub, name: pub }
-          - { path: terraform, name: terraform }
+          - bundler1
+          - bundler2
+          - cargo
+          - common
+          - composer
+          - docker
+          - elm
+          - git_submodules
+          - github_actions
+          - go_modules
+          - gradle
+          - hex
+          - maven
+          - npm_and_yarn
+          - nuget
+          - omnibus
+          - python
+          - python_slow
+          - pub
+          - terraform
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Build dependabot-core image
-        env:
-          DOCKER_BUILDKIT: 1
         run: |
-          docker build \
-            -t "dependabot/dependabot-core:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from ghcr.io/dependabot/dependabot-core \
-            .
+          ./bin/ci-test build-core
       - name: Build dependabot-core-ci image
-        env:
-          DOCKER_BUILDKIT: 1
         run: |
-          docker build \
-            -f Dockerfile.ci \
-            -t "dependabot-core-ci:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            .
+          ./bin/ci-test build-core-ci
       - name: Run ${{ matrix.suite.name }} tests
+        env:
+          LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker run \
-            --env "CI=true" \
-            --env "RAISE_ON_WARNINGS=true" \
-            --env "DEPENDABOT_TEST_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }}" \
-            --env "SUITE_NAME=${{ matrix.suite.name }}" \
-            --rm dependabot-core-ci bash -c \
-            "cd /home/dependabot/dependabot-core/${{ matrix.suite.path }} && ./script/ci-test"
+          ./bin/ci-test run-suite ${{ matrix.suite }}
 
   lint:
     name: Lint

--- a/bin/ci-test
+++ b/bin/ci-test
@@ -1,12 +1,11 @@
 #!/bin/bash -e
-#/ usage: ci-test SUITE
-#/ simulate the process followed by ~/.github/workflows/ci.yml
+#/ usage: ci-test build-core|build-core-ci|<SUITE>|run-suite <SUITE>
 
 function print_usage() {
   grep ^#/ "$0" | cut -c4-
 }
 
-function handle_args() {
+function handle_suite_args() {
   export SUITE=$1
   case $SUITE in
     bundler1 | bundler2)
@@ -34,27 +33,72 @@ function handle_args() {
   fi
 }
 
-function build() {
-  export DOCKER_BUILDKIT=1
-  export DOCKER_SCAN_SUGGEST=false
-  export CORE=dependabot/dependabot-core
-  export CI=dependabot/dependabot-core-ci
-
+function build_core() {
   set -x
-  docker build -qt $CORE .
-  docker build -qt $CI -f Dockerfile.ci .
-  docker run --rm \
-    -e "CI=true" \
-    -e "SUITE_NAME=$SUITE" \
-    -e "DEPENDABOT_TEST_ACCESS_TOKEN=${LOCAL_GITHUB_ACCESS_TOKEN}" \
-    -it $CI \
-    bash -c \
+
+  docker build \
+    -t "dependabot/dependabot-core:latest" \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --cache-from ghcr.io/dependabot/dependabot-core \
+    .
+}
+
+function build_core_ci() {
+  set -x
+
+  docker build \
+    -f Dockerfile.ci \
+    -t "dependabot-core-ci:latest" \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
+    .
+}
+
+function build() {
+  build_core
+  build_core_ci
+  run_suite
+}
+
+function run_suite() {
+  set -x
+
+  test -t 1 && USE_TTY="-it"
+
+  docker run $USE_TTY \
+    --env "CI=true" \
+    --env "RAISE_ON_WARNINGS=true" \
+    --env "DEPENDABOT_TEST_ACCESS_TOKEN=${LOCAL_GITHUB_ACCESS_TOKEN}" \
+    --env "SUITE_NAME=$SUITE" \
+    --rm dependabot-core-ci bash -c \
     "cd /home/dependabot/dependabot-core/$MODULE && ./script/ci-test"
 }
 
 function main() {
-  handle_args "$@"
-  build
+  export DOCKER_BUILDKIT=1
+  export DOCKER_SCAN_SUGGEST=false
+
+  TASK=$1
+
+  if shift; then
+    case $TASK in
+      build-core)
+        build_core
+        ;;
+      build-core-ci)
+        build_core_ci
+        ;;
+      run-suite)
+        handle_suite_args "$@"
+        run_suite
+        ;;
+      *)
+        handle_suite_args "$@"
+        build
+    esac
+  else
+    print_usage
+    exit 1
+  fi
 }
 
 main "$@"

--- a/bin/ci-test
+++ b/bin/ci-test
@@ -12,6 +12,9 @@ function handle_args() {
     bundler1 | bundler2)
       export MODULE=bundler
       ;;
+    python | python_slow)
+      export MODULE=python
+      ;;
     "")
       print_usage
       exit 1


### PR DESCRIPTION
Whenever I get to a new repository, one of the first things I check is the GitHub workflows files, since that gives me a nice hint of what I need to run locally to get my PRs green.

And that's what I did in this project, but since everything is docker based, it's a bit painful to copy-paste all those docker commands spread across multiple lines.

Until I found `bin/ci-test`!

So this change makes it so that CI configuration can reuse `bin/ci-test`, making `bin/ci-test` more discoverable I believe.

Also I maintained backwards compatibility with the previous way of running the script (build + run one suite), since that's useful too and I don't want to break anybody's workflow.

Note that building images with this script does not really work on M1, but that was also the case before. The same handling of `TARGET_PLATFORM` that `bin/docker-dev-shell` does needs to be added here. But I'll leave that for another time!