### PR TITLE
[npm] Randomize advisory id to avoid cache collisions across tests

### DIFF
--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.js
@@ -139,11 +139,6 @@ async function findVulnerableDependencies(directory, advisories) {
 }
 
 function convertAdvisoriesToRegistryBulkFormat(advisories) {
-  // npm audit differentiates advisories by `id`. In order to prevent
-  // advisories from being clobbered, we maintain a counter so that each
-  // advisory gets a unique `id`.
-  let nextAdvisoryId = 1
-
   return advisories.reduce((formattedAdvisories, advisory) => {
     if (!formattedAdvisories[advisory.dependency_name]) {
       formattedAdvisories[advisory.dependency_name] = []
@@ -151,7 +146,7 @@ function convertAdvisoriesToRegistryBulkFormat(advisories) {
     let formattedVersions =
       advisory.affected_versions.reduce((memo, version) => {
         memo.push({
-          id: nextAdvisoryId++,
+          id: Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
           vulnerable_versions: version
         })
         return memo


### PR DESCRIPTION
🤞 This fixes test failures seen when the tests are run in a particular order. Details of the advisories are being cached in the npm cache and shared across test runs. This can lead to faulty analysis of vulnerabilities in the tests because we were using the same advisory ids in each evaluation.

I didn't track down exactly where it goes wrong in the arborist code but I found that once I reproduced the failures locally with a particular test seed I could then reliably reproduce the failure on an individual test. After observing that the audit report didn't completely match up with the advisory I tried changing the advisory id and the test passed.