### PR TITLE
Remove `git` workaround since no longer run as `root`

### DIFF
--- a/Dockerfile.updater
+++ b/Dockerfile.updater
@@ -55,8 +55,4 @@ ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 # Add project
 COPY --chown=dependabot:dependabot updater /home/dependabot/dependabot-updater
 
-# Fix for git vulnerability since we run as root
-# see https://github.blog/2022-04-12-git-security-vulnerability-announced/
-RUN git config --global --add safe.directory /home/dependabot/dependabot-updater/repo
-
 CMD ["bundle", "exec", "ruby", "bin/dependabot_update.rb"]


### PR DESCRIPTION
As part of bringing `updater` into `core`, we stopped running as `root`.

Now:
1. base core Dockerfile flips to [`USER dependabot`](https://github.com/dependabot/dependabot-core/blob/6d1c083a7e1d244096b024f255cea5eb9c232358/Dockerfile#L266) near the end 
2. Updater Dockerfle has [`FROM dependabot/dependabot-core:$OMNIBUS_VERSION`](https://github.com/dependabot/dependabot-core/blob/6d1c083a7e1d244096b024f255cea5eb9c232358/Dockerfile.updater#L2)... buildkit inherits the user from the previous dockerfile.

So now that `git` is running as the `dependabot` user it can access the folder `/home/dependabot/dependabot-updater/repo` owned by user `dependabot` w/o needing us to specify a `safe.directory` exclusion.