### PR TITLE
Speed up dealing with non-reachable git repos

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -365,17 +365,19 @@ module Dependabot
     def listing_tags
       return [] unless listing_source_url
 
-      tags = listing_repo_git_metadata_fetcher.tags
+      @listing_tags ||= begin
+        tags = listing_repo_git_metadata_fetcher.tags
 
-      if dependency_source_details&.fetch(:ref, nil)&.start_with?("tags/")
-        tags = tags.map do |tag|
-          tag.dup.tap { |t| t.name = "tags/#{tag.name}" }
+        if dependency_source_details&.fetch(:ref, nil)&.start_with?("tags/")
+          tags = tags.map do |tag|
+            tag.dup.tap { |t| t.name = "tags/#{tag.name}" }
+          end
         end
-      end
 
-      tags
-    rescue GitDependenciesNotReachable
-      []
+        tags
+      rescue GitDependenciesNotReachable
+        []
+      end
     end
 
     def listing_upload_pack


### PR DESCRIPTION
While working on a spec failure, I observed the failing spec was also soooooo slow:

```
Top 1 slowest examples (48.37 seconds, 100.0% of total time):
  Dependabot::EndToEndJob bundler git dependencies updates dependencies correctly
    48.37 seconds ./spec/dependabot/integration_spec.rb:296
```

Further investigation revealed that this spec was trying to do the following up to 76 times, on a non-existing github repository:

* Try fetch `https://github.com/dependabot/dummy-git-dependency.git/info/refs?service=git-upload-pack`.
* Since the previous fetch failed, try run `git ls-remote https://github.com/dependabot/dummy-git-dependency.git` locally.

This is done every time the update checker needs to fetch remote git tags, and if this fails, the checker considers that there are no remote tags, but will keep on retrying the same thing and failing once and again.

This commit changes the commit fetcher to memoize the tags the first time they are fetched. With this change, the spec is now much faster:

```
Top 1 slowest examples (4.26 seconds, 100.0% of total time):
  Dependabot::EndToEndJob bundler git dependencies updates dependencies correctly
    4.26 seconds ./spec/dependabot/integration_spec.rb:296
```

I expect this to also improve things in production, of course.