### PR TITLE
skip CI if no changes effect the ecosystem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,88 @@ jobs:
           - { path: terraform, name: terraform }
 
     steps:
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            bundler:
+              - Dockerfile
+              - 'common/**'
+              - 'bundler/**'
+            cargo:
+              - Dockerfile
+              - 'common/**'
+              - 'cargo/**'
+            common:
+              - Dockerfile
+              - 'common/**'
+            composer:
+              - Dockerfile
+              - 'common/**'
+              - 'composer/**'
+            docker:
+              - Dockerfile
+              - 'common/**'
+              - 'docker/**'
+            elm:
+              - Dockerfile
+              - 'common/**'
+              - 'elm/**'
+            git_submodules:
+              - Dockerfile
+              - 'common/**'
+              - 'git_submodules/**'
+            github_actions:
+              - Dockerfile
+              - 'common/**'
+              - 'github_actions/**'
+            go_modules:
+              - Dockerfile
+              - 'common/**'
+              - 'go_modules/**'
+            gradle:
+              - Dockerfile
+              - 'common/**'
+              - 'gradle/**'
+            hex:
+              - Dockerfile
+              - 'common/**'
+              - 'hex/**'
+            maven:
+              - Dockerfile
+              - 'common/**'
+              - 'maven/**'
+            npm_and_yarn:
+              - Dockerfile
+              - 'common/**'
+              - 'npm_and_yarn/**'
+            nuget:
+              - Dockerfile
+              - 'common/**'
+              - 'nuget/**'
+            omnibus:
+              - Dockerfile
+              - 'common/**'
+              - 'omnibus/**'
+            pub:
+              - Dockerfile
+              - 'common/**'
+              - 'pub/**'
+            python:
+              - Dockerfile
+              - 'common/**'
+              - 'python/**'
+            terraform:
+              - Dockerfile
+              - 'common/**'
+              - 'terraform/**'
+
       - name: Checkout code
+        if: steps.changes.outputs[matrix.suite.path] == 'true'
         uses: actions/checkout@v3
+
       - name: Build dependabot-core image
+        if: steps.changes.outputs[matrix.suite.path] == 'true'
         env:
           DOCKER_BUILDKIT: 1
         run: |
@@ -69,7 +148,9 @@ jobs:
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --cache-from ghcr.io/dependabot/dependabot-core \
             .
+
       - name: Build dependabot-core-ci image
+        if: steps.changes.outputs[matrix.suite.path] == 'true'
         env:
           DOCKER_BUILDKIT: 1
         run: |
@@ -78,7 +159,9 @@ jobs:
             -t "dependabot-core-ci:latest" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             .
+
       - name: Run ${{ matrix.suite.name }} tests
+        if: steps.changes.outputs[matrix.suite.path] == 'true'
         run: |
           docker run \
             --env "CI=true" \
@@ -93,8 +176,6 @@ jobs:
   updater:
     name: Updater
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -107,17 +188,6 @@ jobs:
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --cache-from ghcr.io/dependabot/dependabot-core \
             .
-      - name: Free up disk space
-        run: |
-          sudo apt autoremove --purge && sudo apt -y clean
-          docker system prune -af --volumes
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          df -h
-      - name: GPR login
-        run: docker login docker.pkg.github.com -u x -p ${{secrets.GITHUB_TOKEN}}
-      - name: GHCR login
-        run: docker login ghcr.io -u x -p ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: script/build
       - name: Lint

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -39,9 +39,99 @@ jobs:
           - submodules
           - terraform
     steps:
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          actions:
+            - Dockerfile
+            - 'common/**'
+            - 'github_actions/**'
+          bundler:
+            - Dockerfile
+            - 'common/**'
+            - 'bundler/**'
+          cargo:
+            - Dockerfile
+            - 'common/**'
+            - 'cargo/**'
+          common:
+            - Dockerfile
+            - 'common/**'
+          composer:
+            - Dockerfile
+            - 'common/**'
+            - 'composer/**'
+          docker:
+            - Dockerfile
+            - 'common/**'
+            - 'docker/**'
+          elm:
+            - Dockerfile
+            - 'common/**'
+            - 'elm/**'
+          go:
+            - Dockerfile
+            - 'common/**'
+            - 'go_modules/**'
+          gradle:
+            - Dockerfile
+            - 'common/**'
+            - 'gradle/**'
+          hex:
+            - Dockerfile
+            - 'common/**'
+            - 'hex/**'
+          maven:
+            - Dockerfile
+            - 'common/**'
+            - 'maven/**'
+          npm:
+            - Dockerfile
+            - 'common/**'
+            - 'npm_and_yarn/**'
+          nuget:
+            - Dockerfile
+            - 'common/**'
+            - 'nuget/**'
+          omnibus:
+            - Dockerfile
+            - 'common/**'
+            - 'omnibus/**'
+          pub:
+            - Dockerfile
+            - 'common/**'
+            - 'pub/**'
+          pip:
+            - Dockerfile
+            - 'common/**'
+            - 'python/**'
+          'pip-compile':
+            - Dockerfile
+            - 'common/**'
+            - 'python/**'
+          pipenv:
+            - Dockerfile
+            - 'common/**'
+            - 'python/**'
+          poetry:
+            - Dockerfile
+            - 'common/**'
+            - 'python/**'
+          submodules:
+            - Dockerfile
+            - 'common/**'
+            - 'git_submodules/**'
+          terraform:
+            - Dockerfile
+            - 'common/**'
+            - 'terraform/**'
+
     - uses: actions/checkout@v3
+      if: steps.changes.outputs[matrix.suite] == 'true'
 
     - name: Download CLI and test
+      if: steps.changes.outputs[matrix.suite] == 'true'
       run: |
         gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
         tar xzvf *.tar.gz >/dev/null 2>&1
@@ -51,16 +141,14 @@ jobs:
 
     # Download the Proxy cache. The job is ideally 100% cached so no real calls are made.
     - name: Download cache
+      if: steps.changes.outputs[matrix.suite] == 'true'
       run: |
         mkdir cache
         cd cache
         gh run download --repo dependabot/cli --name cache-${{ matrix.suite }}
 
-    - name: GPR login
-      run: docker login docker.pkg.github.com -u x -p ${{secrets.GITHUB_TOKEN}}
-    - name: GHCR login
-      run: docker login ghcr.io -u x -p ${{ secrets.GITHUB_TOKEN }}
     - name: Build dependabot-core image
+      if: steps.changes.outputs[matrix.suite] == 'true'
       env:
         DOCKER_BUILDKIT: 1
       run: |
@@ -70,6 +158,7 @@ jobs:
           --cache-from ghcr.io/dependabot/dependabot-core \
           .
     - name: Build dependabot-updater image
+      if: steps.changes.outputs[matrix.suite] == 'true'
       env:
         DOCKER_BUILDKIT: 1
         OMNIBUS_VERSION: latest
@@ -84,6 +173,7 @@ jobs:
           .
 
     - name: ${{ matrix.suite }}
+      if: steps.changes.outputs[matrix.suite] == 'true'
       env:
         LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.E2E_PAT }}
       run: |
@@ -96,6 +186,7 @@ jobs:
       run: diff --ignore-space-change smoke.yaml result.yaml && echo "Contents are identical"
 
     - name: Create summary
+      if: steps.changes.outputs[matrix.suite] == 'true'
       run: tail -n100 log.txt | grep -P '\d+/\d+ calls cached \(\d+%\)' >> $GITHUB_STEP_SUMMARY
 
     # No upload at the end:


### PR DESCRIPTION
Dependabot rebases PRs and kicks off every CI job so we're running out of Actions runners. This reduces the amount of CI jobs run by only running ones that are applicable to the change.
