### PR TITLE
Try fix spec failure due to broken setuptools

### DIFF
--- a/python/spec/fixtures/projects/unresolvable/requirements.in
+++ b/python/spec/fixtures/projects/unresolvable/requirements.in
@@ -13,7 +13,7 @@ jupyter_nbextensions_configurator
 
 librosa
 numba==0.48
-numpy
+numpy==1.23.2
 
 jax
 matplotlib


### PR DESCRIPTION
Just trying to fix CI, like others 😆

This spec is currently locked to numpy 0.19 which did not yet restrict setuptools version. I tried to make sure it uses the latest numpy which does restrict it. I left requirements.txt untouched because I can't for the love of me regenerate it from the updated requirements.in, since I have no idea what I'm doing it. But this change alone fixed the spec locally, so I may as well try it in CI 🤷.