### PR TITLE
[npm] Preserve requirement source when updating transtive dep parents

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -202,7 +202,7 @@ module Dependabot
           version: version,
           requirements: RequirementsUpdater.new(
             requirements: original_dep.requirements,
-            updated_source: original_dep == dependency ? updated_source : nil,
+            updated_source: original_dep == dependency ? updated_source : original_source(original_dep),
             latest_resolvable_version: version,
             update_strategy: requirements_update_strategy
           ).updated_requirements,
@@ -379,8 +379,12 @@ module Dependabot
       end
 
       def dependency_source_details
+        original_source(dependency)
+      end
+
+      def original_source(updated_dependency)
         sources =
-          dependency.requirements.map { |r| r.fetch(:source) }.uniq.compact.
+          updated_dependency.requirements.map { |r| r.fetch(:source) }.uniq.compact.
           sort_by { |source| RegistryFinder.central_registry?(source[:url]) ? 1 : 0 }
 
         sources.first

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -1327,7 +1327,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
                 file: "package.json",
                 requirement: "2.0.2",
                 groups: ["dependencies"],
-                source: nil
+                source: {
+                  type: "registry",
+                  url: "https://registry.npmjs.org"
+                }
               }],
               previous_requirements: [{
                 file: "package.json",
@@ -1391,7 +1394,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
                 requirement: "2.0.2",
                 file: "package.json",
                 groups: ["dependencies"],
-                source: nil
+                source: {
+                  type: "registry",
+                  url: "https://registry.npmjs.org"
+                }
               }],
               version: "2.0.2"
             ),
@@ -1412,7 +1418,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
                 requirement: "2.1.1",
                 file: "package.json",
                 groups: ["dependencies"],
-                source: nil
+                source: {
+                  type: "registry",
+                  url: "https://registry.npmjs.org"
+                }
               }],
               version: "2.1.1"
             ),
@@ -1433,7 +1442,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
                 requirement: "3.0.0",
                 file: "package.json",
                 groups: ["dependencies"],
-                source: nil
+                source: {
+                  type: "registry",
+                  url: "https://registry.npmjs.org"
+                }
               }],
               version: "3.0.0"
             ),
@@ -1485,7 +1497,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
                 requirement: "10.0.1",
                 file: "package.json",
                 groups: ["dependencies"],
-                source: nil
+                source: {
+                  type: "registry",
+                  url: "https://registry.npmjs.org"
+                }
               }],
               version: "10.0.1"
             )
@@ -1543,7 +1558,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
                 requirement: "^1.0.0",
                 file: "package.json",
                 groups: ["dependencies"],
-                source: nil
+                source: {
+                  type: "registry",
+                  url: "https://registry.npmjs.org"
+                }
               }],
               version: "1.0.1"
             )


### PR DESCRIPTION
We had been setting the source of transitive parent dependencies to nil but this caused the FileUpdater to think the requirement was always changing. This might not be the case for a library with a requirement range that already allows the fixed version. We should prefer to preserve the existing source when an updated source is not provided.

Example:
```
#<Dependabot::Dependency:0x0000558c3bf7fc48
 @name="serverless-offline",
 @package_manager="npm_and_yarn",
 @previous_requirements=
  [{:requirement=>"8",
    :file=>"package.json",
    :groups=>["devDependencies"],
    :source=>{:type=>"registry", :url=>"https://registry.npmjs.org"}}],
 @previous_version="8.8.0",
 @removed=false,
 @requirements=[{:requirement=>"8", :file=>"package.json", :groups=>["devDependencies"], :source=>nil}],
 @version="8.8.1">
```

The version is updating from 8.8.0 to 8.8.1 but because this came from a library the requirement did not need to change. However, the source change between the previous/current requirements triggers an attempt to update `package.json` which results in this failure:
```
updater | ERROR <> Expected content to change!
updater | ERROR <> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_updater.rb:36:in `block (2 levels) in updated_package_json_content'
```

The smoke test is failing on this PR because its expectations don't currently include the source populated in the new requirements.