### PR TITLE
allow interactive debugging in the CLI

### DIFF
--- a/updater/bin/fetch_files.rb
+++ b/updater/bin/fetch_files.rb
@@ -7,6 +7,7 @@ $stdout.sync = true
 require "raven"
 require "dependabot/setup"
 require "dependabot/file_fetcher_job"
+require "debug" if ENV["DEBUG"]
 
 class UpdaterKilledError < StandardError; end
 

--- a/updater/bin/update_files.rb
+++ b/updater/bin/update_files.rb
@@ -7,6 +7,7 @@ $stdout.sync = true
 require "raven"
 require "dependabot/setup"
 require "dependabot/update_files_job"
+require "debug" if ENV["DEBUG"]
 
 class UpdaterKilledError < StandardError; end
 


### PR DESCRIPTION
When running in the CLI with `script/dependabot`, this allows us to add `debugger` in the code and then invoke `bin/run fetch_files --debug` to start a debugging session once that line is hit.