### PR TITLE
add a date tag to the docker image when merged

### DIFF
--- a/.github/workflows/docker-branch-releases.yml
+++ b/.github/workflows/docker-branch-releases.yml
@@ -85,8 +85,10 @@ jobs:
       - name: Push latest on main
         if: github.ref == 'refs/heads/main'
         run: |
+          DATE_BASED_VERSION=v2.0.$(date +%Y%m%d%H%M%S)
           docker tag "$UPDATER_IMAGE:$TAG" "$UPDATER_IMAGE_MIRROR:latest"
-          docker push "$UPDATER_IMAGE_MIRROR:latest"
+          docker tag "$UPDATER_IMAGE:$TAG" "$UPDATER_IMAGE_MIRROR:$DATE_BASED_VERSION"
+          docker push --all-tags "$UPDATER_IMAGE_MIRROR"
 
       - name: Set summary
         if: env.DECISION == 'APPROVED'

--- a/.github/workflows/docker-branch-releases.yml
+++ b/.github/workflows/docker-branch-releases.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Push latest on main
         if: github.ref == 'refs/heads/main'
         run: |
+          # The v2 tag is the Updater image tag, not related to the core version.
           DATE_BASED_VERSION=v2.0.$(date +%Y%m%d%H%M%S)
           docker tag "$UPDATER_IMAGE:$TAG" "$UPDATER_IMAGE_MIRROR:latest"
           docker tag "$UPDATER_IMAGE:$TAG" "$UPDATER_IMAGE_MIRROR:$DATE_BASED_VERSION"


### PR DESCRIPTION
This will add a date based version tag to the docker image published on main. 

This fixes some downstream projects relying on a comparable version tag. 