### PR TITLE
publish main branch images

### DIFF
--- a/.github/workflows/docker-branch-releases.yml
+++ b/.github/workflows/docker-branch-releases.yml
@@ -4,6 +4,12 @@ env:
   UPDATER_IMAGE: "dependabot/updater"
   UPDATER_IMAGE_MIRROR: "ghcr.io/dependabot/dependabot-updater"
 on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "CHANGELOG.md"
+      - "common/lib/dependabot/version.rb"
   pull_request:
     paths-ignore:
       - "CHANGELOG.md"

--- a/.github/workflows/docker-branch-releases.yml
+++ b/.github/workflows/docker-branch-releases.yml
@@ -65,4 +65,4 @@ jobs:
           name: updater-${{ github.sha }}.tar
           path: dependabot-updater.tar
       - name: Set summary
-        run: echo "updater uploaded with tag $TAG" >> $GITHUB_STEP_SUMMARY
+        run: echo "updater uploaded \`ghcr.io/dependabot/dependabot-updater/dependabot-updater:$TAG\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,7 @@ jobs:
     name: Push dependabot-updater image to docker hub
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'dependabot/dependabot-core' }}
+    needs: push-core-image
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This should publish a tagged image for commits on main too. This way we can deploy a SHA from a main merge commit.