### PR TITLE
gradle depends on maven gem, so run gradle tests when maven changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
             gradle:
               - Dockerfile
               - 'common/**'
+              - 'maven/**'
               - 'gradle/**'
             hex:
               - Dockerfile

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -78,6 +78,7 @@ jobs:
           gradle:
             - Dockerfile
             - 'common/**'
+            - 'maven/**'
             - 'gradle/**'
           hex:
             - Dockerfile


### PR DESCRIPTION
Thanks to @jurre for pointing this out. I checked the other ecosystems and couldn't find another case of this.