### PR TITLE
Adding code tags around any nwo#number text string

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
       "name": "Debug Tests",
       "type": "Ruby",
       "request": "launch",
-      "program": "${workspaceRoot}/${input:ecosystem}/.bundle/bin/rspec",
+      "program": "${workspaceRoot}/omnibus/.bundle/bin/rspec",
       "cwd": "${workspaceRoot}/${input:ecosystem}",
       "useBundler": true,
       "args": ["${input:test_path}"],
@@ -106,6 +106,7 @@
       "options": [
         "bundler",
         "cargo",
+        "common",
         "composer",
         "docker",
         "elm",

--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -42,7 +42,7 @@ module Dependabot
           sanitize_mentions(doc)
           sanitize_links(doc)
           sanitize_nwo_text(doc)
-          
+
           mode = unsafe ? :UNSAFE : :DEFAULT
           doc.to_html(([mode] + COMMONMARKER_OPTIONS), COMMONMARKER_EXTENSIONS)
         end

--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -107,7 +107,8 @@ module Dependabot
                   node.string_content.match?(GITHUB_REF_REGEX)
               node.string_content = replace_github_host(node.string_content)
             elsif node.type == :text &&
-                  node.string_content.match?(GITHUB_NWO_REGEX)
+                  node.string_content.match?(GITHUB_NWO_REGEX) &&
+                  !parent_node_link?(node)
               match = node.string_content.match(GITHUB_NWO_REGEX)
               repo = match.named_captures.fetch("repo")
               number = match.named_captures.fetch("number")

--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -99,7 +99,7 @@ module Dependabot
                 last_match = subnode.string_content.match(GITHUB_REF_REGEX)
                 number = last_match.named_captures.fetch("number")
                 repo = last_match.named_captures.fetch("repo")
-                subnode.string_content = insert_space_in_link_text("#{repo}##{number}")
+                subnode.string_content = "#{repo}##{number}"
               end
 
               node.url = replace_github_host(node.url)
@@ -111,7 +111,9 @@ module Dependabot
               match = node.string_content.match(GITHUB_NWO_REGEX)
               repo = match.named_captures.fetch("repo")
               number = match.named_captures.fetch("number")
-              node.string_content = insert_space_in_link_text("#{repo}##{number}")
+              new_node = build_nwo_text_node("#{repo}##{number}")
+              node.insert_before(new_node)
+              node.delete
             end
           end
         end
@@ -177,6 +179,12 @@ module Dependabot
           code_node.string_content = insert_zero_width_space_in_mention(text)
           [code_node]
         end
+        
+        def build_nwo_text_node(text)
+          code_node = CommonMarker::Node.new(:code)
+          code_node.string_content = text
+          code_node
+        end
 
         def create_link_node(url, text)
           link_node = CommonMarker::Node.new(:link)
@@ -193,10 +201,6 @@ module Dependabot
         # the content of the pull request body in plain text.
         def insert_zero_width_space_in_mention(mention)
           mention.sub("@", "@\u200B").encode("utf-8")
-        end
-
-        def insert_space_in_link_text(text)
-          text.sub("#", " #").encode("utf-8")
         end
 
         def parent_node_link?(node)

--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -14,6 +14,7 @@ module Dependabot
           github\.com/(?<repo>#{GITHUB_USERNAME}/[^/\s]+)/
           (?:issue|pull)s?/(?<number>\d+)
         }x.freeze
+        # [^/\s#]+ means one or more characters not matching (^) the class /, whitespace (\s), or #
         GITHUB_NWO_REGEX = %r{(?<repo>#{GITHUB_USERNAME}/[^/\s#]+)#(?<number>\d+)}.freeze
         MENTION_REGEX = %r{(?<![A-Za-z0-9`~])@#{GITHUB_USERNAME}/?}.freeze
         # regex to match a team mention on github

--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -191,7 +191,7 @@ module Dependabot
           code_node.string_content = insert_zero_width_space_in_mention(text)
           [code_node]
         end
-        
+
         def build_nwo_text_node(text)
           code_node = CommonMarker::Node.new(:code)
           code_node.string_content = text

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSan
       it do
         is_expected.to eq(
           "<p>Check out <a href=\"https://github-redirect.com/my/repo/" \
-          "issues/5\">my/repo #5</a></p>\n"
+          "issues/5\"><code>my/repo#5</code></a></p>\n"
         )
       end
     end
@@ -263,7 +263,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSan
       it do
         is_expected.to eq(
           "<p>Check out <a href=\"https://github-redirect.com/my/repo/" \
-          "issues/5\">my/repo #5</a></p>\n"
+          "issues/5\"><code>my/repo#5</code></a></p>\n"
         )
       end
     end
@@ -276,7 +276,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSan
       it do
         is_expected.to eq(
           "<p><a href=\"https://github-redirect.com/rust-num/num-traits/" \
-          "pull/144\">rust-num/num-traits #144</a></p>\n"
+          "pull/144\"><code>rust-num/num-traits#144</code></a></p>\n"
         )
       end
     end
@@ -287,7 +287,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSan
       end
       it do
         is_expected.to eq(
-          "<p>dsp-testing/dependabot-ts-definitely-typed #25</p>\n"
+          "<p><code>dsp-testing/dependabot-ts-definitely-typed#25</code></p>\n"
         )
       end
     end

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSan
       it do
         is_expected.to eq(
           "<p>Check out <a href=\"https://github-redirect.com/my/repo/" \
-          "issues/5\"><code>my/repo#5</code></a></p>\n"
+          "issues/5\">my/repo#5</a></p>\n"
         )
       end
     end
@@ -263,7 +263,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSan
       it do
         is_expected.to eq(
           "<p>Check out <a href=\"https://github-redirect.com/my/repo/" \
-          "issues/5\"><code>my/repo#5</code></a></p>\n"
+          "issues/5\">my/repo#5</a></p>\n"
         )
       end
     end
@@ -276,7 +276,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSan
       it do
         is_expected.to eq(
           "<p><a href=\"https://github-redirect.com/rust-num/num-traits/" \
-          "pull/144\"><code>rust-num/num-traits#144</code></a></p>\n"
+          "pull/144\">rust-num/num-traits#144</a></p>\n"
         )
       end
     end

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSan
       it do
         is_expected.to eq(
           "<p>Check out <a href=\"https://github-redirect.com/my/repo/" \
-          "issues/5\">my/repo#5</a></p>\n"
+          "issues/5\">my/repo #5</a></p>\n"
         )
       end
     end
@@ -263,7 +263,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSan
       it do
         is_expected.to eq(
           "<p>Check out <a href=\"https://github-redirect.com/my/repo/" \
-          "issues/5\">my/repo#5</a></p>\n"
+          "issues/5\">my/repo #5</a></p>\n"
         )
       end
     end
@@ -276,7 +276,18 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSan
       it do
         is_expected.to eq(
           "<p><a href=\"https://github-redirect.com/rust-num/num-traits/" \
-          "pull/144\">rust-num/num-traits#144</a></p>\n"
+          "pull/144\">rust-num/num-traits #144</a></p>\n"
+        )
+      end
+    end
+
+    context "with a GitHub NWO and PR number" do
+      let(:text) do
+        "dsp-testing/dependabot-ts-definitely-typed#25"
+      end
+      it do
+        is_expected.to eq(
+          "<p>dsp-testing/dependabot-ts-definitely-typed #25</p>\n"
         )
       end
     end


### PR DESCRIPTION
Attempting to improve our link sanitation to prevent `<org>/<repo>#<pr number>` text strings from being hydrated into full github.com links by PR creation machinery.

I found that a number of our tests produce redirect links, however the link text itself is in the format above, and adding those links to a PR comment or description results in a valid github.com link and creates a mention on the targeted PR timeline.

This should also break up any text string in the above format to prevent flood of mentions experienced in the below issue:
Closes https://github.com/dependabot/dependabot-core/issues/5639

I also added common tests to the test debug dropdown in vscode and fixed a path issue with the vscode debugger.

~~This is still a WIP as there is 1 failing test which I need to fix, and the approach may be overly heavy handed.  I'm not sure my tests which resulted in lots of valid links were valid, so feedback there would be good.~~