### PR TITLE
Properly upgrade github actions pinned to specific commits

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -86,6 +86,10 @@ module Dependabot
       raise Dependabot::GitDependencyReferenceNotFound, dependency.name
     end
 
+    def head_commit_for_local_branch(name)
+      local_repo_git_metadata_fetcher.head_commit_for_ref(name)
+    end
+
     def local_tags_for_latest_version_commit_sha
       tags = allowed_version_tags
       max_tag = max_version_tag(tags)

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -884,6 +884,29 @@ RSpec.describe Dependabot::GitCommitChecker do
     end
   end
 
+  describe "#head_commit_for_local_branch" do
+    let(:tip_of_example) { "303b8a83c87d5c6d749926cf02620465a5dcd0f2" }
+
+    subject { checker.head_commit_for_local_branch("example") }
+
+    let(:repo_url) { "https://github.com/gocardless/business.git" }
+    let(:service_pack_url) { repo_url + "/info/refs?service=git-upload-pack" }
+    before do
+      stub_request(:get, service_pack_url).
+        to_return(
+          status: 200,
+          body: fixture("git", "upload_packs", upload_pack_fixture),
+          headers: {
+            "content-type" => "application/x-git-upload-pack-advertisement"
+          }
+        )
+    end
+
+    let(:upload_pack_fixture) { "monolog" }
+
+    it { is_expected.to eq(tip_of_example) }
+  end
+
   describe "#local_tag_for_latest_version" do
     subject { checker.local_tag_for_latest_version }
     let(:repo_url) { "https://github.com/gocardless/business.git" }

--- a/github_actions/lib/dependabot/github_actions.rb
+++ b/github_actions/lib/dependabot/github_actions.rb
@@ -22,3 +22,6 @@ Dependabot::PullRequestCreator::Labeler.
 require "dependabot/dependency"
 Dependabot::Dependency.
   register_production_check("github_actions", ->(_) { true })
+
+require "dependabot/utils"
+Dependabot::Utils.register_always_clone("github_actions")

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -70,16 +70,25 @@ module Dependabot
           return latest_version
         end
 
-        # If the dependency is pinned to a commit SHA, we return a *version* so
-        # that we get nice behaviour in PullRequestCreator::MessageBuilder
-        if git_commit_checker.pinned_ref_looks_like_commit_sha?
-          latest_tag = git_commit_checker.local_tag_for_latest_version
-          return latest_tag.fetch(:version)
+        if git_commit_checker.pinned_ref_looks_like_commit_sha? && latest_version_tag
+          latest_version = latest_version_tag.fetch(:version)
+          return latest_commit_for_pinned_ref unless git_commit_checker.branch_or_ref_in_release?(latest_version)
+
+          return latest_version
         end
 
         # If the dependency is pinned to a tag that doesn't look like a
         # version or a commit SHA then there's nothing we can do.
         nil
+      end
+
+      def latest_commit_for_pinned_ref
+        @latest_commit_for_pinned_ref ||=
+          SharedHelpers.in_a_temporary_repo_directory("/", repo_contents_path) do
+            ref_branch = find_container_branch(current_commit)
+
+            git_commit_checker.head_commit_for_local_branch(ref_branch)
+          end
       end
 
       def latest_version_tag
@@ -119,16 +128,26 @@ module Dependabot
           return dependency_source_details.merge(ref: new_tag.fetch(:tag))
         end
 
-        latest_tag = git_commit_checker.local_tag_for_latest_version
-
         # Update the pinned git commit if one is available
         if git_commit_checker.pinned_ref_looks_like_commit_sha? &&
-           latest_tag.fetch(:commit_sha) != current_commit
-          return dependency_source_details.merge(ref: latest_tag.fetch(:commit_sha))
+           (new_commit_sha = latest_commit_sha) &&
+           new_commit_sha != current_commit
+          return dependency_source_details.merge(ref: new_commit_sha)
         end
 
         # Otherwise return the original source
         dependency_source_details
+      end
+
+      def latest_commit_sha
+        new_tag = latest_version_tag
+        return unless new_tag
+
+        if git_commit_checker.branch_or_ref_in_release?(new_tag.fetch(:version))
+          new_tag.fetch(:commit_sha)
+        else
+          latest_commit_for_pinned_ref
+        end
       end
 
       def dependency_source_details
@@ -179,6 +198,23 @@ module Dependabot
         other = other_version.to_s
 
         shortened_semver_eq?(base, other) || shortened_semver_eq?(other, base)
+      end
+
+      def find_container_branch(sha)
+        SharedHelpers.run_shell_command("git fetch #{current_commit}")
+
+        branches_including_ref = SharedHelpers.run_shell_command("git branch --contains #{sha}").split("\n")
+
+        current_branch = branches_including_ref.find { |line| line.start_with?("* ") }
+
+        if current_branch
+          current_branch.delete_prefix("* ")
+        elsif branches_including_ref.size > 1
+          # If there are multiple non default branches including the pinned SHA, then it's unclear how we should proceed
+          raise "Multiple ambiguous branches (#{branches_including_ref.join(', ')}) include #{current_commit}!"
+        else
+          branches_including_ref.first
+        end
       end
     end
   end

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -59,7 +59,7 @@ module Dependabot
       end
 
       def fetch_latest_version_for_git_dependency
-        return git_commit_checker.head_commit_for_current_branch unless git_commit_checker.pinned?
+        return current_commit unless git_commit_checker.pinned?
 
         # If the dependency is pinned to a tag that looks like a version then
         # we want to update that tag.

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
     "https://github.com/actions/setup-node.git/info/refs" \
       "?service=git-upload-pack"
   end
+  let(:git_commit_checker) do
+    Dependabot::GitCommitChecker.new(
+      dependency: dependency,
+      credentials: github_credentials,
+      ignored_versions: ignored_versions,
+      raise_on_ignored: raise_on_ignored
+    )
+  end
   before do
     stub_request(:get, service_pack_url).
       to_return(
@@ -276,9 +284,8 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
           }
         end
 
-        allow_any_instance_of(Dependabot::GitCommitChecker).
-          to receive(:local_tags_for_latest_version_commit_sha).
-          and_return(version_tags)
+        checker.instance_variable_set(:@git_commit_checker, git_commit_checker)
+        allow(git_commit_checker).to receive(:local_tags_for_latest_version_commit_sha).and_return(version_tags)
       end
 
       context "using the major version" do

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -210,9 +210,11 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
   describe "#latest_version" do
     subject { checker.latest_version }
 
+    let(:tip_of_master) { "d963e800e3592dd31d6c76252092562d0bc7a3ba" }
+
     context "given a dependency with a branch reference" do
       let(:reference) { "master" }
-      it { is_expected.to eq("d963e800e3592dd31d6c76252092562d0bc7a3ba") }
+      it { is_expected.to eq(tip_of_master) }
     end
 
     context "given a dependency with a tag reference" do


### PR DESCRIPTION
If the pinned commit sha is not the tip of any repo branch, we would "update" to the commit sha of the latest version, which might be actually a parent of the current sha.

The problem is that so far we were not cloning the repository, so all we can access is sha's discoverable through http `/info/refs` endpoint, or through `git ls-remotes`.

To properly update this kind of references, we need to clone the repository.

This is not ready at all, it _at least_ needs some tests, but I wanted to share it.

Fixes #5556.

### Before (downgrades to the sha of v17)

```
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
=> fetching dependency files
=> dumping fetched dependency files: ./dry-run/sigprof/nur-packages/
=> parsing dependency files
🌍 https//github.com:443/cachix/install-nix-action.git/info/refs
=> updating 1 dependencies: cachix/install-nix-action

=== cachix/install-nix-action ()
 => checking for updates 1/1
🌍 https//github.com:443/cachix/install-nix-action.git/info/refs
 => latest available version is 17
 => latest allowed version is 17
 => requirements to unlock: own
 => requirements update strategy: 
 => updating cachix/install-nix-action to 17

    ± .github/workflows/auto-update-flake.yml
    ~~~
    23c23
    <         uses: cachix/install-nix-action@92d36226ca2887d9bfe391bf2d00894d88be3b64
    ---
    >         uses: cachix/install-nix-action@d64e0553100205688c0fb2fa16edb0fc8663c590
    47c47
    <         uses: cachix/install-nix-action@92d36226ca2887d9bfe391bf2d00894d88be3b64
    ---
    >         uses: cachix/install-nix-action@d64e0553100205688c0fb2fa16edb0fc8663c590
    ~~~

    ± .github/workflows/auto-update.yml
    ~~~
    28c28
    <         uses: cachix/install-nix-action@92d36226ca2887d9bfe391bf2d00894d88be3b64
    ---
    >         uses: cachix/install-nix-action@d64e0553100205688c0fb2fa16edb0fc8663c590
    ~~~

    ± .github/workflows/ci.yml
    ~~~
    58c58
    <         uses: cachix/install-nix-action@92d36226ca2887d9bfe391bf2d00894d88be3b64
    ---
    >         uses: cachix/install-nix-action@d64e0553100205688c0fb2fa16edb0fc8663c590
    123c123
    <         uses: cachix/install-nix-action@92d36226ca2887d9bfe391bf2d00894d88be3b64
    ---
    >         uses: cachix/install-nix-action@d64e0553100205688c0fb2fa16edb0fc8663c590
    ~~~
🌍 Total requests made: '2'
```

### After (upgrades to the latest commit in master)

```
bin/dry-run.rb github_actions sigprof/nur-packages --dep cachix/install-nix-action 
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
=> cloning into /home/dependabot/dependabot-core/tmp/sigprof/nur-packages
=> parsing dependency files
🌍 https//github.com:443/cachix/install-nix-action.git/info/refs
=> updating 1 dependencies: cachix/install-nix-action

=== cachix/install-nix-action ()
 => checking for updates 1/1
🌍 https//github.com:443/cachix/install-nix-action.git/info/refs
🌍 https//github.com:443/cachix/install-nix-action.git/info/refs
 => latest available version is e17a164a729f3f908f3997516f02ecaba2b9c201
 => latest allowed version is e17a164a729f3f908f3997516f02ecaba2b9c201
 => requirements to unlock: own
 => requirements update strategy: 
 => updating cachix/install-nix-action to e17a164a729f3f908f3997516f02ecaba2b9c201

    ± .github/workflows/auto-update-flake.yml
    ~~~
    23c23
    <         uses: cachix/install-nix-action@92d36226ca2887d9bfe391bf2d00894d88be3b64
    ---
    >         uses: cachix/install-nix-action@e17a164a729f3f908f3997516f02ecaba2b9c201
    47c47
    <         uses: cachix/install-nix-action@92d36226ca2887d9bfe391bf2d00894d88be3b64
    ---
    >         uses: cachix/install-nix-action@e17a164a729f3f908f3997516f02ecaba2b9c201
    ~~~

    ± .github/workflows/auto-update.yml
    ~~~
    28c28
    <         uses: cachix/install-nix-action@92d36226ca2887d9bfe391bf2d00894d88be3b64
    ---
    >         uses: cachix/install-nix-action@e17a164a729f3f908f3997516f02ecaba2b9c201
    ~~~

    ± .github/workflows/ci.yml
    ~~~
    58c58
    <         uses: cachix/install-nix-action@92d36226ca2887d9bfe391bf2d00894d88be3b64
    ---
    >         uses: cachix/install-nix-action@e17a164a729f3f908f3997516f02ecaba2b9c201
    123c123
    <         uses: cachix/install-nix-action@92d36226ca2887d9bfe391bf2d00894d88be3b64
    ---
    >         uses: cachix/install-nix-action@e17a164a729f3f908f3997516f02ecaba2b9c201
    ~~~
🌍 Total requests made: '3'
```