### PR TITLE
Configure RSpec to allow running `rspec --only-failures`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ vendor
 coverage/
 .ruby-gemset
 .tool-versions
+.rspec_status

--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -38,6 +38,7 @@ RSpec.configure do |config|
   config.order = :rand
   config.mock_with(:rspec) { |mocks| mocks.verify_partial_doubles = true }
   config.raise_errors_for_deprecations!
+  config.example_status_persistence_file_path = ".rspec_status"
 
   config.after do
     # Ensure we clear any cached timeouts between tests


### PR DESCRIPTION
When I make changes and break stuff, I like running `rspec --only-failures` to focus on fixing what I broke. This allows RSpec to keep track of what's currently failing, so that this flag can actually be used.

What do you think?