### PR TITLE
Revert "Add more helpful error messaging when a vulnerable dependency cannot be upgraded"

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -96,19 +96,13 @@ module Dependabot
       end
 
       def conflicting_dependencies
-        conflicts = ConflictingDependencyResolver.new(
+        ConflictingDependencyResolver.new(
           dependency_files: dependency_files,
           credentials: credentials
         ).conflicting_dependencies(
           dependency: dependency,
           target_version: lowest_security_fix_version
         )
-
-        vulnerable = vulnerability_audit.select do |v|
-          !v["fix_available"] && v["explanation"]
-        end
-
-        conflicts + vulnerable
       end
 
       private

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -21,7 +21,6 @@ module Dependabot
           @allow_removal = allow_removal
         end
 
-        # rubocop:disable Metrics/MethodLength
         # Finds any dependencies in the `package-lock.json` or `npm-shrinkwrap.json` that have
         # a subdependency on the given dependency that is locked to a vuln version range.
         #
@@ -42,7 +41,6 @@ module Dependabot
         #       dependency on the blocking dependency
         #   * :top_level_ancestors [Array<String>] the names of all top-level dependencies with a transitive
         #     dependency on the dependency
-        #   * :explanation [String] an explanation for why the project failed the vulnerability auditor run
         def audit(dependency:, security_advisories:)
           fix_unavailable = {
             "dependency_name" => dependency.name,
@@ -76,12 +74,7 @@ module Dependabot
               function: "npm:vulnerabilityAuditor",
               args: [Dir.pwd, vuln_versions]
             )
-
-            validation_result = validate_audit_result(audit_result, security_advisories)
-            unless viable_audit_result?(validation_result)
-              fix_unavailable["explanation"] = explain_fix_unavailable(validation_result, dependency)
-              return fix_unavailable
-            end
+            return fix_unavailable unless viable_audit_result?(audit_result, security_advisories)
 
             audit_result
           end
@@ -89,23 +82,13 @@ module Dependabot
           log_helper_subprocess_failure(dependency, e)
           fix_unavailable
         end
-        # rubocop:enable Metrics/MethodLength
 
         private
 
         attr_reader :dependency_files, :credentials
 
-        def explain_fix_unavailable(validation_result, dependency)
-          case validation_result
-          when :fix_unavailable, :dependency_still_vulnerable, :downgrades_dependencies
-            "No patched version available for #{dependency.name}"
-          when :vulnerable_dependency_removed
-            "#{dependency.name} was removed in the update. Dependabot is not able to " \
-              "deal with this yet, but you can still upgrade manually."
-          end
-        end
-
-        def viable_audit_result?(validation_result)
+        def viable_audit_result?(audit_result, security_advisories)
+          validation_result = validate_audit_result(audit_result, security_advisories)
           return true if validation_result == :viable
 
           Dependabot.logger.info("VulnerabilityAuditor: audit result not viable: #{validation_result}")

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -110,11 +110,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
 
           expect(Dependabot.logger).to receive(:info).with(/audit result not viable: vulnerable_dependency_removed/i)
           expect(subject.audit(dependency: dependency, security_advisories: security_advisories)).
-            to include(
-              "fix_available" => false,
-              "explanation" => "#{dependency.name} was removed in the update. "\
-                "Dependabot is not able to deal with this yet, but you can still upgrade manually."
-            )
+            to include("fix_available" => false)
         end
       end
     end
@@ -141,10 +137,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
 
         expect(Dependabot.logger).to receive(:info).with(/audit result not viable: dependency_still_vulnerable/i)
         expect(subject.audit(dependency: dependency, security_advisories: security_advisories)).
-          to include(
-            "fix_available" => false,
-            "explanation" => "No patched version available for #{dependency.name}"
-          )
+          to include("fix_available" => false)
       end
     end
 
@@ -179,10 +172,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
 
         expect(Dependabot.logger).to receive(:info).with(/audit result not viable: downgrades_dependencies/i)
         expect(subject.audit(dependency: dependency, security_advisories: security_advisories)).
-          to include(
-            "fix_available" => false,
-            "explanation" => "No patched version available for #{dependency.name}"
-          )
+          to include("fix_available" => false)
       end
     end
 


### PR DESCRIPTION
Reverts dependabot/dependabot-core#5542

`#conflicting_dependencies` has a TypeError: no implicit conversion of Hash into Array at

https://github.com/dependabot/dependabot-core/commit/039ce94e0b383baef0458b0e1de94a3c82663ce2#diff-90eca29ed297dba81a7ce1bc74ff4d3293e109bfa4e4183f4170d7322a9cbf27R111