### PR TITLE
Allow updating Java images with "update releases"

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -43,7 +43,7 @@ module Dependabot
   module Docker
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       VERSION_REGEX =
-        /v?(?<version>[0-9]+(?:(?:\.[a-z0-9]+)|(?:-(?:kb)?[0-9]+))*)/i.freeze
+        /v?(?<version>[0-9]+(?:(?:\.[_a-z0-9]+)|(?:-(?:kb)?[0-9]+))*)/i.freeze
       VERSION_WITH_SFX = /^#{VERSION_REGEX}(?<suffix>-[a-z0-9.\-]+)?$/i.freeze
       VERSION_WITH_PFX = /^(?<prefix>[a-z0-9.\-]+-)?#{VERSION_REGEX}$/i.freeze
       VERSION_WITH_PFX_AND_SFX =

--- a/docker/lib/dependabot/docker/version.rb
+++ b/docker/lib/dependabot/docker/version.rb
@@ -5,6 +5,9 @@ require "dependabot/utils"
 module Dependabot
   module Docker
     class Version < Gem::Version
+      def initialize(version)
+        super(version.tr("_", "."))
+      end
     end
   end
 end

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -413,6 +413,43 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("jdk-11.0.2.9-alpine-slim") }
     end
 
+    context "when the dependencies have a underscore" do
+      let(:dependency_name) { "eclipse-temurin" }
+      let(:tags_fixture_name) { "eclipse-temurin.json" }
+      let(:repo_url) do
+        "https://registry.hub.docker.com/v2/library/eclipse-temurin/"
+      end
+      let(:headers_response) do
+        fixture("docker", "registry_manifest_headers", "ubuntu_17.10.json")
+      end
+      before do
+        stub_request(:get, repo_url + "tags/list").
+          and_return(status: 200, body: registry_tags)
+
+        stub_request(:head, repo_url + "manifests/#{version}").
+          and_return(
+            status: 200,
+            body: "",
+            headers: JSON.parse(headers_response)
+          )
+
+        # Stub the latest version to return a different digest
+        ["17.0.2_8-jre-alpine", "latest"].each do |version|
+          stub_request(:head, repo_url + "manifests/#{version}").
+            and_return(
+              status: 200,
+              body: "",
+              headers: JSON.parse(headers_response.gsub("3ea1ca1", "4da71a2"))
+            )
+        end
+      end
+
+      context "followed by numbers" do
+        let(:version) { "17.0.1_12-jre-alpine" }
+        it { is_expected.to eq("17.0.2_8-jre-alpine") }
+      end
+    end
+
     context "when the dependency has a namespace" do
       let(:dependency_name) { "moj/ruby" }
       let(:version) { "2.4.0" }

--- a/docker/spec/fixtures/docker/registry_tags/eclipse-temurin.json
+++ b/docker/spec/fixtures/docker/registry_tags/eclipse-temurin.json
@@ -1,0 +1,11 @@
+{
+    "name": "library/eclipse-temurin",
+    "tags": [
+        "17.0.1_12-jre-windowsservercore-ltsc2022",
+        "17.0.2_8-jre-alpine",
+        "17.0.1_12-jre-alpine",
+        "17-jre-alpine",
+        "11.0.14_9-jre-alpine",
+        "11-jre-alpine"
+    ]
+}


### PR DESCRIPTION
As per
https://www.oracle.com/java/technologies/javase/versioning-naming.html, an underscore is used for "update release" segments.

This PR fixes #5728 and supersedes #4801.

I added attribution to @RodrigoPetter since I used his tests!

Diffferences from his PR are the implementation, which is simpler here, and the scope which limits only to segments followed by numbers, but does not deal with other cases since I have not seen those in real life.

Thanks so much Rodrigo!!