### PR TITLE
Fix `PHP-CS-Fixer` deprecation warnings

### DIFF
--- a/composer/helpers/v1/.php-cs-fixer.dist.php
+++ b/composer/helpers/v1/.php-cs-fixer.dist.php
@@ -2,7 +2,8 @@
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src')
     ->in(__DIR__ . '/bin');
-return PhpCsFixer\Config::create()
+$config = new PhpCsFixer\Config();
+return $config
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
@@ -10,11 +11,10 @@ return PhpCsFixer\Config::create()
         'concat_space' => ['spacing' => 'one'],
         'declare_strict_types' => true,
         'increment_style' => ['style' => 'post'],
-        'is_null' => ['use_yoda_style' => false],
         'list_syntax' => ['syntax' => 'short'],
-        'method_argument_space' => ['ensure_fully_multiline' => true],
+        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
         'modernize_types_casting' => true,
-        'no_multiline_whitespace_before_semicolons' => true,
+        'multiline_whitespace_before_semicolons' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
         'ordered_imports' => true,


### PR DESCRIPTION
Fix the following warnings:
```
15.95 > php-cs-fixer fix --diff --verbose '--dry-run'
16.10 You are running PHP CS Fixer v2, which is not maintained anymore. Please update to v3.
16.10 You may find an UPGRADE guide at https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.3.0/UPGRADE-v3.md .
16.10 If you need help while solving warnings, ask at https://gitter.im/PHP-CS-Fixer, we will help you!
16.10
16.10 PHP CS Fixer 2.19.3 Testament by Fabien Potencier and Dariusz Ruminski
16.10 Runtime: PHP 7.4.30
16.10 Loaded config default from "/opt/composer/v1/.php_cs".
16.14 ......
16.26 Legend: ?-unknown, I-invalid file syntax (file ignored), S-skipped (cached or empty file), .-no changes, F-fixed, E-error
16.26
16.26 Checked all files in 0.134 seconds, 14.000 MB memory used
16.26
16.26 Detected deprecations in use:
16.26 - Option "ensure_fully_multiline" for rule "method_argument_space" is deprecated and will be removed in version 3.0. Use option "on_multiline" instead.
16.26 - Option "use_yoda_style" for rule "is_null" is deprecated and will be removed in version 3.0. Use "yoda_style" fixer instead.
16.26 - PhpCsFixer\Config::create is deprecated since 2.17 and will be removed in 3.0, use the constructor instead.
16.26 - Rule "no_multiline_whitespace_before_semicolons" is deprecated. Use "multiline_whitespace_before_semicolons" instead.
```

Originally I tried bumping `php-cs-fixer` to `v3` as suggested. But in https://github.com/dependabot/dependabot-core/pull/5694 I realized that was impossible given that `composer/composer` `v1` depended `composer/semver` `^v1` but `php-cs-fixer` `v3` requires `composer/semver` `v3`...

So for now just fix some old deprecation warnings and move on.

At least I got what I really wanted from this, which was to learn how Composer works.