### PR TITLE
Add more helpful error messaging when a vulnerable dependency cannot be upgraded

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -105,8 +105,7 @@ module Dependabot
         )
 
         vulnerable = vulnerability_audit.select do |v|
-          v["fix_available"] == false &&
-            v["explanation"]
+          !v["fix_available"] && v["explanation"]
         end
 
         conflicts + vulnerable

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -96,13 +96,20 @@ module Dependabot
       end
 
       def conflicting_dependencies
-        ConflictingDependencyResolver.new(
+        conflicts = ConflictingDependencyResolver.new(
           dependency_files: dependency_files,
           credentials: credentials
         ).conflicting_dependencies(
           dependency: dependency,
           target_version: lowest_security_fix_version
         )
+
+        vulnerable = vulnerability_audit.select do |v|
+          v["fix_available"] == false &&
+            v["explanation"]
+        end
+
+        conflicts + vulnerable
       end
 
       private

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -98,8 +98,8 @@ module Dependabot
             when :fix_unavailable, :dependency_still_vulnerable, :downgrades_dependencies
               "No patched version available for #{fix_unavailable['dependency_name']}"
             when :vulnerable_dependency_removed
-              "#{fix_unavailable['dependency_name']} was removed in the update. Dependabot is unable to " \
-                "open a pull request. Please upgrade manually"
+              "#{fix_unavailable['dependency_name']} was removed in the update. Dependabot is not able to " \
+                "deal with this yet, but you can still upgrade manually."
             end
 
           fix_unavailable

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -78,7 +78,8 @@ module Dependabot
 
             validation_result = validate_audit_result(audit_result, security_advisories)
             unless viable_audit_result?(validation_result)
-              return explain_fix_unavailable(validation_result, fix_unavailable)
+              fix_unavailable["explanation"] = explain_fix_unavailable(validation_result, dependency)
+              return fix_unavailable
             end
 
             audit_result
@@ -92,17 +93,14 @@ module Dependabot
 
         attr_reader :dependency_files, :credentials
 
-        def explain_fix_unavailable(validation_result, fix_unavailable)
-          fix_unavailable["explanation"] =
-            case validation_result
-            when :fix_unavailable, :dependency_still_vulnerable, :downgrades_dependencies
-              "No patched version available for #{fix_unavailable['dependency_name']}"
-            when :vulnerable_dependency_removed
-              "#{fix_unavailable['dependency_name']} was removed in the update. Dependabot is not able to " \
-                "deal with this yet, but you can still upgrade manually."
-            end
-
-          fix_unavailable
+        def explain_fix_unavailable(validation_result, dependency)
+          case validation_result
+          when :fix_unavailable, :dependency_still_vulnerable, :downgrades_dependencies
+            "No patched version available for #{dependency.name}"
+          when :vulnerable_dependency_removed
+            "#{dependency.name} was removed in the update. Dependabot is not able to " \
+              "deal with this yet, but you can still upgrade manually."
+          end
         end
 
         def viable_audit_result?(validation_result)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -41,6 +41,7 @@ module Dependabot
         #       dependency on the blocking dependency
         #   * :top_level_ancestors [Array<String>] the names of all top-level dependencies with a transitive
         #     dependency on the dependency
+        #   * :explanation [String] an explanation for why the project failed the vulnerability auditor run
         def audit(dependency:, security_advisories:)
           fix_unavailable = {
             "dependency_name" => dependency.name,
@@ -60,7 +61,7 @@ module Dependabot
             # `npm-shrinkwrap.js`, if present, takes precedence over `package-lock.js`.
             # Both files use the same format. See https://bit.ly/3lDIAJV for more.
             lockfile = (dependency_files_builder.shrinkwraps + dependency_files_builder.package_locks).first
-            return fix_unavailable unless lockfile
+            return explain_fix_unavailable(:no_lockfile, fix_unavailable) unless lockfile
 
             vuln_versions = security_advisories.map do |a|
               {
@@ -74,7 +75,11 @@ module Dependabot
               function: "npm:vulnerabilityAuditor",
               args: [Dir.pwd, vuln_versions]
             )
-            return fix_unavailable unless viable_audit_result?(audit_result, security_advisories)
+
+            validation_result = validate_audit_result(audit_result, security_advisories)
+            unless viable_audit_result?(validation_result)
+              return explain_fix_unavailable(validation_result, fix_unavailable)
+            end
 
             audit_result
           end
@@ -87,8 +92,22 @@ module Dependabot
 
         attr_reader :dependency_files, :credentials
 
-        def viable_audit_result?(audit_result, security_advisories)
-          validation_result = validate_audit_result(audit_result, security_advisories)
+        def explain_fix_unavailable(validation_result, fix_unavailable)
+          fix_unavailable["explanation"] =
+            case validation_result
+            when :no_lockfile
+              "No lockfile detected"
+            when :fix_unavailable, :dependency_still_vulnerable, :downgrades_dependencies
+              "No patched version available for #{fix_unavailable['dependency_name']}"
+            when :vulnerable_dependency_removed
+              "#{fix_unavailable['dependency_name']} was removed in the update. Dependabot is unable to " \
+                "open a pull request. Please upgrade manually"
+            end
+
+          fix_unavailable
+        end
+
+        def viable_audit_result?(validation_result)
           return true if validation_result == :viable
 
           Dependabot.logger.info("VulnerabilityAuditor: audit result not viable: #{validation_result}")

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -61,7 +61,7 @@ module Dependabot
             # `npm-shrinkwrap.js`, if present, takes precedence over `package-lock.js`.
             # Both files use the same format. See https://bit.ly/3lDIAJV for more.
             lockfile = (dependency_files_builder.shrinkwraps + dependency_files_builder.package_locks).first
-            return explain_fix_unavailable(:no_lockfile, fix_unavailable) unless lockfile
+            return fix_unavailable unless lockfile
 
             vuln_versions = security_advisories.map do |a|
               {
@@ -95,8 +95,6 @@ module Dependabot
         def explain_fix_unavailable(validation_result, fix_unavailable)
           fix_unavailable["explanation"] =
             case validation_result
-            when :no_lockfile
-              "No lockfile detected"
             when :fix_unavailable, :dependency_still_vulnerable, :downgrades_dependencies
               "No patched version available for #{fix_unavailable['dependency_name']}"
             when :vulnerable_dependency_removed

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -21,6 +21,7 @@ module Dependabot
           @allow_removal = allow_removal
         end
 
+        # rubocop:disable Metrics/MethodLength
         # Finds any dependencies in the `package-lock.json` or `npm-shrinkwrap.json` that have
         # a subdependency on the given dependency that is locked to a vuln version range.
         #
@@ -88,6 +89,7 @@ module Dependabot
           log_helper_subprocess_failure(dependency, e)
           fix_unavailable
         end
+        # rubocop:enable Metrics/MethodLength
 
         private
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
             to include(
               "fix_available" => false,
               "explanation" => "#{dependency.name} was removed in the update. "\
-                "Dependabot is unable to open a pull request. Please upgrade manually"
+                "Dependabot is not able to deal with this yet, but you can still upgrade manually."
             )
         end
       end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -110,7 +110,11 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
 
           expect(Dependabot.logger).to receive(:info).with(/audit result not viable: vulnerable_dependency_removed/i)
           expect(subject.audit(dependency: dependency, security_advisories: security_advisories)).
-            to include("fix_available" => false)
+            to include(
+              "fix_available" => false,
+              "explanation" => "#{dependency.name} was removed in the update. "\
+                "Dependabot is unable to open a pull request. Please upgrade manually"
+            )
         end
       end
     end
@@ -137,7 +141,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
 
         expect(Dependabot.logger).to receive(:info).with(/audit result not viable: dependency_still_vulnerable/i)
         expect(subject.audit(dependency: dependency, security_advisories: security_advisories)).
-          to include("fix_available" => false)
+          to include(
+            "fix_available" => false,
+            "explanation" => "No patched version available for #{dependency.name}"
+          )
       end
     end
 
@@ -172,7 +179,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
 
         expect(Dependabot.logger).to receive(:info).with(/audit result not viable: downgrades_dependencies/i)
         expect(subject.audit(dependency: dependency, security_advisories: security_advisories)).
-          to include("fix_available" => false)
+          to include(
+            "fix_available" => false,
+            "explanation" => "No patched version available for #{dependency.name}"
+          )
       end
     end
 
@@ -181,7 +191,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
 
       it "returns fix_available => false" do
         expect(subject.audit(dependency: dependency, security_advisories: [])).
-          to include("fix_available" => false)
+          to include(
+            "fix_available" => false,
+            "explanation" => "No lockfile detected"
+          )
       end
     end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -191,10 +191,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
 
       it "returns fix_available => false" do
         expect(subject.audit(dependency: dependency, security_advisories: [])).
-          to include(
-            "fix_available" => false,
-            "explanation" => "No lockfile detected"
-          )
+          to include("fix_available" => false)
       end
     end
 


### PR DESCRIPTION
This PR adds a new method, `#explain_fix_unavailable`, which adds an `explanation` key to the `fix_unavailable` object when the UpdateChecker returns an `update_not_possible` error.

This `explanation` key is also used in the ConflictingDependencies check which is printed out after a failed job run and also shows up in the Dependabot security alert view.

The UpdateChecker should always raise with an `:update_not_possible` by this point since the call from [`#latest_version_resolvable_with_full_unlock?`](https://github.com/dependabot/dependabot-core/blob/7d717862f7c441f3fafd265e516e9f5a26e1c90f/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb#L121) will not have any [`viable audit results`](https://github.com/dependabot/dependabot-core/blob/7d717862f7c441f3fafd265e516e9f5a26e1c90f/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb#L76) and thus no `fix available`