### PR TITLE
Fix path to python native helpers

### DIFF
--- a/python/lib/dependabot/python/native_helpers.rb
+++ b/python/lib/dependabot/python/native_helpers.rb
@@ -12,7 +12,7 @@ module Dependabot
       end
 
       def self.python_helpers_dir
-        File.join(native_helpers_root, "python/helpers")
+        File.join(native_helpers_root, "python")
       end
 
       def self.native_helpers_root


### PR DESCRIPTION
While working on python native helpers, I was running `python/helpers/build` after making changes to install native helpers to the proper location. However, my changes were not being picked up.

Turns out Dependabot was using `/opt/python/helpers`, the path were helpers are originally copied:

https://github.com/dependabot/dependabot-core/blob/70805187fb63ff1f012446bd32a3d22a6220cc43/Dockerfile#L271

Not the path were helpers are originally installed:

https://github.com/dependabot/dependabot-core/blob/70805187fb63ff1f012446bd32a3d22a6220cc43/python/helpers/build#L10

Initially I just fixed the path but thinking about it more, this file tree duplication seems unnecessary and confusing, specifically for interpreted language (where installed files are exactly the same as copied files).

Should we instead remove any file copying from `build` scripts any use the copied tree directly like it was already done for python?