### PR TITLE
Use a standard filesystem structure in all docker images

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -174,14 +174,25 @@ jobs:
             - 'updater/**'
             - 'npm_and_yarn/**'
 
-    - name: Download CLI and test
+    - name: Download CLI
+      uses: actions/checkout@v3
+      with:
+        repository: dependabot/cli
+        branch: deivid-rodriguez/allow-configuring-job-path-and-friends
+        path: cli
       if: steps.changes.outputs[matrix.suite] == 'true'
+    - name: Build CLI
       run: |
-        gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
-        tar xzvf *.tar.gz >/dev/null 2>&1
-        ./dependabot --version
+        go build -v ./...
+        go run cmd/dependabot/dependabot.go -v
+      working-directory: cli
+      if: steps.changes.outputs[matrix.suite] == 'true'
+    - name: Download tests
+      run: |
         URL=https://api.github.com/repos/dependabot/smoke-tests/contents/tests/smoke-${{ matrix.suite }}.yaml
         curl $(gh api $URL --jq .download_url) -o smoke.yaml
+      if: steps.changes.outputs[matrix.suite] == 'true'
+      working-directory: cli
 
     # Download the Proxy cache. The job is ideally 100% cached so no real calls are made.
     - name: Download cache
@@ -221,20 +232,23 @@ jobs:
       env:
         LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DEPENDABOT_JOB_PATH: /home/dependabot/dependabot-core/updater/job.json
-        DEPENDABOT_OUTPUT_PATH: /home/dependabot/dependabot-core/updater/output/output.json
+        DEPENDABOT_OUTPUT_PATH: /home/dependabot/dependabot-core/updater/output.json
         DEPENDABOT_REPO_CONTENTS_PATH: /home/dependabot/dependabot-core/updater/repo
       run: |
         set -o pipefail
-        ./dependabot test -f=smoke.yaml -o=result.yaml --cache=cache --timeout=20m --updater-image=dependabot/updater:latest 2>&1 | tee -a log.txt
+        go run cmd/dependabot/dependabot.go test -f=smoke.yaml -o=result.yaml --cache=cache --timeout=20m --updater-image=dependabot/updater:latest 2>&1 | tee -a log.txt
+      working-directory: cli
 
     - name: Diff
       if: always()
       continue-on-error: true
       run: diff --ignore-space-change smoke.yaml result.yaml && echo "Contents are identical"
+      working-directory: cli
 
     - name: Create summary
       if: steps.changes.outputs[matrix.suite] == 'true'
       run: tail -n100 log.txt | grep -P '\d+/\d+ calls cached \(\d+%\)' >> $GITHUB_STEP_SUMMARY
+      working-directory: cli
 
     # No upload at the end:
     # - If a test is uncachable in some regard, the cache would grow unbound.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -220,6 +220,9 @@ jobs:
       if: steps.changes.outputs[matrix.suite] == 'true'
       env:
         LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DEPENDABOT_JOB_PATH: /home/dependabot/dependabot-core/updater/job.json
+        DEPENDABOT_OUTPUT_PATH: /home/dependabot/dependabot-core/updater/output/output.json
+        DEPENDABOT_REPO_CONTENTS_PATH: /home/dependabot/dependabot-core/updater/repo
       run: |
         set -o pipefail
         ./dependabot test -f=smoke.yaml -o=result.yaml --cache=cache --timeout=20m --updater-image=dependabot/updater:latest 2>&1 | tee -a log.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -339,3 +339,6 @@ RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo
 # Disable automatic pulling of files stored with Git LFS
 # This avoids downloading large files not necessary for the dependabot scripts
 ENV GIT_LFS_SKIP_SMUDGE=1
+
+ENV CODE_DIR=${HOME}/dependabot-core
+RUN mkdir $CODE_DIR

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -12,11 +12,8 @@ RUN git config --global user.name dependabot-ci \
 RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/main/vimrc-vanilla.vim && \
   echo 'export PS1="[dependabot-core-dev] \w \[$(tput setaf 4)\]$ \[$(tput sgr 0)\]"' >> ~/.bashrc
 
-ARG CODE_DIR=${HOME}/dependabot-core
-
 COPY --chown=dependabot:dependabot common/Gemfile common/dependabot-common.gemspec ${CODE_DIR}/common/
 COPY --chown=dependabot:dependabot common/lib/dependabot/version.rb ${CODE_DIR}/common/lib/dependabot/
-
 COPY --chown=dependabot:dependabot bundler/Gemfile bundler/dependabot-bundler.gemspec ${CODE_DIR}/bundler/
 COPY --chown=dependabot:dependabot cargo/Gemfile cargo/dependabot-cargo.gemspec ${CODE_DIR}/cargo/
 COPY --chown=dependabot:dependabot composer/Gemfile composer/dependabot-composer.gemspec ${CODE_DIR}/composer/
@@ -33,7 +30,6 @@ COPY --chown=dependabot:dependabot nuget/Gemfile nuget/dependabot-nuget.gemspec 
 COPY --chown=dependabot:dependabot python/Gemfile python/dependabot-python.gemspec ${CODE_DIR}/python/
 COPY --chown=dependabot:dependabot pub/Gemfile pub/dependabot-pub.gemspec ${CODE_DIR}/pub/
 COPY --chown=dependabot:dependabot terraform/Gemfile terraform/dependabot-terraform.gemspec ${CODE_DIR}/terraform/
-
 COPY --chown=dependabot:dependabot omnibus/Gemfile omnibus/dependabot-omnibus.gemspec ${CODE_DIR}/omnibus/
 WORKDIR ${CODE_DIR}
 

--- a/Dockerfile.updater
+++ b/Dockerfile.updater
@@ -6,11 +6,8 @@ ENV DEPENDABOT_HOME /home/dependabot
 RUN mkdir $DEPENDABOT_HOME/dependabot-updater
 
 COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock $DEPENDABOT_HOME/dependabot-updater/
-
 COPY --chown=dependabot:dependabot .ruby-version ${DEPENDABOT_HOME}/.ruby-version
 COPY --chown=dependabot:dependabot .rubocop.yml ${DEPENDABOT_HOME}/.rubocop.yml
-
-WORKDIR ${DEPENDABOT_HOME}
 COPY --chown=dependabot:dependabot omnibus ${DEPENDABOT_HOME}/omnibus
 COPY --chown=dependabot:dependabot git_submodules ${DEPENDABOT_HOME}/git_submodules
 COPY --chown=dependabot:dependabot terraform ${DEPENDABOT_HOME}/terraform

--- a/Dockerfile.updater
+++ b/Dockerfile.updater
@@ -1,33 +1,31 @@
 ARG OMNIBUS_VERSION=required:fail_if_not_provided
 FROM dependabot/dependabot-core:$OMNIBUS_VERSION
 
-ENV DEPENDABOT_HOME /home/dependabot
+RUN mkdir $CODE_DIR/updater
 
-RUN mkdir $DEPENDABOT_HOME/dependabot-updater
+COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock $CODE_DIR/updater/
+COPY --chown=dependabot:dependabot .ruby-version ${CODE_DIR}/.ruby-version
+COPY --chown=dependabot:dependabot .rubocop.yml ${CODE_DIR}/.rubocop.yml
+COPY --chown=dependabot:dependabot omnibus ${CODE_DIR}/omnibus
+COPY --chown=dependabot:dependabot git_submodules ${CODE_DIR}/git_submodules
+COPY --chown=dependabot:dependabot terraform ${CODE_DIR}/terraform
+COPY --chown=dependabot:dependabot github_actions ${CODE_DIR}/github_actions
+COPY --chown=dependabot:dependabot hex ${CODE_DIR}/hex
+COPY --chown=dependabot:dependabot elm ${CODE_DIR}/elm
+COPY --chown=dependabot:dependabot docker ${CODE_DIR}/docker
+COPY --chown=dependabot:dependabot nuget ${CODE_DIR}/nuget
+COPY --chown=dependabot:dependabot maven ${CODE_DIR}/maven
+COPY --chown=dependabot:dependabot gradle ${CODE_DIR}/gradle
+COPY --chown=dependabot:dependabot cargo ${CODE_DIR}/cargo
+COPY --chown=dependabot:dependabot composer ${CODE_DIR}/composer
+COPY --chown=dependabot:dependabot go_modules ${CODE_DIR}/go_modules
+COPY --chown=dependabot:dependabot python ${CODE_DIR}/python
+COPY --chown=dependabot:dependabot pub ${CODE_DIR}/pub
+COPY --chown=dependabot:dependabot npm_and_yarn ${CODE_DIR}/npm_and_yarn
+COPY --chown=dependabot:dependabot bundler ${CODE_DIR}/bundler
+COPY --chown=dependabot:dependabot common ${CODE_DIR}/common
 
-COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock $DEPENDABOT_HOME/dependabot-updater/
-COPY --chown=dependabot:dependabot .ruby-version ${DEPENDABOT_HOME}/.ruby-version
-COPY --chown=dependabot:dependabot .rubocop.yml ${DEPENDABOT_HOME}/.rubocop.yml
-COPY --chown=dependabot:dependabot omnibus ${DEPENDABOT_HOME}/omnibus
-COPY --chown=dependabot:dependabot git_submodules ${DEPENDABOT_HOME}/git_submodules
-COPY --chown=dependabot:dependabot terraform ${DEPENDABOT_HOME}/terraform
-COPY --chown=dependabot:dependabot github_actions ${DEPENDABOT_HOME}/github_actions
-COPY --chown=dependabot:dependabot hex ${DEPENDABOT_HOME}/hex
-COPY --chown=dependabot:dependabot elm ${DEPENDABOT_HOME}/elm
-COPY --chown=dependabot:dependabot docker ${DEPENDABOT_HOME}/docker
-COPY --chown=dependabot:dependabot nuget ${DEPENDABOT_HOME}/nuget
-COPY --chown=dependabot:dependabot maven ${DEPENDABOT_HOME}/maven
-COPY --chown=dependabot:dependabot gradle ${DEPENDABOT_HOME}/gradle
-COPY --chown=dependabot:dependabot cargo ${DEPENDABOT_HOME}/cargo
-COPY --chown=dependabot:dependabot composer ${DEPENDABOT_HOME}/composer
-COPY --chown=dependabot:dependabot go_modules ${DEPENDABOT_HOME}/go_modules
-COPY --chown=dependabot:dependabot python ${DEPENDABOT_HOME}/python
-COPY --chown=dependabot:dependabot pub ${DEPENDABOT_HOME}/pub
-COPY --chown=dependabot:dependabot npm_and_yarn ${DEPENDABOT_HOME}/npm_and_yarn
-COPY --chown=dependabot:dependabot bundler ${DEPENDABOT_HOME}/bundler
-COPY --chown=dependabot:dependabot common ${DEPENDABOT_HOME}/common
-
-WORKDIR $DEPENDABOT_HOME/dependabot-updater
+WORKDIR $CODE_DIR/updater
 
 RUN bundle config set --local path 'vendor' && \
 bundle config set --local frozen 'true' && \
@@ -42,7 +40,7 @@ bundle install
 
 # Create the config file manually instead of using yarn/npm config set as this
 # executes the package manager outputs to every job log
-COPY --chown=dependabot:dependabot updater/config/.yarnrc updater/config/.npmrc $DEPENDABOT_HOME/
+COPY --chown=dependabot:dependabot updater/config/.yarnrc updater/config/.npmrc $HOME/
 
 # For Yarn Berry we can set this via an environment variable
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
@@ -50,6 +48,6 @@ ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 # END: HACKY WORKAROUND FOR NPM GIT INSTALLS SPAWNING CHILD PROCESS
 
 # Add project
-COPY --chown=dependabot:dependabot updater /home/dependabot/dependabot-updater
+COPY --chown=dependabot:dependabot updater $CODE_DIR/updater
 
 CMD ["bundle", "exec", "ruby", "bin/dependabot_update.rb"]

--- a/Dockerfile.updater
+++ b/Dockerfile.updater
@@ -40,7 +40,7 @@ bundle install
 # TODO: Remove these hacks once we've deprecated npm 6 support as it no longer
 # spawns a child process to npm install git dependencies.
 
-# Create the config file manually intead of using yarn/npm config set as this
+# Create the config file manually instead of using yarn/npm config set as this
 # executes the package manager outputs to every job log
 COPY --chown=dependabot:dependabot updater/config/.yarnrc updater/config/.npmrc $DEPENDABOT_HOME/
 

--- a/script/_common
+++ b/script/_common
@@ -18,7 +18,7 @@ function docker_exec() {
   docker_build
   docker run --env "DEPENDABOT_TEST_ACCESS_TOKEN=$DEPENDABOT_TEST_ACCESS_TOKEN" \
   --rm \
-  -v "$(pwd)/.:/home/dependabot/dependabot-updater:delegated" \
+  -v "$(pwd)/.:/home/dependabot/dependabot-core/updater:delegated" \
   -ti "$LOCAL_IMAGE" "$@"
 }
 
@@ -33,7 +33,7 @@ function docker_bundle_exec() {
   docker run --env "DEPENDABOT_TEST_ACCESS_TOKEN=$DEPENDABOT_TEST_ACCESS_TOKEN" \
   $VCR_ARGS \
   --rm \
-  -v "$(pwd)/updater/spec/fixtures/vcr_cassettes:/home/dependabot/dependabot-updater/spec/fixtures/vcr_cassettes" \
+  -v "$(pwd)/updater/spec/fixtures/vcr_cassettes:/home/dependabot/dependabot-core/updater/spec/fixtures/vcr_cassettes" \
   "$LOCAL_IMAGE" bundle exec "$@"
 }
 

--- a/script/dependabot
+++ b/script/dependabot
@@ -2,24 +2,24 @@
 
 dependabot \
   -v "$(pwd)"/.core-bash_history:/home/dependabot/.bash_history \
-  -v "$(pwd)"/updater/bin:/home/dependabot/dependabot-updater/bin \
-  -v "$(pwd)"/updater/lib:/home/dependabot/dependabot-updater/lib \
-  -v "$(pwd)"/bin:/home/dependabot/bin \
-  -v "$(pwd)"/bundler:/home/dependabot/bundler \
-  -v "$(pwd)"/cargo:/home/dependabot/cargo \
-  -v "$(pwd)"/common:/home/dependabot/common \
-  -v "$(pwd)"/composer:/home/dependabot/composer \
-  -v "$(pwd)"/docker:/home/dependabot/docker \
-  -v "$(pwd)"/elm:/home/dependabot/elm \
-  -v "$(pwd)"/git_submodules:/home/dependabot/git_submodules \
-  -v "$(pwd)"/github_actions:/home/dependabot/github_actions \
-  -v "$(pwd)"/go_modules:/home/dependabot/go_modules \
-  -v "$(pwd)"/gradle:/home/dependabot/gradle \
-  -v "$(pwd)"/hex:/home/dependabot/hex \
-  -v "$(pwd)"/maven:/home/dependabot/maven \
-  -v "$(pwd)"/npm_and_yarn:/home/dependabot/npm_and_yarn \
-  -v "$(pwd)"/nuget:/home/dependabot/nuget \
-  -v "$(pwd)"/pub:/home/dependabot/pub \
-  -v "$(pwd)"/python:/home/dependabot/python \
-  -v "$(pwd)"/terraform:/home/dependabot/terraform \
+  -v "$(pwd)"/updater/bin:/home/dependabot/dependabot-core/updater/bin \
+  -v "$(pwd)"/updater/lib:/home/dependabot/dependabot-core/updater/lib \
+  -v "$(pwd)"/bin:/home/dependabot/dependabot-core/bin \
+  -v "$(pwd)"/bundler:/home/dependabot/dependabot-core/bundler \
+  -v "$(pwd)"/cargo:/home/dependabot/dependabot-core/cargo \
+  -v "$(pwd)"/common:/home/dependabot/dependabot-core/common \
+  -v "$(pwd)"/composer:/home/dependabot/dependabot-core/composer \
+  -v "$(pwd)"/docker:/home/dependabot/dependabot-core/docker \
+  -v "$(pwd)"/elm:/home/dependabot/dependabot-core/elm \
+  -v "$(pwd)"/git_submodules:/home/dependabot/dependabot-core/git_submodules \
+  -v "$(pwd)"/github_actions:/home/dependabot/dependabot-core/github_actions \
+  -v "$(pwd)"/go_modules:/home/dependabot/dependabot-core/go_modules \
+  -v "$(pwd)"/gradle:/home/dependabot/dependabot-core/gradle \
+  -v "$(pwd)"/hex:/home/dependabot/dependabot-core/hex \
+  -v "$(pwd)"/maven:/home/dependabot/dependabot-core/maven \
+  -v "$(pwd)"/npm_and_yarn:/home/dependabot/dependabot-core/npm_and_yarn \
+  -v "$(pwd)"/nuget:/home/dependabot/dependabot-core/nuget \
+  -v "$(pwd)"/pub:/home/dependabot/dependabot-core/pub \
+  -v "$(pwd)"/python:/home/dependabot/dependabot-core/python \
+  -v "$(pwd)"/terraform:/home/dependabot/dependabot-core/terraform \
   "$@"


### PR DESCRIPTION
And make it the same as in our repository.

While working on improving #5617, I wanted to change the way we install native helpers to be like this:

```diff
diff --git a/Dockerfile b/Dockerfile
index 566941768..0b858d95d 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -267,32 +267,32 @@ USER dependabot
 
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 
-COPY --chown=dependabot:dependabot composer/helpers /opt/composer/helpers
-RUN bash /opt/composer/helpers/v1/build \
-  && bash /opt/composer/helpers/v2/build
+COPY --chown=dependabot:dependabot composer/helpers /home/dependabot/dependabot-core/composer/helpers
+RUN bash /home/dependabot/dependabot-core/composer/helpers/v1/build \
+  && bash /home/dependabot/dependabot-core/composer/helpers/v2/build
 
-COPY --chown=dependabot:dependabot bundler/helpers /opt/bundler/helpers
-RUN bash /opt/bundler/helpers/v1/build \
-  && bash /opt/bundler/helpers/v2/build
+COPY --chown=dependabot:dependabot bundler/helpers /home/dependabot/dependabot-core/bundler/helpers
+RUN bash /home/dependabot/dependabot-core/bundler/helpers/v1/build \
+  && bash /home/dependabot/dependabot-core/bundler/helpers/v2/build
 
-COPY --chown=dependabot:dependabot go_modules/helpers /opt/go_modules/helpers
-RUN bash /opt/go_modules/helpers/build
+COPY --chown=dependabot:dependabot go_modules/helpers /home/dependabot/dependabot-core/go_modules/helpers
+RUN bash /home/dependabot/dependabot-core/go_modules/helpers/build
 
-COPY --chown=dependabot:dependabot hex/helpers /opt/hex/helpers
-ENV MIX_HOME="/opt/hex/mix"
-RUN bash /opt/hex/helpers/build
+COPY --chown=dependabot:dependabot hex/helpers /home/dependabot/dependabot-core/hex/helpers
+ENV MIX_HOME="/home/dependabot/dependabot-core/hex/mix"
+RUN bash /home/dependabot/dependabot-core/hex/helpers/build
 
-COPY --chown=dependabot:dependabot pub/helpers /opt/pub/helpers
-RUN bash /opt/pub/helpers/build
+COPY --chown=dependabot:dependabot pub/helpers /home/dependabot/dependabot-core/pub/helpers
+RUN bash /home/dependabot/dependabot-core/pub/helpers/build
 
-COPY --chown=dependabot:dependabot npm_and_yarn/helpers /opt/npm_and_yarn/helpers
-RUN bash /opt/npm_and_yarn/helpers/build
+COPY --chown=dependabot:dependabot npm_and_yarn/helpers /home/dependabot/dependabot-core/npm_and_yarn/helpers
+RUN bash /home/dependabot/dependabot-core/npm_and_yarn/helpers/build
 
-COPY --chown=dependabot:dependabot python/helpers /opt/python/helpers
-RUN bash /opt/python/helpers/build
+COPY --chown=dependabot:dependabot python/helpers /home/dependabot/dependabot-core/python/helpers
+RUN bash /home/dependabot/dependabot-core/python/helpers/build
 
-COPY --chown=dependabot:dependabot terraform/helpers /opt/terraform/helpers
-RUN bash /opt/terraform/helpers/build
+COPY --chown=dependabot:dependabot terraform/helpers /home/dependabot/dependabot-core/terraform/helpers
+RUN bash /home/dependabot/dependabot-core/terraform/helpers/build
 
 ENV PATH="$PATH:/opt/terraform/bin:/opt/python/bin:/opt/go_modules/bin"
 
```

So that no duplicated file trees at `/opt/<ecosystem>` and `/opt/<ecosystem>/helpers` are generated.

However, I believe this will generate similar confusing duplication at `/home/dependabot/dependabot-core/<ecosystem>/helpers`, and `/home/dependabot/<ecosystem>/helpers` in the updater image.

I want to experiment with unifying the layout across all images & the source repository.