### PR TITLE
Install yarn via corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,9 +120,8 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
   && rm -rf ~/.npm
 
 # Install yarn berry and set it to a stable version
-RUN npm install -g yarn@berry \
-  && yarn set version 3.2.3 \
-  && rm -rf ~/.npm
+RUN corepack enable \
+  && corepack prepare yarn@3.2.3 --activate
 
 ### ELM
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -42,6 +42,7 @@ module Dependabot
         fetched_files << lerna_json if lerna_json
         fetched_files << npmrc if npmrc
         fetched_files << yarnrc if yarnrc
+        fetched_files << yarnrc_yml if yarnrc_yml
         fetched_files += workspace_package_jsons
         fetched_files += lerna_packages
         fetched_files += path_dependencies(fetched_files)
@@ -53,8 +54,8 @@ module Dependabot
       def instrument_package_manager_version
         package_managers = {}
 
-        package_managers["npm"] =  Helpers.npm_version_numeric(package_lock.content) if package_lock
-        package_managers["yarn"] = 1 if yarn_lock
+        package_managers["npm"] = Helpers.npm_version_numeric(package_lock.content) if package_lock
+        package_managers["yarn"] = yarn_version
         package_managers["shrinkwrap"] = 1 if shrinkwrap
 
         Dependabot.instrument(
@@ -62,6 +63,22 @@ module Dependabot
           ecosystem: "npm",
           package_managers: package_managers
         )
+      end
+
+      def yarn_version
+        @yarn_version ||= begin
+          package = JSON.load(package_json.content)
+          if (pkgmanager = package.fetch("packageManager"))
+            @yarn_version = get_yarn_version_from_path(pkgmanager)
+          elsif yarn_lock
+            @yarn_version = 1
+          end
+        end
+      end
+
+      def get_yarn_version_from_path(path)
+        version_match = path.match(/yarn@(?<version>\d+.\d+.\d+)/)
+        version_match.named_captures.fetch("version")
       end
 
       def package_json
@@ -116,6 +133,11 @@ module Dependabot
         end
 
         @yarnrc
+      end
+
+      def yarnrc_yml
+        @yarnrc_yml ||= fetch_file_if_present(".yarnrc.yml")&.
+                       tap { |f| f.support_file = true}
       end
 
       def lerna_json


### PR DESCRIPTION
By installing yarn via corepack we can take advantage of built in version detection based on the `packageManager` key in package.json.

This also enables a repo with a `.yarnrc.yml` file which specifies a `yarnPath` key pointing to a checked in version of yarn to work.  This assumes we get the `.yarnrc.yml` and corresponding `.yarn/releases/<yarn-release>.cjs` files into the tmp directory.  This capability is another argument in favor of clone the repo for yarn berry.