### PR TITLE
Add a fix for when the image tag is the first entry in the array.

### DIFF
--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -163,12 +163,11 @@ module Dependabot
         modified_content = file.content
 
         old_images.each do |old_image|
-          old_image_regex = /^\s+image:\s+#{old_image}(?=\s|$)/
+          old_image_regex = /^\s+(?:-\s)?image:\s+#{old_image}(?=\s|$)/
           modified_content = modified_content.gsub(old_image_regex) do |old_img|
             old_img.gsub(old_image.to_s, new_yaml_image(file).to_s)
           end
         end
-
         modified_content
       end
 

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -582,6 +582,45 @@ RSpec.describe Dependabot::Docker::FileUpdater do
       its(:content) { is_expected.to include "kind: Pod" }
     end
 
+    context "when the image contains a hyphen" do
+      let(:podfile_body) { fixture("kubernetes", "yaml", "hyphen.yaml") }
+      let(:podfile) do
+        Dependabot::DependencyFile.new(
+          content: podfile_body,
+          name: "hyphen.yaml"
+        )
+      end
+      let(:yaml_dependency) do
+        Dependabot::Dependency.new(
+          name: "nginx",
+          version: "1.14.3",
+          previous_version: "1.14.2",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "hyphen.yaml",
+            source: { tag: "1.14.3" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "hyphen.yaml",
+            source: { tag: "1.14.2" }
+          }],
+          package_manager: "kubernetes"
+        )
+      end
+
+      describe "the updated podfile" do
+        subject(:updated_podfile) do
+          updated_files.find { |f| f.name == "hyphen.yaml" }
+        end
+
+        its(:content) { is_expected.to include "  - image: nginx:1.14.3\n    name: nginx" }
+        its(:content) { is_expected.to include "kind: Pod" }
+      end
+    end
+
     context "when multiple identical lines need to be updated" do
       let(:podfile_body) do
         fixture("kubernetes", "yaml", "multiple_identical.yaml")

--- a/docker/spec/fixtures/kubernetes/yaml/hyphen.yaml
+++ b/docker/spec/fixtures/kubernetes/yaml/hyphen.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - image: nginx:1.14.2
+    name: nginx
+    ports:
+    - containerPort: 80


### PR DESCRIPTION
The previous checked in code didn't handle:

```yaml
...
- image: foo
...
```

Add a unit test and fix the updater code.

See https://github.com/brendandburns/arc-prometheus/runs/7919856883?check_suite_focus=true for an example of the bug