### PR TITLE
Fix incomplete clean up of odd python requirements

### DIFF
--- a/python/lib/dependabot/python/requirement.rb
+++ b/python/lib/dependabot/python/requirement.rb
@@ -87,7 +87,7 @@ module Dependabot
         return nil if req_string == "*"
 
         req_string = req_string.gsub("~=", "~>")
-        req_string = req_string.gsub(/(?<=\d)[<=>].*/, "")
+        req_string = req_string.gsub(/(?<=\d)[<=>].*\Z/, "")
 
         if req_string.match?(/~[^>]/) then convert_tilde_req(req_string)
         elsif req_string.start_with?("^") then convert_caret_req(req_string)

--- a/python/spec/dependabot/python/requirement_spec.rb
+++ b/python/spec/dependabot/python/requirement_spec.rb
@@ -116,6 +116,17 @@ RSpec.describe Dependabot::Python::Requirement do
       end
     end
 
+    context "with multiple operators after the first" do
+      let(:requirement_string) { ">=2.0<2.1<2.2" }
+      # Python ignores operators after the first!
+      it { is_expected.to eq(Gem::Requirement.new(">=2.0")) }
+
+      context "separated with a comma" do
+        let(:requirement_string) { ">=2.0,<2.1,<2.2" }
+        it { is_expected.to eq(Gem::Requirement.new(">=2.0", "<2.1", "<2.2")) }
+      end
+    end
+
     context "with an array" do
       let(:requirement_string) { ["== 1.3.*", ">= 1.3.1"] }
       its(:to_s) do


### PR DESCRIPTION
In 45f5b77a776cf8bada4c262af9e39ff492ab6ba9, we started handling odd python requirements, with multiple constraints not separated by colons.

Native behavior is to ignore anything after the first requirement, yet we were only ignoring the first one.