### PR TITLE
Run yarn commands without running scripts

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -4,6 +4,7 @@ require "uri"
 
 require "dependabot/npm_and_yarn/file_updater"
 require "dependabot/npm_and_yarn/file_parser"
+require "dependabot/npm_and_yarn/helpers"
 require "dependabot/npm_and_yarn/update_checker/registry_finder"
 require "dependabot/npm_and_yarn/native_helpers"
 require "dependabot/shared_helpers"
@@ -161,7 +162,7 @@ module Dependabot
             "#{dep[:name]}@#{dep[:requirements].first[:requirement]}"
           end
           command = "yarn add #{updates.join(' ')}"
-          SharedHelpers.run_shell_command(command)
+          Helpers.run_yarn_commands(command)
           { yarn_lock.name => File.read(yarn_lock.name) }
         end
 
@@ -169,10 +170,11 @@ module Dependabot
           dep = sub_dependencies.first
           update = "#{dep.name}@#{dep.version}"
 
-          command = "yarn add #{update}"
-          SharedHelpers.run_shell_command(command)
-          SharedHelpers.run_shell_command("yarn dedupe #{dep.name}")
-          SharedHelpers.run_shell_command("yarn remove #{dep.name}")
+          Helpers.run_yarn_commands(
+            "yarn add #{update}",
+            "yarn dedupe #{dep.name}",
+            "yarn remove #{dep.name}"
+          )
           { yarn_lock.name => File.read(yarn_lock.name) }
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -15,6 +15,16 @@ module Dependabot
       rescue JSON::ParserError
         6
       end
+
+      # Run any number of yarn commands while ensuring that `enableScripts` is
+      # set to false. Yarn commands should _not_ be ran outside of this helper
+      # to ensure that postinstall scripts are never executed, as they could
+      # contain malicious code.
+      def self.run_yarn_commands(*commands)
+        # We never want to execute postinstall scripts
+        SharedHelpers.run_shell_command("yarn config set enableScripts false")
+        commands.each { |cmd| SharedHelpers.run_shell_command(cmd) }
+      end
     end
   end
 end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/sub_dependency_files_filterer.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/sub_dependency_files_filterer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "dependabot/experiments"
 require "dependabot/utils"
 require "dependabot/npm_and_yarn/version"
 require "dependabot/npm_and_yarn/file_parser/lockfile_parser"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -2,7 +2,6 @@
 
 require "dependabot/dependency"
 require "dependabot/errors"
-require "dependabot/experiments"
 require "dependabot/logger"
 require "dependabot/npm_and_yarn/file_parser"
 require "dependabot/npm_and_yarn/file_updater/npmrc_builder"


### PR DESCRIPTION
This config option ensures that we don't run postinstall scripts that ship with npm packages.

This is something we already do for all ecosystems including npm and yarn classic.