### PR TITLE
Increase docker registry client timeout

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -347,7 +347,8 @@ module Dependabot
           DockerRegistry2::Registry.new(
             "https://#{registry_hostname}",
             user: registry_credentials&.fetch("username", nil),
-            password: registry_credentials&.fetch("password", nil)
+            password: registry_credentials&.fetch("password", nil),
+            read_timeout: 10,
           )
       end
 

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -348,7 +348,7 @@ module Dependabot
             "https://#{registry_hostname}",
             user: registry_credentials&.fetch("username", nil),
             password: registry_credentials&.fetch("password", nil),
-            read_timeout: 10,
+            read_timeout: 10
           )
       end
 


### PR DESCRIPTION
DockerRegistry2 has a default read timeout of 5s.  We have seen issues where loading the list of docker tags times out if that list is very large.  This increases the timeout to 10s which in my testing locally is sufficient to load hexpm/elixir with > 150k tags.

