### PR TITLE
Add support for helm files.

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -214,6 +214,8 @@ module Dependabot
         images =
           if !img.nil? && img.is_a?(String) && !img.empty?
             [img]
+          elsif !img.nil? && img.is_a?(Hash) && !img.empty?
+            parse_helm(img)
           else
             []
           end
@@ -224,6 +226,22 @@ module Dependabot
       def manifest_files
         # Dependencies include both Dockerfiles and yaml, select yaml.
         dependency_files.select { |f| f.type == "file" && f.name.match?(/^[^\.]+\.ya?ml/i) }
+      end
+
+      def parse_helm(img_hash)
+        repo = img_hash.fetch("repository", nil)
+        tag = img_hash.key?("tag") ? img_hash.fetch("tag", nil) : img_hash.fetch("version", nil)
+        registry = img_hash.fetch("registry", nil)
+
+        if !repo.nil? && !registry.nil? && !tag.nil?
+          ["#{registry}/#{repo}:#{tag}"]
+        elsif !repo.nil? && !tag.nil?
+          ["#{repo}:#{tag}"]
+        elsif !repo.nil?
+          [repo]
+        else
+          []
+        end
       end
     end
   end

--- a/docker/spec/dependabot/docker/file_fetcher_spec.rb
+++ b/docker/spec/dependabot/docker/file_fetcher_spec.rb
@@ -268,5 +268,58 @@ RSpec.describe Dependabot::Docker::FileFetcher do
           to match_array(%w(pod.yaml))
       end
     end
+
+    context "with a Helm values file" do
+      before do
+        stub_request(:get, url + "?ref=sha").
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "contents_helm_repo.json"),
+            headers: { "content-type" => "application/json" }
+          )
+
+        stub_request(:get, File.join(url, "values.yaml?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: values_fixture,
+            headers: { "content-type" => "application/json" }
+          )
+
+        stub_request(:get, File.join(url, "other-values.yaml?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: values_fixture,
+            headers: { "content-type" => "application/json" }
+          )
+
+        stub_request(:get, File.join(url, "values_other.yaml?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: values_fixture,
+            headers: { "content-type" => "application/json" }
+          )
+
+        stub_request(:get, File.join(url, "values2.yaml?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: values_fixture,
+            headers: { "content-type" => "application/json" }
+          )
+      end
+
+      let(:values_fixture) { fixture("github", "contents_values_yaml.json") }
+      let(:options) { { kubernetes_updates: true } }
+
+      it "fetches the values.yaml" do
+        expect(file_fetcher_instance.files.count).to eq(4)
+        expect(file_fetcher_instance.files.map(&:name)).
+          to match_array(["other-values.yaml", "values.yaml", "values2.yaml", "values_other.yaml"])
+      end
+    end
   end
 end

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -1120,4 +1120,146 @@ RSpec.describe Dependabot::Docker::FileUpdater do
       end
     end
   end
+  let(:helm_updater) do
+    described_class.new(
+      dependency_files: helm_files,
+      dependencies: [helm_dependency],
+      credentials: credentials
+    )
+  end
+  let(:helm_files) { [helmfile] }
+  let(:credentials) do
+    [{
+      "type" => "git_source",
+      "host" => "github.com",
+      "username" => "x-access-token",
+      "password" => "token"
+    }]
+  end
+  let(:helmfile) do
+    Dependabot::DependencyFile.new(
+      content: helmfile_body,
+      name: "values.yaml"
+    )
+  end
+  let(:helmfile_body) { fixture("helm", "yaml", "values.yaml") }
+  let(:helm_dependency) do
+    Dependabot::Dependency.new(
+      name: "nginx",
+      version: "1.14.3",
+      previous_version: "1.14.2",
+      requirements: [{
+        requirement: nil,
+        groups: [],
+        file: "values.yaml",
+        source: { tag: "1.14.3" }
+      }],
+      previous_requirements: [{
+        requirement: nil,
+        groups: [],
+        file: "values.yaml",
+        source: { tag: "1.14.2" }
+      }],
+      package_manager: "kubernetes"
+    )
+  end
+
+  describe "#updated_dependency_files" do
+    subject(:updated_files) { helm_updater.updated_dependency_files }
+
+    it "returns DependencyFile objects" do
+      updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+    end
+
+    its(:length) { is_expected.to eq(1) }
+
+    describe "the updated podfile" do
+      subject(:updated_helmfile) do
+        updated_files.find { |f| f.name == "values.yaml" }
+      end
+
+      its(:content) { is_expected.to include "image:\n  repository: 'nginx'\n  tag: 1.14.3\n" }
+    end
+
+    context "when there are multiple images" do
+      let(:helmfile) do
+        Dependabot::DependencyFile.new(
+          content: helmfile_body,
+          name: "values.yaml"
+        )
+      end
+      let(:helmfile_body) { fixture("helm", "yaml", "multi-image.yaml") }
+      let(:helm_dependency) do
+        Dependabot::Dependency.new(
+          name: "nginx",
+          version: "1.14.3",
+          previous_version: "1.14.2",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "values.yaml",
+            source: { tag: "1.14.3" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "values.yaml",
+            source: { tag: "1.14.2" }
+          }],
+          package_manager: "kubernetes"
+        )
+      end
+
+      its(:length) { is_expected.to eq(1) }
+
+      describe "the updated helmfile" do
+        subject(:updated_helmfile) do
+          updated_files.find { |f| f.name == "values.yaml" }
+        end
+
+        its(:content) { is_expected.to include "  image:\n    repository: 'nginx'\n    tag: 1.14.3\n" }
+        its(:content) { is_expected.to include "  image:\n    repository: 'canonical/ubuntu'\n    tag: 18.04" }
+      end
+    end
+
+    context "when alternate version format" do
+      let(:helmfile) do
+        Dependabot::DependencyFile.new(
+          content: helmfile_body,
+          name: "values.yaml"
+        )
+      end
+      let(:helmfile_body) { fixture("helm", "yaml", "no-registry.yaml") }
+      let(:helm_dependency) do
+        Dependabot::Dependency.new(
+          name: "sql/sql",
+          version: "v1.2.4",
+          previous_version: "v1.2.3",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "values.yaml",
+            source: { tag: "v1.2.4" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "values.yaml",
+            source: { tag: "v1.2.3" }
+          }],
+          package_manager: "kubernetes"
+        )
+      end
+
+      its(:length) { is_expected.to eq(1) }
+
+      describe "the updated helmfile" do
+        subject(:updated_helmfile) do
+          updated_files.find { |f| f.name == "values.yaml" }
+        end
+
+        its(:content) { is_expected.to include "image:\n  repository: 'mcr.microsoft.com/sql/sql'\n  version: v1.2.4" }
+      end
+    end
+  end
 end

--- a/docker/spec/fixtures/github/contents_helm_repo.json
+++ b/docker/spec/fixtures/github/contents_helm_repo.json
@@ -1,0 +1,275 @@
+[
+  {
+    "name": ".circleci",
+    "path": ".circleci",
+    "sha": "a55330d23efd5d7a9f6de2f199025afaee1ec850",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/.circleci?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/tree/master/.circleci",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/a55330d23efd5d7a9f6de2f199025afaee1ec850",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/.circleci?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/a55330d23efd5d7a9f6de2f199025afaee1ec850",
+      "html": "https://github.com/dependabot/dependabot-core/tree/master/.circleci"
+    }
+  },
+  {
+    "name": ".editorconfig",
+    "path": ".editorconfig",
+    "sha": "90198c6fd1a76a01ccaa2bc945687b3fdf46401c",
+    "size": 198,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/.editorconfig?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/.editorconfig",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/90198c6fd1a76a01ccaa2bc945687b3fdf46401c",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/.editorconfig",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/.editorconfig?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/90198c6fd1a76a01ccaa2bc945687b3fdf46401c",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/.editorconfig"
+    }
+  },
+  {
+    "name": ".gitignore",
+    "path": ".gitignore",
+    "sha": "952d80d51793764e2b9761b39dd714d6529c9c89",
+    "size": 346,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/.gitignore?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/.gitignore",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/952d80d51793764e2b9761b39dd714d6529c9c89",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/.gitignore",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/.gitignore?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/952d80d51793764e2b9761b39dd714d6529c9c89",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/.gitignore"
+    }
+  },
+  {
+    "name": ".rubocop.yml",
+    "path": ".rubocop.yml",
+    "sha": "3610f39558406539335bcffbdcb6626ec30f8271",
+    "size": 746,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/.rubocop.yml?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/.rubocop.yml",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/3610f39558406539335bcffbdcb6626ec30f8271",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/.rubocop.yml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/.rubocop.yml?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/3610f39558406539335bcffbdcb6626ec30f8271",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/.rubocop.yml"
+    }
+  },
+  {
+    "name": "CHANGELOG.md",
+    "path": "CHANGELOG.md",
+    "sha": "fc4a6a0790fc4a903ed2a0636f46b361ad6144c6",
+    "size": 114851,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/CHANGELOG.md?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/CHANGELOG.md",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/fc4a6a0790fc4a903ed2a0636f46b361ad6144c6",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/CHANGELOG.md",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/CHANGELOG.md?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/fc4a6a0790fc4a903ed2a0636f46b361ad6144c6",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/CHANGELOG.md"
+    }
+  },
+  {
+    "name": "CONTRIBUTING.md",
+    "path": "CONTRIBUTING.md",
+    "sha": "c60e1930968302a75220f8c09201450ff65e78f7",
+    "size": 2239,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/CONTRIBUTING.md?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/CONTRIBUTING.md",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/c60e1930968302a75220f8c09201450ff65e78f7",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/CONTRIBUTING.md",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/CONTRIBUTING.md?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/c60e1930968302a75220f8c09201450ff65e78f7",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/CONTRIBUTING.md"
+    }
+  },
+  {
+    "name": "values.yaml",
+    "path": "values.yaml",
+    "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",
+    "size": 4927,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/Dockerfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile"
+    }
+  },
+  {
+    "name": "other-values.yaml",
+    "path": "other-values.yaml",
+    "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",
+    "size": 4927,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/Dockerfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile"
+    }
+  },
+  {
+    "name": "values_other.yaml",
+    "path": "values_other.yaml",
+    "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",
+    "size": 4927,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/Dockerfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile"
+    }
+  },
+  {
+    "name": "values2.yaml",
+    "path": "values2.yaml",
+    "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",
+    "size": 4927,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/Dockerfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile"
+    }
+  },
+  {
+    "name": "Gemfile",
+    "path": "Gemfile",
+    "sha": "be173b205f70152dd1e0a0319f131e51c49eb9cd",
+    "size": 70,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Gemfile?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/Gemfile",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/be173b205f70152dd1e0a0319f131e51c49eb9cd",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/Gemfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/Gemfile?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/be173b205f70152dd1e0a0319f131e51c49eb9cd",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/Gemfile"
+    }
+  },
+  {
+    "name": "LICENSE",
+    "path": "LICENSE",
+    "sha": "7c97dc80776f919c97e2ad78893ef196726c3521",
+    "size": 1554,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/LICENSE?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/LICENSE",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/7c97dc80776f919c97e2ad78893ef196726c3521",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/LICENSE",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/LICENSE?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/7c97dc80776f919c97e2ad78893ef196726c3521",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/LICENSE"
+    }
+  },
+  {
+    "name": "README.md",
+    "path": "README.md",
+    "sha": "d9e7b752b507ea93199b52a8866dabd26d0ddae7",
+    "size": 6078,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/README.md?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/README.md",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/d9e7b752b507ea93199b52a8866dabd26d0ddae7",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/README.md",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/README.md?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/d9e7b752b507ea93199b52a8866dabd26d0ddae7",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/README.md"
+    }
+  },
+  {
+    "name": "dependabot-core.gemspec",
+    "path": "dependabot-core.gemspec",
+    "sha": "70ca6dcb9506728ca235748d27fb871497c349a0",
+    "size": 1571,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/dependabot-core.gemspec?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/dependabot-core.gemspec",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/70ca6dcb9506728ca235748d27fb871497c349a0",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/dependabot-core.gemspec",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/dependabot-core.gemspec?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/70ca6dcb9506728ca235748d27fb871497c349a0",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/dependabot-core.gemspec"
+    }
+  },
+  {
+    "name": "helpers",
+    "path": "helpers",
+    "sha": "900f6c83a9611c92478918dfca8e541261912e8c",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/helpers?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/tree/master/helpers",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/900f6c83a9611c92478918dfca8e541261912e8c",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/helpers?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/900f6c83a9611c92478918dfca8e541261912e8c",
+      "html": "https://github.com/dependabot/dependabot-core/tree/master/helpers"
+    }
+  },
+  {
+    "name": "lib",
+    "path": "lib",
+    "sha": "8493ef79eb42da9d8aaa1e78dab729e3c08d22ee",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/lib?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/tree/master/lib",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/8493ef79eb42da9d8aaa1e78dab729e3c08d22ee",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/lib?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/8493ef79eb42da9d8aaa1e78dab729e3c08d22ee",
+      "html": "https://github.com/dependabot/dependabot-core/tree/master/lib"
+    }
+  },
+  {
+    "name": "spec",
+    "path": "spec",
+    "sha": "40e3fc7a0819fac4c3e30b0d4217ad11ffc2ceef",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/spec?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/tree/master/spec",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/40e3fc7a0819fac4c3e30b0d4217ad11ffc2ceef",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/spec?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/40e3fc7a0819fac4c3e30b0d4217ad11ffc2ceef",
+      "html": "https://github.com/dependabot/dependabot-core/tree/master/spec"
+    }
+  }
+]
+

--- a/docker/spec/fixtures/github/contents_other_yaml.json
+++ b/docker/spec/fixtures/github/contents_other_yaml.json
@@ -16,3 +16,4 @@
     "html": "https://github.com/dependabot/dependabot-core/blob/main/other.yaml"
   }
 }
+

--- a/docker/spec/fixtures/github/contents_values_yaml.json
+++ b/docker/spec/fixtures/github/contents_values_yaml.json
@@ -1,0 +1,19 @@
+{
+  "name": "values.yaml",
+  "path": "values.yaml",
+  "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",
+  "size": 4927,
+  "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/values.yaml?ref=master",
+  "html_url": "https://github.com/dependabot/dependabot-core/blob/main/values.yaml",
+  "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+  "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/values.yaml",
+  "type": "file",
+  "content": "aW1hZ2U6CiAgcmVwb3NpdG9yeTogJ25naW54JwogIHRhZzogMS4xNC4yCiAgcmVnaXN0cnk6IHJlZ2lzdHJ5LmV4YW1wbGUuY29tCnNvbWU6CiAgb3RoZXI6CiAgICB0YWc6IGZvbw==",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/values.yaml?ref=master",
+    "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+    "html": "https://github.com/dependabot/dependabot-core/blob/main/values.yaml"
+  }
+}
+

--- a/docker/spec/fixtures/helm/yaml/empty.yaml
+++ b/docker/spec/fixtures/helm/yaml/empty.yaml
@@ -1,0 +1,3 @@
+some:
+  other:
+    tag: foo

--- a/docker/spec/fixtures/helm/yaml/multi-image.yaml
+++ b/docker/spec/fixtures/helm/yaml/multi-image.yaml
@@ -1,0 +1,10 @@
+foo:
+  image:
+    repository: 'nginx'
+    tag: 1.14.2
+    registry: burns.azurecr.io
+
+bar:
+  image:
+    repository: 'canonical/ubuntu'
+    tag: 18.04

--- a/docker/spec/fixtures/helm/yaml/no-registry.yaml
+++ b/docker/spec/fixtures/helm/yaml/no-registry.yaml
@@ -1,0 +1,3 @@
+image:
+  repository: 'mcr.microsoft.com/sql/sql'
+  version: v1.2.3

--- a/docker/spec/fixtures/helm/yaml/values.yaml
+++ b/docker/spec/fixtures/helm/yaml/values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: 'nginx'
+  tag: 1.14.2
+  registry: registry.example.com
+some:
+  other:
+    tag: foo


### PR DESCRIPTION
This PR extends the recent Kubernetes support for Docker containers to common Helm chart formats:

```yaml
foo:
  image:
    repository: sql/sql
    tag: 1.2.3
    registry: docker.io
```

or alternatively:

```yaml
foo:
  image:
    repository: sql/sql
    version: 1.2.3
```
