### PR TITLE
deploy from a fork using a workflow

### DIFF
--- a/.github/workflows/docker-fork-releases.yml
+++ b/.github/workflows/docker-fork-releases.yml
@@ -81,6 +81,7 @@ jobs:
 
       - name: Set summary
         run: |
+          echo "generated for PR ${{ github.event.inputs.pr }}" > $GITHUB_STEP_SUMMARY
           echo "updater uploaded with tag \`$TAG\`" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "$UPDATER_IMAGE_MIRROR:$TAG" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-fork-releases.yml
+++ b/.github/workflows/docker-fork-releases.yml
@@ -1,0 +1,75 @@
+name: Push docker fork images
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  BASE_IMAGE: "ubuntu:20.04"
+  UPDATER_IMAGE: "dependabot/updater"
+  UPDATER_IMAGE_MIRROR: "ghcr.io/dependabot/dependabot-updater"
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        required: true
+        type: string
+        description: PR number
+
+jobs:
+  push-fork-image:
+    name: Build and push fork image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      TAG: ${{ github.sha }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+        # The PR must be approved. This is mostly to ensure you've typed the correct PR.
+      - name: Check if pull request is approved
+        run: |
+          DECISION=$(gh pr view ${{ github.event.inputs.pr }} --json reviewDecision -t {{.reviewDecision}})
+          echo "Review decision is: $DECISION"
+          [[ $DECISION == "APPROVED" ]] || exit 1
+
+      - name: Checkout the fork
+        run: gh pr checkout ${{ github.event.inputs.pr }}
+
+      - name: Build dependabot-core image
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker build \
+            -t "dependabot/dependabot-core:$TAG" \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --cache-from ghcr.io/dependabot/dependabot-core \
+            .
+
+      - name: Build dependabot-updater image
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker build \
+            -t "$UPDATER_IMAGE:$TAG" \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --cache-from "$BASE_IMAGE" \
+            --cache-from "$UPDATER_IMAGE_MIRROR" \
+            --build-arg OMNIBUS_VERSION=$TAG \
+            -f Dockerfile.updater \
+            .
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push fork image
+        run: |
+          docker tag "$UPDATER_IMAGE:$TAG" "$UPDATER_IMAGE_MIRROR:$TAG"
+          docker push "$UPDATER_IMAGE_MIRROR:$TAG"
+
+      - name: Set summary
+        run: |
+          echo "updater uploaded with tag \`$TAG\`" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "$UPDATER_IMAGE_MIRROR:$TAG" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-fork-releases.yml
+++ b/.github/workflows/docker-fork-releases.yml
@@ -25,15 +25,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-        # The PR must be approved. This is mostly to ensure you've typed the correct PR.
       - name: Check if pull request is approved
+        # The PR must be approved. This is mostly to ensure you've typed the correct PR.
+        # Note: forks will have a blank review decision without approval. Not NEEDS_REVIEW.
         run: |
           DECISION=$(gh pr view ${{ github.event.inputs.pr }} --json reviewDecision -t {{.reviewDecision}})
           echo "Review decision is: $DECISION"
           [[ $DECISION == "APPROVED" ]] || exit 1
 
       - name: Checkout the fork
-        run: gh pr checkout ${{ github.event.inputs.pr }}
+        # This checks out the fork and cherry-picks the changes onto main, creating a new merge SHA tag.
+        run: |
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+          gh pr checkout ${{ github.event.inputs.pr }} --branch docker-branch-release-workflow
+          git reset main
+          git add .
+          git commit -m squashed
+          PICK=$(git rev-parse HEAD)
+          git checkout main
+          git cherry-pick $PICK
+          echo "TAG=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Build dependabot-core image
         env:


### PR DESCRIPTION
Since fork PRs can only get read access from GITHUB_TOKEN, we can't use the `docker-branch-releases.yml` workflow to deploy a fork to GHCR before merging it.

This works around that with a manually dispatched workflow that pulls in the PR code, builds, and deploys it. Since it was kicked off by the team it _should_ have the correct permissions.

> **Note**
> While implementing this, I tried to simply `git merge main` after the `gh pr checkout` but git errors with `fatal: refusing  to merge unrelated histories`. So I assume the `gh` command is pulling in the PR as a different tree. To work around that, I squashed the changes and cherry picked them over to main. If anyone has a better or easier solution to that let me know!
