### PR TITLE
Stop disabling new `poetry` installer

### DIFF
--- a/python/helpers/build
+++ b/python/helpers/build
@@ -19,8 +19,3 @@ cp -r \
 
 cd "$install_dir"
 PYENV_VERSION=3.10.6 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"
-
-# Workaround of https://github.com/python-poetry/poetry/issues/3010
-# By default poetry config file is stored under ~/.config/pypoetry
-# and is not bound to any specific Python version
-PYENV_VERSION=3.10.6 pyenv exec poetry config experimental.new-installer false


### PR DESCRIPTION
This was added in https://github.com/dependabot/dependabot-core/pull/3459/ to workaround the underlying issue of https://github.com/python-poetry/poetry/issues/3010.

However, `poetry` `1.2` fixed the underlying issue, and we are now on `poetry` `1.2.1` so we can remove this workaround.

See also:
* https://github.com/python-poetry/poetry/issues/3010#issuecomment-1207683271
* https://github.com/python-poetry/poetry/issues/3010#issuecomment-1076518050
* https://github.com/python-poetry/poetry/issues/3010#issuecomment-1122209272
* https://github.com/dependabot/dependabot-core/pull/5492