### PR TITLE
[npm] Allow updates with both top level and sub dependencies

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -299,6 +299,58 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
             to eq("0.0.2")
         end
       end
+
+      context "when updating both top level and sub dependencies" do
+        let(:files) do
+          project_dependency_files("#{npm_version}/transitive_dependency_locked_by_intermediate_top_and_sub")
+        end
+        let(:dependencies) do
+          [
+            Dependabot::Dependency.new(
+              name: "@dependabot-fixtures/npm-transitive-dependency",
+              version: "1.0.1",
+              previous_version: "1.0.0",
+              requirements: [{
+                file: "package.json",
+                requirement: "1.0.1",
+                groups: ["dependencies"],
+                source: {
+                  type: "registry",
+                  url: "https://registry.npmjs.org"
+                }
+              }],
+              previous_requirements: [{
+                file: "package.json",
+                requirement: "1.0.0",
+                groups: ["dependencies"],
+                source: {
+                  type: "registry",
+                  url: "https://registry.npmjs.org"
+                }
+              }],
+              package_manager: "npm_and_yarn"
+            ),
+            Dependabot::Dependency.new(
+              name: "@dependabot-fixtures/npm-intermediate-dependency",
+              version: "0.0.2",
+              previous_version: "0.0.1",
+              requirements: [],
+              previous_requirements: [],
+              package_manager: "npm_and_yarn"
+            )
+          ]
+        end
+
+        it "updates top level and sub dependencies" do
+          expected_updated_npm_lock_content = fixture(
+            "updated_projects",
+            npm_version,
+            "transitive_dependency_locked_by_intermediate_top_and_sub",
+            "package-lock.json"
+          )
+          expect(updated_npm_lock_content).to eq(expected_updated_npm_lock_content)
+        end
+      end
     end
 
     describe "#{npm_version} errors" do

--- a/npm_and_yarn/spec/fixtures/projects/npm6/transitive_dependency_locked_by_intermediate_top_and_sub/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/transitive_dependency_locked_by_intermediate_top_and_sub/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "transitive-dependency-locked-by-intermediate",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@dependabot-fixtures/npm-intermediate-dependency": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-intermediate-dependency/-/npm-intermediate-dependency-0.0.1.tgz",
+      "integrity": "sha512-/N77Dzpfg8BIfFgpJrMk86ueUYTVhmpc4RobuHpIpKSc3GZr4Ltu4au92brnUGk66UkzgrMmtgqRXO8OrOspKQ==",
+      "requires": {
+        "@dependabot-fixtures/npm-transitive-dependency": "1.0.0"
+      }
+    },
+    "@dependabot-fixtures/npm-parent-dependency": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-parent-dependency/-/npm-parent-dependency-2.0.2.tgz",
+      "integrity": "sha512-r1uDMPr0w1LQ3V0ekkMMYyucBDKj3kWbUI/067iDVAmF1DRwVJurPf7W4NzkuOuEe/EgPx5qCBAMAq8TjdlH7w==",
+      "requires": {
+        "@dependabot-fixtures/npm-intermediate-dependency": "~0.0.1"
+      }
+    },
+    "@dependabot-fixtures/npm-transitive-dependency": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.0.tgz",
+      "integrity": "sha512-nFbzQH0TRgdzSA2/FH6MPnxZDpD+5Bgz00aD5Edgbc1wY/k8VC9s7lnk22dBTgJLwoY7MgbrnAf9rAvN08hHVg=="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm6/transitive_dependency_locked_by_intermediate_top_and_sub/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/transitive_dependency_locked_by_intermediate_top_and_sub/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "transitive-dependency-locked-by-intermediate",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@dependabot-fixtures/npm-parent-dependency": "2.0.2",
+    "@dependabot-fixtures/npm-transitive-dependency": "1.0.0"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm8/transitive_dependency_locked_by_intermediate_top_and_sub/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/transitive_dependency_locked_by_intermediate_top_and_sub/package-lock.json
@@ -1,0 +1,61 @@
+{
+  "name": "transitive-dependency-locked-by-intermediate",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "transitive-dependency-locked-by-intermediate",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@dependabot-fixtures/npm-parent-dependency": "2.0.2",
+        "@dependabot-fixtures/npm-transitive-dependency": "1.0.0"
+      }
+    },
+    "node_modules/@dependabot-fixtures/npm-intermediate-dependency": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-intermediate-dependency/-/npm-intermediate-dependency-0.0.1.tgz",
+      "integrity": "sha512-/N77Dzpfg8BIfFgpJrMk86ueUYTVhmpc4RobuHpIpKSc3GZr4Ltu4au92brnUGk66UkzgrMmtgqRXO8OrOspKQ==",
+      "dependencies": {
+        "@dependabot-fixtures/npm-transitive-dependency": "1.0.0"
+      }
+    },
+    "node_modules/@dependabot-fixtures/npm-parent-dependency": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-parent-dependency/-/npm-parent-dependency-2.0.2.tgz",
+      "integrity": "sha512-r1uDMPr0w1LQ3V0ekkMMYyucBDKj3kWbUI/067iDVAmF1DRwVJurPf7W4NzkuOuEe/EgPx5qCBAMAq8TjdlH7w==",
+      "dependencies": {
+        "@dependabot-fixtures/npm-intermediate-dependency": "~0.0.1"
+      }
+    },
+    "node_modules/@dependabot-fixtures/npm-transitive-dependency": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.0.tgz",
+      "integrity": "sha512-nFbzQH0TRgdzSA2/FH6MPnxZDpD+5Bgz00aD5Edgbc1wY/k8VC9s7lnk22dBTgJLwoY7MgbrnAf9rAvN08hHVg=="
+    }
+  },
+  "dependencies": {
+    "@dependabot-fixtures/npm-intermediate-dependency": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-intermediate-dependency/-/npm-intermediate-dependency-0.0.1.tgz",
+      "integrity": "sha512-/N77Dzpfg8BIfFgpJrMk86ueUYTVhmpc4RobuHpIpKSc3GZr4Ltu4au92brnUGk66UkzgrMmtgqRXO8OrOspKQ==",
+      "requires": {
+        "@dependabot-fixtures/npm-transitive-dependency": "1.0.0"
+      }
+    },
+    "@dependabot-fixtures/npm-parent-dependency": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-parent-dependency/-/npm-parent-dependency-2.0.2.tgz",
+      "integrity": "sha512-r1uDMPr0w1LQ3V0ekkMMYyucBDKj3kWbUI/067iDVAmF1DRwVJurPf7W4NzkuOuEe/EgPx5qCBAMAq8TjdlH7w==",
+      "requires": {
+        "@dependabot-fixtures/npm-intermediate-dependency": "~0.0.1"
+      }
+    },
+    "@dependabot-fixtures/npm-transitive-dependency": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.0.tgz",
+      "integrity": "sha512-nFbzQH0TRgdzSA2/FH6MPnxZDpD+5Bgz00aD5Edgbc1wY/k8VC9s7lnk22dBTgJLwoY7MgbrnAf9rAvN08hHVg=="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm8/transitive_dependency_locked_by_intermediate_top_and_sub/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/transitive_dependency_locked_by_intermediate_top_and_sub/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "transitive-dependency-locked-by-intermediate",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@dependabot-fixtures/npm-parent-dependency": "2.0.2",
+    "@dependabot-fixtures/npm-transitive-dependency": "1.0.0"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm6/transitive_dependency_locked_by_intermediate_top_and_sub/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm6/transitive_dependency_locked_by_intermediate_top_and_sub/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "transitive-dependency-locked-by-intermediate",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@dependabot-fixtures/npm-intermediate-dependency": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-intermediate-dependency/-/npm-intermediate-dependency-0.0.2.tgz",
+      "integrity": "sha512-xj/Xn9vf3zO9b4XQXAWysDyMARCajkyceOqcdIdg9blkz6JPzB5e3ShGH+rAo0TBy+DN7WrFBMt1xxwdqezRLg==",
+      "requires": {
+        "@dependabot-fixtures/npm-transitive-dependency": "^1.0.0"
+      }
+    },
+    "@dependabot-fixtures/npm-parent-dependency": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-parent-dependency/-/npm-parent-dependency-2.0.2.tgz",
+      "integrity": "sha512-r1uDMPr0w1LQ3V0ekkMMYyucBDKj3kWbUI/067iDVAmF1DRwVJurPf7W4NzkuOuEe/EgPx5qCBAMAq8TjdlH7w==",
+      "requires": {
+        "@dependabot-fixtures/npm-intermediate-dependency": "~0.0.1"
+      }
+    },
+    "@dependabot-fixtures/npm-transitive-dependency": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.1.tgz",
+      "integrity": "sha512-nWQzJEqSqKZu+mgNSVdsO69NG6vCGIN9FuM+Vip5nqItqrNeQoITZM6/q6+tqgdM48XkQEOUpEiYpAdoMbxniw=="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm6/transitive_dependency_locked_by_intermediate_top_and_sub/package.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm6/transitive_dependency_locked_by_intermediate_top_and_sub/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "transitive-dependency-locked-by-intermediate",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@dependabot-fixtures/npm-parent-dependency": "2.0.2",
+    "@dependabot-fixtures/npm-transitive-dependency": "1.0.1"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm8/transitive_dependency_locked_by_intermediate_top_and_sub/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm8/transitive_dependency_locked_by_intermediate_top_and_sub/package-lock.json
@@ -1,0 +1,61 @@
+{
+  "name": "transitive-dependency-locked-by-intermediate",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "transitive-dependency-locked-by-intermediate",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@dependabot-fixtures/npm-parent-dependency": "2.0.2",
+        "@dependabot-fixtures/npm-transitive-dependency": "1.0.1"
+      }
+    },
+    "node_modules/@dependabot-fixtures/npm-intermediate-dependency": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-intermediate-dependency/-/npm-intermediate-dependency-0.0.2.tgz",
+      "integrity": "sha512-xj/Xn9vf3zO9b4XQXAWysDyMARCajkyceOqcdIdg9blkz6JPzB5e3ShGH+rAo0TBy+DN7WrFBMt1xxwdqezRLg==",
+      "dependencies": {
+        "@dependabot-fixtures/npm-transitive-dependency": "^1.0.0"
+      }
+    },
+    "node_modules/@dependabot-fixtures/npm-parent-dependency": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-parent-dependency/-/npm-parent-dependency-2.0.2.tgz",
+      "integrity": "sha512-r1uDMPr0w1LQ3V0ekkMMYyucBDKj3kWbUI/067iDVAmF1DRwVJurPf7W4NzkuOuEe/EgPx5qCBAMAq8TjdlH7w==",
+      "dependencies": {
+        "@dependabot-fixtures/npm-intermediate-dependency": "~0.0.1"
+      }
+    },
+    "node_modules/@dependabot-fixtures/npm-transitive-dependency": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.1.tgz",
+      "integrity": "sha512-nWQzJEqSqKZu+mgNSVdsO69NG6vCGIN9FuM+Vip5nqItqrNeQoITZM6/q6+tqgdM48XkQEOUpEiYpAdoMbxniw=="
+    }
+  },
+  "dependencies": {
+    "@dependabot-fixtures/npm-intermediate-dependency": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-intermediate-dependency/-/npm-intermediate-dependency-0.0.2.tgz",
+      "integrity": "sha512-xj/Xn9vf3zO9b4XQXAWysDyMARCajkyceOqcdIdg9blkz6JPzB5e3ShGH+rAo0TBy+DN7WrFBMt1xxwdqezRLg==",
+      "requires": {
+        "@dependabot-fixtures/npm-transitive-dependency": "^1.0.0"
+      }
+    },
+    "@dependabot-fixtures/npm-parent-dependency": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-parent-dependency/-/npm-parent-dependency-2.0.2.tgz",
+      "integrity": "sha512-r1uDMPr0w1LQ3V0ekkMMYyucBDKj3kWbUI/067iDVAmF1DRwVJurPf7W4NzkuOuEe/EgPx5qCBAMAq8TjdlH7w==",
+      "requires": {
+        "@dependabot-fixtures/npm-intermediate-dependency": "~0.0.1"
+      }
+    },
+    "@dependabot-fixtures/npm-transitive-dependency": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.1.tgz",
+      "integrity": "sha512-nWQzJEqSqKZu+mgNSVdsO69NG6vCGIN9FuM+Vip5nqItqrNeQoITZM6/q6+tqgdM48XkQEOUpEiYpAdoMbxniw=="
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/updated_projects/npm8/transitive_dependency_locked_by_intermediate_top_and_sub/package.json
+++ b/npm_and_yarn/spec/fixtures/updated_projects/npm8/transitive_dependency_locked_by_intermediate_top_and_sub/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "transitive-dependency-locked-by-intermediate",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@dependabot-fixtures/npm-parent-dependency": "2.0.2",
+    "@dependabot-fixtures/npm-transitive-dependency": "1.0.1"
+  }
+}


### PR DESCRIPTION
Previously we wouldn't update sub dependencies if a top level dependency was also in the update list. With our new ability to update locking parents of a vulnerable transitive dependency it's now possible for an update to require updating both. This is resulting in incomplete PRs that include fixes for top level dependencies (and their child dependencies) but not fixes for separate sub dependencies that need updates.