### PR TITLE
fix: correctly find workspace.dependencies-declared dependencies and their Cargo.toml

### DIFF
--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -264,6 +264,16 @@ module Dependabot
           end
         end
 
+        # Paths specified for workspace-wide dependencies
+        workspace = parsed_file(file).fetch("workspace", {})
+        workspace.fetch("dependencies", {}).each do |_, details|
+          next unless details.is_a?(Hash)
+          next unless details["path"]
+          next unless path == File.join(details["path"], "Cargo.toml")
+
+          return true if details["git"].nil?
+        end
+
         # Paths specified as replacements
         parsed_file(file).fetch("replace", {}).each do |_, details|
           next unless details.is_a?(Hash)


### PR DESCRIPTION
I would like help for writing a test, I have found `cargo/file_fetcher_spec.rb`, but I don't
understand how it works.

Closes #5864