### PR TITLE
Skip cron run of CodeQL in forks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,7 @@ on:
       - 'CHANGELOG.md'
       - 'common/lib/dependabot/version.rb'
   schedule:
+    if: ${{ github.repository == 'dependabot/dependabot-core' }}
     - cron: '41 4 * * 3'
 
 jobs:


### PR DESCRIPTION
We run CI via actions on `main` on a daily cron to catch any unexpected regressions, or if CodeQL adds a new check that suddenly flags something.

However, this can result in some unexpected notification noise:
1. I merged a PR from an external contributor: https://github.com/dependabot/dependabot-core/pull/5580
2. That PR was opened from the fork's `main` branch
3. Before merging, I clicked the "Update by rebase". So a commit from me landed on the fork's `main` branch.
4. I'm now receiving daily emails about failing CI runs from the fork. These are pure noise, since I don't care about the state of an external contributor's forked repo.

This hasn't happened for any other PR's that I've merged from external contributors, so I suspect it's related to the rebase so I'm now seen as a committer to the fork's `main` branch. Not really sure though.

I double-checked and I am _not_ subscribed to notifications on the repo. I am aware that after 30 days this should age out because actions are disabled for forks after 30 days assuming the external contributor doesn't update his fork/click re-enable actions, but it's still annoying.

I checked internally with the Actions team, and they said this is known behavior, and it's complicated.

So for now, let's default to disabling running cron for forks.