### PR TITLE
Rename `e2e` to `smoke_tests`

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,7 +13,7 @@ on:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
-  e2e:
+  smoke_tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
The workflow name is `smoke`, the associated repo is https://github.com/dependabot/smoke-tests, so lets call the job names `smoke_tests` for consistency.

Note to self: Whenever this is resolved, update https://github.com/dependabot/dependabot-core/settings/branch_protection_rules/6220890 to make the smoke/e2e tests required to pass.