### PR TITLE
Make quotes around Yarn private registry sources optional

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/registry_finder.rb
@@ -18,11 +18,11 @@ module Dependabot
         NPM_GLOBAL_REGISTRY_REGEX =
           /^registry\s*=\s*['"]?(?<registry>.*?)['"]?$/.freeze
         YARN_GLOBAL_REGISTRY_REGEX =
-          /^(?:--)?registry\s+['"](?<registry>.*)['"]/.freeze
+          /^(?:--)?registry\s+((['"](?<registry>.*)['"])|(?<registry>.*))/.freeze
         NPM_SCOPED_REGISTRY_REGEX =
           /^(?<scope>@[^:]+)\s*:registry\s*=\s*['"]?(?<registry>.*?)['"]?$/.freeze
         YARN_SCOPED_REGISTRY_REGEX =
-          /['"](?<scope>@[^:]+):registry['"]\s['"](?<registry>.*)['"]/.freeze
+          /['"](?<scope>@[^:]+):registry['"]\s((['"](?<registry>.*)['"])|(?<registry>.*))/.freeze
 
         def initialize(dependency:, credentials:, npmrc_file: nil,
                        yarnrc_file: nil)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/registry_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/registry_finder_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RegistryFinder do
       it { is_expected.to eq("http://example.com") }
     end
 
+    context "with a global yarn registry not wrapped in quotes" do
+      let(:yarnrc_file) { Dependabot::DependencyFile.new(name: ".yarnrc", content: "registry http://example.com") }
+
+      it { is_expected.to eq("http://example.com") }
+    end
+
     context "with a scoped npm registry" do
       let(:dependency_name) { "@dependabot/some_dep" }
       let(:npmrc_file) { Dependabot::DependencyFile.new(name: ".npmrc", content: "@dependabot:registry=http://example.com") }
@@ -66,6 +72,13 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RegistryFinder do
     context "with a scoped yarn registry" do
       let(:dependency_name) { "@dependabot/some_dep" }
       let(:yarnrc_file) { Dependabot::DependencyFile.new(name: ".yarnrc", content: '"@dependabot:registry" "http://example.com"') }
+
+      it { is_expected.to eq("http://example.com") }
+    end
+
+    context "with a scoped yarn registry not wrapped in quotes" do
+      let(:dependency_name) { "@dependabot/some_dep" }
+      let(:yarnrc_file) { Dependabot::DependencyFile.new(name: ".yarnrc", content: '"@dependabot:registry" http://example.com') }
 
       it { is_expected.to eq("http://example.com") }
     end


### PR DESCRIPTION
Adding a yarn global or scoped registry can be done via the yarn CLI with `yarn config add <key> <value>`.

For some reason, yarn will remove any quotes around the value when writing to `.yarnrc`, so this change teaches Dependabot to parse values not encased in quotation marks.

