### PR TITLE
Fix multiple Python requirements separated by whitespace

### DIFF
--- a/python/lib/dependabot/python/requirement.rb
+++ b/python/lib/dependabot/python/requirement.rb
@@ -60,6 +60,9 @@ module Dependabot
         requirements = requirements.flatten.flat_map do |req_string|
           next if req_string.nil?
 
+          # Standard python doesn't support whitespace in requirements, but Poetry does.
+          req_string = req_string.gsub(/(\d +)([<=>])/, '\1,\2')
+
           req_string.split(",").map(&:strip).map do |r|
             convert_python_constraint_to_ruby_constraint(r)
           end

--- a/python/spec/dependabot/python/requirement_spec.rb
+++ b/python/spec/dependabot/python/requirement_spec.rb
@@ -114,6 +114,11 @@ RSpec.describe Dependabot::Python::Requirement do
         let(:requirement_string) { ">=2.0,<2.1" }
         it { is_expected.to eq(Gem::Requirement.new(">=2.0", "<2.1")) }
       end
+
+      context "separated by whitespace (supported by Poetry)" do
+        let(:requirement_string) { ">=2.0 <2.1" }
+        it { is_expected.to eq(Gem::Requirement.new(">=2.0", "<2.1")) }
+      end
     end
 
     context "with multiple operators after the first" do
@@ -123,6 +128,11 @@ RSpec.describe Dependabot::Python::Requirement do
 
       context "separated with a comma" do
         let(:requirement_string) { ">=2.0,<2.1,<2.2" }
+        it { is_expected.to eq(Gem::Requirement.new(">=2.0", "<2.1", "<2.2")) }
+      end
+
+      context "separated by whitespace (supported by Poetry)" do
+        let(:requirement_string) { ">=2.0 <2.1 <2.2" }
         it { is_expected.to eq(Gem::Requirement.new(">=2.0", "<2.1", "<2.2")) }
       end
     end


### PR DESCRIPTION
Standard Python does not support this, but Poetry does, so when they appear on Poetry dependency files, they make dependabot crash.

Fixes https://github.com/dependabot/dependabot-core/issues/5363.