### PR TITLE
Add new interface to register experiments

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -224,6 +224,10 @@ option_parse = OptionParser.new do |opts|
         [o.strip.downcase.to_sym, true]
       end
     end
+
+    $options[:updater_options].each do |name, val|
+      Dependabot::Experiment.register(name, val)
+    end
   end
 
   opts.on("--security-updates-only",

--- a/common/lib/dependabot/experiments.rb
+++ b/common/lib/dependabot/experiments.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Dependabot
+  module Experiments
+    @experiments = {}
+
+    def self.reset!
+      @experiments = {}
+    end
+
+    def self.register(name, value)
+      @experiments[name.to_sym] = value
+    end
+
+    def self.enabled?(name)
+      !!@experiments[name.to_sym]
+    end
+  end
+end

--- a/common/spec/dependabot/experiments_spec.rb
+++ b/common/spec/dependabot/experiments_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/experiments"
+
+RSpec.describe Dependabot::Experiments do
+  before do
+    described_class.reset!
+  end
+
+  it "can register experiments as enabled" do
+    described_class.register(:my_test, true)
+
+    expect(described_class.enabled?(:my_test)).to be_truthy
+  end
+
+  it "works with string names and symbols" do
+    described_class.register("my_test", true)
+
+    expect(described_class.enabled?("my_test")).to be_truthy
+    expect(described_class.enabled?(:my_test)).to be_truthy
+  end
+end

--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require "stackprof"
 require "uri"
 
 require "dependabot/dependency_file"
+require "dependabot/experiments"
 require "dependabot/registry_client"
 require_relative "dummy_package_manager/dummy"
 require_relative "warning_monkey_patch"
@@ -43,6 +44,9 @@ RSpec.configure do |config|
   config.after do
     # Ensure we clear any cached timeouts between tests
     Dependabot::RegistryClient.clear_cache!
+
+    # Ensure we reset any experiments between tests
+    Dependabot::Experiments.reset!
   end
 
   config.around do |example|

--- a/docker/lib/dependabot/docker/file_fetcher.rb
+++ b/docker/lib/dependabot/docker/file_fetcher.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dependabot/experiments"
 require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
 
@@ -21,7 +22,7 @@ module Dependabot
       private
 
       def kubernetes_enabled?
-        options.key?(:kubernetes_updates) && options[:kubernetes_updates]
+        Experiments.enabled?(:kubernetes_updates)
       end
 
       def fetch_files

--- a/docker/spec/dependabot/docker/file_fetcher_spec.rb
+++ b/docker/spec/dependabot/docker/file_fetcher_spec.rb
@@ -18,11 +18,9 @@ RSpec.describe Dependabot::Docker::FileFetcher do
     described_class.new(
       source: source,
       credentials: credentials,
-      repo_contents_path: nil,
-      options: options
+      repo_contents_path: nil
     )
   end
-  let(:options) { {} }
   let(:directory) { "/" }
   let(:github_url) { "https://api.github.com/" }
   let(:url) { github_url + "repos/gocardless/bump/contents/" }
@@ -184,7 +182,9 @@ RSpec.describe Dependabot::Docker::FileFetcher do
     end
 
     let(:kubernetes_fixture) { fixture("github", "contents_kubernetes.json") }
-    let(:options) { { kubernetes_updates: true } }
+    before do
+      Dependabot::Experiments.register(:kubernetes_updates, true)
+    end
 
     it "fetches the pod.yaml" do
       expect(file_fetcher_instance.files.count).to eq(1)
@@ -211,7 +211,9 @@ RSpec.describe Dependabot::Docker::FileFetcher do
     end
 
     context "with kubernetes not enabled" do
-      let(:options) { { kubernetes_updates: false } }
+      before do
+        Dependabot::Experiments.register(:kubernetes_updates, false)
+      end
 
       it "raises a helpful error" do
         expect { file_fetcher_instance.files }.
@@ -247,7 +249,9 @@ RSpec.describe Dependabot::Docker::FileFetcher do
 
     let(:kubernetes_fixture) { fixture("github", "contents_kubernetes.json") }
     let(:kubernetes_2_fixture) { fixture("github", "contents_kubernetes.json") }
-    let(:options) { { kubernetes_updates: true } }
+    before do
+      Dependabot::Experiments.register(:kubernetes_updates, true)
+    end
 
     it "fetches both YAMLs" do
       expect(file_fetcher_instance.files.count).to eq(2)

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -62,6 +62,10 @@ module Dependabot
     def run
       return unless job
 
+      job.experiments.each do |name, value|
+        Dependabot::Experiments.register(name, value)
+      end
+
       if job.updating_a_pull_request?
         logger_info("Starting PR update job for #{job.source.repo}")
         check_and_update_existing_pr_with_error_handling(dependencies)


### PR DESCRIPTION
Currently experiments are required to be passed in as an optional
`options` flag to the individual classes like the FileFetcher and
FileUpdater. This is fine, but it becomes a bit cumbersome when more
deeply nested objects need to access this flag, as we need to pass it
down to all of them.

This introduces a global `Dependabot::Experiments` interface that we can
use to register experiments and access them where needed.

The idea is that these are set in the Updater before running an update,
and will be available for the duration of the job.

Right now most of the existing experiments are left as is, using the `options` flags,
but I've ported the `kubernetes_enabled` feature flag for the Docker ecosystem to
demonstrate how this would work.

There is more functionality we could add to this interface, but for now it just adds what
is needed.