### PR TITLE
Sanitize metadata links on all platforms

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -245,8 +245,6 @@ module Dependabot
         end
 
         def sanitize_links_and_mentions(text, unsafe: false)
-          return text unless source.provider == "github" || source.provider == "gitlab"
-
           LinkAndMentionSanitizer.
             new(github_redirection_service: github_redirection_service).
             sanitize_links_and_mentions(text: text, unsafe: unsafe)


### PR DESCRIPTION
As pointed out in https://github.com/dependabot/dependabot-core/issues/5729, we should be using the "source" of the metadata for deciding how to sanitize, not the "place where Dependabot is hosted".

This hack was annoying the folks who use GitLab to the point that [they monkey-patched this code to also run the sanitizer on GitLab](https://github.com/dependabot/dependabot-core/pull/3437#issuecomment-816582168), and then contributed that back in #3437.

If it's true on GitLab, it's even more true on other platforms as well for the reasons explained in https://github.com/dependabot/dependabot-core/pull/3437#issuecomment-1247597678.

So remove this guard altogether.