### PR TITLE
Regenerate `updater/Gemfile.lock`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ ARG RUBY_INSTALL_VERSION=0.8.3
 ARG RUBYGEMS_SYSTEM_VERSION=3.3.22
 
 ARG BUNDLER_V1_VERSION=1.17.3
+# When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
 ARG BUNDLER_V2_VERSION=2.3.22
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
 # Allow gem installs as the dependabot user

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -330,4 +330,4 @@ DEPENDENCIES
   webmock (~> 3.18)
 
 BUNDLED WITH
-   2.2.20
+   2.3.22


### PR DESCRIPTION
I noticed the following log lines in [the output of building the `updater`](https://github.com/dependabot/dependabot-core/actions/runs/3212248230/jobs/5250946524) Docker image:
```
32 sha256:563a023320753425444761bd82772c641463b33ea716db65998c70bdc931dd95
32 1.167 Bundler 2.3.22 is running, but your lockfile was generated with 2.2.20. Installing Bundler 2.2.20 and restarting using that version.
32 2.192 Fetching gem metadata from https://rubygems.org/.
32 2.217 Fetching bundler 2.2.20
32 2.297 Installing bundler 2.2.20
32 2.511 Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
32 3.308 Fetching gem metadata from https://rubygems.org/.........
```

That's probably because of
https://github.com/dependabot/dependabot-core/pull/5509 which updated `bundler` to `2.3.22` which doesn't match the version of Bundler specified in `Gemfile.lock`:
* https://bundler.io/blog/2022/01/23/bundler-v2-3.html
* https://github.com/dependabot/dependabot-core/blob/2ba96fcc09564675d94140b7f8ee6fefa32de935/updater/Gemfile.lock#L333

So I built the docker updater image (couldn't use the core image unfortunately because it doesn't mount `/updater`, and for good reason).

And then within that docker image ran:
```
$ bundler update --bundler
```