### PR TITLE
Yarn Berry: Run commands in `update-lockfile` mode

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -161,7 +161,7 @@ module Dependabot
             # updated to a single new version, so we just pick the first one.
             "#{dep[:name]}@#{dep[:requirements].first[:requirement]}"
           end
-          command = "yarn add #{updates.join(' ')}"
+          command = "yarn add #{updates.join(' ')} --mode=update-lockfile"
           Helpers.run_yarn_commands(command)
           { yarn_lock.name => File.read(yarn_lock.name) }
         end
@@ -171,9 +171,9 @@ module Dependabot
           update = "#{dep.name}@#{dep.version}"
 
           Helpers.run_yarn_commands(
-            "yarn add #{update}",
-            "yarn dedupe #{dep.name}",
-            "yarn remove #{dep.name}"
+            "yarn add #{update} --mode=update-lockfile",
+            "yarn dedupe #{dep.name} --mode=update-lockfile",
+            "yarn remove #{dep.name} --mode=update-lockfile"
           )
           { yarn_lock.name => File.read(yarn_lock.name) }
         end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -2995,7 +2995,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         it "updates the .yarn/cache folder" do
           expect(updated_files.map(&:name)).to match_array(
             [
-              ".yarn/cache/fetch-factory-npm-0.0.1-e67abc1f87-ff7fe6fdb8.zip",
               ".yarn/cache/fetch-factory-npm-0.0.2-816f8766e1-200ddd8ae3.zip",
               ".yarn/install-state.gz",
               "package.json",


### PR DESCRIPTION
Yarn Berry commands related to performing updates can run in a mode called `update-lockfile`, which was purpose-built for exactly what Dependabot does:

```
- `update-lockfile` will skip the link step altogether, and only fetch packages
  that are missing from the lockfile (or that have no associated checksums).
  This mode is typically used by tools like Renovate or Dependabot to keep a
  lockfile up-to-date without incurring the full install cost.
```

This makes yarn berry updates _significantly_ more performant, but it has the downside that when the yarn cache is committed to the repo, old entries in there are not cleaned up. Everything still works as expected when this happens, but over time it could lead to that cache folder getting larger than is necessary.

I've opened an issue about this upstream:
https://github.com/yarnpkg/berry/issues/4886, not entirely sure if this is a bug or just a consequence of how this works.

For now I think it's worth the trade-off, as many projects don't commit the cache folder to repo, and the performance benefits are very significant.

I'll try to find some time to address this upstream.