### PR TITLE
Fixed disabledPackageSources for nuget.org

### DIFF
--- a/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/repository_finder_spec.rb
@@ -228,6 +228,84 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RepositoryFinder do
         )
       end
 
+      context "include the default repository" do
+        let(:config_file_fixture_name) { "include_default_disable_ext_sources.config" }
+
+        it "with disable external source" do
+          expect(dependency_urls).to match_array(
+            [{
+              repository_url: "https://www.myget.org/F/exceptionless/api/v3/" \
+                              "index.json",
+              versions_url: "https://www.myget.org/F/exceptionless/api/v3/" \
+                            "flatcontainer/microsoft.extensions." \
+                            "dependencymodel/index.json",
+              search_url: "https://www.myget.org/F/exceptionless/api/v3/" \
+                          "query?q=microsoft.extensions.dependencymodel" \
+                          "&prerelease=true&semVerLevel=2.0.0",
+              auth_header: { "Authorization" => "Basic bXk6cGFzc3cwcmQ=" },
+              repository_type: "v3"
+            }, {
+              repository_url: "https://api.nuget.org/v3/index.json",
+              versions_url: "https://api.nuget.org/v3-flatcontainer/" \
+                            "microsoft.extensions.dependencymodel/index.json",
+              search_url: "https://azuresearch-usnc.nuget.org/query" \
+                          "?q=microsoft.extensions.dependencymodel" \
+                          "&prerelease=true&semVerLevel=2.0.0",
+              auth_header: {},
+              repository_type: "v3"
+            }]
+          )
+        end
+      end
+
+      context "that overides the default package sources" do
+        let(:config_file_fixture_name) { "override_def_source_with_same_key.config" }
+
+        before do
+          repo_url = "https://www.myget.org/F/exceptionless/api/v3/index.json"
+          stub_request(:get, repo_url).
+            to_return(
+              status: 200,
+              body: fixture("nuget_responses", "myget_base.json")
+            )
+        end
+
+        it "when the default api key of defaut registry is provided without clear" do
+          expect(dependency_urls).to match_array(
+            [{
+              repository_url: "https://www.myget.org/F/exceptionless/api/v3/" \
+                              "index.json",
+              versions_url: "https://www.myget.org/F/exceptionless/api/v3/" \
+                            "flatcontainer/microsoft.extensions." \
+                            "dependencymodel/index.json",
+              search_url: "https://www.myget.org/F/exceptionless/api/v3/" \
+                          "query?q=microsoft.extensions.dependencymodel" \
+                          "&prerelease=true&semVerLevel=2.0.0",
+              auth_header: {},
+              repository_type: "v3"
+            }]
+          )
+        end
+
+        let(:config_file_fixture_name) { "override_def_source_with_same_key_default.config" }
+        it "when the default api key of defaut registry is provided with clear" do
+          expect(dependency_urls).to match_array(
+            [{
+              repository_url: "https://www.myget.org/F/exceptionless/api/v3/" \
+                              "index.json",
+              versions_url: "https://www.myget.org/F/exceptionless/api/v3/" \
+                            "flatcontainer/microsoft.extensions." \
+                            "dependencymodel/index.json",
+              search_url: "https://www.myget.org/F/exceptionless/api/v3/" \
+                          "query?q=microsoft.extensions.dependencymodel" \
+                          "&prerelease=true&semVerLevel=2.0.0",
+              auth_header: {},
+              repository_type: "v3"
+            }]
+          )
+        end
+      end
+
       context "that doesn't include the default repository" do
         let(:config_file_fixture_name) { "excludes_default.config" }
 
@@ -282,6 +360,27 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RepositoryFinder do
           let(:config_file_fixture_name) { "disabled_sources.config" }
 
           it "only includes the enabled package sources" do
+            expect(dependency_urls).to match_array(
+              [{
+                repository_url: "https://www.myget.org/F/exceptionless/api/v3/" \
+                                "index.json",
+                versions_url: "https://www.myget.org/F/exceptionless/api/v3/" \
+                              "flatcontainer/microsoft.extensions." \
+                              "dependencymodel/index.json",
+                search_url: "https://www.myget.org/F/exceptionless/api/v3/" \
+                            "query?q=microsoft.extensions.dependencymodel" \
+                            "&prerelease=true&semVerLevel=2.0.0",
+                auth_header: { "Authorization" => "Basic bXk6cGFzc3cwcmQ=" },
+                repository_type: "v3"
+              }]
+            )
+          end
+        end
+
+        context "that has disabled default package sources" do
+          let(:config_file_fixture_name) { "disabled_default_sources.config" }
+
+          it "only includes the enable package sources" do
             expect(dependency_urls).to match_array(
               [{
                 repository_url: "https://www.myget.org/F/exceptionless/api/v3/" \

--- a/nuget/spec/fixtures/configs/clears_default.config
+++ b/nuget/spec/fixtures/configs/clears_default.config
@@ -1,37 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <config>
-        <!--
-            Used to specify the default location to expand packages.
-            See: nuget.exe help install
-            See: nuget.exe help update
-
-            In this example, %PACKAGEHOME% is an environment variable. On Mac/Linux,
-            use $PACKAGE_HOME/External as the value.
-        -->
-        <add key="repositoryPath" value="%PACKAGEHOME%\External" />
-
-        <!--
-            Used to specify default source for the push command.
-            See: nuget.exe help push
-        -->
-
-        <add key="defaultPushSource" value="https://MyRepo/ES/api/v2/package" />
-
-        <!-- Proxy settings -->
-        <add key="http_proxy" value="host" />
-        <add key="http_proxy.user" value="username" />
-        <add key="http_proxy.password" value="encrypted_password" />
-    </config>
-
-    <packageRestore>
-        <!-- Allow NuGet to download missing packages -->
-        <add key="enabled" value="True" />
-
-        <!-- Automatically check for missing packages during build in Visual Studio -->
-        <add key="automatic" value="True" />
-    </packageRestore>
-
     <!--
         Used to specify the default Sources for list, install and update.
         See: nuget.exe help list
@@ -49,19 +17,9 @@
         <MyRepo_x0020_-_x0020_ES>
             <add key="Username" value="my" />
             <add key="ClearTextPassword" value="passw0rd" />
-        </Test_x0020_Source>
+        </MyRepo_x0020_-_x0020_ES>
     </packageSourceCredentials>
 
     <!-- Used to disable package sources  -->
     <disabledPackageSources />
-
-    <!--
-        Used to specify default API key associated with sources.
-        See: nuget.exe help setApiKey
-        See: nuget.exe help push
-        See: nuget.exe help mirror
-    -->
-    <apikeys>
-        <add key="https://MyRepo/ES/api/v2/package" value="encrypted_api_key" />
-    </apikeys>
 </configuration>

--- a/nuget/spec/fixtures/configs/disabled_default_sources.config
+++ b/nuget/spec/fixtures/configs/disabled_default_sources.config
@@ -7,10 +7,8 @@
         See: nuget.exe help update
     -->
     <packageSources>
-        <clear />
         <add key="MyRepo - ES" value="https://www.myget.org/F/exceptionless/api/v3/index.json" />
-        <add key="Local repo" value="lib" />
-        <add key="Some disabled source" value="https://disabled.example/api/v3/index.json" />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
 
     <!-- Used to store credentials -->
@@ -23,8 +21,7 @@
 
     <!-- Used to disable package sources  -->
     <disabledPackageSources>
-        <add key="Some disabled source" value="true" />
-        <add key="missing source" value="true" />
         <add key="MyRepo - ES" value="false" />
+        <add key="nuget.org" value="true" />
     </disabledPackageSources>
 </configuration>

--- a/nuget/spec/fixtures/configs/excludes_default.config
+++ b/nuget/spec/fixtures/configs/excludes_default.config
@@ -1,37 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <config>
-        <!--
-            Used to specify the default location to expand packages.
-            See: nuget.exe help install
-            See: nuget.exe help update
-
-            In this example, %PACKAGEHOME% is an environment variable. On Mac/Linux,
-            use $PACKAGE_HOME/External as the value.
-        -->
-        <add key="repositoryPath" value="%PACKAGEHOME%\External" />
-
-        <!--
-            Used to specify default source for the push command.
-            See: nuget.exe help push
-        -->
-
-        <add key="defaultPushSource" value="https://MyRepo/ES/api/v2/package" />
-
-        <!-- Proxy settings -->
-        <add key="http_proxy" value="host" />
-        <add key="http_proxy.user" value="username" />
-        <add key="http_proxy.password" value="encrypted_password" />
-    </config>
-
-    <packageRestore>
-        <!-- Allow NuGet to download missing packages -->
-        <add key="enabled" value="True" />
-
-        <!-- Automatically check for missing packages during build in Visual Studio -->
-        <add key="automatic" value="True" />
-    </packageRestore>
-
     <!--
         Used to specify the default Sources for list, install and update.
         See: nuget.exe help list
@@ -48,19 +16,9 @@
         <MyRepo_x0020_-_x0020_ES>
             <add key="Username" value="my" />
             <add key="ClearTextPassword" value="passw0rd" />
-        </Test_x0020_Source>
+        </MyRepo_x0020_-_x0020_ES>
     </packageSourceCredentials>
 
     <!-- Used to disable package sources  -->
     <disabledPackageSources />
-
-    <!--
-        Used to specify default API key associated with sources.
-        See: nuget.exe help setApiKey
-        See: nuget.exe help push
-        See: nuget.exe help mirror
-    -->
-    <apikeys>
-        <add key="https://MyRepo/ES/api/v2/package" value="encrypted_api_key" />
-    </apikeys>
 </configuration>

--- a/nuget/spec/fixtures/configs/include_default_disable_ext_sources.config
+++ b/nuget/spec/fixtures/configs/include_default_disable_ext_sources.config
@@ -7,10 +7,8 @@
         See: nuget.exe help update
     -->
     <packageSources>
-        <clear />
         <add key="MyRepo - ES" value="https://www.myget.org/F/exceptionless/api/v3/index.json" />
         <add key="Local repo" value="lib" />
-        <add key="Some disabled source" value="https://disabled.example/api/v3/index.json" />
     </packageSources>
 
     <!-- Used to store credentials -->
@@ -22,9 +20,7 @@
     </packageSourceCredentials>
 
     <!-- Used to disable package sources  -->
-    <disabledPackageSources>
-        <add key="Some disabled source" value="true" />
-        <add key="missing source" value="true" />
-        <add key="MyRepo - ES" value="false" />
+    <disabledPackageSources />
+        <add key="Local repo" value="false" />
     </disabledPackageSources>
 </configuration>

--- a/nuget/spec/fixtures/configs/nuget.config
+++ b/nuget/spec/fixtures/configs/nuget.config
@@ -49,7 +49,7 @@
         <MyRepo_x0020_-_x0020_ES>
             <add key="Username" value="my" />
             <add key="ClearTextPassword" value="passw0rd" />
-        </Test_x0020_Source>
+        </MyRepo_x0020_-_x0020_ES>
     </packageSourceCredentials>
 
     <!-- Used to disable package sources  -->

--- a/nuget/spec/fixtures/configs/override_def_source_with_same_key.config
+++ b/nuget/spec/fixtures/configs/override_def_source_with_same_key.config
@@ -7,10 +7,8 @@
         See: nuget.exe help update
     -->
     <packageSources>
-        <clear />
-        <add key="MyRepo - ES" value="https://www.myget.org/F/exceptionless/api/v3/index.json" />
+        <add key="nuget.org" value="https://www.myget.org/F/exceptionless/api/v3/index.json" />
         <add key="Local repo" value="lib" />
-        <add key="Some disabled source" value="https://disabled.example/api/v3/index.json" />
     </packageSources>
 
     <!-- Used to store credentials -->
@@ -22,9 +20,5 @@
     </packageSourceCredentials>
 
     <!-- Used to disable package sources  -->
-    <disabledPackageSources>
-        <add key="Some disabled source" value="true" />
-        <add key="missing source" value="true" />
-        <add key="MyRepo - ES" value="false" />
-    </disabledPackageSources>
+    <disabledPackageSources />
 </configuration>

--- a/nuget/spec/fixtures/configs/override_def_source_with_same_key_default.config
+++ b/nuget/spec/fixtures/configs/override_def_source_with_same_key_default.config
@@ -8,9 +8,8 @@
     -->
     <packageSources>
         <clear />
-        <add key="MyRepo - ES" value="https://www.myget.org/F/exceptionless/api/v3/index.json" />
+        <add key="nuget.org" value="https://www.myget.org/F/exceptionless/api/v3/index.json" />
         <add key="Local repo" value="lib" />
-        <add key="Some disabled source" value="https://disabled.example/api/v3/index.json" />
     </packageSources>
 
     <!-- Used to store credentials -->
@@ -22,9 +21,5 @@
     </packageSourceCredentials>
 
     <!-- Used to disable package sources  -->
-    <disabledPackageSources>
-        <add key="Some disabled source" value="true" />
-        <add key="missing source" value="true" />
-        <add key="MyRepo - ES" value="false" />
-    </disabledPackageSources>
+    <disabledPackageSources />
 </configuration>


### PR DESCRIPTION
In the nuget.config, adding the default public Nuget registry to `disabledPackageSources` section was not disabling it. Dependabot was still able to access the default public registry (nuget.org). 

With this modification, the dependabot won't contact the default public registry if a user disable the public nuget registry in the `disabledPackageSources` section even without using the `<clear />` tag in the nuget.config. [[ref](https://learn.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#example-nugetdefaultsconfig-and-application)]


