### PR TITLE
Use correct label for tech debt form

### DIFF
--- a/.github/ISSUE_TEMPLATE/tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yml
@@ -1,6 +1,6 @@
 name: ⚙ Tech Debt
 description: Tech debt is for code improvements that do not change the user-facing behavior (ie, neither adding features nor fixing bugs).
-labels: "T: tech-debt"
+labels: "T: tech-debt ⚙️"
 body:
   - type: checkboxes
     attributes:


### PR DESCRIPTION
## Changes:

- Use correct label for tech debt form

## Context:

The tech debt label uses an ⚙️ emoji, which was missing from the `labels` string.