### PR TITLE
prevent forks from trying and failing to deploy to GHCR

### DIFF
--- a/.github/workflows/docker-branch-releases.yml
+++ b/.github/workflows/docker-branch-releases.yml
@@ -46,6 +46,11 @@ jobs:
           echo "Review decision is: $DECISION"
           echo "DECISION=$DECISION" >> $GITHUB_ENV
 
+      # overwrite the previous result if this is a fork since forks can't publish to GHCR
+      - name: Skip forks
+        if: github.event.pull_request.head.repo.fork
+        run: echo "DECISION=FORK" >> $GITHUB_ENV
+
       - name: Build dependabot-core image
         if: env.DECISION == 'APPROVED'
         env:


### PR DESCRIPTION
Another attempt to prevent forks from trying to deploy, which will fail. Previous attempt reverted in #5711.

I found a fork boolean in the payload so this seems to be the way to go. If the run is found to be a fork, it sets DECISION to FORK which is not APPROVED and so it skips the rest of the steps. 

Dependabot PRs are not considered forks.