### PR TITLE
Fix commitlint message style detection

### DIFF
--- a/common/lib/dependabot/config/file.rb
+++ b/common/lib/dependabot/config/file.rb
@@ -71,7 +71,7 @@ module Dependabot
         commit_message = cfg&.dig(:"commit-message") || {}
         Dependabot::Config::UpdateConfig::CommitMessageOptions.new(
           prefix: commit_message[:prefix],
-          prefix_development: commit_message[:"prefix-development"],
+          prefix_development: commit_message[:"prefix-development"] || commit_message[:prefix],
           include: commit_message[:include]
         )
       end

--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -43,8 +43,6 @@ module Dependabot
       end
 
       def capitalize_first_word?
-        return !commit_message_options[:prefix]&.strip&.match?(/\A[a-z]/) if commit_message_options.key?(:prefix)
-
         return capitalise_first_word_from_last_dependabot_commit_style if last_dependabot_commit_style
 
         capitalise_first_word_from_previous_commits

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       credentials: credentials,
       pr_message_header: pr_message_header,
       pr_message_footer: pr_message_footer,
-      commit_message_options: { signoff_details: signoff_details, trailers: trailers },
+      commit_message_options: commit_message_options,
       vulnerabilities_fixed: vulnerabilities_fixed,
       github_redirection_service: github_redirection_service
     )
@@ -41,6 +41,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
   let(:credentials) { github_credentials }
   let(:pr_message_header) { nil }
   let(:pr_message_footer) { nil }
+  let(:commit_message_options) { { signoff_details: signoff_details, trailers: trailers } }
   let(:signoff_details) { nil }
   let(:trailers) { nil }
   let(:vulnerabilities_fixed) { { "business" => [] } }
@@ -443,6 +444,29 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
           it do
             is_expected.to eq("Chore(deps): Bump business from 1.4.0 to 1.5.0")
+          end
+        end
+
+        context "and capitalizes the message but not the prefix" do
+          before do
+            stub_request(:get, watched_repo_url + "/commits?per_page=100").
+              to_return(
+                status: 200,
+                body: fixture("github", "commits_angular_sentence_case.json"),
+                headers: json_header
+              )
+          end
+
+          it do
+            is_expected.to eq("chore(deps): Bump business from 1.4.0 to 1.5.0")
+          end
+
+          context "and with commit messages explicitly configured" do
+            let(:commit_message_options) { super().update(prefix: "chore(dependencies)") }
+
+            it do
+              is_expected.to eq("chore(dependencies): Bump business from 1.4.0 to 1.5.0")
+            end
           end
         end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -462,7 +462,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
 
           context "and with commit messages explicitly configured" do
-            let(:commit_message_options) { super().update(prefix: "chore(dependencies)") }
+            let(:commit_message_options) { super().merge(prefix: "chore(dependencies)") }
 
             it do
               is_expected.to eq("chore(dependencies): Bump business from 1.4.0 to 1.5.0")

--- a/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
@@ -225,6 +225,15 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
     end
 
     context "when commit_message_options are provided" do
+      before do
+        stub_request(:get, watched_repo_url + "/commits?per_page=100").
+          to_return(
+            status: 200,
+            body: commits_response,
+            headers: json_header
+          )
+      end
+      let(:commits_response) { fixture("github", "commits.json") }
       let(:commit_message_options) do
         {
           prefix: prefix,

--- a/common/spec/fixtures/github/commits_angular_sentence_case.json
+++ b/common/spec/fixtures/github/commits_angular_sentence_case.json
@@ -1,0 +1,78 @@
+[
+  {
+    "sha": "10c8e4fc039ec6fa512264149067fbb8b0752452",
+    "commit": {
+      "author": {
+        "name": "dependabot[bot]",
+        "email": "dependabot[bot]@users.noreply.github.com",
+        "date": "2017-12-08T08:52:57Z"
+      },
+      "committer": {
+        "name": "Lipis",
+        "email": "lipiridis@gmail.com",
+        "date": "2017-12-08T08:52:57Z"
+      },
+      "message": "chore(dependencies): Bump sinon from 4.1.2 to 4.1.3 (#103)\n\nBumps [sinon](https://github.com/sinonjs/sinon) from 4.1.2 to 4.1.3.\r\n- [Changelog](https://github.com/sinonjs/sinon/blob/master/History.md)\r\n- [Commits](https://github.com/sinonjs/sinon/commits/v4.1.3)",
+      "tree": {
+        "sha": "6eb23c51f73515e851071be31319ea1a9e109bba",
+        "url": "https://api.github.com/repos/wireapp/wire-web-packages/git/trees/6eb23c51f73515e851071be31319ea1a9e109bba"
+      },
+      "url": "https://api.github.com/repos/wireapp/wire-web-packages/git/commits/10c8e4fc039ec6fa512264149067fbb8b0752452",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null
+      }
+    },
+    "url": "https://api.github.com/repos/wireapp/wire-web-packages/commits/10c8e4fc039ec6fa512264149067fbb8b0752452",
+    "html_url": "https://github.com/wireapp/wire-web-packages/commit/10c8e4fc039ec6fa512264149067fbb8b0752452",
+    "comments_url": "https://api.github.com/repos/wireapp/wire-web-packages/commits/10c8e4fc039ec6fa512264149067fbb8b0752452/comments",
+    "author": {
+      "login": "dependabot[bot]",
+      "id": 27856297,
+      "avatar_url": "https://avatars3.githubusercontent.com/in/2141?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/dependabot%5Bbot%5D",
+      "html_url": "https://github.com/apps/dependabot",
+      "followers_url": "https://api.github.com/users/dependabot%5Bbot%5D/followers",
+      "following_url": "https://api.github.com/users/dependabot%5Bbot%5D/following{/other_user}",
+      "gists_url": "https://api.github.com/users/dependabot%5Bbot%5D/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/dependabot%5Bbot%5D/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/dependabot%5Bbot%5D/subscriptions",
+      "organizations_url": "https://api.github.com/users/dependabot%5Bbot%5D/orgs",
+      "repos_url": "https://api.github.com/users/dependabot%5Bbot%5D/repos",
+      "events_url": "https://api.github.com/users/dependabot%5Bbot%5D/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/dependabot%5Bbot%5D/received_events",
+      "type": "Bot",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "lipis",
+      "id": 125676,
+      "avatar_url": "https://avatars1.githubusercontent.com/u/125676?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/lipis",
+      "html_url": "https://github.com/lipis",
+      "followers_url": "https://api.github.com/users/lipis/followers",
+      "following_url": "https://api.github.com/users/lipis/following{/other_user}",
+      "gists_url": "https://api.github.com/users/lipis/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/lipis/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/lipis/subscriptions",
+      "organizations_url": "https://api.github.com/users/lipis/orgs",
+      "repos_url": "https://api.github.com/users/lipis/repos",
+      "events_url": "https://api.github.com/users/lipis/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/lipis/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "b855453dd17c485121387eb24139bec9f25f5f37",
+        "url": "https://api.github.com/repos/wireapp/wire-web-packages/commits/b855453dd17c485121387eb24139bec9f25f5f37",
+        "html_url": "https://github.com/wireapp/wire-web-packages/commit/b855453dd17c485121387eb24139bec9f25f5f37"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
We should not try to be too smart since there's too many different commitlint setups. Instead, it seems more sound to use the style of previous commits.

Also, I think commit message should default to use the configured prefix for development dependencies if `prefix` is configured, but `prefix-development` is not.

This is just a naive approach that works with `bin/dry-run.rb` but probably specs need fixing, etc.

Fixes #1666.