### PR TITLE
WIP: Surface indirect deps from go.mod for security updates

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -53,7 +53,7 @@ module Dependabot
         Dependency.new(
           name: details["Path"],
           version: version,
-          requirements: details["Indirect"] || dependency_is_replaced(details) ? [] : reqs,
+          requirements: dependency_is_replaced(details) ? [] : reqs,
           package_manager: "go_modules"
         )
       end
@@ -152,7 +152,7 @@ module Dependabot
       end
 
       def skip_dependency?(dep)
-        return true if dep["Indirect"]
+        return true if dep["Indirect"] && !security_update?
 
         begin
           path_uri = URI.parse("https://#{dep['Path']}")
@@ -160,6 +160,11 @@ module Dependabot
         rescue URI::InvalidURIError
           false
         end
+      end
+
+      def security_update?
+        # TODO: Implement this
+        return true
       end
 
       def dependency_is_replaced(details)

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -14,6 +14,8 @@ module Dependabot
 
       def latest_resolvable_version
         # We don't yet support updating indirect dependencies for go_modules
+        # except for security fixes where the indirect dependency is in the
+        # go.mod file.
         #
         # To update indirect dependencies we'll need to promote the indirect
         # dependency to the go.mod file forcing the resolver to pick this


### PR DESCRIPTION
This will allow us to propose updates to vulnerable transitive dependencies.

When the `go.mod` is in a recent format (go 1.17+) we can expect that any transitive dependencies that are used by the project are included in the `go.mod` but labeled as `// indirect`. By surfacing these as dependencies during a security update we can update them like any other dependency.

When the `go.mod` is in an older format, the vulnerable transitive dependency might only be in the `go.sum` file and we won't propose an update. This should become less common over time but we could revisit this in the future if we find that adoption of the newer format isn't widespread.

An alternative to updating the transitive dependency directly would be to look for an update to the parent dependency which requires a fixed version of the transitive dependency. I don't think that's something we currently want to maintain but may adopt in the future if the go tooling provided support for it.

Fix https://github.com/dependabot/dependabot-core/issues/1158