### PR TITLE
Adds a TODO and more detailed comment about python 3.6 support

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -1,5 +1,5 @@
-pip>=21.3.1,<22.2.3  # Allow earlier versions to retain python 3.6 support
-pip-tools>=6.4.0,<6.8.1  # Allow earlier versions to retain python 3.6 support
+pip>=21.3.1,<22.2.3  # Range maintains py36 support TODO: Review python 3.6 support in April 2023 (eol ubuntu 18.04)
+pip-tools>=6.4.0,<6.8.1  # Range maintains py36 support TODO: Review python 3.6 support in April 2023 (eol ubuntu 18.04)
 flake8==5.0.4
 hashin==0.17.0
 pipenv==2022.4.8


### PR DESCRIPTION
As per the discussion on this [abandoned PR](https://github.com/dependabot/dependabot-core/pull/5506) this documents our intention to review python 3.6 support once Ubuntu 18.04 is EoL in April 2023.
