### PR TITLE
Work around the bad setuptools release

### DIFF
--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -31,6 +31,7 @@ module Dependabot
         NATIVE_COMPILATION_ERROR =
           "pip._internal.exceptions.InstallationSubprocessError: Command errored out with exit status 1:"
         # See https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata
+        UNPINNED_SETUPTOOLS = "ModuleNotFoundError: No module named 'distutils.msvccompiler'"
         PYTHON_PACKAGE_NAME_REGEX = /[A-Za-z0-9_\-]+/.freeze
         RESOLUTION_IMPOSSIBLE_ERROR = "ResolutionImpossible"
         ERROR_REGEX = /(?<=ERROR\:\W).*$/.freeze
@@ -107,7 +108,7 @@ module Dependabot
         end
 
         def compilation_error?(error)
-          error.message.include?(NATIVE_COMPILATION_ERROR)
+          error.message.include?(NATIVE_COMPILATION_ERROR) || error.message.include?(UNPINNED_SETUPTOOLS)
         end
 
         # rubocop:disable Metrics/AbcSize


### PR DESCRIPTION
Setuptools removed some modules https://github.com/pypa/setuptools/pull/3505 which caused a breaking API change which other projects were not expecting, esp numpy.

Due to this, dependabot fails to create PRs if the project is using pip-compile and depends on `numpy<1.3.2`.  If we see an uptick in user complaints, this PR should alleviate the issue.