### PR TITLE
Remove label filter for azure

### DIFF
--- a/common/lib/dependabot/pull_request_creator/labeler.rb
+++ b/common/lib/dependabot/pull_request_creator/labeler.rb
@@ -174,7 +174,11 @@ module Dependabot
       end
 
       def default_labels_for_pr
-        if custom_labels then custom_labels & labels
+        if custom_labels
+          # Azure does not have centralised labels
+          return custom_labels if source.provider == "azure"
+
+          custom_labels & labels
         else
           [
             default_dependencies_label,


### PR DESCRIPTION
Azure does not have centralized labels, as such none are fetched. Filtering labels in the `Labeler` results in no labels if `custom_labels` is not null. This PR removes the filtering if `source.provider == "azure"`.

Fix: #6231 

Related to: 
- https://github.com/tinglesoftware/dependabot-azure-devops/pull/348
- https://github.com/tinglesoftware/dependabot-azure-devops/issues/317