### PR TITLE
Ensure always_clone is enabled for yarn_berry during file_fetching

### DIFF
--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dependabot/experiments"
 require "dependabot/source"
 require "wildcard_matcher"
 
@@ -33,6 +34,8 @@ module Dependabot
       @update_subdependencies       = attributes.fetch(:update_subdependencies)
       @updating_a_pull_request      = attributes.fetch(:updating_a_pull_request)
       @vendor_dependencies          = attributes.fetch(:vendor_dependencies, false)
+
+      register_experiments
     end
 
     def clone?
@@ -140,6 +143,14 @@ module Dependabot
     end
 
     private
+
+    def register_experiments
+      experiments.each do |name, value|
+        Dependabot::Experiments.register(name, value)
+      end
+
+      Dependabot::Utils.register_always_clone("npm_and_yarn") if Dependabot::Experiments.enabled?(:yarn_berry)
+    end
 
     def name_match?(name1, name2)
       WildcardMatcher.match?(

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -63,12 +63,6 @@ module Dependabot
     def run
       return unless job
 
-      job.experiments.each do |name, value|
-        Dependabot::Experiments.register(name, value)
-      end
-
-      Dependabot::Utils.register_always_clone("npm_and_yarn") if Dependabot::Experiments.enabled?(:yarn_berry)
-
       if job.updating_a_pull_request?
         logger_info("Starting PR update job for #{job.source.repo}")
         check_and_update_existing_pr_with_error_handling(dependencies)

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -277,6 +277,12 @@ RSpec.describe Dependabot::Job do
       it "transforms the keys" do
         expect(job.experiments).to eq(simple: false, kebab_case: true)
       end
+
+      it "registers the experiments with Dependabot::Experiments" do
+        job
+        expect(Dependabot::Experiments.enabled?(:kebab_case)).to be_truthy
+        expect(Dependabot::Experiments.enabled?(:simpe)).to be_falsey
+      end
     end
 
     context "with experimental values" do
@@ -284,6 +290,33 @@ RSpec.describe Dependabot::Job do
 
       it "preserves the values" do
         expect(job.experiments).to eq(timeout_per_operation_seconds: 600)
+      end
+    end
+
+    describe "yarn_berry experiment" do
+      let(:experiments) { { "yarn_berry" => true } }
+      let(:package_manager) { "npm_and_yarn" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "ansi-regex",
+          package_manager: "npm_and_yarn",
+          version: "6.0.0",
+          requirements: [
+            {
+              file: "package.json",
+              requirement: "^6.0.0",
+              groups: ["devDependencies"],
+              source: {
+                type: "registry",
+                url: "https://registry.npmjs.org"
+              }
+            }
+          ]
+        )
+      end
+
+      it "enables cloning when yarn_berry is enabled" do
+        expect(job.clone?).to be_truthy
       end
     end
   end


### PR DESCRIPTION
Previously we set the `always_clone` flag in the updater, but in prod we run file fetching as a separate step, and as a result the flag was not set at that point.

This change sets all the experiments on Dependabot::Experiment whenever we initialize a job. That way we can ensure that all the experiments are globally available during all steps.