### PR TITLE
Fix Dependabot removes double backslashes in maven plugin configurations

### DIFF
--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -89,10 +89,9 @@ module Dependabot
         updated_content = file.content
 
         original_file_declarations(dependency, previous_req).each do |old_dec|
-          updated_content = updated_content.gsub(
-            old_dec,
+          updated_content = updated_content.gsub(old_dec) do
             updated_file_declaration(old_dec, previous_req, requirement)
-          )
+          end
         end
 
         raise "Expected content to change!" if updated_content == file.content

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -599,6 +599,37 @@ RSpec.describe Dependabot::Maven::FileUpdater do
           end
         end
       end
+
+      context "with double backslashes in plugin" do
+        let(:pom_body) { fixture("poms", "plugin_with_double_backslashes.xml") }
+        let(:dependencies) do
+          [
+            Dependabot::Dependency.new(
+              name: "com.diffplug.spotless:spotless-maven-plugin",
+              version: "2.27.1",
+              requirements: [{
+                file: "pom.xml",
+                requirement: "2.27.1",
+                groups: [],
+                source: nil,
+                metadata: { packaging_type: "jar" }
+              }],
+              previous_requirements: [{
+                file: "pom.xml",
+                requirement: "2.27.0",
+                groups: [],
+                source: nil,
+                metadata: { packaging_type: "jar" }
+              }],
+              package_manager: "maven"
+            )
+          ]
+        end
+
+        its(:content) do
+          is_expected.to include("<order>java,javax,org,com,,\\\\#</order>")
+        end
+      end
     end
 
     context "the updated extensions.xml file" do

--- a/maven/spec/fixtures/poms/plugin_with_double_backslashes.xml
+++ b/maven/spec/fixtures/poms/plugin_with_double_backslashes.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.dependabot</groupId>
+  <artifactId>basic-pom</artifactId>
+  <version>0.0.1-RELEASE</version>
+  <name>Dependabot Plugin POM</name>
+
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.27.0</version>
+        <configuration>
+          <java>
+            <importOrder>
+              <order>java,javax,org,com,,\\#</order>
+            </importOrder>
+          </java>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
## Problem

Dependabot removes backslashes in maven pom.
This PR will fix it.

<img width="1010" alt="pr" src="https://user-images.githubusercontent.com/19996/194045840-e0e01e5f-6312-4b5e-8553-31338a883d7b.png">

Example PR: https://github.com/mallowlabs/dependabot-maven-double-backslashes-test/pull/1

## Reason

`String#gsub` escapes double backslashes.
Using block prevents this problem.

```
irb(main):001:0> "\\\\".gsub("\\\\","\\\\")
=> "\\"
irb(main):001:0> "\\\\".gsub("\\\\") { "\\\\" }
=> "\\\\"
```

## Background

I use spotless-maven-plugin.
The `importOrder` configuration contains `\\#`.

https://github.com/diffplug/spotless/blob/7667a849d377b546d45350b77b65e0793e3d17dc/plugin-maven/README.md?plain=1#L184

