### PR TITLE
Fix URIs logged by dry-run

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -465,7 +465,7 @@ $network_trace_count = 0
 ActiveSupport::Notifications.subscribe(/excon.request/) do |*args|
   $network_trace_count += 1
   payload = args.last
-  puts "🌍 #{payload[:scheme]}//#{payload[:host]}:#{payload[:port]}#{payload[:path]}"
+  puts "🌍 #{payload[:scheme]}://#{payload[:host]}#{payload[:path]}"
 end
 
 $package_manager_version_log = []


### PR DESCRIPTION
On the one hand, it was missing ":" after the colon. On the other hand, including the port makes the url not browsable, which I think it's the point of logging this.

Please trust me and don't even try to visit `https//pypi.org`, which is how I got here 🤣.