### PR TITLE
Support `increase-if-necessary` versioning strategy in python

### DIFF
--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -175,11 +175,25 @@ module Dependabot
         end
         # rubocop:enable Metrics/PerceivedComplexity
 
-        # rubocop:disable Metrics/PerceivedComplexity
         def updated_requirement(req)
           return req unless latest_resolvable_version
           return req unless req.fetch(:requirement)
 
+          case update_strategy
+          when :bump_versions
+            update_requirement(req)
+          when :bump_versions_if_necessary
+            update_requirement_if_needed(req)
+          end
+        end
+
+        def update_requirement_if_needed(req)
+          return req if new_version_satisfies?(req)
+
+          update_requirement(req)
+        end
+
+        def update_requirement(req)
           requirement_strings = req[:requirement].split(",").map(&:strip)
 
           new_requirement =
@@ -197,7 +211,6 @@ module Dependabot
         rescue UnfixableRequirement
           req.merge(requirement: :unfixable)
         end
-        # rubocop:enable Metrics/PerceivedComplexity
 
         def new_version_satisfies?(req)
           requirement_class.

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -147,12 +147,24 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           context "that supports the new version" do
             let(:requirement_txt_req_string) { "~=1.3" }
             its([:requirement]) { is_expected.to eq("~=1.5") }
+
+            context "with the bump_versions_if_necessary update strategy" do
+              let(:update_strategy) { :bump_versions_if_necessary }
+
+              its([:requirement]) { is_expected.to eq("~=1.3") }
+            end
           end
 
           context "that needs to be updated and maintain its precision" do
             let(:requirement_txt_req_string) { "~=1.3" }
             let(:latest_resolvable_version) { "2.1.0" }
             its([:requirement]) { is_expected.to eq("~=2.1") }
+
+            context "with the bump_versions_if_necessary update strategy" do
+              let(:update_strategy) { :bump_versions_if_necessary }
+
+              its([:requirement]) { is_expected.to eq("~=2.1") }
+            end
           end
         end
 


### PR DESCRIPTION
I still want to add some specs, but this is just a quick patch to get this started.

Fixes #3212.
Fixes #4435.
Fixes #5537.