### PR TITLE
Cleanup updater specs output

### DIFF
--- a/updater/spec/dependabot/file_fetcher_job_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_job_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Dependabot::FileFetcherJob do
           )
         expect(api_client).to receive(:mark_job_as_processed)
 
-        perform_job
+        expect { perform_job }.to output(/Error during file fetching; aborting/).to_stdout_from_any_process
       end
     end
 
@@ -94,7 +94,7 @@ RSpec.describe Dependabot::FileFetcherJob do
           )
         expect(api_client).to receive(:mark_job_as_processed)
 
-        perform_job
+        expect { perform_job }.to output(/Error during file fetching; aborting/).to_stdout_from_any_process
       end
     end
 
@@ -123,7 +123,7 @@ RSpec.describe Dependabot::FileFetcherJob do
           )
         expect(api_client).to receive(:mark_job_as_processed)
 
-        perform_job
+        expect { perform_job }.to output(/Repository is rate limited, attempting to retry/).to_stdout_from_any_process
       end
     end
 
@@ -181,7 +181,7 @@ RSpec.describe Dependabot::FileFetcherJob do
         end
         expect(api_client).to receive(:mark_job_as_processed)
 
-        perform_job
+        expect { perform_job }.to output(/Something went wrong/).to_stdout_from_any_process
 
         expect(Dir.exist?(Dependabot::Environment.repo_contents_path)).to be_truthy
         expect(Dir.empty?(Dependabot::Environment.repo_contents_path)).to be_truthy

--- a/updater/spec/dependabot/integration_spec.rb
+++ b/updater/spec/dependabot/integration_spec.rb
@@ -175,18 +175,18 @@ RSpec.describe Dependabot::EndToEndJob do
         expect(api_client).to receive(:record_update_job_error).
           with(job_id, { error_type: "unknown_error", error_details: nil })
 
-        end_to_end_job.run
+        expect { end_to_end_job.run }.to output(/oh no!/).to_stdout_from_any_process
       end
 
       it "indicates there was an error in the summary" do
         expect(Dependabot.logger).not_to receive(:info).with(/Changes to Dependabot Pull Requests/)
         expect(Dependabot.logger).to receive(:info).with(/Dependabot encountered '1' error/)
 
-        end_to_end_job.run
+        expect { end_to_end_job.run }.to output(/oh no!/).to_stdout_from_any_process
       end
 
       it "does not raise an exception" do
-        expect { end_to_end_job.run }.not_to raise_error
+        expect { end_to_end_job.run }.to output(/oh no!/).to_stdout_from_any_process
       end
 
       context "when GITHUB_ACTIONS is set" do
@@ -195,7 +195,8 @@ RSpec.describe Dependabot::EndToEndJob do
         end
 
         it "raises an exception" do
-          expect { end_to_end_job.run }.to raise_error(Dependabot::RunFailure)
+          expect { end_to_end_job.run }.to raise_error(Dependabot::RunFailure).
+            and output(/oh no!/).to_stdout_from_any_process
         end
       end
     end


### PR DESCRIPTION
Up to now, running updater specs prints a lot of server logs with a lot of "E" letters that can be confused with spec failures, and it's hard to process.

This commit adds some bare assertions on the output instead of printing it, so that it's clean.

As a side effect, it also avoids using `expect { foo }.not_to raise_error`. This is not considered a great testing practice because an empty implementation of `foo` passes it, so it's not testing much 😅.

Sample output here (not everything because it's so verbose that exceeds maximum PR size 😆)

### Before

```
Randomized with seed 17332
..............................E, [2022-09-08T18:56:26.044927 #1] ERROR -- : <job_123123> Error during file fetching; aborting
...E, [2022-09-08T18:56:27.451602 #1] ERROR -- : <job_123123> Error during file fetching; aborting
E, [2022-09-08T18:56:27.451664 #1] ERROR -- : <job_123123> Something went wrong
E, [2022-09-08T18:56:27.451763 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/spec/dependabot/file_fetcher_job_spec.rb:180:in `block (5 levels) in <top (required)>'
E, [2022-09-08T18:56:27.451796 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-mocks-3.11.0/lib/rspec/mocks/message_expectation.rb:801:in `call'
E, [2022-09-08T18:56:27.451814 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-mocks-3.11.0/lib/rspec/mocks/message_expectation.rb:615:in `invoke_incrementing_actual_calls_by'
E, [2022-09-08T18:56:27.451829 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-mocks-3.11.0/lib/rspec/mocks/message_expectation.rb:470:in `invoke'
E, [2022-09-08T18:56:27.451888 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-mocks-3.11.0/lib/rspec/mocks/proxy.rb:214:in `message_received'
E, [2022-09-08T18:56:27.451920 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-mocks-3.11.0/lib/rspec/mocks/proxy.rb:361:in `message_received'
E, [2022-09-08T18:56:27.451937 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-mocks-3.11.0/lib/rspec/mocks/method_double.rb:78:in `proxy_method_invoked'
E, [2022-09-08T18:56:27.451952 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-mocks-3.11.0/lib/rspec/mocks/verifying_proxy.rb:161:in `proxy_method_invoked'
E, [2022-09-08T18:56:27.451967 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-mocks-3.11.0/lib/rspec/mocks/method_double.rb:64:in `block (2 levels) in define_proxy_method'
E, [2022-09-08T18:56:27.452001 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/lib/dependabot/file_fetcher_job.rb:15:in `perform_job'
E, [2022-09-08T18:56:27.452026 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/spec/dependabot/file_fetcher_job_spec.rb:25:in `block (3 levels) in <top (required)>'
E, [2022-09-08T18:56:27.452048 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/memoized_helpers.rb:343:in `block (2 levels) in let'
E, [2022-09-08T18:56:27.452063 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/memoized_helpers.rb:179:in `block (3 levels) in fetch_or_store'
E, [2022-09-08T18:56:27.452180 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/memoized_helpers.rb:179:in `fetch'
E, [2022-09-08T18:56:27.452209 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/memoized_helpers.rb:179:in `block (2 levels) in fetch_or_store'
E, [2022-09-08T18:56:27.452224 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-support-3.11.0/lib/rspec/support/reentrant_mutex.rb:23:in `synchronize'
E, [2022-09-08T18:56:27.452239 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/memoized_helpers.rb:178:in `block in fetch_or_store'
E, [2022-09-08T18:56:27.452254 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/memoized_helpers.rb:177:in `fetch'
E, [2022-09-08T18:56:27.452280 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/memoized_helpers.rb:177:in `fetch_or_store'
E, [2022-09-08T18:56:27.452295 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/memoized_helpers.rb:343:in `block in let'
E, [2022-09-08T18:56:27.452324 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/spec/dependabot/file_fetcher_job_spec.rb:184:in `block (4 levels) in <top (required)>'
E, [2022-09-08T18:56:27.452389 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:263:in `instance_exec'
E, [2022-09-08T18:56:27.452439 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:263:in `block in run'
E, [2022-09-08T18:56:27.452470 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'
E, [2022-09-08T18:56:27.452504 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'
E, [2022-09-08T18:56:27.452551 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:486:in `block in run'
E, [2022-09-08T18:56:27.452615 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'
E, [2022-09-08T18:56:27.452639 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:352:in `call'
E, [2022-09-08T18:56:27.452654 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/webmock-3.17.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
E, [2022-09-08T18:56:27.452669 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:457:in `instance_exec'
E, [2022-09-08T18:56:27.452684 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:457:in `instance_exec'
E, [2022-09-08T18:56:27.452722 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:390:in `execute_with'
E, [2022-09-08T18:56:27.452737 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'
E, [2022-09-08T18:56:27.452753 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:352:in `call'
E, [2022-09-08T18:56:27.452768 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'
E, [2022-09-08T18:56:27.452782 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/hooks.rb:486:in `run'
E, [2022-09-08T18:56:27.452797 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:468:in `with_around_example_hooks'
E, [2022-09-08T18:56:27.452922 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'
E, [2022-09-08T18:56:27.453014 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example.rb:259:in `run'
E, [2022-09-08T18:56:27.453036 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:646:in `block in run_examples'
E, [2022-09-08T18:56:27.453083 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:642:in `map'
E, [2022-09-08T18:56:27.453244 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:642:in `run_examples'
E, [2022-09-08T18:56:27.453276 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:607:in `run'
E, [2022-09-08T18:56:27.453296 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:608:in `block in run'
E, [2022-09-08T18:56:27.453313 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:608:in `map'
E, [2022-09-08T18:56:27.453349 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:608:in `run'
E, [2022-09-08T18:56:27.453369 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:608:in `block in run'
E, [2022-09-08T18:56:27.453385 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:608:in `map'
E, [2022-09-08T18:56:27.453402 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:608:in `run'
E, [2022-09-08T18:56:27.453441 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
E, [2022-09-08T18:56:27.453482 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:121:in `map'
E, [2022-09-08T18:56:27.453502 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
E, [2022-09-08T18:56:27.453526 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2068:in `with_suite_hooks'
E, [2022-09-08T18:56:27.453547 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:116:in `block in run_specs'
E, [2022-09-08T18:56:27.453583 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/reporter.rb:74:in `report'
E, [2022-09-08T18:56:27.453610 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:115:in `run_specs'
E, [2022-09-08T18:56:27.453627 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:89:in `run'
E, [2022-09-08T18:56:27.453642 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:71:in `run'
E, [2022-09-08T18:56:27.453657 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:45:in `invoke'
E, [2022-09-08T18:56:27.453691 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/gems/rspec-core-3.11.0/exe/rspec:4:in `<top (required)>'
E, [2022-09-08T18:56:27.453708 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/bin/rspec:23:in `load'
E, [2022-09-08T18:56:27.453730 #1] ERROR -- : <job_123123> /home/dependabot/dependabot-updater/vendor/ruby/2.7.0/bin/rspec:23:in `<top (required)>'
E, [2022-09-08T18:56:27.453745 #1] ERROR -- : <job_123123> /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `load'
E, [2022-09-08T18:56:27.453768 #1] ERROR -- : <job_123123> /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:58:in `kernel_load'
E, [2022-09-08T18:56:27.453805 #1] ERROR -- : <job_123123> /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.14/lib/bundler/cli/exec.rb:23:in `run'
E, [2022-09-08T18:56:27.453831 #1] ERROR -- : <job_123123> /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.14/lib/bundler/cli.rb:483:in `exec'
E, [2022-09-08T18:56:27.453846 #1] ERROR -- : <job_123123> /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
E, [2022-09-08T18:56:27.453952 #1] ERROR -- : <job_123123> /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
E, [2022-09-08T18:56:27.453993 #1] ERROR -- : <job_123123> /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
E, [2022-09-08T18:56:27.454014 #1] ERROR -- : <job_123123> /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.14/lib/bundler/cli.rb:31:in `dispatch'
E, [2022-09-08T18:56:27.454029 #1] ERROR -- : <job_123123> /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.14/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
E, [2022-09-08T18:56:27.454047 #1] ERROR -- : <job_123123> /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.14/lib/bundler/cli.rb:25:in `start'
E, [2022-09-08T18:56:27.454067 #1] ERROR -- : <job_123123> /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.14/exe/bundle:48:in `block in <top (required)>'
E, [2022-09-08T18:56:27.454221 #1] ERROR -- : <job_123123> /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.14/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
E, [2022-09-08T18:56:27.454248 #1] ERROR -- : <job_123123> /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.14/exe/bundle:36:in `<top (required)>'
E, [2022-09-08T18:56:27.454264 #1] ERROR -- : <job_123123> .bundle/bin/bundle:113:in `load'
E, [2022-09-08T18:56:27.454290 #1] ERROR -- : <job_123123> .bundle/bin/bundle:113:in `<main>'
..E, [2022-09-08T18:56:28.732554 #1] ERROR -- : <job_123123> Repository is rate limited, attempting to retry in 29.267511201s
.E, [2022-09-08T18:56:28.734889 #1] ERROR -- : <job_123123> Error during file fetching; aborting
.................E, [2022-09-08T18:56:59.416785 #1] ERROR -- : <job_1> Error processing dummy-pkg-b (StandardError)
```

### After

```
Randomized with seed 6835
...............................................................................................................................................................................................................................To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
...

Top 10 slowest examples (129.27 seconds, 69.5% of total time):
  Dependabot::EndToEndJob bundler git dependencies updates dependencies correctly
    48 seconds ./spec/dependabot/integration_spec.rb:297
  Dependabot::EndToEndJob bundler git dependencies summarizes the changes
    47.6 seconds ./spec/dependabot/integration_spec.rb:361
  Dependabot::EndToEndJob JavaScript updates dependencies correctly
    13.94 seconds ./spec/dependabot/integration_spec.rb:437
  Dependabot::EndToEndJob JavaScript summarizes the changes
    5.05 seconds ./spec/dependabot/integration_spec.rb:509
  Dependabot::EndToEndJob bundler summarizes the changes
    3.04 seconds ./spec/dependabot/integration_spec.rb:155
  Dependabot::EndToEndJob composer updates dependencies correctly
    2.51 seconds ./spec/dependabot/integration_spec.rb:575
  bin/run fetch_files completes the job successfully and persists the files
    2.38 seconds ./spec/bin_run_spec.rb:24
  Dependabot::EndToEndJob composer summarizes the changes
    2.32 seconds ./spec/dependabot/integration_spec.rb:637
  Dependabot::FileFetcherJob#perform_job when package ecosystem always clones clones the repo
    2.25 seconds ./spec/dependabot/file_fetcher_job_spec.rb:166
  Dependabot::EndToEndJob bundler instruments the package manager version
    2.17 seconds ./spec/dependabot/integration_spec.rb:163

Top 10 slowest example groups:
  Dependabot::EndToEndJob
    8.69 seconds average (139 seconds / 16 examples) ./spec/dependabot/integration_spec.rb:11
  bin/run
    2.38 seconds average (2.38 seconds / 1 example) ./spec/bin_run_spec.rb:6
  Dependabot::FileFetcherJob
    0.4985 seconds average (4.99 seconds / 10 examples) ./spec/dependabot/file_fetcher_job_spec.rb:7
  Dependabot::Updater
    0.43225 seconds average (39.33 seconds / 91 examples) ./spec/dependabot/updater_spec.rb:12
  npm and yarn config
    0.15339 seconds average (0.30677 seconds / 2 examples) ./spec/npm_and_yarn_config_spec.rb:5
  Dependabot::UpdateFilesJob
    0.00298 seconds average (0.00595 seconds / 2 examples) ./spec/dependabot/update_files_job_spec.rb:7
  Dependabot::ApiClient
    0.00194 seconds average (0.02138 seconds / 11 examples) ./spec/dependabot/api_client_spec.rb:7
  dependabot instrumentation
    0.00072 seconds average (0.00072 seconds / 1 example) ./spec/dependabot/instrumentation_spec.rb:7
  Dependabot::Service
    0.00049 seconds average (0.01332 seconds / 27 examples) ./spec/dependabot/service_spec.rb:7
  Dependabot::Job
    0.00028 seconds average (0.00846 seconds / 30 examples) ./spec/dependabot/job_spec.rb:8

Finished in 3 minutes 6.1 seconds (files took 1.47 seconds to load)
226 examples, 0 failures

Randomized with seed 6835
```