### PR TITLE
Add support for Python 3.10.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,10 +102,10 @@ ENV PYENV_ROOT=/usr/local/.pyenv \
   PATH="/usr/local/.pyenv/bin:$PATH"
 RUN mkdir -p "$PYENV_ROOT" && chown dependabot:dependabot "$PYENV_ROOT"
 USER dependabot
-RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch v2.3.2 --single-branch --depth=1 /usr/local/.pyenv \
+RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch v2.3.4 --single-branch --depth=1 /usr/local/.pyenv \
   # This is the version of CPython that gets installed
-  && pyenv install 3.10.5 \
-  && pyenv global 3.10.5 \
+  && pyenv install 3.10.6 \
+  && pyenv global 3.10.6 \
   && rm -Rf /tmp/python-build*
 USER root
 

--- a/python/helpers/build
+++ b/python/helpers/build
@@ -18,9 +18,9 @@ cp -r \
   "$install_dir"
 
 cd "$install_dir"
-PYENV_VERSION=3.10.5 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"
+PYENV_VERSION=3.10.6 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"
 
 # Workaround of https://github.com/python-poetry/poetry/issues/3010
 # By default poetry config file is stored under ~/.config/pypoetry
 # and is not bound to any specific Python version
-PYENV_VERSION=3.10.5 pyenv exec poetry config experimental.new-installer false
+PYENV_VERSION=3.10.6 pyenv exec poetry config experimental.new-installer false

--- a/python/lib/dependabot/python/python_versions.rb
+++ b/python/lib/dependabot/python/python_versions.rb
@@ -4,13 +4,13 @@ module Dependabot
   module Python
     module PythonVersions
       PRE_INSTALLED_PYTHON_VERSIONS = %w(
-        3.10.5
+        3.10.6
       ).freeze
 
       # Due to an OpenSSL issue we can only install the following versions in
       # the Dependabot container.
       SUPPORTED_VERSIONS = %w(
-        3.10.5 3.10.4 3.10.3 3.10.2 3.10.1 3.10.0
+        3.10.6 3.10.5 3.10.4 3.10.3 3.10.2 3.10.1 3.10.0
         3.9.13 3.9.12 3.9.11 3.9.10 3.9.9 3.9.8 3.9.7 3.9.6 3.9.5 3.9.4 3.9.2 3.9.1 3.9.0
         3.8.13 3.8.12 3.8.11 3.8.10 3.8.9 3.8.8 3.8.7 3.8.6 3.8.5 3.8.4 3.8.3 3.8.2 3.8.1 3.8.0
         3.7.13 3.7.12 3.7.11 3.7.10 3.7.9 3.7.8 3.7.7 3.7.6 3.7.5 3.7.4 3.7.3 3.7.2 3.7.1 3.7.0

--- a/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipenvVersionResolver do
                 to start_with("Dependabot detected the following Python")
               expect(error.message).to include("3.4.*")
               expect(error.message).
-                to include("supported in Dependabot: 3.10.5, 3.10.4, 3.10.3")
+                to include("supported in Dependabot: 3.10.6, 3.10.5, 3.10.4")
             end
         end
       end


### PR DESCRIPTION
Bump pyenv from v2.3.2 to v2.3.4. Python 3.10.7, 3.9.14, 3.8.14, and 3.7.14 have all been released, but are not yet supported by a released version of pyenv.