### PR TITLE
fix Poetry not using system git

### DIFF
--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -177,6 +177,11 @@ module Dependabot
                                    "#{NativeHelpers.python_requirements_path}")
               end
 
+              # use system git instead of the pure Python dulwich
+              unless python_version&.start_with?("3.6")
+                run_poetry_command("pyenv exec poetry config experimental.system-git-client true")
+              end
+
               run_poetry_command(poetry_update_command)
 
               return File.read("poetry.lock") if File.exist?("poetry.lock")

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -28,6 +28,10 @@ module Dependabot
           'checkout',
           '(?<tag>.+?)'
           |
+          Failed to checkout
+          (?<tag>.+?)
+          (?<url>.+?).git at '(?<tag>.+?)'
+          |
           ...Failedtoclone
           (?<url>.+?).gitat'(?<tag>.+?)',
           verifyrefexistsonremote)
@@ -78,6 +82,7 @@ module Dependabot
 
         private
 
+        # rubocop:disable Metrics/PerceivedComplexity
         def fetch_latest_resolvable_version_string(requirement:)
           @latest_resolvable_version_string ||= {}
           return @latest_resolvable_version_string[requirement] if @latest_resolvable_version_string.key?(requirement)
@@ -97,6 +102,11 @@ module Dependabot
                   )
                 end
 
+                # use system git instead of the pure Python dulwich
+                unless python_version&.start_with?("3.6")
+                  run_poetry_command("pyenv exec poetry config experimental.system-git-client true")
+                end
+
                 # Shell out to Poetry, which handles everything for us.
                 run_poetry_command(poetry_update_command)
 
@@ -113,6 +123,7 @@ module Dependabot
               end
             end
         end
+        # rubocop:enable Metrics/PerceivedComplexity
 
         def fetch_version_from_parsed_lockfile(updated_lockfile)
           version =


### PR DESCRIPTION
fixes #5655

Poetry recently released 1.2.0 which uses [dulwich](https://github.com/jelmer/dulwich), a pure Python implementation of Git. Like other ecosystems, we actually want to use the system Git with Dependabot so the Git shim will rewrite URLs to be HTTPS. 

But also, in #5655 we are probably seeing a bug in dulwich that doesn't honor proxy authentication settings in the `http_proxy` environment variables. I tested this change locally and it fixed my reproduction repo.