### PR TITLE
Fixes for transitive dependency vulnerabilities without a top level dependency update

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -743,10 +743,9 @@ dependencies.each do |dep|
   updater = file_updater_for(deps_to_update)
   updated_files = updater.updated_dependency_files
 
-  # Currently unused but used to create pull requests (from the updater)
-  updated_deps.reject do |d|
+  updated_deps = updated_deps.reject do |d|
     next false if d.name == checker.dependency.name
-    next true if d.requirements == d.previous_requirements
+    next true if d.top_level? && d.requirements == d.previous_requirements
 
     d.version == d.previous_version
   end

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -735,7 +735,11 @@ module Dependabot
         dependency_names = updated_dependencies.map(&:name)
         logger_info("Updating #{dependency_names.join(', ')}")
       end
-      updater = file_updater_for(updated_dependencies)
+
+      # Removal is only supported for transitive dependencies which are removed as a
+      # side effect of the parent update
+      deps_to_update = updated_dependencies.reject(&:removed?)
+      updater = file_updater_for(deps_to_update)
       updater.updated_dependency_files
     end
 

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -181,7 +181,7 @@ module Dependabot
       updated_files = generate_dependency_files_for(updated_deps)
       updated_deps = updated_deps.reject do |d|
         next false if d.name == checker.dependency.name
-        next true if d.requirements == d.previous_requirements
+        next true if d.top_level? && d.requirements == d.previous_requirements
 
         d.version == d.previous_version
       end
@@ -308,7 +308,7 @@ module Dependabot
       updated_files = generate_dependency_files_for(updated_deps)
       updated_deps = updated_deps.reject do |d|
         next false if d.name == checker.dependency.name
-        next true if d.requirements == d.previous_requirements
+        next true if d.top_level? && d.requirements == d.previous_requirements
 
         d.version == d.previous_version
       end


### PR DESCRIPTION
With a dependency chain of A -> B -> C a vulnerability on C could require an update to B but not A so the resulting update would be for B & C. This fixes a few issues in that scenario.

- When C is removed an error occurs when attempting to update B. This was because I missed applying this [filter](https://github.com/dependabot/dependabot-core/blob/e11608fd17da3275cefca5e22eb01d01eb62fe09/bin/dry-run.rb#L740-L742) from the dry-run script to the updater after the merge.
- When we create the PR for B & C then B was being filtered out resulting in a single dependency PR instead of a multi dependency PR. When C is removed this was causing an error because we don't support removal in single dependency PRs.

These aren't things that are easily tested in the updater spec but I'm planning on adding coverage via the end to end tests in the future.