### PR TITLE
Improve PR message for removed dependencies

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -366,7 +366,7 @@ module Dependabot
 
         dependencies.map do |dep|
           msg = if dep.removed?
-                  "\nRemoves `#{dep.display_name}`"
+                  "\nRemoves `#{dep.display_name}`\n"
                 else
                   "\nUpdates `#{dep.display_name}` " \
                     "#{from_version_msg(previous_version(dep))}" \

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1615,7 +1615,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               "Removes [statesman](https://github.com/gocardless/statesman). It's no longer used after updating " \
               "ancestor dependency [business](https://github.com/gocardless/business). " \
               "These dependencies need to be updated together.\n\n" \
-              "Removes `statesman`\n" \
+              "Removes `statesman`\n\n" \
               "Updates `business` from 1.4.0 to 1.5.0\n" \
               "<details>\n" \
               "<summary>Changelog</summary>\n" \

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1612,9 +1612,9 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         it "includes details of both dependencies" do
           expect(pr_message).
             to eq(
-              "Bumps [statesman](https://github.com/gocardless/statesman) " \
-              "and [business](https://github.com/gocardless/business). " \
-              "These dependencies needed to be updated together.\n" \
+              "Removes [statesman](https://github.com/gocardless/statesman). It's no longer used after updating " \
+              "ancestor dependency [business](https://github.com/gocardless/business). " \
+              "These dependencies need to be updated together.\n\n" \
               "Removes `statesman`\n" \
               "Updates `business` from 1.4.0 to 1.5.0\n" \
               "<details>\n" \


### PR DESCRIPTION
This builds on the message improvements in https://github.com/dependabot/dependabot-core/pull/5595 to also support cases where a dependency is removed.

### Old
Bumps [xmldom](https://github.com/xmldom/xmldom) and [read-excel-file](https://gitlab.com/catamphetamine/read-excel-file). These dependencies needed to be updated together.
Removes `xmldom`
Updates `read-excel-file` from 4.1.0 to 5.4.7

### New
Removes [xmldom](https://github.com/xmldom/xmldom). It's no longer used after updating ancestor dependency [read-excel-file](https://gitlab.com/catamphetamine/read-excel-file). These dependencies need to be updated together.

Removes `xmldom`

Updates `read-excel-file` from 4.1.0 to 5.4.7