### PR TITLE
Yarn Berry: run git lfs pull before running yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -317,4 +317,5 @@ ENV PATH="$HOME/bin:$PATH"
 # Configure cargo to use git CLI so the above takes effect
 RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo/config.toml
 # Disable automatic pulling of files stored with Git LFS
+# This avoids downloading large files not necessary for the dependabot scripts
 ENV GIT_LFS_SKIP_SMUDGE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
     build-essential \
     dirmngr \
     git \
+    git-lfs \
     bzr \
     mercurial \
     gnupg2 \
@@ -315,3 +316,5 @@ RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar
 ENV PATH="$HOME/bin:$PATH"
 # Configure cargo to use git CLI so the above takes effect
 RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo/config.toml
+# Disable automatic pulling of files stored with Git LFS
+ENV GIT_LFS_SKIP_SMUDGE=1

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -30,6 +30,19 @@ module Dependabot
         "Repo must contain a package.json."
       end
 
+      # Overridden to pull any yarn data or plugins which may be stored with Git LFS.
+      def _clone_repo_contents(target_directory:)
+        path = super(target_directory: target_directory)
+        begin
+          SharedHelpers.with_git_configured(credentials: credentials) do
+            SharedHelpers.run_shell_command("git -C #{path} lfs pull --include .yarn")
+            path
+          end
+        rescue StandardError
+          path
+        end
+      end
+
       private
 
       def fetch_files

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -38,11 +38,7 @@ module Dependabot
         begin
           SharedHelpers.with_git_configured(credentials: credentials) do
             Dir.chdir(path) do
-              cache_dir = if File.exist?(".yarnrc.yml")
-                            YAML.load_file(".yarnrc.yml").fetch("cacheFolder", "./.yarn/cache")
-                          else
-                            "./.yarn/cache"
-                          end
+              cache_dir = Helpers.fetch_yarnrc_yml_value("cacheFolder", "./yarn/cache")
               SharedHelpers.run_shell_command("git lfs pull --include .yarn,#{cache_dir}")
             end
             path

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -30,23 +30,25 @@ module Dependabot
         "Repo must contain a package.json."
       end
 
-      private
-
       # Overridden to pull any yarn data or plugins which may be stored with Git LFS.
-      def _clone_repo_contents(target_directory:)
-        path = super(target_directory: target_directory)
+      def clone_repo_contents
+        return @git_lfs_cloned_repo_contents_path if defined?(@git_lfs_cloned_repo_contents_path)
+
+        @git_lfs_cloned_repo_contents_path = super
         begin
           SharedHelpers.with_git_configured(credentials: credentials) do
-            Dir.chdir(path) do
+            Dir.chdir(@git_lfs_cloned_repo_contents_path) do
               cache_dir = Helpers.fetch_yarnrc_yml_value("cacheFolder", "./yarn/cache")
               SharedHelpers.run_shell_command("git lfs pull --include .yarn,#{cache_dir}")
             end
-            path
+            @git_lfs_cloned_repo_contents_path
           end
         rescue StandardError
-          path
+          @git_lfs_cloned_repo_contents_path
         end
       end
+
+      private
 
       def fetch_files
         fetched_files = []

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -73,21 +73,13 @@ module Dependabot
       def vendor_cache_dir
         return @vendor_cache_dir if defined?(@vendor_cache_dir)
 
-        @vendor_cache_dir = if File.exist?(".yarnrc.yml")
-                              YAML.load_file(".yarnrc.yml").fetch("cacheFolder", "./.yarn/cache")
-                            else
-                              "./.yarn/cache"
-                            end
+        @vendor_cache_dir = Helpers.fetch_yarnrc_yml_value("cacheFolder", "./.yarn/cache")
       end
 
       def install_state_path
         return @install_state_path if defined?(@install_state_path)
 
-        @install_state_path = if File.exist?(".yarnrc.yml")
-                                YAML.load_file(".yarnrc.yml").fetch("installStatePath", "./.yarn/install-state.gz")
-                              else
-                                "./.yarn/install-state.gz"
-                              end
+        @install_state_path = Helpers.fetch_yarnrc_yml_value("installStatePath", "./.yarn/install-state.gz")
       end
 
       def vendor_updater

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -55,6 +55,8 @@ module Dependabot
         def updated_yarn_lock(yarn_lock)
           base_dir = dependency_files.first.directory
           SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
+            # Pull any yarn data or plugins which may be stored with Git LFS
+            SharedHelpers.run_shell_command("git lfs pull --include .yarn")
             write_temporary_dependency_files
             lockfile_name = Pathname.new(yarn_lock.name).basename.to_s
             path = Pathname.new(yarn_lock.name).dirname.to_s

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -55,8 +55,6 @@ module Dependabot
         def updated_yarn_lock(yarn_lock)
           base_dir = dependency_files.first.directory
           SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
-            # Pull any yarn data or plugins which may be stored with Git LFS
-            SharedHelpers.run_shell_command("git lfs pull --include .yarn")
             write_temporary_dependency_files
             lockfile_name = Pathname.new(yarn_lock.name).basename.to_s
             path = Pathname.new(yarn_lock.name).dirname.to_s

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -16,6 +16,14 @@ module Dependabot
         6
       end
 
+      def self.fetch_yarnrc_yml_value(key, default_value)
+        if File.exist?(".yarnrc.yml") && (yarnrc = YAML.load_file(".yarnrc.yml"))
+          yarnrc.fetch(key, default_value)
+        else
+          default_value
+        end
+      end
+
       # Run any number of yarn commands while ensuring that `enableScripts` is
       # set to false. Yarn commands should _not_ be ran outside of this helper
       # to ensure that postinstall scripts are never executed, as they could

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         directory: directory
       )
     end
-    let(:url) { "https://api.github.com/repos/jtbandes/dependabot-yarn-lfs-fixture/contents/" }
-    let(:repo) { "jtbandes/dependabot-yarn-lfs-fixture" }
+    let(:url) { "https://api.github.com/repos/dependabot-fixtures/yarn-berry-lfs-fixture/contents/" }
+    let(:repo) { "dependabot-fixtures/yarn-berry-lfs-fixture" }
     let(:repo_contents_path) { Dir.mktmpdir }
     after { FileUtils.rm_rf(repo_contents_path) }
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         directory: directory
       )
     end
-    let(:url) { "https://api.github.com/repos/dependabot-fixtures/yarn-berry-lfs-fixture/contents/" }
-    let(:repo) { "dependabot-fixtures/yarn-berry-lfs-fixture" }
+    let(:url) { "https://api.github.com/repos/dependabot-fixtures/dependabot-yarn-lfs-fixture/contents/" }
+    let(:repo) { "dependabot-fixtures/dependabot-yarn-lfs-fixture" }
     let(:repo_contents_path) { Dir.mktmpdir }
     after { FileUtils.rm_rf(repo_contents_path) }
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -82,14 +82,18 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     it "pulls files from lfs after cloning" do
       # Calling #files triggers the clone
       expect(file_fetcher_instance.files.map(&:name)).to contain_exactly("package.json", "yarn.lock", ".yarnrc.yml")
-      expect(File.read(
-        File.join(repo_contents_path, ".yarn", "releases", "yarn-3.2.4.cjs")
-      )).to start_with("#!/usr/bin/env node")
+      expect(
+        File.read(
+          File.join(repo_contents_path, ".yarn", "releases", "yarn-3.2.4.cjs")
+        )
+      ).to start_with("#!/usr/bin/env node")
 
       # LFS files not needed by dependabot are not pulled
-      expect(File.read(
-        File.join(repo_contents_path, ".pnp.cjs")
-      )).to start_with("version https://git-lfs.github.com/spec/v1")
+      expect(
+        File.read(
+          File.join(repo_contents_path, ".pnp.cjs")
+        )
+      ).to start_with("version https://git-lfs.github.com/spec/v1")
     end
   end
 


### PR DESCRIPTION
cc @jurre  @defunctzombie
Run `git lfs pull --include .yarn` before using yarn for dependency updating. Yarn plugins stored with LFS can now be used.

Resolves LFS issues described in https://github.com/dependabot/dependabot-core/issues/1297, see example Dependabot PR at https://github.com/foxglove/studio/pull/4528

Tested with `bin/dry-run.rb npm_and_yarn foxglove/studio --clone --dep rc-tree`, which now updates yarn.lock instead of failing with an error.

Ran unit test with `cd npm_and_yarn && bundle exec rspec spec/dependabot/npm_and_yarn/file_fetcher_spec.rb -e "with .yarn data stored in git-lfs"`