### PR TITLE
Log when the FileFetcher can't determine the base_commit_sha

### DIFF
--- a/updater/lib/dependabot/file_fetcher_job.rb
+++ b/updater/lib/dependabot/file_fetcher_job.rb
@@ -7,10 +7,12 @@ require "octokit"
 
 module Dependabot
   class FileFetcherJob < BaseJob
+    REF_UNKNOWN = "unknown"
+
     def perform_job
       begin
         connectivity_check if ENV["ENABLE_CONNECTIVITY_CHECK"] == "1"
-        base_commit_sha
+        logger_info("Could not determine base_commit_sha") if base_commit_sha == REF_UNKNOWN
         dependency_files
         clone_repo_contents
       rescue StandardError => e
@@ -85,11 +87,11 @@ module Dependabot
     end
 
     def base_commit_sha
-      @base_commit_sha ||= file_fetcher.commit || "unknown"
+      @base_commit_sha ||= file_fetcher.commit || REF_UNKNOWN
     rescue StandardError
       # If an error occurs, set the commit SHA instance variable (so that we
       # don't raise when recording the error later) and re-raise
-      @base_commit_sha = "unknown"
+      @base_commit_sha = REF_UNKNOWN
       raise
     end
 


### PR DESCRIPTION
We've been observing some PRs with diffs that seem to indicate that the PR is opened against a different sha then the one that was used to fetch the files.

In order to determine if that's related to not being able to determine the base_commit_sha, I'd like to start logging this.