### PR TITLE
[npm] Only shortcut search when non-vuln version of advisory dep is found

### DIFF
--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
@@ -192,11 +192,12 @@ function buildDependencyChains(auditReport, name) {
     }
     if (auditReport.has(node.name)) {
       const vuln = auditReport.get(node.name)
-      if (!vuln.isVulnerable(node)) {
-        // This is a non-vulnerable version of the dependency; end path.
+      if (vuln.isVulnerable(node)) {
+        return [{ fixAvailable: vuln.fixAvailable, nodes: [node, ...chain.nodes] }]
+      } else if (node.name == name) {
+        // This is a non-vulnerable version of the advisory dependency; end path.
         return []
       }
-      return [{ fixAvailable: vuln.fixAvailable, nodes: [node, ...chain.nodes] }]
     }
     if (!node.edgesOut.size) {
       // This is a leaf node that is unaffected by the vuln; end path.


### PR DESCRIPTION
There can be other deps marked as vulnerable that aren't the advisory dep (locking parents) and we can't be sure that a non-vulnerable version of those deps doesn't still have a vulnerable version of the advisory dep as a child.

For ex for an advisory on C:
```
A -> B (vuln) -> C (vuln)
| -> D -> B(not vuln) -> C (vuln)
```

I haven't found real examples of this occurring yet but this is worth fixing since it could lead to PRs that don't fully fix an alert.