### PR TITLE
Gate yarn berry changes behind feature-flag

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn.rb
@@ -24,6 +24,3 @@ Dependabot::Dependency.register_production_check(
     groups.include?("dependencies")
   end
 )
-
-require "dependabot/utils"
-Dependabot::Utils.register_always_clone("npm_and_yarn")

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -3,6 +3,7 @@
 # See https://docs.npmjs.com/files/package.json for package.json format docs.
 
 require "dependabot/dependency"
+require "dependabot/experiments"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
 require "dependabot/shared_helpers"
@@ -327,7 +328,7 @@ module Dependabot
               dependency_files.
               select { |f| f.name.end_with?("package.json") }.
               reject { |f| f.name == "package.json" }.
-              reject { |f| f.name.include?("node_modules/") }.
+              reject { |f| f.name.include?("node_modules/") if Experiments.enabled?(:yarn_berry) }.
               reject(&:support_file?)
 
             [

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -96,8 +96,8 @@ module Dependabot
             parse_yarn_lock(yarn_lock).each do |req, details|
               next unless semver_version_for(details["version"])
               next if alias_package?(req)
-              next if workspace_package?(req)
-              next if req == "__metadata"
+              next if Experiments.enabled?(:yarn_berry) && workspace_package?(req)
+              next if Experiments.enabled?(:yarn_berry) && req == "__metadata"
 
               # NOTE: The DependencySet will de-dupe our dependencies, so they
               # end up unique by name. That's not a perfect representation of
@@ -190,7 +190,7 @@ module Dependabot
         end
 
         def alias_package?(requirement)
-          requirement.match?(/@npm:(.+@(?!npm))/)
+          Experiments.enabled?(:yarn_berry) ? requirement.match?(/@npm:(.+@(?!npm))/) : requirement.include?("@npm:")
         end
 
         def workspace_package?(requirement)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dependabot/experiments"
 require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
 require "dependabot/file_updaters/vendor_updater"
@@ -54,12 +55,14 @@ module Dependabot
           )
         end
 
-        # There's probably a way to avoid this duplication between the
-        # vendor_updater and install_state_updater, but yeah.
-        base_dir = updated_files.first.directory
-        vendor_updater.updated_vendor_cache_files(base_directory: base_dir).each { |file| updated_files << file }
-        install_state_updater.updated_vendor_cache_files(base_directory: base_dir).each do |file|
-          updated_files << file
+        if Experiments.enabled?(:yarn_berry)
+          # There's probably a way to avoid this duplication between the
+          # vendor_updater and install_state_updater, but yeah.
+          base_dir = updated_files.first.directory
+          vendor_updater.updated_vendor_cache_files(base_directory: base_dir).each { |file| updated_files << file }
+          install_state_updater.updated_vendor_cache_files(base_directory: base_dir).each do |file|
+            updated_files << file
+          end
         end
 
         updated_files

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -8,6 +8,7 @@ require "dependabot/npm_and_yarn/update_checker/registry_finder"
 require "dependabot/npm_and_yarn/native_helpers"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
+require "dependabot/experiments"
 
 # rubocop:disable Metrics/ClassLength
 module Dependabot
@@ -143,6 +144,8 @@ module Dependabot
         # rubocop:enable Metrics/PerceivedComplexity
 
         def yarn_berry?(yarn_lock)
+          return false unless Experiments.enabled?(:yarn_berry)
+
           yaml = YAML.safe_load(yarn_lock.content)
           yaml.key?("__metadata")
         rescue StandardError

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/sub_dependency_files_filterer.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/sub_dependency_files_filterer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dependabot/experiments"
 require "dependabot/utils"
 require "dependabot/npm_and_yarn/version"
 require "dependabot/npm_and_yarn/file_parser/lockfile_parser"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -2,6 +2,7 @@
 
 require "dependabot/dependency"
 require "dependabot/errors"
+require "dependabot/experiments"
 require "dependabot/logger"
 require "dependabot/npm_and_yarn/file_parser"
 require "dependabot/npm_and_yarn/file_updater/npmrc_builder"

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
@@ -5,6 +5,10 @@ require "dependabot/dependency_file"
 require "dependabot/npm_and_yarn/file_parser/lockfile_parser"
 
 RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
+  before do
+    Dependabot::Experiments.register(:yarn_berry, true)
+  end
+
   subject(:lockfile_parser) do
     described_class.new(dependency_files: dependency_files)
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/yarn_lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/yarn_lockfile_parser_spec.rb
@@ -5,6 +5,10 @@ require "dependabot/dependency_file"
 require "dependabot/npm_and_yarn/file_parser/yarn_lockfile_parser"
 
 RSpec.describe Dependabot::NpmAndYarn::FileParser::YarnLockfileParser do
+  before do
+    Dependabot::Experiments.register(:yarn_berry, true)
+  end
+
   subject(:yarn_lockfile_parser) do
     described_class.new(lockfile: yarn_lockfile)
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
     }]
   end
 
+  before do
+    Dependabot::Experiments.register(:yarn_berry, true)
+  end
+
   describe "parse" do
     subject(:dependencies) { parser.parse }
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -58,7 +58,10 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
   let(:tmp_path) { Dependabot::Utils::BUMP_TMP_DIR_PATH }
   let(:repo_contents_path) { nil }
 
-  before { FileUtils.mkdir_p(tmp_path) }
+  before do
+    FileUtils.mkdir_p(tmp_path)
+    Dependabot::Experiments.register(:yarn_berry, true)
+  end
 
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/sub_dependency_files_filterer_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/sub_dependency_files_filterer_spec.rb
@@ -3,9 +3,14 @@
 require "spec_helper"
 require "dependabot/dependency"
 require "dependabot/dependency_file"
+require "dependabot/experiments"
 require "dependabot/npm_and_yarn/sub_dependency_files_filterer"
 
 RSpec.describe Dependabot::NpmAndYarn::SubDependencyFilesFilterer do
+  before do
+    Dependabot::Experiments.register(:yarn_berry, true)
+  end
+
   subject(:files_requiring_update) do
     described_class.new(
       dependency_files: dependency_files,

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 require "dependabot/dependency"
 require "dependabot/dependency_file"
+require "dependabot/experiments"
 require "dependabot/npm_and_yarn/update_checker"
 require "dependabot/npm_and_yarn/metadata_finder"
 require_common_spec "update_checkers/shared_examples_for_update_checkers"
@@ -59,6 +60,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
     )
   end
   let(:dependency_version) { "1.0.0" }
+
+  before do
+    Dependabot::Experiments.register(:yarn_berry, true)
+  end
 
   describe "#up_to_date?", :vcr do
     context "with no lockfile" do

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -4,6 +4,7 @@ require "raven"
 require "dependabot/config/ignore_condition"
 require "dependabot/config/update_config"
 require "dependabot/environment"
+require "dependabot/experiments"
 require "dependabot/file_fetchers"
 require "dependabot/file_parsers"
 require "dependabot/file_updaters"
@@ -65,6 +66,8 @@ module Dependabot
       job.experiments.each do |name, value|
         Dependabot::Experiments.register(name, value)
       end
+
+      Dependabot::Utils.register_always_clone("npm_and_yarn") if Dependabot::Experiments.enabled?(:yarn_berry)
 
       if job.updating_a_pull_request?
         logger_info("Starting PR update job for #{job.source.repo}")


### PR DESCRIPTION
In order to merge these changes into main without disrupting existing behavior, gate the changes behind a feature flag, so we can gradually roll them out and iron out issues without building up a huge set of changes.

I've opted to explicitly _enable_ the feature in our tests, so they run against the new situation, we can add a few tests that ensure the new behavior doesn't run _without_ the flag present, but I'm a little concerned about how invasive this feature-flag change is to be honest, needing to pass the feature flag around etc. and would like to possibly rethink the approach first.

This also still includes the changes to always clone the full repo, which we should flag in updater/api instead.