### PR TITLE
fix Python tests

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -1,4 +1,3 @@
-setuptools<65.0.0 # https://github.com/pypa/setuptools/pull/3505
 pip>=21.3.1,<22.2.3  # Range maintains py36 support TODO: Review python 3.6 support in April 2023 (eol ubuntu 18.04)
 pip-tools>=6.4.0,<6.8.1  # Range maintains py36 support TODO: Review python 3.6 support in April 2023 (eol ubuntu 18.04)
 flake8==5.0.4

--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -1,3 +1,4 @@
+setuptools<65.0.0 # https://github.com/pypa/setuptools/pull/3505
 pip>=21.3.1,<22.2.3  # Range maintains py36 support TODO: Review python 3.6 support in April 2023 (eol ubuntu 18.04)
 pip-tools>=6.4.0,<6.8.1  # Range maintains py36 support TODO: Review python 3.6 support in April 2023 (eol ubuntu 18.04)
 flake8==5.0.4

--- a/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe namespace::PipCompileVersionResolver do
         }]
       end
 
-      it "raises a helpful error", :skip => "see https://github.com/pypa/setuptools/pull/3505" do
+      it "raises a helpful error", skip: "see https://github.com/pypa/setuptools/pull/3505" do
         expect { subject }.
           to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
             expect(error.message).

--- a/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pip_compile_version_resolver_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe namespace::PipCompileVersionResolver do
         }]
       end
 
-      it "raises a helpful error", :slow do
+      it "raises a helpful error", :skip => "see https://github.com/pypa/setuptools/pull/3505" do
         expect { subject }.
           to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
             expect(error.message).


### PR DESCRIPTION
We test using numpy and that was recently broken https://github.com/pypa/setuptools/pull/3505

This solution is to pin setuptools to before that PR was released.