### PR TITLE
[npm] fix to preserve all_versions metadata from the lockfile

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -87,7 +87,7 @@ module Dependabot
       end
 
       def lockfile_dependencies
-        DependencySet.new(lockfile_parser.parse)
+        lockfile_parser.parse_set
       end
 
       def build_dependency(file:, type:, name:, requirement:)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -12,13 +12,17 @@ module Dependabot
           @dependency_files = dependency_files
         end
 
-        def parse
+        def parse_set
           dependency_set = Dependabot::NpmAndYarn::FileParser::DependencySet.new
           dependency_set += yarn_lock_dependencies if yarn_locks.any?
           dependency_set += package_lock_dependencies if package_locks.any?
           dependency_set += shrinkwrap_dependencies if shrinkwraps.any?
 
-          Helpers.dependencies_with_all_versions_metadata(dependency_set)
+          dependency_set
+        end
+
+        def parse
+          Helpers.dependencies_with_all_versions_metadata(parse_set)
         end
 
         def lockfile_details(dependency_name:, requirement:, manifest_name:)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -1406,15 +1406,15 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
       let(:files) { project_dependency_files("npm8/transitive_dependency_multiple_versions") }
 
       it "stores all versions of the dependency in its metadata" do
-        name = "@dependabot-fixtures/npm-transitive-dependency"
+        name = "kind-of"
         dependency = subject.find { |dep| dep.name == name }
 
         expect(dependency.metadata[:all_versions]).to eq([
           Dependabot::Dependency.new(
             name: name,
-            version: "1.0.1",
+            version: "3.2.2",
             requirements: [{
-              requirement: "1.0.1",
+              requirement: "^3.2.2",
               file: "package.json",
               groups: ["dependencies"],
               source: { type: "registry", url: "https://registry.npmjs.org" }
@@ -1423,7 +1423,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           ),
           Dependabot::Dependency.new(
             name: name,
-            version: "1.0.0",
+            version: "6.0.2",
             requirements: [],
             package_manager: "npm_and_yarn"
           )

--- a/npm_and_yarn/spec/fixtures/projects/npm8/transitive_dependency_multiple_versions/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/transitive_dependency_multiple_versions/package-lock.json
@@ -1,57 +1,80 @@
 {
-  "name": "transitive-dependency-multiple-versions",
+  "name": "vuln-multiversion",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "transitive-dependency-multiple-versions",
+      "name": "vuln-multiversion",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@dependabot-fixtures/npm-intermediate-dependency": "0.0.1",
-        "@dependabot-fixtures/npm-transitive-dependency": "1.0.1"
+        "is-accessor-descriptor": "^1.0.0",
+        "kind-of": "^3.2.2"
       }
     },
-    "node_modules/@dependabot-fixtures/npm-intermediate-dependency": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-intermediate-dependency/-/npm-intermediate-dependency-0.0.1.tgz",
-      "integrity": "sha512-/N77Dzpfg8BIfFgpJrMk86ueUYTVhmpc4RobuHpIpKSc3GZr4Ltu4au92brnUGk66UkzgrMmtgqRXO8OrOspKQ==",
-      "dependencies": {
-        "@dependabot-fixtures/npm-transitive-dependency": "1.0.0"
-      }
-    },
-    "node_modules/@dependabot-fixtures/npm-intermediate-dependency/node_modules/@dependabot-fixtures/npm-transitive-dependency": {
+    "node_modules/is-accessor-descriptor": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.0.tgz",
-      "integrity": "sha512-nFbzQH0TRgdzSA2/FH6MPnxZDpD+5Bgz00aD5Edgbc1wY/k8VC9s7lnk22dBTgJLwoY7MgbrnAf9rAvN08hHVg=="
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "node_modules/@dependabot-fixtures/npm-transitive-dependency": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.1.tgz",
-      "integrity": "sha512-nWQzJEqSqKZu+mgNSVdsO69NG6vCGIN9FuM+Vip5nqItqrNeQoITZM6/q6+tqgdM48XkQEOUpEiYpAdoMbxniw=="
+    "node_modules/is-accessor-descriptor/node_modules/kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     }
   },
   "dependencies": {
-    "@dependabot-fixtures/npm-intermediate-dependency": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-intermediate-dependency/-/npm-intermediate-dependency-0.0.1.tgz",
-      "integrity": "sha512-/N77Dzpfg8BIfFgpJrMk86ueUYTVhmpc4RobuHpIpKSc3GZr4Ltu4au92brnUGk66UkzgrMmtgqRXO8OrOspKQ==",
+    "is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "requires": {
-        "@dependabot-fixtures/npm-transitive-dependency": "1.0.0"
+        "kind-of": "^6.0.0"
       },
       "dependencies": {
-        "@dependabot-fixtures/npm-transitive-dependency": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.0.tgz",
-          "integrity": "sha512-nFbzQH0TRgdzSA2/FH6MPnxZDpD+5Bgz00aD5Edgbc1wY/k8VC9s7lnk22dBTgJLwoY7MgbrnAf9rAvN08hHVg=="
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz"
         }
       }
     },
-    "@dependabot-fixtures/npm-transitive-dependency": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@dependabot-fixtures/npm-transitive-dependency/-/npm-transitive-dependency-1.0.1.tgz",
-      "integrity": "sha512-nWQzJEqSqKZu+mgNSVdsO69NG6vCGIN9FuM+Vip5nqItqrNeQoITZM6/q6+tqgdM48XkQEOUpEiYpAdoMbxniw=="
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
     }
   }
 }

--- a/npm_and_yarn/spec/fixtures/projects/npm8/transitive_dependency_multiple_versions/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/transitive_dependency_multiple_versions/package.json
@@ -1,16 +1,15 @@
 {
-  "name": "transitive-dependency-multiple-versions",
+  "name": "vuln-multiversion",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@dependabot-fixtures/npm-intermediate-dependency": "0.0.1",
-    "@dependabot-fixtures/npm-transitive-dependency": "1.0.1"
+    "is-accessor-descriptor": "^1.0.0",
+    "kind-of": "^3.2.2"
   }
 }


### PR DESCRIPTION
Minor follow up to https://github.com/dependabot/dependabot-core/pull/5801

In testing I saw that https://github.com/dsp-testing/npm-multiple-versions/ was still reporting the dependency was no longer vulnerable. It seems that in some cases when a dependency exists in both `package.json` and `package-lock.json` we weren't preserving all the versions. This turned out to be because when parsing dependencies from `package-lock.json` we converted the `DependencySet` to a list of dependencies and back to a `DependencySet` which loses a bit of the version tracking state. Rather than try to preserve everything in the conversion I found it easier to just skip the unnecessary conversion.