### PR TITLE
Clone full repo so yarn cache is available

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -24,3 +24,6 @@ Dependabot::Dependency.register_production_check(
     groups.include?("dependencies")
   end
 )
+
+require "dependabot/utils"
+Dependabot::Utils.register_always_clone("npm_and_yarn")


### PR DESCRIPTION
In order for us to update yarn berry's cache, we need that folder to be available. The easiest way to do that is to just check out the full repo. No other changes are required, the file fetcher should use functionality available in the base class in order to grab files from the repo on disk instead of making API calls.

If we were to roll this out, we should put it behind a feature flag and roll it out incrementally though, but for the purpose of a PoC for yarn berry, this should suffice, and I was able to perform a dry-run update that updates the cache correctly with this change:

```
=== @braintree/sanitize-url (5.0.2)
 => checking for updates 1/1
🌍 https//registry.npmjs.org:443/@braintree%2Fsanitize-url
🌍 https//registry.npmjs.org:443/@braintree%2Fsanitize-url/6.0.0
 => latest available version is 6.0.0
 => latest allowed version is 6.0.0
 => requirements to unlock: own
 => requirements update strategy: bump_versions
 => updating @braintree/sanitize-url from 5.0.2 to 6.0.0

    ± package.json
    ~~~
    4c4
    <     "@braintree/sanitize-url": "5.0.2"
    ---
    >     "@braintree/sanitize-url": "6.0.0"
    ~~~

    ± yarn.lock
    ~~~
    8,11c8,11
    < "@braintree/sanitize-url@npm:5.0.2":
    <   version: 5.0.2
    <   resolution: "@braintree/sanitize-url@npm:5.0.2"
    <   checksum: c033f9a0e6dd6fbd4022df2d3916a278510f759971b1e8ab278b3ce1123a3816d5fdd9d84c5c9fbcd6c94c05f8421c4c669f110c8db67eaf58f3018825af514e
    ---
    > "@braintree/sanitize-url@npm:6.0.0":
    >   version: 6.0.0
    >   resolution: "@braintree/sanitize-url@npm:6.0.0"
    >   checksum: 409ce7709dc1a0c67bc887d20af1becd4145d5c62cc5124b1c4c1f3ea2a8d69b0ee9f582d446469c6f5294b56442b99048cbbba6861dd5c834d4e019b95e1f40
    19c19
    <     "@braintree/sanitize-url": 5.0.2
    ---
    >     "@braintree/sanitize-url": 6.0.0
    ~~~
deleted .yarn/cache/@braintree-sanitize-url-npm-5.0.2-ef365f598a-c033f9a0e6.zip
added .yarn/cache/@braintree-sanitize-url-npm-6.0.0-c4f0ae4c7f-409ce7709d.zip
added .yarn/install-state.gz
🌍 Total requests made: '2'
```