### PR TITLE
Update file size to 500 kilobytes

### DIFF
--- a/python/lib/dependabot/python/file_fetcher.rb
+++ b/python/lib/dependabot/python/file_fetcher.rb
@@ -169,7 +169,7 @@ module Dependabot
         repo_contents.
           select { |f| f.type == "file" }.
           select { |f| f.name.end_with?(".txt", ".in") }.
-          reject { |f| f.size > 200_000 }.
+          reject { |f| f.size > 500_000 }.
           map { |f| fetch_file_from_host(f.name) }.
           select { |f| requirements_file?(f) }.
           each { |f| @req_txt_and_in_files << f }
@@ -189,7 +189,7 @@ module Dependabot
         repo_contents(dir: relative_reqs_dir).
           select { |f| f.type == "file" }.
           select { |f| f.name.end_with?(".txt", ".in") }.
-          reject { |f| f.size > 200_000 }.
+          reject { |f| f.size > 500_000 }.
           map { |f| fetch_file_from_host("#{relative_reqs_dir}/#{f.name}") }.
           select { |f| requirements_file?(f) }
       end


### PR DESCRIPTION
Hi there,

This PR is a result from a discussion in https://github.com/dependabot/dependabot-core/pull/5580 where @jeffwidman asked to split up the original PR into two.

The purpose of this PR is to increase the file size of `requirements.txt` files to 500 kilobytes.

Especially in large projects, `pip-tools`-compiled `requirement.txt` files can get pretty big.

As @dws mentioned [here](https://github.com/dependabot/dependabot-core/pull/5580#issuecomment-1226148657) the ideal solution would be to have the file size as a configurable parameter.

If this change requires any unit tests please point me to existing examples.

Thanks!