### PR TITLE
Make `script/debug` a simple wrapper over the CLI

### DIFF
--- a/script/dependabot
+++ b/script/dependabot
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-dependabot "$@" --debug \
+dependabot "$@" \
   -v "$(pwd)"/.core-bash_history:/home/dependabot/.bash_history \
   -v "$(pwd)"/updater/bin:/home/dependabot/dependabot-updater/bin \
   -v "$(pwd)"/updater/lib:/home/dependabot/dependabot-updater/lib \


### PR DESCRIPTION
Not sure if this makes sense to you, but today I wanted to use a full CLI run, with my development copy of dependabot-core code, but without a debugging shell. And the current `script/debug` script doesn't let you do that.

I thought about removing the hardcoded `--debug` flag, and if you want a debugger console, you can pass the `--debug` flag explicitly. Of course, that's more typing, so alternatively we could, for example:

* Use `dep` for the script name.
* Keep `script/debug` and do what I'm doing here in a separate script.

Does this make sense?