### PR TITLE
allow updating at a commit, for testing

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -518,6 +518,16 @@ module Dependabot
               git clone --no-tags --no-recurse-submodules --depth 1#{br_opt} #{source.url} #{path}
             CMD
           )
+          if source.commit
+            # This code will only be called for testing. Production will never pass a commit
+            # since Dependabot always wants to test the latest commit on a branch.
+            Dir.chdir(path) do
+              # Need to fetch the commit due to the --depth 1 above.
+              SharedHelpers.run_shell_command("git fetch --depth 1 origin #{source.commit}")
+              # Set HEAD to this commit so later calls so git reset HEAD will work.
+              SharedHelpers.run_shell_command("git reset --hard #{source.commit}")
+            end
+          end
           path
         end
       end


### PR DESCRIPTION
## Context

We can use [Dependabot CLI](https://github.com/dependabot/cli) to test specific commits of a repository with an input file like this:

```
job:
   package-manager: go_modules
   allowed-updates:
     - dependency-type: direct
   source:
     provider: github
     repo: dependabot/smoke-tests
     directory: "/."
     commit: 147f31acdcaf088f1ecfefeb8ef33f603a944420
```

This is useful in smoke testing so there's no fear of breaking all of the tests when making a new commit to the repo, the tests are essentially pinned. This is also useful for testing customer issues since the customer may have made new commits that changed the situation since the job ran.

## Problem

Ecosystems that use the clone method to fetch code are not honoring the commit since they only call clone with a branch, or use the default branch. That makes it impossible to test arbitrary commits in Go, Github Actions, Pub, Terraform, and Yarn Berry. 

## Solution

I've added additional calls to checkout the correct branch. This is low risk since it's guarded by a check to `source.commit` which should never be set in production. Production Dependabot is always interested in running against the latest commit in a branch.