### PR TITLE
Watch the new `updater/Gemfile`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/common"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "bundler"
+    directory: "/updater"
+    schedule:
+      interval: "weekly"
 
   # Watch the per-ecosystem gemspecs
   - package-ecosystem: "bundler"


### PR DESCRIPTION
Now that we've merged `updater` into `core`, 
we should also have Dependabot watch its `Gemfile`.