### PR TITLE
[npm] Flag indirect transitive updates to be ignored by the FileUpdater

### DIFF
--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -115,6 +115,13 @@ module Dependabot
       all_versions.filter_map(&:version)
     end
 
+    # This dependency is being indirectly updated by an update to another
+    # dependency. We don't need to try and update it ourselves but want to
+    # surface it to the user in the PR.
+    def informational_only?
+      metadata[:information_only]
+    end
+
     def ==(other)
       other.instance_of?(self.class) && to_h == other.to_h
     end

--- a/hex/spec/dependabot/hex/update_checker_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
         [{ file: "mix.exs", requirement: "~> 1.2.1", groups: [], source: nil }]
       end
 
-      it { is_expected.to eq(Gem::Version.new("1.3.4")) }
+      it { is_expected.to eq(Gem::Version.new("1.3.5")) }
     end
 
     context "when the user is ignoring the latest version" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -1363,18 +1363,18 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
 
     # Dependency doesn't consider metadata as part of equality checks
     # so this allows us to check that the metadata is updated in tests.
-    RSpec::Matchers.define :with_metadata do |expected|
+    RSpec::Matchers.define :including_metadata do |expected|
       match do |actual|
         actual == expected && actual.metadata == expected.metadata
       end
     end
 
-    def contain_exactly_with_metadata(*expected)
-      contain_exactly(*expected.map { |e| with_metadata(e) })
+    def contain_exactly_including_metadata(*expected)
+      contain_exactly(*expected.map { |e| including_metadata(e) })
     end
 
-    def eq_with_metadata(expected_array)
-      eq(expected_array).and contain_exactly_with_metadata(*expected_array)
+    def eq_including_metadata(expected_array)
+      eq(expected_array).and contain_exactly_including_metadata(*expected_array)
     end
 
     context "for a security update for a locked transitive dependency" do
@@ -1401,7 +1401,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
 
       it "correctly updates the transitive dependency" do
         expect(checker.send(:updated_dependencies_after_full_unlock)).
-          to eq_with_metadata([
+          to eq_including_metadata([
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-transitive-dependency",
               version: "1.0.1",
@@ -1443,7 +1443,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         let(:registry_listing_url) { "https://registry.npmjs.org/transitive-dependency-locked-by-intermediate" }
 
         it "correctly updates the transitive dependency" do
-          expect(checker.send(:updated_dependencies_after_full_unlock)).to eq_with_metadata([
+          expect(checker.send(:updated_dependencies_after_full_unlock)).to eq_including_metadata([
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-transitive-dependency",
               package_manager: "npm_and_yarn",
@@ -1470,7 +1470,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         let(:registry_listing_url) { "https://registry.npmjs.org/transitive-dependency-locked-by-multiple" }
 
         it "correctly updates the transitive dependency" do
-          expect(checker.send(:updated_dependencies_after_full_unlock)).to contain_exactly_with_metadata(
+          expect(checker.send(:updated_dependencies_after_full_unlock)).to contain_exactly_including_metadata(
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-parent-dependency",
               package_manager: "npm_and_yarn",
@@ -1566,7 +1566,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         end
 
         it "correctly updates the parent dependency and removes the transitive because removal is enabled" do
-          expect(checker.send(:updated_dependencies_after_full_unlock)).to contain_exactly_with_metadata(
+          expect(checker.send(:updated_dependencies_after_full_unlock)).to contain_exactly_including_metadata(
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-transitive-dependency",
               package_manager: "npm_and_yarn",
@@ -1628,7 +1628,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         end
 
         it "correctly updates the transitive dependency by unlocking the parent" do
-          expect(checker.send(:updated_dependencies_after_full_unlock)).to eq_with_metadata([
+          expect(checker.send(:updated_dependencies_after_full_unlock)).to eq_including_metadata([
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-transitive-dependency-with-more-versions",
               package_manager: "npm_and_yarn",

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -1361,6 +1361,22 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         )
     end
 
+    # Dependency doesn't consider metadata as part of equality checks
+    # so this allows us to check that the metadata is updated in tests.
+    RSpec::Matchers.define :with_metadata do |expected|
+      match do |actual|
+        actual == expected && actual.metadata == expected.metadata
+      end
+    end
+
+    def contain_exactly_with_metadata(*expected)
+      contain_exactly(*expected.map { |e| with_metadata(e) })
+    end
+
+    def eq_with_metadata(expected_array)
+      eq(expected_array).and contain_exactly_with_metadata(*expected_array)
+    end
+
     context "for a security update for a locked transitive dependency" do
       let(:dependency_files) { project_dependency_files("npm8/locked_transitive_dependency") }
       let(:registry_listing_url) { "https://registry.npmjs.org/locked-transitive-dependency" }
@@ -1385,14 +1401,15 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
 
       it "correctly updates the transitive dependency" do
         expect(checker.send(:updated_dependencies_after_full_unlock)).
-          to eq([
+          to eq_with_metadata([
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-transitive-dependency",
               version: "1.0.1",
               package_manager: "npm_and_yarn",
               previous_version: "1.0.0",
               requirements: [],
-              previous_requirements: []
+              previous_requirements: [],
+              metadata: { information_only: true }
             ),
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-parent-dependency",
@@ -1426,14 +1443,15 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         let(:registry_listing_url) { "https://registry.npmjs.org/transitive-dependency-locked-by-intermediate" }
 
         it "correctly updates the transitive dependency" do
-          expect(checker.send(:updated_dependencies_after_full_unlock)).to eq([
+          expect(checker.send(:updated_dependencies_after_full_unlock)).to eq_with_metadata([
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-transitive-dependency",
               package_manager: "npm_and_yarn",
               previous_requirements: [],
               previous_version: "1.0.0",
               requirements: [],
-              version: "1.0.1"
+              version: "1.0.1",
+              metadata: { information_only: true }
             ),
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-intermediate-dependency",
@@ -1452,7 +1470,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         let(:registry_listing_url) { "https://registry.npmjs.org/transitive-dependency-locked-by-multiple" }
 
         it "correctly updates the transitive dependency" do
-          expect(checker.send(:updated_dependencies_after_full_unlock)).to contain_exactly(
+          expect(checker.send(:updated_dependencies_after_full_unlock)).to contain_exactly_with_metadata(
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-parent-dependency",
               package_manager: "npm_and_yarn",
@@ -1531,7 +1549,8 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
               previous_requirements: [],
               previous_version: "1.0.0",
               requirements: [],
-              version: "1.0.1"
+              version: "1.0.1",
+              metadata: { information_only: true }
             )
           )
         end
@@ -1547,14 +1566,15 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         end
 
         it "correctly updates the parent dependency and removes the transitive because removal is enabled" do
-          expect(checker.send(:updated_dependencies_after_full_unlock)).to contain_exactly(
+          expect(checker.send(:updated_dependencies_after_full_unlock)).to contain_exactly_with_metadata(
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-transitive-dependency",
               package_manager: "npm_and_yarn",
               previous_requirements: [],
               previous_version: "1.0.0",
               requirements: [],
-              removed: true
+              removed: true,
+              metadata: { information_only: true }
             ),
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-remove-dependency",
@@ -1608,14 +1628,15 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
         end
 
         it "correctly updates the transitive dependency by unlocking the parent" do
-          expect(checker.send(:updated_dependencies_after_full_unlock)).to eq([
+          expect(checker.send(:updated_dependencies_after_full_unlock)).to eq_with_metadata([
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-transitive-dependency-with-more-versions",
               package_manager: "npm_and_yarn",
               previous_requirements: [],
               previous_version: "1.0.0",
               requirements: [],
-              version: "2.0.0"
+              version: "2.0.0",
+              metadata: { information_only: true }
             ),
             Dependabot::Dependency.new(
               name: "@dependabot-fixtures/npm-parent-dependency-with-more-versions",

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -736,7 +736,7 @@ module Dependabot
       # Ignore dependencies that are tagged as information_only. These will be
       # updated indirectly as a result of a parent dependency update and are
       # only included here to be included in the PR info.
-      deps_to_update = updated_dependencies.reject { |d| d.metadata[:information_only] }
+      deps_to_update = updated_dependencies.reject(&:informational_only?)
       updater = file_updater_for(deps_to_update)
       updater.updated_dependency_files
     end

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -733,9 +733,10 @@ module Dependabot
         logger_info("Updating #{dependency_names.join(', ')}")
       end
 
-      # Removal is only supported for transitive dependencies which are removed as a
-      # side effect of the parent update
-      deps_to_update = updated_dependencies.reject(&:removed?)
+      # Ignore dependencies that are tagged as information_only. These will be
+      # updated indirectly as a result of a parent dependency update and are
+      # only included here to be included in the PR info.
+      deps_to_update = updated_dependencies.reject { |d| d.metadata[:information_only] }
       updater = file_updater_for(deps_to_update)
       updater.updated_dependency_files
     end


### PR DESCRIPTION
When we need to update a parent dependency to fix an alert on a transitive child dependency we currently return both the parent & child as dependencies to update. Only the parent actually needs to be directly updated as its child dependencies will be automatically updated as part of that process. Still, we include the child dependency in the updated dependency list so it will be included in the PR title/description for context.

Since introducing https://github.com/dependabot/dependabot-core/pull/5822 that means we'll attempt to do a sub-dependency update of the child which has no effect.

This adds a flag to indicate dependencies returned by the updater that don't need to be directly updated and then filters them out before sending them to the FileUpdater. This also works for removed dependencies so we no longer need to filter them explicitly.

I'm making use of the new dependency metadata field that was added in https://github.com/dependabot/dependabot-core/pull/5801. It's currently meant for temporary data that doesn't need to be persisted or used in equals checks so I ended up working on some custom matchers to help validate the metadata output in tests. Let me know if theres a better way I could have done that!