### PR TITLE
Bump `friendsofphp/php-cs-fixer` to `3.x` in `/composer/helpers/v1`

### DIFF
--- a/composer/helpers/v1/.php-cs-fixer.dist.php
+++ b/composer/helpers/v1/.php-cs-fixer.dist.php
@@ -2,19 +2,16 @@
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src')
     ->in(__DIR__ . '/bin');
-return PhpCsFixer\Config::create()
+$config = new PhpCsFixer\Config();
+return $config
     ->setRules([
         '@Symfony' => true,
-        'array_syntax' => ['syntax' => 'short'],
         'blank_line_after_opening_tag' => true,
         'concat_space' => ['spacing' => 'one'],
         'declare_strict_types' => true,
         'increment_style' => ['style' => 'post'],
-        'is_null' => ['use_yoda_style' => false],
-        'list_syntax' => ['syntax' => 'short'],
-        'method_argument_space' => ['ensure_fully_multiline' => true],
         'modernize_types_casting' => true,
-        'no_multiline_whitespace_before_semicolons' => true,
+        'multiline_whitespace_before_semicolons' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
         'ordered_imports' => true,

--- a/composer/helpers/v1/composer.json
+++ b/composer/helpers/v1/composer.json
@@ -5,7 +5,7 @@
         "composer/composer": "^1.10.9"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.9",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/phpstan": "~1.8.5"
     },
     "autoload": {


### PR DESCRIPTION
Bumped to V3 in order to fix the following deprecation warnings:
```
15.95 > php-cs-fixer fix --diff --verbose '--dry-run'
16.10 You are running PHP CS Fixer v2, which is not maintained anymore. Please update to v3.
16.10 You may find an UPGRADE guide at https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.3.0/UPGRADE-v3.md .
16.10 If you need help while solving warnings, ask at https://gitter.im/PHP-CS-Fixer, we will help you!
16.10
16.10 PHP CS Fixer 2.19.3 Testament by Fabien Potencier and Dariusz Ruminski
16.10 Runtime: PHP 7.4.30
16.10 Loaded config default from "/opt/composer/v1/.php_cs".
16.14 ......
16.26 Legend: ?-unknown, I-invalid file syntax (file ignored), S-skipped (cached or empty file), .-no changes, F-fixed, E-error
16.26
16.26 Checked all files in 0.134 seconds, 14.000 MB memory used
16.26
16.26 Detected deprecations in use:
16.26 - Option "ensure_fully_multiline" for rule "method_argument_space" is deprecated and will be removed in version 3.0. Use option "on_multiline" instead.
16.26 - Option "use_yoda_style" for rule "is_null" is deprecated and will be removed in version 3.0. Use "yoda_style" fixer instead.
16.26 - PhpCsFixer\Config::create is deprecated since 2.17 and will be removed in 3.0, use the constructor instead.
16.26 - Rule "no_multiline_whitespace_before_semicolons" is deprecated. Use "multiline_whitespace_before_semicolons" instead.
```

I also removed a couple of rules to make the config file consistent with the changes made in
https://github.com/dependabot/dependabot-core/pull/3840/files.

As best I can tell, the removed rules were removed because their defaults changed to match what we were specifying. The one curious change was `method_argument_space`, as the default _did_ change, but not to what we were specifying. For now I thought simplest to match the other config and put up the PR and see if it complains at all. If so, I can dig in further.