### PR TITLE
Update all versions of the same private module in single terraform file

### DIFF
--- a/common/lib/dependabot/file_updaters/base.rb
+++ b/common/lib/dependabot/file_updaters/base.rb
@@ -41,7 +41,8 @@ module Dependabot
 
       def requirement_changed?(file, dependency)
         changed_requirements =
-          dependency.requirements - dependency.previous_requirements
+          dependency.requirements - dependency.previous_requirements |
+          dependency.previous_requirements - dependency.requirements
 
         changed_requirements.any? { |f| f[:file] == file.name }
       end

--- a/common/lib/dependabot/file_updaters/base.rb
+++ b/common/lib/dependabot/file_updaters/base.rb
@@ -41,8 +41,7 @@ module Dependabot
 
       def requirement_changed?(file, dependency)
         changed_requirements =
-          dependency.requirements - dependency.previous_requirements |
-          dependency.previous_requirements - dependency.requirements
+          dependency.requirements - dependency.previous_requirements
 
         changed_requirements.any? { |f| f[:file] == file.name }
       end

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -52,15 +52,17 @@ module Dependabot
       # To detect any changes in dependencies we need to overwrite an implementation from the base class
       #
       # Example (for simplicity other parameters are skipped):
-      # previous_requirements  = [{requirement: "0.9.1"}, {requirement: "0.11.0"}]
+      # previous_requirements = [{requirement: "0.9.1"}, {requirement: "0.11.0"}]
       # requirements = [{requirement: "0.11.0"}, {requirement: "0.11.0"}]
       #
       # Simple difference between arrays gives:
-      # requirements - previous_requirements = []
+      # requirements - previous_requirements
+      #  => []
       # which loses an information that one of our requirements has changed.
       #
       # By using symmetric difference:
-      # (requirements - previous_requirements) | (previous_requirements - requirements) = [{requirement: "0.9.1"}]
+      # (requirements - previous_requirements) | (previous_requirements - requirements)
+      #  => [{requirement: "0.9.1"}]
       # we can detect that change.
       def requirement_changed?(file, dependency)
         changed_requirements =

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -89,7 +89,7 @@ module Dependabot
 
       def update_registry_declaration(new_req, old_req, updated_content)
         regex = new_req[:source][:type] == "provider" ? provider_declaration_regex : registry_declaration_regex
-        updated_content.sub!(regex) do |regex_match|
+        updated_content.gsub!(regex) do |regex_match|
           regex_match.sub(/^\s*version\s*=.*/) do |req_line_match|
             req_line_match.sub(old_req[:requirement], new_req[:requirement])
           end

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -46,6 +46,14 @@ module Dependabot
         updated_files
       end
 
+      def requirement_changed?(file, dependency)
+        changed_requirements =
+          (dependency.requirements - dependency.previous_requirements) |
+          (dependency.previous_requirements - dependency.requirements)
+
+        changed_requirements.any? { |f| f[:file] == file.name }
+      end
+
       private
 
       def updated_terraform_file_content(file)

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -48,6 +48,20 @@ module Dependabot
 
       private
 
+      # Terraform allows to use a module from the same source multiple times
+      # To detect any changes in dependencies we need to overwrite an implementation from the base class
+      #
+      # Example (for simplicity other parameters are skipped):
+      # previous_requirements  = [{requirement: "0.9.1"}, {requirement: "0.11.0"}]
+      # requirements = [{requirement: "0.11.0"}, {requirement: "0.11.0"}]
+      #
+      # Simple difference between arrays gives:
+      # requirements - previous_requirements = []
+      # which loses an information that one of our requirements has changed.
+      #
+      # By using symmetric difference:
+      # (requirements - previous_requirements) | (previous_requirements - requirements) = [{requirement: "0.9.1"}]
+      # we can detect that change.
       def requirement_changed?(file, dependency)
         changed_requirements =
           (dependency.requirements - dependency.previous_requirements) |

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -46,6 +46,8 @@ module Dependabot
         updated_files
       end
 
+      private
+
       def requirement_changed?(file, dependency)
         changed_requirements =
           (dependency.requirements - dependency.previous_requirements) |
@@ -53,8 +55,6 @@ module Dependabot
 
         changed_requirements.any? { |f| f[:file] == file.name }
       end
-
-      private
 
       def updated_terraform_file_content(file)
         content = file.content.dup

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -122,6 +122,75 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       end
     end
 
+    context "with private modules with different versions" do
+      let(:project_name) { "private_modules_with_different_versions" }
+
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "example-org-5d3190/s3-webapp/aws",
+            version: "0.11.0",
+            previous_version: "0.9.1",
+            requirements: [{
+              requirement: "0.11.0",
+              groups: [],
+              file: "main.tf",
+              source: {
+                type: "registry",
+                registry_hostname: "app.terraform.io",
+                module_identifier: "example-org-5d3190/s3-webapp/aws"
+              }
+            }, {
+              requirement: "0.11.0",
+              groups: [],
+              file: "main.tf",
+              source: {
+                type: "registry",
+                registry_hostname: "app.terraform.io",
+                module_identifier: "example-org-5d3190/s3-webapp/aws"
+              }
+            }],
+            previous_requirements: [{
+              requirement: "0.9.1",
+              groups: [],
+              file: "main.tf",
+              source: {
+                type: "registry",
+                registry_hostname: "app.terraform.io",
+                module_identifier: "example-org-5d3190/s3-webapp/aws"
+              }
+            }, {
+              requirement: "0.11.0",
+              groups: [],
+              file: "main.tf",
+              source: {
+                type: "registry",
+                registry_hostname: "app.terraform.io",
+                module_identifier: "example-org-5d3190/s3-webapp/aws"
+              }
+            }],
+            package_manager: "terraform"
+          )
+        ]
+      end
+
+      it "updates all private modules versions" do
+        updated_file = subject.find { |file| file.name == "main.tf" }
+
+        expect(updated_file.content).to include(<<~HCL)
+          module "s3-webapp" {
+            source  = "app.terraform.io/example-org-5d3190/s3-webapp/aws"
+            version = "0.11.0"
+          }
+
+          module "s3-webapp" {
+            source  = "app.terraform.io/example-org-5d3190/s3-webapp/aws"
+            version = "0.11.0"
+          }
+        HCL
+      end
+    end
+
     context "with a private provider" do
       let(:project_name) { "private_provider" }
 

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -178,12 +178,12 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
         updated_file = subject.find { |file| file.name == "main.tf" }
 
         expect(updated_file.content).to include(<<~HCL)
-          module "s3-webapp" {
+          module "s3-webapp-first" {
             source  = "app.terraform.io/example-org-5d3190/s3-webapp/aws"
             version = "0.11.0"
           }
 
-          module "s3-webapp" {
+          module "s3-webapp-second" {
             source  = "app.terraform.io/example-org-5d3190/s3-webapp/aws"
             version = "0.11.0"
           }

--- a/terraform/spec/fixtures/projects/private_modules_with_different_versions/main.tf
+++ b/terraform/spec/fixtures/projects/private_modules_with_different_versions/main.tf
@@ -1,0 +1,9 @@
+module "s3-webapp" {
+  source  = "app.terraform.io/example-org-5d3190/s3-webapp/aws"
+  version = "0.11.0"
+}
+
+module "s3-webapp" {
+  source  = "app.terraform.io/example-org-5d3190/s3-webapp/aws"
+  version = "0.9.1"
+}

--- a/terraform/spec/fixtures/projects/private_modules_with_different_versions/main.tf
+++ b/terraform/spec/fixtures/projects/private_modules_with_different_versions/main.tf
@@ -1,9 +1,9 @@
-module "s3-webapp" {
+module "s3-webapp-first" {
   source  = "app.terraform.io/example-org-5d3190/s3-webapp/aws"
   version = "0.11.0"
 }
 
-module "s3-webapp" {
+module "s3-webapp-second" {
   source  = "app.terraform.io/example-org-5d3190/s3-webapp/aws"
   version = "0.9.1"
 }


### PR DESCRIPTION
Hello,
I noticed that dependabot running for one our repositories had issues with updating one dependency.

```
updater | ERROR <job_468187453> No files changed!
updater | ERROR <job_468187453> /home/dependabot/terraform/lib/dependabot/terraform/file_updater.rb:44:in `updated_dependency_files'
updater | ERROR <job_468187453> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:746:in `generate_dependency_files_for'
updater | ERROR <job_468187453> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:311:in `check_and_create_pull_request'
updater | ERROR <job_468187453> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:109:in `check_and_create_pr_with_error_handling'
updater | ERROR <job_468187453> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:80:in `block in run'
updater | ERROR <job_468187453> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:80:in `each'
updater | ERROR <job_468187453> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:80:in `run'
updater | ERROR <job_468187453> /home/dependabot/dependabot-updater/lib/dependabot/update_files_job.rb:17:in `perform_job'
updater | ERROR <job_468187453> /home/dependabot/dependabot-updater/lib/dependabot/base_job.rb:50:in `run'
updater | ERROR <job_468187453> bin/update_files.rb:22:in `<main>'
```

After investigation I found out that when single terraform file uses the same private module multiple times, but with different versions, then only first occurrence is found and other are not updated.
This pull request is a bug fix for this situation.