### PR TITLE
Add RuboCop Performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
 ---
+require: rubocop-performance
+
 AllCops:
   DisplayCopNames: true
   Exclude:
@@ -122,6 +124,102 @@ Metrics/PerceivedComplexity:
   Max: 10
 Naming/FileName:
   Enabled: false
+Performance/AncestorsInclude:
+  Enabled: true
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+Performance/BindCall:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/Caller:
+  Enabled: true
+Performance/CaseWhenSplat:
+  Enabled: true
+Performance/Casecmp:
+  Enabled: true
+Performance/ChainArrayAllocation:
+  Enabled: false
+Performance/CollectionLiteralInLoop:
+  Enabled: true
+Performance/CompareWithBlock:
+  Enabled: true
+Performance/ConcurrentMonotonicTime:
+  Enabled: true
+Performance/ConstantRegexp:
+  Enabled: true
+Performance/Count:
+  Enabled: true
+Performance/DeletePrefix:
+  Enabled: true
+Performance/DeleteSuffix:
+  Enabled: true
+Performance/Detect:
+  Enabled: true
+Performance/DoubleStartEndWith:
+  Enabled: true
+Performance/EndWith:
+  Enabled: true
+Performance/FixedSize:
+  Enabled: true
+Performance/FlatMap:
+  Enabled: true
+Performance/InefficientHashSearch:
+  Enabled: true
+Performance/IoReadlines:
+  Enabled: true
+Performance/MapCompact:
+  Enabled: true
+Performance/MethodObjectAsBlock:
+  Enabled: true
+Performance/OpenStruct:
+  Enabled: false
+Performance/RangeInclude:
+  Enabled: true
+Performance/RedundantBlockCall:
+  Enabled: true
+Performance/RedundantEqualityComparisonBlock:
+  Enabled: true
+Performance/RedundantMatch:
+  Enabled: true
+Performance/RedundantMerge:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantSplitRegexpArgument:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/RegexpMatch:
+  Enabled: true
+Performance/ReverseEach:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SelectMap:
+  Enabled: false
+Performance/Size:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: true
+Performance/Squeeze:
+  Enabled: true
+Performance/StartWith:
+  Enabled: true
+Performance/StringIdentifierArgument:
+  Enabled: true
+Performance/StringInclude:
+  Enabled: true
+Performance/StringReplacement:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
+Performance/TimesMap:
+  Enabled: true
+Performance/UnfreezeString:
+  Enabled: true
+Performance/UriDefaultParser:
+  Enabled: true
 Style/AccessorGrouping:
   Enabled: false
 Style/ArgumentsForwarding:
@@ -170,6 +268,8 @@ Style/KeywordParametersOrder:
   Enabled: false
 Style/MultilineInPatternThen:
   Enabled: true
+Style/MultipleComparison:
+  Enabled: false
 Style/NegatedIfElseCondition:
   Enabled: true
 Style/NilLambda:

--- a/bundler/helpers/v1/lib/functions/file_parser.rb
+++ b/bundler/helpers/v1/lib/functions/file_parser.rb
@@ -14,13 +14,13 @@ module Functions
       Bundler::Definition.build(gemfile_name, nil, {}).
         dependencies.select(&:current_platform?).
         reject { |dep| dep.source.is_a?(Bundler::Source::Gemspec) }.
-        map(&method(:serialize_bundler_dependency))
+        map { |dep| serialize_bundler_dependency(dep) }
     end
 
     def parsed_gemspec(gemspec_name:)
       Bundler.load_gemspec_uncached(gemspec_name).
         dependencies.
-        map(&method(:serialize_bundler_dependency))
+        map { |dep| serialize_bundler_dependency(dep) }
     end
 
     private

--- a/bundler/helpers/v1/lib/functions/file_parser.rb
+++ b/bundler/helpers/v1/lib/functions/file_parser.rb
@@ -71,15 +71,17 @@ module Functions
       }
     end
 
+    RUBYGEMS_HOSTS = [
+      "rubygems.org",
+      "www.rubygems.org"
+    ].freeze
+
     def default_rubygems?(source)
       return true if source.nil?
       return false unless source.is_a?(Bundler::Source::Rubygems)
 
       source.remotes.any? do |r|
-        [
-          "rubygems.org",
-          "www.rubygems.org"
-        ].include?(URI(r.to_s).host)
+        RUBYGEMS_HOSTS.include?(URI(r.to_s).host)
       end
     end
 

--- a/bundler/helpers/v1/lib/functions/lockfile_updater.rb
+++ b/bundler/helpers/v1/lib/functions/lockfile_updater.rb
@@ -160,9 +160,9 @@ module Functions
       potentials_deps =
         error.cause.conflicts.values.
         flat_map(&:requirement_trees).
-        map do |tree|
+        filter_map do |tree|
           tree.find { |req| allowed_new_unlocks.include?(req.name) }
-        end.compact.map(&:name)
+        end.map(&:name)
 
       # If there are specific dependencies we can unlock, unlock them
       return dependencies_to_unlock.append(*potentials_deps) if potentials_deps.any?

--- a/bundler/helpers/v1/monkey_patches/fileutils_keyword_splat_patch.rb
+++ b/bundler/helpers/v1/monkey_patches/fileutils_keyword_splat_patch.rb
@@ -11,7 +11,7 @@ module BundlerFileUtilsKeywordSplatPatch
     opts = {}
     opts[:encoding] = ::Encoding::UTF_8 if fu_windows?
     Dir.entries(path, **opts).
-      reject { |n| [".", ".."].include?(n) }.
+      reject { |n| n == "." || n == ".." }.
       map { |n| self.class.new(prefix, join(rel, n.untaint)) }
   end
 end

--- a/bundler/helpers/v2/lib/functions/file_parser.rb
+++ b/bundler/helpers/v2/lib/functions/file_parser.rb
@@ -14,13 +14,13 @@ module Functions
       Bundler::Definition.build(gemfile_name, nil, {}).
         dependencies.select(&:current_platform?).
         reject { |dep| dep.source.is_a?(Bundler::Source::Gemspec) }.
-        map(&method(:serialize_bundler_dependency))
+        map { |dep| serialize_bundler_dependency(dep) }
     end
 
     def parsed_gemspec(gemspec_name:)
       Bundler.load_gemspec_uncached(gemspec_name).
         dependencies.
-        map(&method(:serialize_bundler_dependency))
+        map { |dep| serialize_bundler_dependency(dep) }
     end
 
     private

--- a/bundler/helpers/v2/lib/functions/file_parser.rb
+++ b/bundler/helpers/v2/lib/functions/file_parser.rb
@@ -72,15 +72,17 @@ module Functions
       }
     end
 
+    RUBYGEMS_HOSTS = [
+      "rubygems.org",
+      "www.rubygems.org"
+    ].freeze
+
     def default_rubygems?(source)
       return true if source.nil?
       return false unless source.is_a?(Bundler::Source::Rubygems)
 
       source.remotes.any? do |r|
-        [
-          "rubygems.org",
-          "www.rubygems.org"
-        ].include?(URI(r.to_s).host)
+        RUBYGEMS_HOSTS.include?(URI(r.to_s).host)
       end
     end
 

--- a/bundler/helpers/v2/lib/functions/lockfile_updater.rb
+++ b/bundler/helpers/v2/lib/functions/lockfile_updater.rb
@@ -161,9 +161,9 @@ module Functions
       potentials_deps =
         error.cause.conflicts.values.
         flat_map(&:requirement_trees).
-        map do |tree|
+        filter_map do |tree|
           tree.find { |req| allowed_new_unlocks.include?(req.name) }
-        end.compact.map(&:name)
+        end.map(&:name)
 
       # If there are specific dependencies we can unlock, unlock them
       return dependencies_to_unlock.append(*potentials_deps) if potentials_deps.any?

--- a/bundler/helpers/v2/monkey_patches/git_source_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/git_source_patch.rb
@@ -13,7 +13,7 @@ module Bundler
         # Instead, we convert all `git@github.com:` URLs to use HTTPS.
         def configured_uri_for(uri)
           uri = uri.gsub(%r{git@(.*?):/?}, 'https://\1/')
-          if /https?:/ =~ uri
+          if /https?:/.match?(uri)
             remote = Bundler::URI(uri)
             config_auth = Bundler.settings[remote.to_s] || Bundler.settings[remote.host]
             remote.userinfo ||= config_auth

--- a/bundler/helpers/v2/spec/functions_spec.rb
+++ b/bundler/helpers/v2/spec/functions_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Functions do
       expect(git_specs.size).to eq(count)
       git_specs.each do |gs|
         uri = URI.parse(gs[:auth_uri])
-        expect(uri.scheme).to(satisfy { |s| %w(http https).include?(s) })
+        expect(uri.scheme).to(satisfy { |s| s.match?(/https?/o) })
       end
     end
 

--- a/bundler/lib/dependabot/bundler/file_updater/gemfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/gemfile_updater.rb
@@ -6,6 +6,8 @@ module Dependabot
   module Bundler
     class FileUpdater
       class GemfileUpdater
+        GEMFILE_FILENAMES = %w(Gemfile gems.rb).freeze
+
         require_relative "git_pin_replacer"
         require_relative "git_source_remover"
         require_relative "requirement_replacer"
@@ -68,13 +70,13 @@ module Dependabot
         def remove_git_source?(dependency)
           old_gemfile_req =
             dependency.previous_requirements.
-            find { |f| %w(Gemfile gems.rb).include?(f[:file]) }
+            find { |f| GEMFILE_FILENAMES.include?(f[:file]) }
 
           return false unless old_gemfile_req&.dig(:source, :type) == "git"
 
           new_gemfile_req =
             dependency.requirements.
-            find { |f| %w(Gemfile gems.rb).include?(f[:file]) }
+            find { |f| GEMFILE_FILENAMES.include?(f[:file]) }
 
           new_gemfile_req[:source].nil?
         end
@@ -82,7 +84,7 @@ module Dependabot
         def update_git_pin?(dependency)
           new_gemfile_req =
             dependency.requirements.
-            find { |f| %w(Gemfile gems.rb).include?(f[:file]) }
+            find { |f| GEMFILE_FILENAMES.include?(f[:file]) }
           return false unless new_gemfile_req&.dig(:source, :type) == "git"
 
           # If the new requirement is a git dependency with a ref then there's

--- a/bundler/lib/dependabot/bundler/metadata_finder.rb
+++ b/bundler/lib/dependabot/bundler/metadata_finder.rb
@@ -76,7 +76,7 @@ module Dependabot
       end
 
       def find_source_from_git_url
-        info = dependency.requirements.map { |r| r[:source] }.compact.first
+        info = dependency.requirements.filter_map { |r| r[:source] }.first
 
         url = info[:url] || info.fetch("url")
         Source.from_url(url)
@@ -198,7 +198,7 @@ module Dependabot
       def registry_url
         return "https://rubygems.org/" if new_source_type == "default"
 
-        info = dependency.requirements.map { |r| r[:source] }.compact.first
+        info = dependency.requirements.filter_map { |r| r[:source] }.first
         info[:url] || info.fetch("url")
       end
 

--- a/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
@@ -85,7 +85,7 @@ module Dependabot
           #
           # This is kind of a bug in Bundler, and we should try to fix it,
           # but resolving it won't necessarily be easy.
-          updated_deps.map do |dep|
+          updated_deps.filter_map do |dep|
             original_dep =
               original_dependencies.find { |d| d.name == dep.fetch("name") }
             spec = specs.find { |d| d.fetch("name") == dep.fetch("name") }
@@ -93,7 +93,7 @@ module Dependabot
             next if spec.fetch("version") == original_dep.version
 
             build_dependency(original_dep, spec)
-          end.compact
+          end
         end
 
         def build_dependency(original_dep, updated_spec)

--- a/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
@@ -28,7 +28,7 @@ module Dependabot
 
         def updated_requirements
           requirements.map do |req|
-            if req[:file].match?(/\.gemspec/)
+            if req[:file].include?('.gemspec')
               update_gemspec_requirement(req)
             else
               # If a requirement doesn't come from a gemspec, it must be from

--- a/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
@@ -28,7 +28,7 @@ module Dependabot
 
         def updated_requirements
           requirements.map do |req|
-            if req[:file].include?('.gemspec')
+            if req[:file].include?(".gemspec")
               update_gemspec_requirement(req)
             else
               # If a requirement doesn't come from a gemspec, it must be from

--- a/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
@@ -181,7 +181,7 @@ module Dependabot
             )
             git_specs.reject do |spec|
               uri = URI.parse(spec.fetch("auth_uri"))
-              next false unless %w(http https).include?(uri.scheme)
+              next false unless uri.scheme&.match?(/https?/o)
 
               Dependabot::RegistryClient.get(
                 url: uri.to_s

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -559,7 +559,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
         end
 
         it "includes details of each sub-dependency" do
-          expect(dependencies.reject(&:top_level?).count).to eq(23)
+          expect(dependencies.count { |dep| !dep.top_level? }).to eq(23)
 
           diff_lcs = dependencies.find { |d| d.name == "diff-lcs" }
           expect(diff_lcs.subdependency_metadata).to eq([{ production: false }])

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -555,7 +555,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
         let(:dependency_files) { bundler_project_dependency_files("imports_gemspec_imports_gemspec_large") }
 
         it "includes details of each declaration" do
-          expect(dependencies.select(&:top_level?).count).to eq(13)
+          expect(dependencies.count(&:top_level?)).to eq(13)
         end
 
         it "includes details of each sub-dependency" do
@@ -607,7 +607,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
           let(:dependency_files) { bundler_project_dependency_files("imports_gemspec_with_require") }
 
           it "includes details of each declaration" do
-            expect(dependencies.select(&:top_level?).count).to eq(13)
+            expect(dependencies.count(&:top_level?)).to eq(13)
           end
         end
 

--- a/cargo/lib/dependabot/cargo/metadata_finder.rb
+++ b/cargo/lib/dependabot/cargo/metadata_finder.rb
@@ -35,7 +35,6 @@ module Dependabot
           SOURCE_KEYS.
           filter_map { |key| crates_listing.dig("crate", key) }
 
-
         source_url = potential_source_urls.find { |url| Source.from_url(url) }
         Source.from_url(source_url)
       end

--- a/cargo/lib/dependabot/cargo/metadata_finder.rb
+++ b/cargo/lib/dependabot/cargo/metadata_finder.rb
@@ -33,15 +33,15 @@ module Dependabot
       def find_source_from_crates_listing
         potential_source_urls =
           SOURCE_KEYS.
-          map { |key| crates_listing.dig("crate", key) }.
-          compact
+          filter_map { |key| crates_listing.dig("crate", key) }
+          
 
         source_url = potential_source_urls.find { |url| Source.from_url(url) }
         Source.from_url(source_url)
       end
 
       def find_source_from_git_url
-        info = dependency.requirements.map { |r| r[:source] }.compact.first
+        info = dependency.requirements.filter_map { |r| r[:source] }.first
 
         url = info[:url] || info.fetch("url")
         Source.from_url(url)

--- a/cargo/lib/dependabot/cargo/metadata_finder.rb
+++ b/cargo/lib/dependabot/cargo/metadata_finder.rb
@@ -34,7 +34,7 @@ module Dependabot
         potential_source_urls =
           SOURCE_KEYS.
           filter_map { |key| crates_listing.dig("crate", key) }
-          
+
 
         source_url = potential_source_urls.find { |url| Source.from_url(url) }
         Source.from_url(source_url)

--- a/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
@@ -206,8 +206,7 @@ module Dependabot
               dependency.version
             else
               version_from_requirement =
-                dependency.requirements.map { |r| r.fetch(:requirement) }.
-                compact.
+                dependency.requirements.filter_map { |r| r.fetch(:requirement) }.
                 flat_map { |req_str| Cargo::Requirement.new(req_str) }.
                 flat_map(&:requirements).
                 reject { |req_array| req_array.first.start_with?("<") }.

--- a/cargo/spec/dependabot/cargo/file_parser_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_parser_spec.rb
@@ -732,7 +732,7 @@ RSpec.describe Dependabot::Cargo::FileParser do
           let(:lockfile_fixture_name) { "feature_dependency" }
 
           describe "the first dependency" do
-            subject(:dependency) { dependencies.select(&:top_level?).first }
+            subject(:dependency) { dependencies.find(&:top_level?) }
 
             it "has the right details" do
               expect(dependency).to be_a(Dependabot::Dependency)
@@ -753,7 +753,7 @@ RSpec.describe Dependabot::Cargo::FileParser do
             let(:manifest_fixture_name) { "feature_dependency_no_version" }
 
             describe "the first dependency" do
-              subject(:dependency) { dependencies.select(&:top_level?).first }
+              subject(:dependency) { dependencies.find(&:top_level?) }
 
               it "has the right details" do
                 expect(dependency).to be_a(Dependabot::Dependency)

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_development_dependency "rspec-its", "~> 1.2"
   spec.add_development_dependency "rubocop", "~> 1.35.1"
+  spec.add_development_dependency "rubocop-performance", "~> 1.14.2"
   spec.add_development_dependency "ruby-debug-ide", "~> 0.7.3"
   spec.add_development_dependency "simplecov", "~> 0.21.0"
   spec.add_development_dependency "simplecov-console", "~> 0.9.1"

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -310,7 +310,7 @@ module Dependabot
         # https://developercommunity.visualstudio.com/content/problem/608770/remove-4000-character-limit-on-pull-request-descri.html
         pr_description = pr_description.dup.force_encoding(Encoding::UTF_16)
         if pr_description.length > MAX_PR_DESCRIPTION_LENGTH
-          truncated_msg = "...\n\n_Description has been truncated_".dup.force_encoding(Encoding::UTF_16)
+          truncated_msg = (+"...\n\n_Description has been truncated_").force_encoding(Encoding::UTF_16)
           truncate_length = MAX_PR_DESCRIPTION_LENGTH - truncated_msg.length
           pr_description = (pr_description[0..truncate_length] + truncated_msg)
         end

--- a/common/lib/dependabot/config/ignore_condition.rb
+++ b/common/lib/dependabot/config/ignore_condition.rb
@@ -28,7 +28,7 @@ module Dependabot
       private
 
       def transformed_update_types
-        update_types.map(&:downcase).map(&:strip).compact
+        update_types.map(&:downcase).filter_map(&:strip)
       end
 
       def versions_by_type(dependency)

--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -120,9 +120,7 @@ module Dependabot
     private
 
     def check_values
-      if [version, previous_version].any?("")
-        raise ArgumentError, "blank strings must not be provided as versions"
-      end
+      raise ArgumentError, "blank strings must not be provided as versions" if [version, previous_version].any?("")
 
       check_requirement_fields
       check_subdependency_metadata

--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -120,7 +120,7 @@ module Dependabot
     private
 
     def check_values
-      if [version, previous_version].any? { |v| v == "" }
+      if [version, previous_version].any?("")
         raise ArgumentError, "blank strings must not be provided as versions"
       end
 
@@ -130,8 +130,8 @@ module Dependabot
 
     def check_requirement_fields
       requirement_fields = [requirements, previous_requirements].compact
-      unless requirement_fields.all? { |r| r.is_a?(Array) } &&
-             requirement_fields.flatten.all? { |r| r.is_a?(Hash) }
+      unless requirement_fields.all?(Array) &&
+             requirement_fields.flatten.all?(Hash)
         raise ArgumentError, "requirements must be an array of hashes"
       end
 
@@ -154,7 +154,7 @@ module Dependabot
       return unless subdependency_metadata
 
       unless subdependency_metadata.is_a?(Array) &&
-             subdependency_metadata.all? { |r| r.is_a?(Hash) }
+             subdependency_metadata.all?(Hash)
         raise ArgumentError, "subdependency_metadata must be an array of hashes"
       end
     end

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -234,7 +234,7 @@ module Dependabot
         return [] unless Dir.exist?(repo_path)
 
         Dir.entries(repo_path).filter_map do |name|
-          next if [".", ".."].include?(name)
+          next if name == "." || name == ".."
 
           absolute_path = File.join(repo_path, name)
           type = if File.symlink?(absolute_path)

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -233,7 +233,7 @@ module Dependabot
         repo_path = File.join(clone_repo_contents, relative_path)
         return [] unless Dir.exist?(repo_path)
 
-        Dir.entries(repo_path).map do |name|
+        Dir.entries(repo_path).filter_map do |name|
           next if [".", ".."].include?(name)
 
           absolute_path = File.join(repo_path, name)
@@ -251,7 +251,7 @@ module Dependabot
             type: type,
             size: 0 # NOTE: added for parity with github contents API
           )
-        end.compact
+        end
       end
 
       def update_linked_paths(repo, path, commit, github_response)

--- a/common/lib/dependabot/file_parsers/base/dependency_set.rb
+++ b/common/lib/dependabot/file_parsers/base/dependency_set.rb
@@ -10,7 +10,7 @@ module Dependabot
       class DependencySet
         def initialize(dependencies = [], case_sensitive: false)
           unless dependencies.is_a?(Array) &&
-                 dependencies.all? { |dep| dep.is_a?(Dependency) }
+                 dependencies.all?(Dependency)
             raise ArgumentError, "must be an array of Dependency objects"
           end
 

--- a/common/lib/dependabot/file_updaters/vendor_updater.rb
+++ b/common/lib/dependabot/file_updaters/vendor_updater.rb
@@ -18,7 +18,9 @@ module Dependabot
         return [] unless repo_contents_path && vendor_dir
 
         Dir.chdir(repo_contents_path) do
+          # rubocop:disable Performance/DeletePrefix
           relative_dir = Pathname.new(base_directory).sub(%r{\A/}, "").join(vendor_dir)
+          # rubocop:enable Performance/DeletePrefix
 
           status = SharedHelpers.run_shell_command(
             "git status --untracked-files all --porcelain v1 #{relative_dir}"

--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -239,7 +239,7 @@ module Dependabot
           files += github_client.contents(source.repo, opts)
 
           files.uniq.each do |f|
-            next unless %w(doc docs).include?(f.name) && f.type == "dir"
+            next unless f.type == "dir" && f.name.match?(/docs?/o)
 
             opts = { path: f.path, ref: ref }.compact
             files += github_client.contents(source.repo, opts)

--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -300,16 +300,16 @@ module Dependabot
         end
 
         def previous_ref
-          previous_refs = dependency.previous_requirements.map do |r|
+          previous_refs = dependency.previous_requirements.filter_map do |r|
             r.dig(:source, "ref") || r.dig(:source, :ref)
-          end.compact.uniq
+          end.uniq
           return previous_refs.first if previous_refs.count == 1
         end
 
         def new_ref
-          new_refs = dependency.requirements.map do |r|
+          new_refs = dependency.requirements.filter_map do |r|
             r.dig(:source, "ref") || r.dig(:source, :ref)
-          end.compact.uniq
+          end.uniq
           return new_refs.first if new_refs.count == 1
         end
 

--- a/common/lib/dependabot/metadata_finders/base/changelog_pruner.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_pruner.rb
@@ -137,16 +137,16 @@ module Dependabot
         end
 
         def previous_ref
-          previous_refs = dependency.previous_requirements.map do |r|
+          previous_refs = dependency.previous_requirements.filter_map do |r|
             r.dig(:source, "ref") || r.dig(:source, :ref)
-          end.compact.uniq
+          end.uniq
           return previous_refs.first if previous_refs.count == 1
         end
 
         def new_ref
-          new_refs = dependency.requirements.map do |r|
+          new_refs = dependency.requirements.filter_map do |r|
             r.dig(:source, "ref") || r.dig(:source, :ref)
-          end.compact.uniq
+          end.uniq
           return new_refs.first if new_refs.count == 1
         end
 

--- a/common/lib/dependabot/metadata_finders/base/commits_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/commits_finder.rb
@@ -136,18 +136,18 @@ module Dependabot
         def previous_ref
           return unless git_source?(dependency.previous_requirements)
 
-          previous_refs = dependency.previous_requirements.map do |r|
+          previous_refs = dependency.previous_requirements.filter_map do |r|
             r.dig(:source, "ref") || r.dig(:source, :ref)
-          end.compact.uniq
+          end.uniq
           return previous_refs.first if previous_refs.count == 1
         end
 
         def new_ref
           return unless git_source?(dependency.previous_requirements)
 
-          new_refs = dependency.requirements.map do |r|
+          new_refs = dependency.requirements.filter_map do |r|
             r.dig(:source, "ref") || r.dig(:source, :ref)
-          end.compact.uniq
+          end.uniq
           return new_refs.first if new_refs.count == 1
         end
 

--- a/common/lib/dependabot/metadata_finders/base/release_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/release_finder.rb
@@ -275,16 +275,16 @@ module Dependabot
         end
 
         def previous_ref
-          previous_refs = dependency.previous_requirements.map do |r|
+          previous_refs = dependency.previous_requirements.filter_map do |r|
             r.dig(:source, "ref") || r.dig(:source, :ref)
-          end.compact.uniq
+          end.uniq
           return previous_refs.first if previous_refs.count == 1
         end
 
         def new_ref
-          new_refs = dependency.requirements.map do |r|
+          new_refs = dependency.requirements.filter_map do |r|
             r.dig(:source, "ref") || r.dig(:source, :ref)
-          end.compact.uniq
+          end.uniq
           return new_refs.first if new_refs.count == 1
         end
 

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -185,11 +185,7 @@ module Dependabot
           # Remove forbidden characters (those not already replaced elsewhere)
           gsub(%r{[^A-Za-z0-9/\-_.(){}]}, "").
           # Slashes can't be followed by periods
-          gsub(%r{/\.}, "/dot-").
-          # Two or more sequential periods are forbidden
-          gsub(/\.+/, ".").
-          # Two or more sequential slashes are forbidden
-          gsub(%r{/+}, "/").
+          gsub(%r{/\.}, "/dot-").squeeze('.').squeeze('/').
           # Trailing periods are forbidden
           sub(/\.$/, "")
       end

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -127,8 +127,8 @@ module Dependabot
         elsif dependency.version == dependency.previous_version &&
               package_manager == "docker"
           dependency.requirements.
-            filter_map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }
-                    .first.split(":").last[0..6]
+            filter_map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }.
+                    first.split(":").last[0..6]
         else
           dependency.version
         end

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -128,7 +128,7 @@ module Dependabot
               package_manager == "docker"
           dependency.requirements.
             filter_map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }
-            .first.split(":").last[0..6]
+                    .first.split(":").last[0..6]
         else
           dependency.version
         end

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -185,7 +185,7 @@ module Dependabot
           # Remove forbidden characters (those not already replaced elsewhere)
           gsub(%r{[^A-Za-z0-9/\-_.(){}]}, "").
           # Slashes can't be followed by periods
-          gsub(%r{/\.}, "/dot-").squeeze('.').squeeze('/').
+          gsub(%r{/\.}, "/dot-").squeeze(".").squeeze("/").
           # Trailing periods are forbidden
           sub(/\.$/, "")
       end

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -128,7 +128,7 @@ module Dependabot
               package_manager == "docker"
           dependency.requirements.
             filter_map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }.
-                    first.split(":").last[0..6]
+            first.split(":").last[0..6]
         else
           dependency.version
         end

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -127,24 +127,24 @@ module Dependabot
         elsif dependency.version == dependency.previous_version &&
               package_manager == "docker"
           dependency.requirements.
-            map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }.
-            compact.first.split(":").last[0..6]
+            filter_map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }
+            .first.split(":").last[0..6]
         else
           dependency.version
         end
       end
 
       def previous_ref(dependency)
-        previous_refs = dependency.previous_requirements.map do |r|
+        previous_refs = dependency.previous_requirements.filter_map do |r|
           r.dig(:source, "ref") || r.dig(:source, :ref)
-        end.compact.uniq
+        end.uniq
         return previous_refs.first if previous_refs.count == 1
       end
 
       def new_ref(dependency)
-        new_refs = dependency.requirements.map do |r|
+        new_refs = dependency.requirements.filter_map do |r|
           r.dig(:source, "ref") || r.dig(:source, :ref)
-        end.compact.uniq
+        end.uniq
         return new_refs.first if new_refs.count == 1
       end
 

--- a/common/lib/dependabot/pull_request_creator/labeler.rb
+++ b/common/lib/dependabot/pull_request_creator/labeler.rb
@@ -105,7 +105,9 @@ module Dependabot
           new_version_parts = version(dep).split(/[.+]/)
           old_version_parts = previous_version(dep)&.split(/[.+]/) || []
           all_parts = new_version_parts.first(3) + old_version_parts.first(3)
+          # rubocop:disable Performance/RedundantEqualityComparisonBlock
           next 0 unless all_parts.all? { |part| part.to_i.to_s == part }
+          # rubocop:enable Performance/RedundantEqualityComparisonBlock
           next 1 if new_version_parts[0] != old_version_parts[0]
           next 2 if new_version_parts[1] != old_version_parts[1]
 

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -428,7 +428,7 @@ module Dependabot
       def docker_digest_from_reqs(requirements)
         requirements.
           filter_map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }
-          .first
+                    .first
       end
 
       def previous_ref(dependency)

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -428,7 +428,7 @@ module Dependabot
       def docker_digest_from_reqs(requirements)
         requirements.
           filter_map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }.
-                    first
+          first
       end
 
       def previous_ref(dependency)

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -427,8 +427,8 @@ module Dependabot
 
       def docker_digest_from_reqs(requirements)
         requirements.
-          filter_map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }
-                    .first
+          filter_map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }.
+                    first
       end
 
       def previous_ref(dependency)

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -427,21 +427,21 @@ module Dependabot
 
       def docker_digest_from_reqs(requirements)
         requirements.
-          map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }.
-          compact.first
+          filter_map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }
+          .first
       end
 
       def previous_ref(dependency)
-        previous_refs = dependency.previous_requirements.map do |r|
+        previous_refs = dependency.previous_requirements.filter_map do |r|
           r.dig(:source, "ref") || r.dig(:source, :ref)
-        end.compact.uniq
+        end.uniq
         return previous_refs.first if previous_refs.count == 1
       end
 
       def new_ref(dependency)
-        new_refs = dependency.requirements.map do |r|
+        new_refs = dependency.requirements.filter_map do |r|
           r.dig(:source, "ref") || r.dig(:source, :ref)
-        end.compact.uniq
+        end.uniq
         return new_refs.first if new_refs.count == 1
       end
 

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -112,7 +112,7 @@ module Dependabot
 
           msg = ""
 
-          commits.reverse.first(10).each do |commit|
+          commits.last(10).reverse.each do |commit|
             title = commit[:message].strip.split("\n").first
             title = title.slice(0..76) + "..." if title && title.length > 80
             title = title&.gsub(/(?<=[^\w.-])([_*`~])/, '\\1')

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -112,7 +112,7 @@ module Dependabot
 
           msg = ""
 
-          commits.last(10).reverse.each do |commit|
+          commits.last(10).reverse_each do |commit|
             title = commit[:message].strip.split("\n").first
             title = title.slice(0..76) + "..." if title && title.length > 80
             title = title&.gsub(/(?<=[^\w.-])([_*`~])/, '\\1')

--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -280,8 +280,7 @@ module Dependabot
           reject { |c| c.author&.type == "Bot" }.
           reject { |c| c.commit&.message&.start_with?("Merge") }.
           map(&:commit).
-          map(&:message).
-          compact.
+          filter_map(&:message).
           map(&:strip)
       end
 
@@ -292,8 +291,7 @@ module Dependabot
         @recent_gitlab_commit_messages.
           reject { |c| c.author_email == dependabot_email }.
           reject { |c| c.message&.start_with?("merge !") }.
-          map(&:message).
-          compact.
+          filter_map(&:message).
           map(&:strip)
       end
 
@@ -304,8 +302,7 @@ module Dependabot
         @recent_azure_commit_messages.
           reject { |c| azure_commit_author_email(c) == dependabot_email }.
           reject { |c| c.fetch("comment")&.start_with?("Merge") }.
-          map { |c| c.fetch("comment") }.
-          compact.
+          filter_map { |c| c.fetch("comment") }.
           map(&:strip)
       end
 
@@ -315,8 +312,7 @@ module Dependabot
 
         @recent_bitbucket_commit_messages.
           reject { |c| bitbucket_commit_author_email(c) == dependabot_email }.
-          map { |c| c.fetch("message", nil) }.
-          compact.
+          filter_map { |c| c.fetch("message", nil) }.
           reject { |m| m.start_with?("Merge") }.
           map(&:strip)
       end
@@ -327,8 +323,7 @@ module Dependabot
         @recent_codecommit_commit_messages.commits.
           reject { |c| c.author.email == dependabot_email }.
           reject { |c| c.message&.start_with?("Merge") }.
-          map(&:message).
-          compact.
+          filter_map(&:message).
           map(&:strip)
       end
 

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -173,7 +173,7 @@ module Dependabot
 
         if e.message.match?(/protected branch/i) ||
            e.message.match?(/not authorized to push/i) ||
-           e.message.match?(/must not contain merge commits/) ||
+           e.message.include?('must not contain merge commits') ||
            e.message.match?(/required status check/i)
           raise BranchProtected
         end

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -173,7 +173,7 @@ module Dependabot
 
         if e.message.match?(/protected branch/i) ||
            e.message.match?(/not authorized to push/i) ||
-           e.message.include?('must not contain merge commits') ||
+           e.message.include?("must not contain merge commits") ||
            e.message.match?(/required status check/i)
           raise BranchProtected
         end

--- a/common/lib/dependabot/security_advisory.rb
+++ b/common/lib/dependabot/security_advisory.rb
@@ -51,7 +51,7 @@ module Dependabot
     # @return [Boolean]
     def fixed_by?(dependency)
       # Handle case mismatch between the security advisory and parsed name
-      return false unless dependency_name.downcase == dependency.name.downcase
+      return false unless dependency_name.casecmp(dependency.name).zero?
       return false unless package_manager == dependency.package_manager
       # TODO: Support no previous version to the same level as dependency graph
       # and security alerts. We currently ignore dependency updates without a

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -287,7 +287,7 @@ module Dependabot
 
       def version_from_requirements
         @version_from_requirements ||=
-          dependency.requirements.map { |r| r.fetch(:requirement) }.compact.
+          dependency.requirements.filter_map { |r| r.fetch(:requirement) }.
           flat_map { |req_str| requirement_class.requirements_array(req_str) }.
           flat_map(&:requirements).
           reject { |req_array| req_array.first.start_with?("<") }.

--- a/common/spec/dependabot/file_updaters/vendor_updater_spec.rb
+++ b/common/spec/dependabot/file_updaters/vendor_updater_spec.rb
@@ -179,6 +179,6 @@ RSpec.describe Dependabot::FileUpdaters::VendorUpdater do
   private
 
   def in_cloned_repository(repo_contents_path, &block)
-    Dir.chdir(repo_contents_path) { block.call }
+    Dir.chdir(repo_contents_path, &block)
   end
 end

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe Dependabot::SharedHelpers do
           (|
           \+https://github.com/dependabot/|dependabot-core|
           )|
-        }x
+        }xo
       )
     end
 

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe Dependabot::SharedHelpers do
     let(:credentials) { [] }
 
     def with_git_configured(&block)
-      Dependabot::SharedHelpers.with_git_configured(credentials: credentials) { block.call }
+      Dependabot::SharedHelpers.with_git_configured(credentials: credentials, &block)
     end
 
     let(:configured_git_config) { with_git_configured { `cat ~/.gitconfig` } }

--- a/common/spec/dummy_package_manager/version.rb
+++ b/common/spec/dummy_package_manager/version.rb
@@ -12,7 +12,7 @@ module DummyPackageManager
     def self.remove_leading_v(version)
       return version unless version.to_s.match?(/\Av([0-9])/)
 
-      version.to_s.gsub(/\Av/, "")
+      version.to_s.delete_prefix('v')
     end
 
     def self.correct?(version)

--- a/common/spec/dummy_package_manager/version.rb
+++ b/common/spec/dummy_package_manager/version.rb
@@ -12,7 +12,7 @@ module DummyPackageManager
     def self.remove_leading_v(version)
       return version unless version.to_s.match?(/\Av([0-9])/)
 
-      version.to_s.delete_prefix('v')
+      version.to_s.delete_prefix("v")
     end
 
     def self.correct?(version)

--- a/composer/lib/dependabot/composer/file_fetcher.rb
+++ b/composer/lib/dependabot/composer/file_fetcher.rb
@@ -93,13 +93,13 @@ module Dependabot
       end
 
       def build_unfetchable_deps(unfetchable_deps)
-        unfetchable_deps.map do |path|
+        unfetchable_deps.filter_map do |path|
           PathDependencyBuilder.new(
             path: path,
             directory: directory,
             lockfile: composer_lock
           ).dependency_file
-        end.compact
+        end
       end
 
       def expand_path(path)

--- a/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
@@ -185,8 +185,7 @@ module Dependabot
           # NOTE: This matches an error message from composer plugins used to install ACF PRO
           # https://github.com/PhilippBaschke/acf-pro-installer/blob/772cec99c6ef8bc67ba6768419014cc60d141b27/src/ACFProInstaller/Exceptions/MissingKeyException.php#L14
           # https://github.com/pivvenit/acf-pro-installer/blob/f2d4812839ee2c333709b0ad4c6c134e4c25fd6d/src/Exceptions/MissingKeyException.php#L25
-          if error.message.start_with?("Could not find a key for ACF PRO") ||
-             error.message.start_with?("Could not find a license key for ACF PRO")
+          if error.message.start_with?("Could not find a key for ACF PRO", "Could not find a license key for ACF PRO")
             raise MissingEnvironmentVariable, "ACF_PRO_KEY"
           end
 

--- a/composer/lib/dependabot/composer/metadata_finder.rb
+++ b/composer/lib/dependabot/composer/metadata_finder.rb
@@ -18,7 +18,7 @@ module Dependabot
       def source_from_dependency
         source_url =
           dependency.requirements.
-          map { |r| r.fetch(:source) }.compact.
+          filter_map { |r| r.fetch(:source) }.
           first&.fetch(:url, nil)
 
         Source.from_url(source_url)

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -104,7 +104,7 @@ module Dependabot
 
           urls = repositories.
                  select { |h| h["type"] == "composer" }.
-                 map { |h| h["url"] }.compact.
+                 filter_map { |h| h["url"] }.
                  map { |url| url.gsub(%r{\/$}, "") + "/packages.json" }
 
           unless repositories.any? { |rep| rep["packagist.org"] == false }

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -207,7 +207,7 @@ module Dependabot
               ">= #{dependency.version}"
             else
               version_for_requirement =
-                dependency.requirements.map { |r| r[:requirement] }.compact.
+                dependency.requirements.filter_map { |r| r[:requirement] }.
                 reject { |req_string| req_string.start_with?("<") }.
                 select { |req_string| req_string.match?(VERSION_REGEX) }.
                 map { |req_string| req_string.match(VERSION_REGEX) }.

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -317,7 +317,7 @@ module Dependabot
 
             source = url.gsub(%r{/packages.json$}, "")
             raise Dependabot::PrivateSourceTimedOut, source
-          elsif error.message.start_with?("Allowed memory size") || error.message.start_with?("Out of memory")
+          elsif error.message.start_with?("Allowed memory size", "Out of memory")
             raise Dependabot::OutOfMemory
           elsif error.error_context[:process_termsig] == Dependabot::SharedHelpers::SIGKILL
             # If the helper was SIGKILL-ed, assume the OOMKiller did it

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -198,7 +198,6 @@ module Dependabot
         end
 
         # rubocop:disable Metrics/PerceivedComplexity
-        # rubocop:disable Metrics/AbcSize
         def updated_version_requirement_string
           lower_bound =
             if requirements_to_unlock == :none
@@ -232,7 +231,6 @@ module Dependabot
 
           lower_bound + ", <= #{latest_allowable_version}"
         end
-        # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/PerceivedComplexity
 
         # TODO: Extract error handling and share between the lockfile updater

--- a/elm/lib/dependabot/elm/update_checker/elm_19_version_resolver.rb
+++ b/elm/lib/dependabot/elm/update_checker/elm_19_version_resolver.rb
@@ -36,7 +36,7 @@ module Dependabot
         def updated_dependencies_after_full_unlock
           changed_deps = install_metadata
 
-          original_dependency_details.map do |original_dep|
+          original_dependency_details.filter_map do |original_dep|
             new_version = changed_deps.fetch(original_dep.name, nil)
             next unless new_version
 
@@ -60,7 +60,7 @@ module Dependabot
               previous_requirements: original_dep.requirements,
               package_manager: original_dep.package_manager
             )
-          end.compact
+          end
         end
 
         private

--- a/elm/lib/dependabot/elm/update_checker/elm_19_version_resolver.rb
+++ b/elm/lib/dependabot/elm/update_checker/elm_19_version_resolver.rb
@@ -158,10 +158,8 @@ module Dependabot
           # `elm install <dependency_name>` to generate the install plan
           %w(dependencies test-dependencies).each do |type|
             json[type].delete(dependency.name) if json.dig(type, dependency.name)
-
-            %w(direct indirect).each do |category|
-              json[type][category].delete(dependency.name) if json.dig(type, category, dependency.name)
-            end
+            json[type]["direct"].delete(dependency.name) if json.dig(type, "direct", dependency.name)
+            json[type]["indirect"].delete(dependency.name) if json.dig(type, "indirect", dependency.name)
           end
 
           json["source-directories"] = []

--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -109,7 +109,7 @@ module Dependabot
         steps = json_object.fetch("steps", [])
 
         uses_strings =
-          if steps.is_a?(Array) && steps.all? { |s| s.is_a?(Hash) }
+          if steps.is_a?(Array) && steps.all?(Hash)
             steps.
               map { |step| step.fetch("uses", nil) }.
               select { |use| use.is_a?(String) }

--- a/github_actions/lib/dependabot/github_actions/metadata_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/metadata_finder.rb
@@ -9,7 +9,7 @@ module Dependabot
       private
 
       def look_up_source
-        info = dependency.requirements.map { |r| r[:source] }.compact.first
+        info = dependency.requirements.filter_map { |r| r[:source] }.first
 
         url =
           if info.nil?

--- a/github_actions/lib/dependabot/github_actions/version.rb
+++ b/github_actions/lib/dependabot/github_actions/version.rb
@@ -13,7 +13,7 @@ module Dependabot
       def self.remove_leading_v(version)
         return version unless version.to_s.match?(/\Av([0-9])/)
 
-        version.to_s.delete_prefix('v')
+        version.to_s.delete_prefix("v")
       end
 
       def self.correct?(version)

--- a/github_actions/lib/dependabot/github_actions/version.rb
+++ b/github_actions/lib/dependabot/github_actions/version.rb
@@ -13,7 +13,7 @@ module Dependabot
       def self.remove_leading_v(version)
         return version unless version.to_s.match?(/\Av([0-9])/)
 
-        version.to_s.gsub(/\Av/, "")
+        version.to_s.delete_prefix('v')
       end
 
       def self.correct?(version)

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -188,9 +188,7 @@ module Dependabot
 
         def in_repo_path(&block)
           SharedHelpers.in_a_temporary_repo_directory(directory, repo_contents_path) do
-            SharedHelpers.with_git_configured(credentials: credentials) do
-              block.call
-            end
+            SharedHelpers.with_git_configured(credentials: credentials, &block)
           end
         end
 

--- a/go_modules/lib/dependabot/go_modules/replace_stubber.rb
+++ b/go_modules/lib/dependabot/go_modules/replace_stubber.rb
@@ -42,7 +42,7 @@ module Dependabot
 
       def relative_replacement_path?(path)
         # https://golang.org/ref/mod#go-mod-file-replace
-        path.start_with?("./") || path.start_with?("../")
+        path.start_with?("./", "../")
       end
 
       def module_pathname(directory)

--- a/go_modules/lib/dependabot/go_modules/replace_stubber.rb
+++ b/go_modules/lib/dependabot/go_modules/replace_stubber.rb
@@ -17,8 +17,7 @@ module Dependabot
 
       def stub_paths(manifest, directory)
         (manifest["Replace"] || []).
-          map { |r| r["New"]["Path"] }.
-          compact.
+          filter_map { |r| r["New"]["Path"] }.
           select { |p| stub_replace_path?(p, directory) }.
           to_h { |p| [p, "./" + Digest::SHA2.hexdigest(p)] }
       end

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -52,7 +52,7 @@ module Dependabot
         attr_reader :dependency, :dependency_files, :credentials, :ignored_versions, :security_advisories
 
         def fetch_latest_version
-          return dependency.version if dependency.version =~ PSEUDO_VERSION_REGEX
+          return dependency.version if PSEUDO_VERSION_REGEX.match?(dependency.version)
 
           candidate_versions = available_versions
           candidate_versions = filter_prerelease_versions(candidate_versions)
@@ -62,7 +62,7 @@ module Dependabot
         end
 
         def fetch_lowest_security_fix_version
-          return dependency.version if dependency.version =~ PSEUDO_VERSION_REGEX
+          return dependency.version if PSEUDO_VERSION_REGEX.match?(dependency.version)
 
           relevant_versions = available_versions
           relevant_versions = filter_prerelease_versions(relevant_versions)
@@ -110,7 +110,7 @@ module Dependabot
         def handle_subprocess_error(error)
           if RESOLVABILITY_ERROR_REGEXES.any? { |rgx| error.message =~ rgx }
             ResolvabilityErrors.handle(error.message, credentials: credentials, goprivate: @goprivate)
-          elsif INVALID_VERSION_REGEX =~ error.message
+          elsif INVALID_VERSION_REGEX.match?(error.message)
             raise Dependabot::DependencyFileNotResolvable, error.message
           end
 

--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -53,7 +53,7 @@ module Dependabot
             new(settings_file: settings_file).
             subproject_paths
 
-          subproject_paths.map do |path|
+          subproject_paths.filter_map do |path|
             if @buildfile_name
               fetch_file_from_host(File.join(path, @buildfile_name))
             else
@@ -62,7 +62,7 @@ module Dependabot
           rescue Dependabot::DependencyFileNotFound
             # Gradle itself doesn't worry about missing subprojects, so we don't
             nil
-          end.compact
+          end
         end
       end
 
@@ -78,14 +78,14 @@ module Dependabot
           map { |path| path.gsub("$rootDir", ".") }.
           uniq
 
-        dependency_plugin_paths.map do |path|
+        dependency_plugin_paths.filter_map do |path|
           fetch_file_from_host(path)
         rescue Dependabot::DependencyFileNotFound
           next nil if file_exists_in_submodule?(path)
           next nil if path.include?("${")
 
           raise
-        end.compact
+        end
       end
       # rubocop:enable Metrics/PerceivedComplexity
 

--- a/gradle/lib/dependabot/gradle/file_fetcher/settings_file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher/settings_file_parser.rb
@@ -16,7 +16,7 @@ module Dependabot
           comment_free_content.scan(function_regex("include")) do
             args = Regexp.last_match.named_captures.fetch("args")
             args = args.split(",")
-            args = args.map { |p| p.gsub(/["']/, "").strip }.compact
+            args = args.filter_map { |p| p.gsub(/["']/, "").strip }
             subprojects += args
           end
 

--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -161,9 +161,9 @@ module Dependabot
 
         plugin_blocks.each do |blk|
           blk.lines.each do |line|
-            name_regex = /(id|kotlin)(\s+#{PLUGIN_ID_REGEX}|\(#{PLUGIN_ID_REGEX}\))/
+            name_regex = /(id|kotlin)(\s+#{PLUGIN_ID_REGEX}|\(#{PLUGIN_ID_REGEX}\))/o
             name = line.match(name_regex)&.named_captures&.fetch("id")
-            version_regex = /version\s+['"](?<version>#{VSN_PART})['"]/
+            version_regex = /version\s+['"](?<version>#{VSN_PART})['"]/o
             version = line.match(version_regex)&.named_captures&.
                 fetch("version")
             next unless name && version
@@ -178,7 +178,7 @@ module Dependabot
       end
 
       def extra_groups(line)
-        line.match?(/kotlin(\s+#{PLUGIN_ID_REGEX}|\(#{PLUGIN_ID_REGEX}\))/) ? ["kotlin"] : []
+        line.match?(/kotlin(\s+#{PLUGIN_ID_REGEX}|\(#{PLUGIN_ID_REGEX}\))/o) ? ["kotlin"] : []
       end
 
       def argument_from_string(string, arg_name)

--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -60,7 +60,7 @@ module Dependabot
       def self.find_includes(buildfile, dependency_files)
         FileParser.find_include_names(buildfile).
           filter_map { |f| dependency_files.find { |bf| bf.name == f } }
-          
+
       end
 
       private

--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -60,7 +60,6 @@ module Dependabot
       def self.find_includes(buildfile, dependency_files)
         FileParser.find_include_names(buildfile).
           filter_map { |f| dependency_files.find { |bf| bf.name == f } }
-
       end
 
       private

--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -59,8 +59,8 @@ module Dependabot
 
       def self.find_includes(buildfile, dependency_files)
         FileParser.find_include_names(buildfile).
-          map { |f| dependency_files.find { |bf| bf.name == f } }.
-          compact
+          filter_map { |f| dependency_files.find { |bf| bf.name == f } }
+          
       end
 
       private

--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -178,7 +178,7 @@ module Dependabot
       end
 
       def extra_groups(line)
-        line.match(/kotlin(\s+#{PLUGIN_ID_REGEX}|\(#{PLUGIN_ID_REGEX}\))/) ? ["kotlin"] : []
+        line.match?(/kotlin(\s+#{PLUGIN_ID_REGEX}|\(#{PLUGIN_ID_REGEX}\))/) ? ["kotlin"] : []
       end
 
       def argument_from_string(string, arg_name)

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -185,7 +185,7 @@ module Dependabot
         end
 
         def check_response(response, repository_url)
-          return unless [401, 403].include?(response.status)
+          return unless response.status == 401 || response.status == 403
           return if @forbidden_urls.include?(repository_url)
           return if central_repo_urls.include?(repository_url)
 

--- a/gradle/lib/dependabot/gradle/version.rb
+++ b/gradle/lib/dependabot/gradle/version.rb
@@ -117,11 +117,11 @@ module Dependabot
       end
 
       def trim_version(version)
-        version.split("-").map do |v|
+        version.split("-").filter_map do |v|
           parts = v.split(".")
           parts = parts[0..-2] while NULL_VALUES.include?(parts&.last)
           parts&.join(".")
-        end.compact.reject(&:empty?).join("-")
+        end.reject(&:empty?).join("-")
       end
 
       def convert_dates(version, other_version)

--- a/gradle/spec/dependabot/gradle/file_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Dependabot::Gradle::FileUpdater do
     describe "the updated build.gradle file" do
       subject(:updated_buildfile) do
         updated_files.find do |f|
-          %w(build.gradle build.gradle.kts).include?(f.name)
+          Dependabot::Gradle::FileUpdater::SUPPORTED_BUILD_FILE_NAMES.include?(f.name)
         end
       end
 

--- a/hex/lib/dependabot/hex/file_fetcher.rb
+++ b/hex/lib/dependabot/hex/file_fetcher.rb
@@ -64,14 +64,14 @@ module Dependabot
         subapp_directories += umbrella_app_directories
         subapp_directories += sub_project_directories
 
-        subapp_directories.map do |dir|
+        subapp_directories.filter_map do |dir|
           fetch_file_from_host("#{dir}/mix.exs")
         rescue Dependabot::DependencyFileNotFound
           # If the folder doesn't have a mix.exs it *might* be because it's
           # not an app. Ignore the fact we couldn't fetch one and proceed with
           # updating (it will blow up later if there are problems)
           nil
-        end.compact
+        end
       rescue Octokit::NotFound, Gitlab::Error::NotFound
         # If the path specified in apps_path doesn't exist then it's not being
         # used. We can just return an empty array of subapp files.

--- a/hex/lib/dependabot/hex/file_fetcher.rb
+++ b/hex/lib/dependabot/hex/file_fetcher.rb
@@ -82,7 +82,7 @@ module Dependabot
         mixfiles = [mixfile] + subapp_mixfiles
 
         mixfiles.flat_map do |mixfile|
-          mixfile_dir = mixfile.path.sub("/mix.exs", "").delete_prefix("/")
+          mixfile_dir = mixfile.path.to_s.delete_prefix("/").delete_suffix("/mix.exs")
 
           mixfile.content.gsub(/__DIR__/, "\"#{mixfile_dir}\"").scan(SUPPORT_FILE).map do |support_file_args|
             path = Pathname.new(File.join(*support_file_args.compact.reverse)).

--- a/hex/lib/dependabot/hex/file_updater/mixfile_sanitizer.rb
+++ b/hex/lib/dependabot/hex/file_updater/mixfile_sanitizer.rb
@@ -23,11 +23,13 @@ module Dependabot
         PIPED_VERSION_FILE_READ_BANG =
           /#{VERSION_FILE}[[:space:]]+#{PIPE}[[:space:]]+#{FILE_READ_BANG}/.freeze
 
+        # rubocop:disable Performance/MethodObjectAsBlock
         def sanitized_content
           mixfile_content.
             then(&method(:prevent_version_file_loading)).
             then(&method(:prevent_config_path_loading))
         end
+        # rubocop:enable Performance/MethodObjectAsBlock
 
         private
 

--- a/hex/lib/dependabot/hex/metadata_finder.rb
+++ b/hex/lib/dependabot/hex/metadata_finder.rb
@@ -39,7 +39,7 @@ module Dependabot
         potential_source_urls =
           SOURCE_KEYS.
           filter_map { |key| hex_listing.dig("meta", "links", key) }
-          
+
 
         source_url = potential_source_urls.find { |url| Source.from_url(url) }
         Source.from_url(source_url)

--- a/hex/lib/dependabot/hex/metadata_finder.rb
+++ b/hex/lib/dependabot/hex/metadata_finder.rb
@@ -38,15 +38,15 @@ module Dependabot
       def find_source_from_hex_listing
         potential_source_urls =
           SOURCE_KEYS.
-          map { |key| hex_listing.dig("meta", "links", key) }.
-          compact
+          filter_map { |key| hex_listing.dig("meta", "links", key) }
+          
 
         source_url = potential_source_urls.find { |url| Source.from_url(url) }
         Source.from_url(source_url)
       end
 
       def find_source_from_git_url
-        info = dependency.requirements.map { |r| r[:source] }.compact.first
+        info = dependency.requirements.filter_map { |r| r[:source] }.first
 
         url = info[:url] || info.fetch("url")
         Source.from_url(url)

--- a/hex/lib/dependabot/hex/metadata_finder.rb
+++ b/hex/lib/dependabot/hex/metadata_finder.rb
@@ -40,7 +40,6 @@ module Dependabot
           SOURCE_KEYS.
           filter_map { |key| hex_listing.dig("meta", "links", key) }
 
-
         source_url = potential_source_urls.find { |url| Source.from_url(url) }
         Source.from_url(source_url)
       end

--- a/hex/lib/dependabot/hex/update_checker/file_preparer.rb
+++ b/hex/lib/dependabot/hex/update_checker/file_preparer.rb
@@ -99,7 +99,7 @@ module Dependabot
           elsif dependency.version then ">= #{dependency.version}"
           else
             version_for_requirement =
-              dependency.requirements.map { |r| r[:requirement] }.compact.
+              dependency.requirements.filter_map { |r| r[:requirement] }.
               reject { |req_string| req_string.start_with?("<") }.
               select { |req_string| req_string.match?(version_regex) }.
               map { |req_string| req_string.match(version_regex) }.

--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -283,7 +283,7 @@ module Dependabot
 
       def internal_dependency_names
         @internal_dependency_names ||=
-          dependency_files.map do |pom|
+          dependency_files.filter_map do |pom|
             doc = Nokogiri::XML(pom.content)
             group_id = doc.at_css("project > groupId") ||
                        doc.at_css("project > parent > groupId")
@@ -292,7 +292,7 @@ module Dependabot
             next unless group_id && artifact_id
 
             [group_id.content.strip, artifact_id.content.strip].join(":")
-          end.compact
+          end
       end
 
       def check_required_files

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -31,7 +31,7 @@ module Dependabot
           )
         end
 
-        updated_files.select! { |f| f.name.end_with?("pom.xml") || f.name.end_with?("extensions.xml") }
+        updated_files.select! { |f| f.name.end_with?("pom.xml", "extensions.xml") }
         updated_files.reject! { |f| dependency_files.include?(f) }
 
         raise "No files changed!" if updated_files.none?

--- a/maven/lib/dependabot/maven/file_updater/property_value_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater/property_value_updater.rb
@@ -28,7 +28,7 @@ module Dependabot
             \s*#{Regexp.quote(node.content)}\s*
             </#{Regexp.quote(node.name)}>}xm
           property_text = node.to_s
-          if pom_to_update.content =~ property_re
+          if pom_to_update.content&.match?(property_re)
             updated_content = pom_to_update.content.sub(
               property_re,
               "<#{node.name}>#{updated_value}</#{node.name}>"

--- a/maven/lib/dependabot/maven/version.rb
+++ b/maven/lib/dependabot/maven/version.rb
@@ -117,11 +117,11 @@ module Dependabot
       end
 
       def trim_version(version)
-        version.split("-").map do |v|
+        version.split("-").filter_map do |v|
           parts = v.split(".")
           parts = parts[0..-2] while NULL_VALUES.include?(parts&.last)
           parts&.join(".")
-        end.compact.reject(&:empty?).join("-")
+        end.reject(&:empty?).join("-")
       end
 
       def convert_dates(version, other_version)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -200,7 +200,7 @@ module Dependabot
         resolution_objects = parsed_manifest.values_at("resolutions").compact
         manifest_objects = dependency_objects + resolution_objects
 
-        raise Dependabot::DependencyFileNotParseable, file.path unless manifest_objects.all? { |o| o.is_a?(Hash) }
+        raise Dependabot::DependencyFileNotParseable, file.path unless manifest_objects.all?(Hash)
 
         resolution_deps = resolution_objects.flat_map(&:to_a).
                           map do |path, value|

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -159,7 +159,7 @@ module Dependabot
 
       def workspace_package_names
         @workspace_package_names ||=
-          package_files.map { |f| JSON.parse(f.content)["name"] }.compact
+          package_files.filter_map { |f| JSON.parse(f.content)["name"] }
       end
 
       def version_for(name, requirement, manifest_name)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -48,8 +48,8 @@ module Dependabot
             %w(yarn.lock package-lock.json npm-shrinkwrap.json)
 
           possible_lockfile_names.uniq.
-            map { |nm| dependency_files.find { |f| f.name == nm } }.
-            compact
+            filter_map { |nm| dependency_files.find { |f| f.name == nm } }
+            
         end
 
         def npm_lockfile_details(lockfile, dependency_name, manifest_name)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -49,7 +49,7 @@ module Dependabot
 
           possible_lockfile_names.uniq.
             filter_map { |nm| dependency_files.find { |f| f.name == nm } }
-            
+
         end
 
         def npm_lockfile_details(lockfile, dependency_name, manifest_name)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -49,7 +49,6 @@ module Dependabot
 
           possible_lockfile_names.uniq.
             filter_map { |nm| dependency_files.find { |f| f.name == nm } }
-
         end
 
         def npm_lockfile_details(lockfile, dependency_name, manifest_name)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -123,12 +123,12 @@ module Dependabot
       end
 
       def updated_manifest_files
-        package_files.map do |file|
+        package_files.filter_map do |file|
           updated_content = updated_package_json_content(file)
           next if updated_content == file.content
 
           updated_file(file: file, content: updated_content)
-        end.compact
+        end
       end
 
       def updated_lockfiles

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -89,7 +89,7 @@ module Dependabot
           if package_lock
             @dependency_urls +=
               parsed_package_lock.fetch("dependencies", {}).
-              map { |_, details| details["resolved"] }.compact.
+              filter_map { |_, details| details["resolved"] }.
               select { |url| url.is_a?(String) }.
               reject { |url| url.start_with?("git") }
           end
@@ -166,8 +166,8 @@ module Dependabot
 
           @npmrc_scoped_registries ||=
             npmrc_file.content.lines.select { |line| line.match?(SCOPED_REGISTRY) }.
-            map { |line| line.match(SCOPED_REGISTRY)&.named_captures&.fetch("registry") }.
-            compact
+            filter_map { |line| line.match(SCOPED_REGISTRY)&.named_captures&.fetch("registry") }
+            
         end
 
         # rubocop:disable Metrics/PerceivedComplexity

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -167,7 +167,6 @@ module Dependabot
           @npmrc_scoped_registries ||=
             npmrc_file.content.lines.select { |line| line.match?(SCOPED_REGISTRY) }.
             filter_map { |line| line.match(SCOPED_REGISTRY)&.named_captures&.fetch("registry") }
-
         end
 
         # rubocop:disable Metrics/PerceivedComplexity

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -167,7 +167,7 @@ module Dependabot
           @npmrc_scoped_registries ||=
             npmrc_file.content.lines.select { |line| line.match?(SCOPED_REGISTRY) }.
             filter_map { |line| line.match(SCOPED_REGISTRY)&.named_captures&.fetch("registry") }
-            
+
         end
 
         # rubocop:disable Metrics/PerceivedComplexity

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -155,11 +155,11 @@ module Dependabot
         def requirements_for_path(requirements, path)
           return requirements if path.to_s == "."
 
-          requirements.map do |r|
+          requirements.filter_map do |r|
             next unless r[:file].start_with?("#{path}/")
 
             r.merge(file: r[:file].gsub(/^#{Regexp.quote("#{path}/")}/, ""))
-          end.compact
+          end
         end
 
         # rubocop:disable Metrics/AbcSize

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -64,7 +64,7 @@ module Dependabot
 
         all_version_listings.
           reject { |v, _| Time.parse(times[v]) > cutoff }.
-          map { |_, d| d.fetch("_npmUser", nil)&.fetch("name", nil) }.compact
+          filter_map { |_, d| d.fetch("_npmUser", nil)&.fetch("name", nil) }
       end
 
       def find_source_from_registry

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -214,11 +214,11 @@ module Dependabot
       end
 
       def latest_resolvable_version_with_no_unlock_for_git_dependency
-        reqs = dependency.requirements.map do |r|
+        reqs = dependency.requirements.filter_map do |r|
           next if r.fetch(:requirement).nil?
 
           requirement_class.requirements_array(r.fetch(:requirement))
-        end.compact
+        end
 
         current_version =
           if existing_version_is_sha? ||

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -121,9 +121,9 @@ module Dependabot
         end
 
         def filter_out_of_range_versions(versions_array)
-          reqs = dependency.requirements.map do |r|
+          reqs = dependency.requirements.filter_map do |r|
             NpmAndYarn::Requirement.requirements_array(r.fetch(:requirement))
-          end.compact
+          end
 
           versions_array.
             select { |v| reqs.all? { |r| r.any? { |o| o.satisfied_by?(v) } } }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
@@ -63,7 +63,7 @@ module Dependabot
         def updating_from_git_to_npm?
           return false unless updated_source.nil?
 
-          original_source = requirements.map { |r| r[:source] }.compact.first
+          original_source = requirements.filter_map { |r| r[:source] }.first
           original_source&.fetch(:type) == "git"
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -355,7 +355,7 @@ module Dependabot
             requirement_name:
               captures.fetch("required_dep").sub(/@[^@]+$/, ""),
             requirement_version:
-              captures.fetch("required_dep").split("@").last.gsub('"', ""),
+              captures.fetch("required_dep").split("@").last.delete('"'),
             requiring_dep_name:
               captures.fetch("requiring_dep").sub(/@[^@]+$/, "")
           }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -157,7 +157,7 @@ module Dependabot
             relevant_versions = latest_version_finder(dependency).
                                 possible_previous_versions_with_details.
                                 map(&:first)
-            reqs = dep.requirements.map { |r| r[:requirement] }.compact.
+            reqs = dep.requirements.filter_map { |r| r[:requirement] }.
                    map { |r| requirement_class.requirements_array(r) }
 
             # Pick the lowest version from the max possible version from all
@@ -543,11 +543,11 @@ module Dependabot
         def requirements_for_path(requirements, path)
           return requirements if path.to_s == "."
 
-          requirements.map do |r|
+          requirements.filter_map do |r|
             next unless r[:file].start_with?("#{path}/")
 
             r.merge(file: r[:file].gsub(/^#{Regexp.quote("#{path}/")}/, ""))
-          end.compact
+          end
         end
 
         # Top level dependencies are required in the peer dep checker
@@ -581,7 +581,7 @@ module Dependabot
         def version_for_dependency(dep)
           return version_class.new(dep.version) if dep.version && version_class.correct?(dep.version)
 
-          dep.requirements.map { |r| r[:requirement] }.compact.
+          dep.requirements.filter_map { |r| r[:requirement] }.
             reject { |req_string| req_string.start_with?("<") }.
             select { |req_string| req_string.match?(version_regex) }.
             map { |req_string| req_string.match(version_regex) }.

--- a/nuget/lib/dependabot/nuget/file_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher.rb
@@ -73,11 +73,11 @@ module Dependabot
           [*project_files.map { |f| File.dirname(f.name) }, "."].uniq
 
         @packages_config_files ||=
-          candidate_paths.map do |dir|
+          candidate_paths.filter_map do |dir|
             file = repo_contents(dir: dir).
                    find { |f| f.name.casecmp("packages.config").zero? }
             fetch_file_from_host(File.join(dir, file.name)) if file
-          end.compact
+          end
       end
 
       # rubocop:disable Metrics/PerceivedComplexity
@@ -157,7 +157,7 @@ module Dependabot
                 project_paths
             end
 
-            paths.map do |path|
+            paths.filter_map do |path|
               fetch_file_from_host(path)
             rescue Dependabot::DependencyFileNotFound => e
               @missing_sln_project_file_errors ||= []
@@ -165,7 +165,7 @@ module Dependabot
               # Don't worry about missing files too much for now (at least
               # until we start resolving properties)
               nil
-            end.compact
+            end
           end
       end
 
@@ -209,12 +209,12 @@ module Dependabot
           [*project_files.map { |f| File.dirname(f.name) }, "."].uniq
 
         @nuget_config_files ||=
-          candidate_paths.map do |dir|
+          candidate_paths.filter_map do |dir|
             file = repo_contents(dir: dir).
                    find { |f| f.name.casecmp("nuget.config").zero? }
             file = fetch_file_from_host(File.join(dir, file.name)) if file
             file&.tap { |f| f.support_file = true }
-          end.compact
+          end
       end
 
       def global_json

--- a/nuget/lib/dependabot/nuget/file_parser/packages_config_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/packages_config_parser.rb
@@ -61,7 +61,7 @@ module Dependabot
         def dependency_type(dependency_node)
           val = dependency_node.attribute("developmentDependency")&.value&.strip ||
                 dependency_node.at_xpath("./developmentDependency")&.content&.strip
-          val.to_s.downcase == "true" ? "devDependencies" : "dependencies"
+          val.to_s.casecmp("true").zero? ? "devDependencies" : "dependencies"
         end
       end
     end

--- a/nuget/lib/dependabot/nuget/file_parser/property_value_finder.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/property_value_finder.rb
@@ -47,7 +47,7 @@ module Dependabot
             find_property_in_packages_props(property: property_name)
 
           return unless node_details
-          return node_details unless node_details[:value] =~ PROPERTY_REGEX
+          return node_details unless PROPERTY_REGEX.match?(node_details[:value])
 
           check_next_level_of_stack(node_details, stack)
         end

--- a/nuget/lib/dependabot/nuget/file_parser/property_value_finder.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/property_value_finder.rb
@@ -91,8 +91,7 @@ module Dependabot
           ]
 
           file = import_paths.
-                 map { |p| dependency_files.find { |f| f.name == p } }.
-                 compact.
+                 filter_map { |p| dependency_files.find { |f| f.name == p } }.
                  find { |f| deep_find_prop_node(property: property, file: f) }
 
           return unless file

--- a/nuget/lib/dependabot/nuget/metadata_finder.rb
+++ b/nuget/lib/dependabot/nuget/metadata_finder.rb
@@ -63,7 +63,7 @@ module Dependabot
 
       def extract_source_repo(body)
         JSON.parse(body).fetch("data", []).each do |search_result|
-          next unless search_result["id"].downcase == dependency.name.downcase
+          next unless search_result["id"].casecmp(dependency.name).zero?
 
           if search_result.key?("projectUrl")
             source = Source.from_url(search_result.fetch("projectUrl"))

--- a/nuget/lib/dependabot/nuget/update_checker/requirements_updater.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/requirements_updater.rb
@@ -38,7 +38,7 @@ module Dependabot
                 # replace anything that looks like a version with the new
                 # version
                 req[:requirement].sub(
-                  /#{Nuget::Version::VERSION_PATTERN}/,
+                  /#{Nuget::Version::VERSION_PATTERN}/o,
                   latest_version.to_s
                 )
               end

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -172,7 +172,7 @@ module Dependabot
 
           dependency.requirements.any? do |req|
             reqs = parse_requirement_string(req.fetch(:requirement) || "")
-            return true if reqs.any? { |r| r == "*-*" }
+            return true if reqs.any?("*-*")
             next unless reqs.any? { |r| r.include?("-") }
 
             requirement_class.

--- a/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
+++ b/nuget/lib/dependabot/nuget/update_checker/version_finder.rb
@@ -127,7 +127,7 @@ module Dependabot
             doc = Nokogiri::XML(body)
             doc.remove_namespaces!
 
-            doc.xpath("/feed/entry").map do |entry|
+            doc.xpath("/feed/entry").filter_map do |entry|
               listed = entry.at_xpath("./properties/Listed")&.content&.strip
               next if listed&.casecmp("false")&.zero?
 
@@ -136,7 +136,7 @@ module Dependabot
                 repo_url: listing.fetch("listing_details").
                           fetch(:repository_url)
               )
-            end.compact
+            end
           end
         end
 
@@ -193,12 +193,12 @@ module Dependabot
           @v3_nuget_listings ||=
             dependency_urls.
             select { |details| details.fetch(:repository_type) == "v3" }.
-            map do |url_details|
+            filter_map do |url_details|
               versions = versions_for_v3_repository(url_details)
               next unless versions
 
               { "versions" => versions, "listing_details" => url_details }
-            end.compact
+            end
         end
 
         def v2_nuget_listings
@@ -208,14 +208,14 @@ module Dependabot
             dependency_urls.
             select { |details| details.fetch(:repository_type) == "v2" }.
             flat_map { |url_details| fetch_paginated_v2_nuget_listings(url_details) }.
-            map do |url_details, response|
+            filter_map do |url_details, response|
               next unless response.status == 200
 
               {
                 "xml_body" => response.body,
                 "listing_details" => url_details
               }
-            end.compact
+            end
         end
 
         def fetch_paginated_v2_nuget_listings(url_details, results = {})

--- a/pub/lib/dependabot/pub/requirement.rb
+++ b/pub/lib/dependabot/pub/requirement.rb
@@ -78,7 +78,7 @@ module Dependabot
 
       def convert_range_req(req_string)
         req_string.scan(
-          /((?:>|<|=|<=|>=)\s*#{Pub::Version::VERSION_PATTERN})\s*/
+          /((?:>|<|=|<=|>=)\s*#{Pub::Version::VERSION_PATTERN})\s*/o
         ).map { |x| x[0].strip }
       end
 

--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -13,6 +13,7 @@ module Dependabot
     class FileFetcher < Dependabot::FileFetchers::Base
       CHILD_REQUIREMENT_REGEX = /^-r\s?(?<path>.*\.(?:txt|in))/.freeze
       CONSTRAINT_REGEX = /^-c\s?(?<path>.*\.(?:txt|in))/.freeze
+      DEPENDENCY_TYPES = %w(packages dev-packages).freeze
 
       def self.required_files_in?(filenames)
         return true if filenames.any? { |name| name.end_with?(".txt", ".in") }
@@ -372,7 +373,7 @@ module Dependabot
         return [] unless pipfile
 
         paths = []
-        %w(packages dev-packages).each do |dep_type|
+        DEPENDENCY_TYPES.each do |dep_type|
           next unless parsed_pipfile[dep_type]
 
           parsed_pipfile[dep_type].each do |_, req|

--- a/python/lib/dependabot/python/file_parser/poetry_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/poetry_files_parser.rb
@@ -61,7 +61,7 @@ module Dependabot
 
         # @param req can be an Array, Hash or String that represents the constraints for a dependency
         def parse_requirements_from(req, type)
-          [req].flatten.compact.map do |requirement|
+          [req].flatten.compact.filter_map do |requirement|
             next if requirement.is_a?(Hash) && (UNSUPPORTED_DEPENDENCY_TYPES & requirement.keys).any?
 
             check_requirements(requirement)
@@ -72,7 +72,7 @@ module Dependabot
               source: nil,
               groups: [type]
             }
-          end.compact
+          end
         end
 
         # Create a DependencySet where each element has no requirement. Any

--- a/python/lib/dependabot/python/file_parser/poetry_files_parser.rb
+++ b/python/lib/dependabot/python/file_parser/poetry_files_parser.rb
@@ -81,8 +81,9 @@ module Dependabot
         def lockfile_dependencies
           dependencies = Dependabot::FileParsers::Base::DependencySet.new
 
+          source_types = %w(directory git url)
           parsed_lockfile.fetch("package", []).each do |details|
-            next if %w(directory git url).include?(details.dig("source", "type"))
+            next if source_types.include?(details.dig("source", "type"))
 
             dependencies <<
               Dependency.new(

--- a/python/lib/dependabot/python/file_parser/python_requirement_parser.rb
+++ b/python/lib/dependabot/python/file_parser/python_requirement_parser.rb
@@ -33,8 +33,7 @@ module Dependabot
           requirement_files.flat_map do |file|
             file.content.lines.
               select { |l| l.include?(";") && l.include?("python") }.
-              map { |l| l.match(/python_version(?<req>.*?["'].*?['"])/) }.
-              compact.
+              filter_map { |l| l.match(/python_version(?<req>.*?["'].*?['"])/) }.
               map { |re| re.named_captures.fetch("req").gsub(/['"]/, "") }.
               select { |r| valid_requirement?(r) }
           end

--- a/python/lib/dependabot/python/file_updater.rb
+++ b/python/lib/dependabot/python/file_updater.rb
@@ -60,8 +60,8 @@ module Dependabot
 
         # Otherwise, this is a top-level dependency, and we can figure out
         # which resolver to use based on the filename of its requirements
-        return :pipfile if changed_req_files.any? { |f| f == "Pipfile" }
-        return :poetry if changed_req_files.any? { |f| f == "pyproject.toml" }
+        return :pipfile if changed_req_files.any?("Pipfile")
+        return :poetry if changed_req_files.any?("pyproject.toml")
         return :pip_compile if changed_req_files.any? { |f| f.end_with?(".in") }
 
         :requirements

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -92,7 +92,7 @@ module Dependabot
             # Remove any .python-version file before parsing the reqs
             FileUtils.remove_entry(".python-version", true)
 
-            dependency_files.map do |file|
+            dependency_files.filter_map do |file|
               next unless file.name.end_with?(".txt")
 
               updated_content = File.read(file.name)
@@ -102,12 +102,12 @@ module Dependabot
               next if updated_content == file.content
 
               file.dup.tap { |f| f.content = updated_content }
-            end.compact
+            end
           end
         end
 
         def update_manifest_files
-          dependency_files.map do |file|
+          dependency_files.filter_map do |file|
             next unless file.name.end_with?(".in")
 
             file = file.dup
@@ -116,7 +116,7 @@ module Dependabot
 
             file.content = updated_content
             file
-          end.compact
+          end
         end
 
         def update_uncompiled_files(updated_files)

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -352,7 +352,7 @@ module Dependabot
         end
 
         def deps_to_augment_hashes_for(updated_content, original_content)
-          regex = /^#{RequirementParser::INSTALL_REQ_WITH_REQUIREMENT}/
+          regex = /^#{RequirementParser::INSTALL_REQ_WITH_REQUIREMENT}/o
 
           new_matches = []
           updated_content.scan(regex) { new_matches << Regexp.last_match }

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -18,6 +18,8 @@ module Dependabot
         require_relative "pipfile_manifest_updater"
         require_relative "setup_file_sanitizer"
 
+        DEPENDENCY_TYPES = %w(packages dev-packages).freeze
+
         attr_reader :dependencies, :dependency_files, :credentials
 
         def initialize(dependencies:, dependency_files:, credentials:)
@@ -145,7 +147,7 @@ module Dependabot
           pipfile_object = TomlRB.parse(pipfile_content)
 
           dependencies.each do |dep|
-            %w(packages dev-packages).each do |type|
+            DEPENDENCY_TYPES.each do |type|
               names = pipfile_object[type]&.keys || []
               pkg_name = names.find { |nm| normalise(nm) == dep.name }
               next unless pkg_name || subdep_type?(type)

--- a/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
@@ -55,6 +55,7 @@ module Dependabot
           Dependabot::Python::FileParser::PoetryFilesParser::POETRY_DEPENDENCY_TYPES.each do |key|
             next unless poetry_object[key]
 
+            source_types = %w(directory file url)
             poetry_object.fetch(key).each do |dep_name, _|
               next if excluded_names.include?(normalise(dep_name))
 
@@ -62,7 +63,7 @@ module Dependabot
 
               next unless (locked_version = locked_details&.fetch("version"))
 
-              next if %w(directory file url).include?(locked_details&.dig("source", "type"))
+              next if source_types.include?(locked_details&.dig("source", "type"))
 
               if locked_details&.dig("source", "type") == "git"
                 poetry_object[key][dep_name] = {

--- a/python/lib/dependabot/python/file_updater/requirement_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/requirement_file_updater.rb
@@ -36,7 +36,7 @@ module Dependabot
         def fetch_updated_dependency_files
           reqs = dependency.requirements.zip(dependency.previous_requirements)
 
-          reqs.map do |(new_req, old_req)|
+          reqs.filter_map do |(new_req, old_req)|
             next if new_req == old_req
 
             file = get_original_file(new_req.fetch(:file)).dup
@@ -46,7 +46,7 @@ module Dependabot
 
             file.content = updated_content
             file
-          end.compact
+          end
         end
 
         def updated_requirement_or_setup_file_content(new_req, old_req)

--- a/python/lib/dependabot/python/file_updater/requirement_replacer.rb
+++ b/python/lib/dependabot/python/file_updater/requirement_replacer.rb
@@ -52,7 +52,7 @@ module Dependabot
           if add_space_after_operators?
             new_req_string =
               new_req_string.
-              gsub(/(#{RequirementParser::COMPARISON})\s*(?=\d)/, '\1 ')
+              gsub(/(#{RequirementParser::COMPARISON})\s*(?=\d)/o, '\1 ')
           end
 
           new_req_string
@@ -92,7 +92,7 @@ module Dependabot
         def add_space_after_operators?
           original_dependency_declaration_string(old_requirement).
             match(RequirementParser::REQUIREMENTS).
-            to_s.match?(/#{RequirementParser::COMPARISON}\s+\d/)
+            to_s.match?(/#{RequirementParser::COMPARISON}\s+\d/o)
         end
 
         def original_declaration_replacement_regex

--- a/python/lib/dependabot/python/file_updater/setup_file_sanitizer.rb
+++ b/python/lib/dependabot/python/file_updater/setup_file_sanitizer.rb
@@ -38,22 +38,22 @@ module Dependabot
 
         def install_requires_array
           @install_requires_array ||=
-            parsed_setup_file.dependencies.map do |dep|
+            parsed_setup_file.dependencies.filter_map do |dep|
               next unless dep.requirements.first[:groups].
                           include?("install_requires")
 
               dep.name + dep.requirements.first[:requirement].to_s
-            end.compact
+            end
         end
 
         def setup_requires_array
           @setup_requires_array ||=
-            parsed_setup_file.dependencies.map do |dep|
+            parsed_setup_file.dependencies.filter_map do |dep|
               next unless dep.requirements.first[:groups].
                           include?("setup_requires")
 
               dep.name + dep.requirements.first[:requirement].to_s
-            end.compact
+            end
         end
 
         def extras_require_hash

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -238,7 +238,7 @@ module Dependabot
         return ">= #{dependency.version}" if dependency.version
 
         version_for_requirement =
-          dependency.requirements.map { |r| r[:requirement] }.compact.
+          dependency.requirements.filter_map { |r| r[:requirement] }.
           reject { |req_string| req_string.start_with?("<") }.
           select { |req_string| req_string.match?(VERSION_REGEX) }.
           map { |req_string| req_string.match(VERSION_REGEX) }.

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -144,8 +144,8 @@ module Dependabot
 
         # Otherwise, this is a top-level dependency, and we can figure out
         # which resolver to use based on the filename of its requirements
-        return :pipenv if req_files.any? { |f| f == "Pipfile" }
-        return :poetry if req_files.any? { |f| f == "pyproject.toml" }
+        return :pipenv if req_files.any?("Pipfile")
+        return :poetry if req_files.any?("pyproject.toml")
         return :pip_compile if req_files.any? { |f| f.end_with?(".in") }
 
         if dependency.version && !exact_requirement?(reqs)

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -132,7 +132,6 @@ module Dependabot
         resolver.resolvable?(version: fix_version) ? fix_version : nil
       end
 
-      # rubocop:disable Metrics/PerceivedComplexity
       def resolver_type
         reqs = dependency.requirements
         req_files = reqs.map { |r| r.fetch(:file) }
@@ -154,7 +153,6 @@ module Dependabot
           :requirements
         end
       end
-      # rubocop:enable Metrics/PerceivedComplexity
 
       def subdependency_resolver
         return :pipenv if pipfile_lock

--- a/python/lib/dependabot/python/update_checker/index_finder.rb
+++ b/python/lib/dependabot/python/update_checker/index_finder.rb
@@ -171,7 +171,7 @@ module Dependabot
           authed_url = config_variable_urls.find { |u| u.match?(regexp) }
           return authed_url if authed_url
 
-          cleaned_url = url.gsub(%r{#{ENVIRONMENT_VARIABLE_REGEX}/?}, "")
+          cleaned_url = url.gsub(%r{#{ENVIRONMENT_VARIABLE_REGEX}/?}o, "")
           authed_url = authed_base_url(cleaned_url)
           return authed_url if credential_for(cleaned_url)
 

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -85,14 +85,14 @@ module Dependabot
         end
 
         def filter_unsupported_versions(versions_array, python_version)
-          versions_array.map do |details|
+          versions_array.filter_map do |details|
             python_requirement = details.fetch(:python_requirement)
             next details.fetch(:version) unless python_version
             next details.fetch(:version) unless python_requirement
             next unless python_requirement.satisfied_by?(python_version)
 
             details.fetch(:version)
-          end.compact
+          end
         end
 
         def filter_prerelease_versions(versions_array)
@@ -118,9 +118,9 @@ module Dependabot
         end
 
         def filter_out_of_range_versions(versions_array)
-          reqs = dependency.requirements.map do |r|
+          reqs = dependency.requirements.filter_map do |r|
             requirement_class.requirements_array(r.fetch(:requirement))
-          end.compact
+          end
 
           versions_array.
             select { |v| reqs.all? { |r| r.any? { |o| o.satisfied_by?(v) } } }

--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -144,11 +144,14 @@ module Dependabot
           @available_versions ||=
             index_urls.flat_map do |index_url|
               sanitized_url = index_url.gsub(%r{(?<=//).*(?=@)}, "redacted")
-              index_response = registry_response_for_dependency(index_url)
 
-              if [401, 403].include?(index_response.status) &&
-                 [401, 403].include?(registry_index_response(index_url).status)
-                raise PrivateSourceAuthenticationFailure, sanitized_url
+              index_response = registry_response_for_dependency(index_url)
+              if index_response.status == 401 || index_response.status == 403
+                registry_index_response = registry_index_response(index_url)
+
+                if registry_index_response.status == 401 || registry_index_response.status == 403
+                  raise PrivateSourceAuthenticationFailure, sanitized_url
+                end
               end
 
               version_links = []

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -47,6 +47,8 @@ module Dependabot
         PIPENV_RANGE_WARNING = /Warning:\sPython\s[<>].* was not found/.freeze
         # rubocop:enable Layout/LineLength
 
+        DEPENDENCY_TYPES = %w(packages dev-packages).freeze
+
         attr_reader :dependency, :dependency_files, :credentials
 
         def initialize(dependency:, dependency_files:, credentials:)
@@ -363,7 +365,7 @@ module Dependabot
 
           pipfile_object = TomlRB.parse(pipfile_content)
 
-          %w(packages dev-packages).each do |type|
+          DEPENDENCY_TYPES.each do |type|
             names = pipfile_object[type]&.keys || []
             pkg_name = names.find { |nm| normalise(nm) == dependency.name }
             next unless pkg_name || subdep_type?(type)

--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -260,7 +260,7 @@ module Dependabot
         # Updates the version in a constraint to be the given version
         def bump_version(req_string, version_to_be_permitted)
           old_version = req_string.
-                        match(/(#{RequirementParser::VERSION})/).
+                        match(/(#{RequirementParser::VERSION})/o).
                         captures.first
 
           req_string.sub(

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -262,7 +262,7 @@ module Dependabot
         return :path if source_string.start_with?(".")
         return :github if source_string.start_with?("github.com/")
         return :bitbucket if source_string.start_with?("bitbucket.org/")
-        return :git if source_string.start_with?("git::") || source_string.start_with?("git@")
+        return :git if source_string.start_with?("git::", "git@")
         return :mercurial if source_string.start_with?("hg::")
         return :s3 if source_string.start_with?("s3::")
 

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -313,7 +313,7 @@ module Dependabot
       end
 
       def registry_host_for(dependency)
-        source = dependency.requirements.map { |r| r[:source] }.compact.first
+        source = dependency.requirements.filter_map { |r| r[:source] }.first
         source[:registry_hostname] || source["registry_hostname"] || "registry.terraform.io"
       end
 

--- a/terraform/lib/dependabot/terraform/metadata_finder.rb
+++ b/terraform/lib/dependabot/terraform/metadata_finder.rb
@@ -31,14 +31,14 @@ module Dependabot
       end
 
       def find_source_from_git_url
-        info = dependency.requirements.map { |r| r[:source] }.compact.first
+        info = dependency.requirements.filter_map { |r| r[:source] }.first
 
         url = info[:url] || info.fetch("url")
         Source.from_url(url)
       end
 
       def find_source_from_registry_details
-        info = dependency.requirements.map { |r| r[:source] }.compact.first
+        info = dependency.requirements.filter_map { |r| r[:source] }.first
         hostname = info[:registry_hostname] || info["registry_hostname"]
 
         RegistryClient.

--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -104,9 +104,7 @@ module Dependabot
 
           source_url = response.headers.fetch("X-Terraform-Get")
           source_url = URI.join(download_url, source_url) if
-            source_url.start_with?("/") ||
-            source_url.start_with?("./") ||
-            source_url.start_with?("../")
+            source_url.start_with?("/", "./", "../")
           source_url = RegistryClient.get_proxied_source(source_url) if source_url
         when "provider", "providers"
           response = http_get(URI.join(base_url, "#{dependency.name}/#{dependency.version}"))

--- a/terraform/lib/dependabot/terraform/requirements_updater.rb
+++ b/terraform/lib/dependabot/terraform/requirements_updater.rb
@@ -130,7 +130,7 @@ module Dependabot
 
       def at_same_precision(new_version, old_version)
         release_precision =
-          old_version.to_s.split(".").select { |i| i.match?(/^\d+$/) }.count
+          old_version.to_s.split(".").count { |i| i.match?(/^\d+$/) }
         prerelease_precision =
           old_version.to_s.split(".").count - release_precision
 

--- a/updater/lib/dependabot/file_fetcher_job.rb
+++ b/updater/lib/dependabot/file_fetcher_job.rb
@@ -152,6 +152,11 @@ module Dependabot
           }
         when Octokit::Unauthorized
           { "error-type": "octokit_unauthorized" }
+        when Octokit::ServerError
+          # If we get a 500 from GitHub there's very little we can do about it,
+          # and responsibility for fixing it is on them, not us. As a result we
+          # quietly log these as errors
+          { "error-type": "unknown_error" }
         when *Octokit::RATE_LIMITED_ERRORS
           # If we get a rate-limited error we let dependabot-api handle the
           # retry by re-enqueing the update job after the reset
@@ -161,11 +166,6 @@ module Dependabot
               "rate-limit-reset": error.response_headers["X-RateLimit-Reset"]
             }
           }
-        when Octokit::ServerError
-          # If we get a 500 from GitHub there's very little we can do about it,
-          # and responsibility for fixing it is on them, not us. As a result we
-          # quietly log these as errors
-          { "error-type": "unknown_error" }
         else
           logger_error error.message
           error.backtrace.each { |line| logger_error line }


### PR DESCRIPTION
Related to https://github.com/dependabot/dependabot-core/pull/5588

[RuboCop Performance](https://docs.rubocop.org/rubocop-performance/index.html) is a RuboCop extension that adds linters for Ruby (anti-)patterns that have an outsized performance impact.

This PR adds `rubocop-performance` as a development dependency to `dependabot-common` and updates the shared `.rubocop.yml` file to enable [Performance cops](https://docs.rubocop.org/rubocop-performance/cops.html).