### PR TITLE
Run `rspec` with `--profile` flag by default in Python

### DIFF
--- a/python/spec/spec_helper.rb
+++ b/python/spec/spec_helper.rb
@@ -26,4 +26,6 @@ RSpec.configure do |config|
       example.skip
     end
   end
+
+  config.profile_examples = 10
 end


### PR DESCRIPTION
This flag prints the slowest 10 specs and their run times after each rspec run.

Because our Python test suite is so slow, It just occurred to me that maybe using it by default in Python would raise awareness on the areas that need more love with regards to test speed.