### PR TITLE
fix #5751 run CI and smoke tests on stacked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
     paths-ignore:
       - "CHANGELOG.md"
       - "common/lib/dependabot/version.rb"
-    branches:
-      - "main"
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
     paths-ignore:
       - docs/**
       - README.md


### PR DESCRIPTION
We noticed the CI and Smoke tests weren't running on stacked PRs so this should fix that. Tested in https://github.com/dependabot/dependabot-core/pull/5753.
