### PR TITLE
move devcontainer to allow debugging updater with the default devcontainer

### DIFF
--- a/.devcontainer/core-dev/devcontainer.json
+++ b/.devcontainer/core-dev/devcontainer.json
@@ -1,6 +1,9 @@
 {
-  "name": "Ruby",
-  "dockerFile": "../Dockerfile.development",
+  "name": "core-dev",
+  "build": {
+    "dockerfile": "../../Dockerfile.development",
+    "cacheFrom": "ghcr.io/dependabot/dependabot-core-development"
+  },
 
   "workspaceFolder": "/home/dependabot/dependabot-core",
 
@@ -120,11 +123,11 @@
   // "postCreateCommand": "ruby --version"
 
   "extensions": [
-		"rebornix.ruby",
-		"castwide.solargraph",
-		"misogi.ruby-rubocop",
-		"groksrc.ruby",
-		"hoovercj.ruby-linter",
-		"miguel-savignano.ruby-symbols"
+    "rebornix.ruby",
+    "castwide.solargraph",
+    "misogi.ruby-rubocop",
+    "groksrc.ruby",
+    "hoovercj.ruby-linter",
+    "miguel-savignano.ruby-symbols"
   ]
 }


### PR DESCRIPTION
Now that updater is in core, there's no way to use Codespaces to run the updater tests since the devcontainer.json we specified drops us in docker-dev-shell where updater doesn't exist. 

So I've moved devcontainer.json to a subdirectory which gives us the ability to choose between the devcontainer.json we specified and the default one Codespaces uses:

<img width="249" alt="Screen Shot 2022-09-07 at 9 29 19 AM" src="https://user-images.githubusercontent.com/886768/188904230-eef68191-76e3-4638-81f3-0c6b76e8f2a8.png">

Bonus: I noticed there was no cacheFrom specified, so I've added one and it seems to be using it when building. This should save some time!