### PR TITLE
[npm] Only return a chain if a node matches a vulnerable version

### DIFF
--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
@@ -192,9 +192,11 @@ function buildDependencyChains(auditReport, name) {
     }
     if (auditReport.has(node.name)) {
       const vuln = auditReport.get(node.name)
-      if (vuln.isVulnerable(node)) {
-        return [{ fixAvailable: vuln.fixAvailable, nodes: [node, ...chain.nodes] }]
+      if (!vuln.isVulnerable(node)) {
+        // This is a non-vulnerable version of the dependency; end path.
+        return []
       }
+      return [{ fixAvailable: vuln.fixAvailable, nodes: [node, ...chain.nodes] }]
     }
     if (!node.edgesOut.size) {
       // This is a leaf node that is unaffected by the vuln; end path.

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
@@ -192,7 +192,9 @@ function buildDependencyChains(auditReport, name) {
     }
     if (auditReport.has(node.name)) {
       const vuln = auditReport.get(node.name)
-      return [{ fixAvailable: vuln.fixAvailable, nodes: [node, ...chain.nodes] }]
+      if (vuln.isVulnerable(node)) {
+        return [{ fixAvailable: vuln.fixAvailable, nodes: [node, ...chain.nodes] }]
+      }
     }
     if (!node.edgesOut.size) {
       // This is a leaf node that is unaffected by the vuln; end path.

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -81,6 +81,37 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
       end
     end
 
+    context "when a fix is available but a fixed version is also a dependency" do
+      let(:dependency_files) { project_dependency_files("npm8/locked_transitive_dependency_plus_fixed") }
+
+      it "logs viable result and returns fix_available => true" do
+        security_advisories = [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: dependency.name,
+            package_manager: "npm_and_yarn",
+            vulnerable_versions: ["<1.0.1"],
+            safe_versions: ["1.0.1"]
+          )
+        ]
+
+        expect(Dependabot.logger).to receive(:info).with(/audit result viable/i)
+        expect(subject.audit(dependency: dependency, security_advisories: security_advisories)).
+          to include(
+            "dependency_name" => dependency.name,
+            "current_version" => "1.0.0",
+            "target_version" => "1.0.1",
+            "fix_available" => true,
+            "fix_updates" => [{
+              "dependency_name" => "@dependabot-fixtures/npm-parent-dependency",
+              "current_version" => "2.0.0",
+              "target_version" => "2.0.2",
+              "top_level_ancestors" => []
+            }],
+            "top_level_ancestors" => ["@dependabot-fixtures/npm-parent-dependency"]
+          )
+      end
+    end
+
     context "when a fix removes the vulnerable dependency" do
       let(:dependency_files) { project_dependency_files("npm8/locked_transitive_dependency_removed") }
 

--- a/npm_and_yarn/spec/fixtures/projects/npm8/locked_transitive_dependency_plus_fixed/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/locked_transitive_dependency_plus_fixed/package-lock.json
@@ -1,0 +1,89 @@
+{
+  "name": "locked-transitive-dependency",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "locked-transitive-dependency",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@dependabot-fixtures/npm-intermediate-dependency": "^0.0.2",
+        "@dependabot-fixtures/npm-parent-dependency": "^2.0.0"
+      }
+    },
+    "node_modules/@dependabot-fixtures/npm-intermediate-dependency": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-intermediate-dependency/-/npm-intermediate-dependency-0.0.2.tgz",
+      "integrity": "sha512-xj/Xn9vf3zO9b4XQXAWysDyMARCajkyceOqcdIdg9blkz6JPzB5e3ShGH+rAo0TBy+DN7WrFBMt1xxwdqezRLg==",
+      "dependencies": {
+        "@dependabot-fixtures/npm-transitive-dependency": "^1.0.0"
+      }
+    },
+    "node_modules/@dependabot-fixtures/npm-parent-dependency": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-parent-dependency/-/npm-parent-dependency-2.0.0.tgz",
+      "integrity": "sha512-5LtLEL1yzO2TdkNX3R9cvr+nKmhw5h4xM0wkFTJeK14wxlI9d8gEYA+I2hUi+IP96ucBSztAnOgZVwoJHEZb6A==",
+      "dependencies": {
+        "@dependabot-fixtures/npm-intermediate-dependency": "0.0.1"
+      }
+    },
+    "node_modules/@dependabot-fixtures/npm-parent-dependency/node_modules/@dependabot-fixtures/npm-intermediate-dependency": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-intermediate-dependency/-/npm-intermediate-dependency-0.0.1.tgz",
+      "integrity": "sha512-/N77Dzpfg8BIfFgpJrMk86ueUYTVhmpc4RobuHpIpKSc3GZr4Ltu4au92brnUGk66UkzgrMmtgqRXO8OrOspKQ==",
+      "dependencies": {
+        "@dependabot-fixtures/npm-transitive-dependency": "1.0.0"
+      }
+    },
+    "node_modules/@dependabot-fixtures/npm-parent-dependency/node_modules/@dependabot-fixtures/npm-transitive-dependency": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.0.tgz",
+      "integrity": "sha512-nFbzQH0TRgdzSA2/FH6MPnxZDpD+5Bgz00aD5Edgbc1wY/k8VC9s7lnk22dBTgJLwoY7MgbrnAf9rAvN08hHVg=="
+    },
+    "node_modules/@dependabot-fixtures/npm-transitive-dependency": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.1.tgz",
+      "integrity": "sha512-nWQzJEqSqKZu+mgNSVdsO69NG6vCGIN9FuM+Vip5nqItqrNeQoITZM6/q6+tqgdM48XkQEOUpEiYpAdoMbxniw=="
+    }
+  },
+  "dependencies": {
+    "@dependabot-fixtures/npm-intermediate-dependency": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-intermediate-dependency/-/npm-intermediate-dependency-0.0.2.tgz",
+      "integrity": "sha512-xj/Xn9vf3zO9b4XQXAWysDyMARCajkyceOqcdIdg9blkz6JPzB5e3ShGH+rAo0TBy+DN7WrFBMt1xxwdqezRLg==",
+      "requires": {
+        "@dependabot-fixtures/npm-transitive-dependency": "^1.0.0"
+      }
+    },
+    "@dependabot-fixtures/npm-parent-dependency": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-parent-dependency/-/npm-parent-dependency-2.0.0.tgz",
+      "integrity": "sha512-5LtLEL1yzO2TdkNX3R9cvr+nKmhw5h4xM0wkFTJeK14wxlI9d8gEYA+I2hUi+IP96ucBSztAnOgZVwoJHEZb6A==",
+      "requires": {
+        "@dependabot-fixtures/npm-intermediate-dependency": "0.0.1"
+      },
+      "dependencies": {
+        "@dependabot-fixtures/npm-intermediate-dependency": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-intermediate-dependency/-/npm-intermediate-dependency-0.0.1.tgz",
+          "integrity": "sha512-/N77Dzpfg8BIfFgpJrMk86ueUYTVhmpc4RobuHpIpKSc3GZr4Ltu4au92brnUGk66UkzgrMmtgqRXO8OrOspKQ==",
+          "requires": {
+            "@dependabot-fixtures/npm-transitive-dependency": "1.0.0"
+          }
+        },
+        "@dependabot-fixtures/npm-transitive-dependency": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.0.tgz",
+          "integrity": "sha512-nFbzQH0TRgdzSA2/FH6MPnxZDpD+5Bgz00aD5Edgbc1wY/k8VC9s7lnk22dBTgJLwoY7MgbrnAf9rAvN08hHVg=="
+        }
+      }
+    },
+    "@dependabot-fixtures/npm-transitive-dependency": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.1.tgz",
+      "integrity": "sha512-nWQzJEqSqKZu+mgNSVdsO69NG6vCGIN9FuM+Vip5nqItqrNeQoITZM6/q6+tqgdM48XkQEOUpEiYpAdoMbxniw=="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm8/locked_transitive_dependency_plus_fixed/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/locked_transitive_dependency_plus_fixed/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "locked-transitive-dependency",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@dependabot-fixtures/npm-intermediate-dependency": "^0.0.2",
+    "@dependabot-fixtures/npm-parent-dependency": "^2.0.0"
+  }
+}


### PR DESCRIPTION
Without this check we can surface already fixed versions of the dependency as needing to be updated which confuses Dependabot.