### PR TITLE
add dependabot CLI dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version (use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon): ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
+ARG VARIANT="jammy"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/ubuntu
+{
+  "name": "Ubuntu",
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick an Ubuntu version: jammy / ubuntu-22.04, focal / ubuntu-20.04, bionic /ubuntu-18.04
+    // Use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon.
+    "args": {
+      "VARIANT": "ubuntu-22.04"
+    }
+  },
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  "onCreateCommand": "bash .devcontainer/on-create.sh",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode",
+  "features": {
+    "docker-from-docker": "latest",
+    "github-cli": "latest",
+    "node": "lts",
+    "golang": "latest",
+    "ruby": "latest",
+    "rust": "latest",
+    "dotnet": "latest",
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    }
+  }
+}

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# This pull takes a while, adding it to the prebuild
+docker pull ghcr.io/dependabot/dependabot-updater:latest
+docker pull ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
+tar xzvf "*.tar.gz" >/dev/null 2>&1
+sudo mv dependabot /usr/local/bin
+rm "*.tar.gz"
+
+echo "export LOCAL_GITHUB_ACCESS_TOKEN=$GITHUB_TOKEN" >> ~/.bashrc


### PR DESCRIPTION
This allows us to quickly launch a Codespace and execute `script/dependabot` without having to figure out how to download the CLI. 