### PR TITLE
Update workflows to support multi architecture image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: docker/build-push-action@v3.1.1
         with:
           load: true
-          cache-from: type=registry,ref=dependabot/dependabot-core:latest
+          cache-from: type=registry,ref=ghcr.io/dependabot/dependabot-core:latest
           tags: dependabot/dependabot-core:latest
       - name: Build dependabot-core-ci image
         uses: docker/build-push-action@v3.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   push:
     branches:
@@ -60,24 +61,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.0.0
       - name: Build dependabot-core image
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -t "dependabot/dependabot-core:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from ghcr.io/dependabot/dependabot-core \
-            .
+        uses: docker/build-push-action@v3.1.1
+        with:
+          load: true
+          cache-from: type=registry,ref=dependabot/dependabot-core:latest
+          tags: dependabot/dependabot-core:latest
       - name: Build dependabot-core-ci image
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -f Dockerfile.ci \
-            -t "dependabot-core-ci:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            .
+        uses: docker/build-push-action@v3.1.1
+        with:
+          load: true
+          file: Dockerfile.ci
+          tags: dependabot-core-ci:latest
       - name: Run ${{ matrix.suite.name }} tests
         run: |
           docker run \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,12 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm64
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -40,14 +46,15 @@ jobs:
           tags: |
             type=raw,value=latest
             type=semver,pattern={{version}}
-      - name: Build and push dependabot-core image
+      - name: Build and push ${{ matrix.arch }} dependabot-core image
         uses: docker/build-push-action@v3.1.1
         with:
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.arch }}
           cache-from: type=registry,ref=dependabot/dependabot-core:latest
           cache-to: type=inline
           tags: ${{ steps.tags.outputs.tags }}
+
   push-development-image:
     name: Push dependabot-core-development image to GHCR
     runs-on: ubuntu-latest
@@ -76,12 +83,12 @@ jobs:
           tags: |
             type=raw,value=latest
             type=semver,pattern={{version}}
-      - name: Build dependabot-core image
+      - name: Build and push ${{ matrix.arch }} dependabot-core-development image
         uses: docker/build-push-action@v3.1.1
         with:
           push: true
           file: Dockerfile.development
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.arch }}
           cache-from: type=registry,ref=ghcr.io/dependabot/dependabot-core-development:latest
           cache-to: type=inline
           tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,12 @@
 name: Push docker images
-env:
-  BASE_IMAGE: "ubuntu:20.04"
-  CORE_IMAGE: "dependabot/dependabot-core"
-  CORE_IMAGE_MIRROR: "ghcr.io/dependabot/dependabot-core"
+
 on:
   push:
     branches:
       - main
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
+
 jobs:
   push-core-image:
     name: Push dependabot-core image to docker hub
@@ -20,35 +18,36 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Build dependabot-core image
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -t "$CORE_IMAGE:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from "$BASE_IMAGE" \
-            --cache-from "$CORE_IMAGE:latest" \
-            .
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.0.0
       - name: Log in to the Docker registry
         run: |
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Log in to GHCR
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Push latest image
-        run: |
-          docker push "$CORE_IMAGE:latest"
-          docker tag "$CORE_IMAGE:latest" "$CORE_IMAGE_MIRROR:latest"
-          docker push "$CORE_IMAGE_MIRROR:latest"
-      - name: Push tagged image
-        if: "contains(github.ref, 'refs/tags')"
-        run: |
-          VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)"
-          docker tag "$CORE_IMAGE:latest" "$CORE_IMAGE:$VERSION"
-          docker push "$CORE_IMAGE:$VERSION"
-          docker tag "$CORE_IMAGE:latest" "$CORE_IMAGE_MIRROR:$VERSION"
-          docker push "$CORE_IMAGE_MIRROR:$VERSION"
+      - name: Docker tags
+        id: tags
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            dependabot/dependabot-core
+            ghcr.io/dependabot/dependabot-core
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+      - name: Build and push dependabot-core image
+        uses: docker/build-push-action@v3.1.1
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=registry,ref=dependabot/dependabot-core:latest
+          cache-to: type=inline
+          tags: ${{ steps.tags.outputs.tags }}
   push-development-image:
     name: Push dependabot-core-development image to GHCR
     runs-on: ubuntu-latest
@@ -56,31 +55,33 @@ jobs:
       contents: read
       packages: write
     needs: push-core-image
-    env:
-      DEV_IMAGE: ghcr.io/dependabot/dependabot-core-development
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Build dependabot-core image
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -t "$DEV_IMAGE:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from "$BASE_IMAGE" \
-            --cache-from "$CORE_IMAGE:latest" \
-            --cache-from "$DEV_IMAGE:latest" \
-            -f Dockerfile.development .
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.0.0
       - name: Log in to GHCR
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Push latest image
-        run: |
-          docker push "$DEV_IMAGE:latest"
-      - name: Push tagged image
-        if: "contains(github.ref, 'refs/tags')"
-        run: |
-          VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)"
-          docker tag "$DEV_IMAGE:latest" "$DEV_IMAGE:$VERSION"
-          docker push "$DEV_IMAGE:$VERSION"
+      - name: Docker tags
+        id: tags
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/dependabot/dependabot-core-development
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+      - name: Build dependabot-core image
+        uses: docker/build-push-action@v3.1.1
+        with:
+          push: true
+          file: Dockerfile.development
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=registry,ref=ghcr.io/dependabot/dependabot-core-development:latest
+          cache-to: type=inline
+          tags: ${{ steps.tags.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -127,8 +127,7 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
 # - https://github.com/elm/compiler/issues/2007
 # - https://github.com/elm/compiler/issues/2232
 ENV PATH="$PATH:/node_modules/.bin"
-RUN [ "$TARGETARCH" != "amd64" ] \
-  || (curl -sSLfO "https://github.com/elm/compiler/releases/download/0.19.0/binaries-for-linux.tar.gz" \
+RUN [ "${TARGETARCH:-amd64}" != "amd64" ] || (curl -sSLfO "https://github.com/elm/compiler/releases/download/0.19.0/binaries-for-linux.tar.gz" \
   && tar xzf binaries-for-linux.tar.gz \
   && mv elm /usr/local/bin/elm19 \
   && rm -f binaries-for-linux.tar.gz)
@@ -193,7 +192,8 @@ ARG GOLANG_AMD64_CHECKSUM=464b6b66591f6cf055bc5df90a9750bf5fbc9d038722bb84a9d56a
 ARG GOLANG_ARM64_CHECKSUM=efa97fac9574fc6ef6c9ff3e3758fb85f1439b046573bf434cccb5e012bd00c8
 
 ENV PATH=/opt/go/bin:$PATH
-RUN cd /tmp \
+RUN export TARGETARCH=${TARGETARCH:-amd64}; \
+  cd /tmp \
   && curl --http1.1 -o go-${TARGETARCH}.tar.gz https://dl.google.com/go/go${GOLANG_VERSION}.linux-${TARGETARCH}.tar.gz \
   && printf "$GOLANG_AMD64_CHECKSUM go-amd64.tar.gz\n$GOLANG_ARM64_CHECKSUM go-arm64.tar.gz\n" | sha256sum -c --ignore-missing - \
   && tar -xzf go-${TARGETARCH}.tar.gz -C /opt \
@@ -237,7 +237,8 @@ USER root
 ARG TERRAFORM_VERSION=1.2.3
 ARG TERRAFORM_AMD64_CHECKSUM=728b6fbcb288ad1b7b6590585410a98d3b7e05efe4601ef776c37e15e9a83a96
 ARG TERRAFORM_ARM64_CHECKSUM=a48991e938a25bfe5d257f4b6cbbdc73d920cc34bbc8f0e685e28b9610ad75fe
-RUN cd /tmp \
+RUN export TARGETARCH=${TARGETARCH:-amd64}; \
+  cd /tmp \
   && curl -o terraform-${TARGETARCH}.tar.gz https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip \
   && printf "$TERRAFORM_AMD64_CHECKSUM terraform-amd64.tar.gz\n$TERRAFORM_ARM64_CHECKSUM terraform-arm64.tar.gz\n" | sha256sum -c --ignore-missing - \
   && unzip -d /usr/local/bin terraform-${TARGETARCH}.tar.gz \
@@ -251,7 +252,8 @@ ENV PUB_CACHE=/opt/dart/pub-cache \
   PATH="${PATH}:/opt/dart/dart-sdk/bin"
 
 ARG DART_VERSION=2.17.0
-RUN DART_ARCH=${TARGETARCH} \
+RUN export TARGETARCH=${TARGETARCH:-amd64}; \
+  DART_ARCH=${TARGETARCH} \
   && if [ "$TARGETARCH" = "amd64" ]; then DART_ARCH=x64; fi \
   && curl --connect-timeout 15 --retry 5 "https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/dartsdk-linux-${DART_ARCH}-release.zip" > "/tmp/dart-sdk.zip" \
   && mkdir -p "$PUB_CACHE" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -294,8 +294,11 @@ ENV HOME="/home/dependabot"
 WORKDIR ${HOME}
 
 # Place a git shim ahead of git on the path to rewrite git arguments to use HTTPS.
-ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-amd64.tar.gz"
-RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
+RUN export TARGETARCH=${TARGETARCH:-amd64}; \
+  curl -sL "https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-${TARGETARCH}.tar.gz" -o git-shim.tar.gz \
+  && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin \
+  && rm git-shim.tar.gz
+
 ENV PATH="$HOME/bin:$PATH"
 # Configure cargo to use git CLI so the above takes effect
 RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo/config.toml


### PR DESCRIPTION
Implements: https://github.com/dependabot/dependabot-core/issues/5037

This pr updates workflows to support multi-arch docker image builds.

This is done by adding https://github.com/docker/build-push-action github action to build images.

This pr implements following changes:

* Use [buildx](https://github.com/docker/buildx#building-multi-platform-images) with QEMU to build multi-arch images. Benefit of this approach is minimal modifications to Dockerfile. Downside is increased build time since emulation is not very fast.
* Build ci docker image once and pass it to test jobs as an artifact. It can potentially reduce flakiness as I observed that docker build can sometimes fail when fetching dependencies etc.

Since we can't fully test this workflow in scope of pull request, I ran a few builds in my fork. Full time of core image build takes around 2h when no cache is present: https://github.com/andrcuns/dependabot-core/runs/7818717934?check_suite_focus=true. It produces correct images for both architectures: https://github.com/andrcuns/dependabot-core/pkgs/container/dependabot-core. I have also tried to build another image using dependabot-core as base and it seems to work correctly on M1 macbook now.

Some potential follow ups to improve build speeds:

* Switch from inline cache to [github](https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api) cache. This also allows to use `max` cache mode which is useful for multi-stage dockerfiles. It will also add branch scoped caches so changes in pr's would be cached properly instead of always fetching inline cache from latest published image.
* Split dockerfile in multiple stages. It should improve caching since update in some of the first instructions wouldn't invalidate whole Dockerfile cache. Though change is less trivial for some of the ecosystems since they also install system packages and it's not possible to simply copy produced executable from the separate stage. But I believe there was a closed pr which already attempted to split the core image in to multiple dockerfiles, it could be useful to use as a base