### PR TITLE
Use `"latest"` for ESLint `ecmaVersion`

### DIFF
--- a/npm_and_yarn/helpers/.eslintrc
+++ b/npm_and_yarn/helpers/.eslintrc
@@ -6,6 +6,6 @@
     "node": true
   },
   "parserOptions": {
-    "ecmaVersion": 9
+    "ecmaVersion": "latest"
   }
 }


### PR DESCRIPTION
Previously we were at 9, which is from back in 2018...

You can see the map of node versions to Ecma versions here: https://node.green/ Currently we're shipping `node` `16`, which has solid support through ES2021.

We could just bump the pin to a version, but then we have to remember to manually keep bumping it (Dependabot doesn't _yet_ support bumping this option).

Instead, by switching to [`"latest"`](https://eslint.org/docs/latest/user-guide/configuring/language-options#specifying-parser-options) we don't have to continue to maintain the pin.

Admittedly, this is a little YOLO'ish, since it will default to Ecma 2023 soon, but OTOH we will probably bump to Node 18 at the end of next month [when it goes to `Active` status[(https://nodejs.org/en/about/releases/). And Node 18 currently has good support for Ecma 2023.

I suspect overall the risk of `"latest"` diverging from what's actually supported in our node  version is less than the risk of us simply forgetting and _not_ bumping the pin at all for several years.

Plus this is just a linter, so it's not going to immediately break production...