### PR TITLE
Share omnibus gems with all projects to reduce install time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,9 +77,7 @@ ARG BUNDLER_V1_VERSION=1.17.3
 ARG BUNDLER_V2_VERSION=2.3.14
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
 # Allow gem installs as the dependabot user
-ENV BUNDLE_PATH=".bundle" \
-    BUNDLE_BIN=".bundle/bin"
-ENV PATH="$BUNDLE_BIN:$PATH:$BUNDLE_PATH/bin"
+ENV BUNDLE_PATH=".bundle"
 
 # Install Ruby, update RubyGems, and install Bundler
 RUN mkdir -p /tmp/ruby-install \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -16,9 +16,6 @@ ARG CODE_DIR=${HOME}/dependabot-core
 
 COPY --chown=dependabot:dependabot common/Gemfile common/dependabot-common.gemspec ${CODE_DIR}/common/
 COPY --chown=dependabot:dependabot common/lib/dependabot/version.rb ${CODE_DIR}/common/lib/dependabot/
-WORKDIR ${CODE_DIR}
-RUN cd common \
-  && bundle install
 
 COPY --chown=dependabot:dependabot bundler/Gemfile bundler/dependabot-bundler.gemspec ${CODE_DIR}/bundler/
 COPY --chown=dependabot:dependabot cargo/Gemfile cargo/dependabot-cargo.gemspec ${CODE_DIR}/cargo/
@@ -36,22 +33,29 @@ COPY --chown=dependabot:dependabot nuget/Gemfile nuget/dependabot-nuget.gemspec 
 COPY --chown=dependabot:dependabot python/Gemfile python/dependabot-python.gemspec ${CODE_DIR}/python/
 COPY --chown=dependabot:dependabot pub/Gemfile pub/dependabot-pub.gemspec ${CODE_DIR}/pub/
 COPY --chown=dependabot:dependabot terraform/Gemfile terraform/dependabot-terraform.gemspec ${CODE_DIR}/terraform/
+
+COPY --chown=dependabot:dependabot omnibus/Gemfile omnibus/dependabot-omnibus.gemspec ${CODE_DIR}/omnibus/
+WORKDIR ${CODE_DIR}
+
+RUN cd omnibus \
+  && bundle install
+# Make omnibus gems available to bundler in root directory
+RUN echo 'eval_gemfile File.join(File.dirname(__FILE__), "omnibus/Gemfile")' > Gemfile
+
+RUN cd common \
+  && bundle config path ${CODE_DIR}/omnibus/.bundle
+
 RUN GREEN='\033[0;32m'; NC='\033[0m'; \
   for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
     -not -path "${CODE_DIR}/common/Gemfile" \
+    -not -path "${CODE_DIR}/omnibus/Gemfile" \
     -name 'Gemfile' | xargs dirname`; do \
     echo && \
     echo "---------------------------------------------------------------------------" && \
     echo "Installing gems for ${GREEN}$(realpath --relative-to=${CODE_DIR} $d)${NC}..." && \
     echo "---------------------------------------------------------------------------" && \
-    cd $d && bundle install; \
+    cd $d && bundle config path ${CODE_DIR}/omnibus/.bundle; \
   done
-
-COPY --chown=dependabot:dependabot omnibus/Gemfile omnibus/dependabot-omnibus.gemspec ${CODE_DIR}/omnibus/
-RUN cd omnibus \
-  && bundle install
-# Make omnibus gems available to bundler in root directory
-RUN echo 'eval_gemfile File.join(File.dirname(__FILE__), "omnibus/Gemfile")' > Gemfile
 
 # Create directory for volume containing VS Code extensions, to avoid reinstalling on image rebuilds
 RUN mkdir -p ~/.vscode-server ~/.vscode-server-insiders


### PR DESCRIPTION
Similar to https://github.com/dependabot/dependabot-core/pull/5528/files but re-using the omnibus gems instead of common to make sure we have the full set.

A few issues/changes I've noticed:
- Due to the path change I need to `bundle exec rspec` in a dir rather than being able to just run `rspec`.
-  Rspec didn't work on the first try and complained of
```
Could not find gem 'rubocop (~> 1.33.0)' in locally installed gems.

The source contains the following gems matching 'rubocop':
  * rubocop-1.35.0
```
A `bundle install` resulted `Installing rubocop 1.33.0` which cleared up the issue.