### PR TITLE
Set custom CA file path for yarn berry

### DIFF
--- a/Dockerfile.updater
+++ b/Dockerfile.updater
@@ -47,7 +47,6 @@ bundle install
 COPY --chown=dependabot:dependabot updater/config/.yarnrc updater/config/.npmrc $DEPENDABOT_HOME/
 
 # For Yarn Berry we can set this via an environment variable
-ENV YARN_HTTPS_CA_FILE_PATH=/etc/ssl/certs/ca-certificates.crt
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
 # END: HACKY WORKAROUND FOR NPM GIT INSTALLS SPAWNING CHILD PROCESS

--- a/Dockerfile.updater
+++ b/Dockerfile.updater
@@ -47,7 +47,7 @@ bundle install
 COPY --chown=dependabot:dependabot updater/config/.yarnrc updater/config/.npmrc $DEPENDABOT_HOME/
 
 # For Yarn Berry we can set this via an environment variable
-ENV YARN_CA_FILE_PATH=/etc/ssl/certs/ca-certificates.crt
+ENV YARN_HTTPS_CA_FILE_PATH=/etc/ssl/certs/ca-certificates.crt
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
 # END: HACKY WORKAROUND FOR NPM GIT INSTALLS SPAWNING CHILD PROCESS

--- a/Dockerfile.updater
+++ b/Dockerfile.updater
@@ -46,6 +46,8 @@ bundle install
 # executes the package manager outputs to every job log
 COPY --chown=dependabot:dependabot updater/config/.yarnrc updater/config/.npmrc $DEPENDABOT_HOME/
 
+# For Yarn Berry we can set this via an environment variable
+ENV YARN_CA_FILE_PATH=/etc/ssl/certs/ca-certificates.crt
 # END: HACKY WORKAROUND FOR NPM GIT INSTALLS SPAWNING CHILD PROCESS
 
 # Add project

--- a/Dockerfile.updater
+++ b/Dockerfile.updater
@@ -48,6 +48,8 @@ COPY --chown=dependabot:dependabot updater/config/.yarnrc updater/config/.npmrc 
 
 # For Yarn Berry we can set this via an environment variable
 ENV YARN_CA_FILE_PATH=/etc/ssl/certs/ca-certificates.crt
+ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
 # END: HACKY WORKAROUND FOR NPM GIT INSTALLS SPAWNING CHILD PROCESS
 
 # Add project

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -23,8 +23,8 @@ module Dependabot
       def self.run_yarn_commands(*commands)
         # We never want to execute postinstall scripts
         SharedHelpers.run_shell_command("yarn config set enableScripts false")
-        SharedHelpers.run_shell_command("yarn config set httpProxy #{ENV.fetch('HTTP_PROXY')}")
-        SharedHelpers.run_shell_command("yarn config set httpsProxy #{ENV.fetch('HTTPS_PROXY')}")
+        SharedHelpers.run_shell_command("yarn config set httpProxy #{ENV.fetch('HTTP_PROXY', '')}")
+        SharedHelpers.run_shell_command("yarn config set httpsProxy #{ENV.fetch('HTTPS_PROXY', '')}")
         commands.each { |cmd| SharedHelpers.run_shell_command(cmd) }
       end
     end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -29,6 +29,15 @@ module Dependabot
         if (https_proxy = ENV.fetch("HTTPS_PROXY", false))
           SharedHelpers.run_shell_command("yarn config set httpsProxy #{https_proxy}")
         end
+        if (ca_file_path = ENV.fetch("NODE_EXTRA_CA_CERTS", false))
+          output = SharedHelpers.run_shell_command("yarn --version")
+          major_version = Version.new(output).major
+          if major_version >= 4
+            SharedHelpers.run_shell_command("yarn config set httpsCaFilePath #{ca_file_path}")
+          else
+            SharedHelpers.run_shell_command("yarn config set caFilePath #{ca_file_path}")
+          end
+        end
         commands.each { |cmd| SharedHelpers.run_shell_command(cmd) }
       end
     end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -23,6 +23,8 @@ module Dependabot
       def self.run_yarn_commands(*commands)
         # We never want to execute postinstall scripts
         SharedHelpers.run_shell_command("yarn config set enableScripts false")
+        SharedHelpers.run_shell_command("yarn config set httpProxy #{ENV.fetch('HTTP_PROXY')}")
+        SharedHelpers.run_shell_command("yarn config set httpsProxy #{ENV.fetch('HTTPS_PROXY')}")
         commands.each { |cmd| SharedHelpers.run_shell_command(cmd) }
       end
     end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -23,8 +23,12 @@ module Dependabot
       def self.run_yarn_commands(*commands)
         # We never want to execute postinstall scripts
         SharedHelpers.run_shell_command("yarn config set enableScripts false")
-        SharedHelpers.run_shell_command("yarn config set httpProxy #{ENV.fetch('HTTP_PROXY', '')}")
-        SharedHelpers.run_shell_command("yarn config set httpsProxy #{ENV.fetch('HTTPS_PROXY', '')}")
+        if (http_proxy = ENV.fetch("HTTP_PROXY", false))
+          SharedHelpers.run_shell_command("yarn config set httpProxy #{http_proxy}")
+        end
+        if (https_proxy = ENV.fetch("HTTPS_PROXY", false))
+          SharedHelpers.run_shell_command("yarn config set httpsProxy #{https_proxy}")
+        end
         commands.each { |cmd| SharedHelpers.run_shell_command(cmd) }
       end
     end


### PR DESCRIPTION
In order for yarn berry to pick up our custom CA file path, we can set an environment variable instead of a custom config file.

See https://yarnpkg.com/configuration/yarnrc#caFilePath:

> Finally, note that most settings can also be defined through environment variables (at least for the simpler ones; arrays and objects aren't supported yet). To do this, just prefix the names and write them in snake case: YARN_CACHE_FOLDER will set the cache folder (such values will overwrite any that might have been defined in the RC files - use them sparingly).