### PR TITLE
swap history file from `byebug` to new `debug` gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ vendor
 /.vscode/
 /.vscode-server/
 /.vscode-server-insiders/
-.byebug_history
 **/helpers/install-dir
 /npm_and_yarn/helpers/node_modules
 /npm_and_yarn/helpers/.node-version
@@ -30,3 +29,4 @@ coverage/
 .ruby-gemset
 .tool-versions
 .rspec_status
+.rdbg_history


### PR DESCRIPTION
`byebug` was replaced with the new `debug` gem as part of the `ruby` `3.1` upgrade.

So swap out the history file locations in `.gitignore` to the new one... see `RUBY_DEBUG_HISTORY_FILE` default value [here](https://github.com/ruby/debug#configuration-list).

This was originally removed in https://github.com/dependabot/dependabot-core/pull/4567/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5L19, then put back in  https://github.com/dependabot/dependabot-core/commit/847d111805b78c64c9883e31b421734cb74637fa#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947R20.

However, the last trace of `byebug` was removed from `Gemfile.lock` in https://github.com/dependabot/dependabot-core/pull/5849/files#diff-0c7825d57fc79377b294d76c04d7bf63931bba3e9cd7946e19b5d3cb955c5548L144, so it's now safe to remove the history file.