### PR TITLE
Handle invalid version with dots

### DIFF
--- a/python/spec/dependabot/python/version_spec.rb
+++ b/python/spec/dependabot/python/version_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe Dependabot::Python::Version do
         "1.0+foo&asd",
         "1.0+1+1",
         "1.0.0+abc 123",
+        "v1.8.0-failed.release.attempt",
         "v1.8.0--failed-release-attempt"
       ]
 


### PR DESCRIPTION
This adds a test case for an invalid version with dots.

We expect the test to pass, but today it fails with:
```
eval error: Malformed version number string 1.8.0-failed.release.attempt
  /usr/local/lib/ruby/site_ruby/2.7.0/rubygems/version.rb:214:in `initialize'
  /home/dependabot/dependabot-core/python/lib/dependabot/python/version.rb:43:in `initialize'
  /usr/local/lib/ruby/site_ruby/2.7.0/rubygems/version.rb:203:in `new'
  /usr/local/lib/ruby/site_ruby/2.7.0/rubygems/version.rb:203:in `new'
  (rdbg)//home/dependabot/dependabot-core/common/lib/dependabot/metadata_finders/base/commits_finder.rb:1:in `tag_matches_version?'
```

The relevant [version pattern regex](https://github.com/dependabot/dependabot-core/blob/6d1c083a7e1d244096b024f255cea5eb9c232358/python/lib/dependabot/python/version.rb#L18-L20).