### PR TITLE
Relax the composer pin to make it less confusing

### DIFF
--- a/composer/helpers/v1/composer.json
+++ b/composer/helpers/v1/composer.json
@@ -2,7 +2,7 @@
     "require": {
         "php": "^7.4",
         "ext-json": "*",
-        "composer/composer": "^1.10.9"
+        "composer/composer": "^1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.9",

--- a/composer/helpers/v1/composer.lock
+++ b/composer/helpers/v1/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f2c53b67946a00c067c0930ea168be9",
+    "content-hash": "a0dd40524c184de01243997f04394e71",
     "packages": [
         {
             "name": "composer/ca-bundle",


### PR DESCRIPTION
The previous pin technically allowed any version of composer >= 1.10.9, < 2.0... but because it included the full version pin, it was easy to overlook the `^` and think it was pulling in that older version of composer.

Over in the `v2/composer.json` file, we only pin to `"^2", so I made this pin less explicit for both improved consistency and less confusion.

There is no functional change to `composer.lock`, so this shouldn't have any impact beyond clearer documentation.