### PR TITLE
The new pip resolver is not backwards compatible

### DIFF
--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -31,7 +31,6 @@ module Dependabot
         NATIVE_COMPILATION_ERROR =
           "pip._internal.exceptions.InstallationSubprocessError: Command errored out with exit status 1:"
         # See https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata
-        UNPINNED_SETUPTOOLS = "ModuleNotFoundError: No module named 'distutils.msvccompiler'"
         PYTHON_PACKAGE_NAME_REGEX = /[A-Za-z0-9_\-]+/.freeze
         RESOLUTION_IMPOSSIBLE_ERROR = "ResolutionImpossible"
         ERROR_REGEX = /(?<=ERROR\:\W).*$/.freeze
@@ -107,7 +106,7 @@ module Dependabot
         end
 
         def compilation_error?(error)
-          error.message.include?(NATIVE_COMPILATION_ERROR) || error.message.include?(UNPINNED_SETUPTOOLS)
+          error.message.include?(NATIVE_COMPILATION_ERROR)
         end
 
         # rubocop:disable Metrics/AbcSize

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -216,7 +216,7 @@ module Dependabot
         end
 
         def new_resolver_supported?
-          python_version.to_s.start_with?("3.6")
+          !python_version.to_s.start_with?("3.6")
         end
 
         def pip_compile_options(filename)

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -109,10 +109,6 @@ module Dependabot
           error.message.include?(NATIVE_COMPILATION_ERROR)
         end
 
-        def unknown_option_error?(error)
-          error.message.include?(UNKNOWN_OPTION_ERROR)
-        end
-
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/PerceivedComplexity
         def handle_pip_compile_errors(error)
@@ -219,7 +215,7 @@ module Dependabot
           )
         end
 
-        def backwards_compat?
+        def new_resolver_supported?
           python_version.to_s.start_with?("3.6")
         end
 
@@ -227,7 +223,7 @@ module Dependabot
           options = @build_isolation ? ["--build-isolation"] : ["--no-build-isolation"]
           options += pip_compile_index_options
           options += ["--allow-unsafe"]
-          options += ["--resolver backtracking"] unless backwards_compat?
+          options += ["--resolver backtracking"] if new_resolver_supported?
 
           if (requirements_file = compiled_file_for_filename(filename))
             options << "--output-file=#{requirements_file.name}"

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -31,6 +31,7 @@ module Dependabot
         NATIVE_COMPILATION_ERROR =
           "pip._internal.exceptions.InstallationSubprocessError: Command errored out with exit status 1:"
         # See https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata
+        UNPINNED_SETUPTOOLS = "ModuleNotFoundError: No module named 'distutils.msvccompiler'"
         PYTHON_PACKAGE_NAME_REGEX = /[A-Za-z0-9_\-]+/.freeze
         RESOLUTION_IMPOSSIBLE_ERROR = "ResolutionImpossible"
         ERROR_REGEX = /(?<=ERROR\:\W).*$/.freeze
@@ -106,7 +107,7 @@ module Dependabot
         end
 
         def compilation_error?(error)
-          error.message.include?(NATIVE_COMPILATION_ERROR)
+          error.message.include?(NATIVE_COMPILATION_ERROR) || error.message.include?(UNPINNED_SETUPTOOLS)
         end
 
         # rubocop:disable Metrics/AbcSize

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -216,7 +216,7 @@ module Dependabot
         end
 
         def new_resolver_supported?
-          !python_version.to_s.start_with?("3.6")
+          python_version >= Python::Version.new("3.7")
         end
 
         def pip_compile_options(filename)


### PR DESCRIPTION
Fixes #5405

Adding error handling and a retry if the pip-compile is not new enough to have the --resolver argument.