### PR TITLE
Update smoke test to download CLI from `dependabot/cli` repo

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -163,7 +163,7 @@ jobs:
     - name: Download CLI and test
       if: steps.changes.outputs[matrix.suite] == 'true'
       run: |
-        gh release download --repo dependabot/cli-releases -p "*linux-amd64.tar.gz"
+        gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
         tar xzvf *.tar.gz >/dev/null 2>&1
         ./dependabot --version
         URL=https://api.github.com/repos/dependabot/smoke-tests/contents/tests/smoke-${{ matrix.suite }}.yaml


### PR DESCRIPTION
This PR updates our smoke testing workflow to download CLI from the [`dependabot/cli` repo](https://github.com/dependabot/cli).

Before, when the CLI repo was private, we hosted built executables in the `dependabot/cli-releases` repo. Now that it's public, we can download them directly from the source repo.