### PR TITLE
Fixing PR failures if pypi.org unavailable

### DIFF
--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -220,7 +220,7 @@ module Dependabot
         end
 
         def install_required_python
-          return if run_command("pyenv versions").include?("#{python_version}")
+          return if run_command("pyenv versions").include?(python_version.to_s)
 
           run_command("pyenv install -s #{python_version}")
           run_command("pyenv exec pip install --upgrade pip")

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -220,7 +220,7 @@ module Dependabot
         end
 
         def install_required_python
-          return if run_command("pyenv versions").include?(python_version.to_s)
+          return if run_command("pyenv versions").include?(python_version)
 
           run_command("pyenv install -s #{python_version}")
           run_command("pyenv exec pip install --upgrade pip")

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -449,8 +449,6 @@ module Dependabot
                 "--extra-index-url=#{authed_url}"
               end
             end
-          index_finder = Dependabot::Python::UpdateChecker::IndexFinder.new(dependency_files: dependency_files, credentials: credentials)
-          ["--index-url=#{index_finder.index_url_for_dependency('')}"]
         end
 
         def includes_unsafe_packages?(content)

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -220,7 +220,7 @@ module Dependabot
         end
 
         def install_required_python
-          return if run_command("pyenv versions").include?(" #{python_version}")
+          return if run_command("pyenv versions").include?("\ #{python_version}")
 
           run_command("pyenv install -s #{python_version}")
           run_command("pyenv exec pip install --upgrade pip")

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -220,7 +220,7 @@ module Dependabot
         end
 
         def install_required_python
-          return if run_command("pyenv versions").include?("#{python_version}\n")
+          return if run_command("pyenv versions").include?("#{python_version}")
 
           run_command("pyenv install -s #{python_version}")
           run_command("pyenv exec pip install --upgrade pip")
@@ -449,6 +449,8 @@ module Dependabot
                 "--extra-index-url=#{authed_url}"
               end
             end
+          index_finder = Dependabot::Python::UpdateChecker::IndexFinder.new(dependency_files: dependency_files, credentials: credentials)
+          ["--index-url=#{index_finder.index_url_for_dependency('')}"]
         end
 
         def includes_unsafe_packages?(content)

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -220,7 +220,7 @@ module Dependabot
         end
 
         def install_required_python
-          return if run_command("pyenv versions").include?(python_version)
+          return if run_command("pyenv versions").include?(" #{python_version}")
 
           run_command("pyenv install -s #{python_version}")
           run_command("pyenv exec pip install --upgrade pip")

--- a/python/lib/dependabot/python/metadata_finder.rb
+++ b/python/lib/dependabot/python/metadata_finder.rb
@@ -131,6 +131,8 @@ module Dependabot
           return @pypi_listing
         rescue JSON::ParserError
           next
+        rescue Excon::Error::Timeout
+          next
         end
 
         @pypi_listing = {} # No listing found

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -277,6 +277,8 @@ module Dependabot
 
         pypi_info = JSON.parse(index_response.body)["info"] || {}
         pypi_info["summary"] == details["description"]
+      rescue Excon::Error::Timeout
+        false
       rescue URI::InvalidURIError
         false
       end

--- a/python/lib/dependabot/python/update_checker/index_finder.rb
+++ b/python/lib/dependabot/python/update_checker/index_finder.rb
@@ -36,6 +36,9 @@ module Dependabot
           end.uniq
         end
 
+        def index_url_for_dependency(dependency_name)
+          return main_index_url if main_index_url
+        end
         private
 
         attr_reader :dependency_files, :credentials

--- a/python/lib/dependabot/python/update_checker/index_finder.rb
+++ b/python/lib/dependabot/python/update_checker/index_finder.rb
@@ -36,9 +36,6 @@ module Dependabot
           end.uniq
         end
 
-        def index_url_for_dependency(dependency_name)
-          return main_index_url if main_index_url
-        end
         private
 
         attr_reader :dependency_files, :credentials

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -244,8 +244,6 @@ module Dependabot
                 "--extra-index-url=#{authed_url}"
               end
             end
-          index_finder = IndexFinder.new(dependency_files: dependency_files, credentials: credentials)
-          ["--index-url=#{index_finder.index_url_for_dependency('')}"]
         end
 
         def run_pip_compile_command(command)

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -314,7 +314,7 @@ module Dependabot
         end
 
         def install_required_python
-          return if run_command("pyenv versions").include?(python_version.to_s)
+          return if run_command("pyenv versions").include?(python_version)
 
           run_command("pyenv install -s #{python_version}")
           run_command("pyenv exec pip install --upgrade pip")

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -314,7 +314,8 @@ module Dependabot
         end
 
         def install_required_python
-          return if run_command("pyenv versions").include?("#{python_version}")
+          return if run_command("pyenv versions").include?(python_version.to_s)
+
           run_command("pyenv install -s #{python_version}")
           run_command("pyenv exec pip install --upgrade pip")
           run_command("pyenv exec pip install -r" \

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -314,7 +314,7 @@ module Dependabot
         end
 
         def install_required_python
-          return if run_command("pyenv versions").include?(python_version)
+          return if run_command("pyenv versions").include?(" #{python_version}")
 
           run_command("pyenv install -s #{python_version}")
           run_command("pyenv exec pip install --upgrade pip")

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -244,6 +244,8 @@ module Dependabot
                 "--extra-index-url=#{authed_url}"
               end
             end
+          index_finder = IndexFinder.new(dependency_files: dependency_files, credentials: credentials)
+          ["--index-url=#{index_finder.index_url_for_dependency('')}"]
         end
 
         def run_pip_compile_command(command)
@@ -314,8 +316,7 @@ module Dependabot
         end
 
         def install_required_python
-          return if run_command("pyenv versions").include?("#{python_version}\n")
-
+          return if run_command("pyenv versions").include?("#{python_version}")
           run_command("pyenv install -s #{python_version}")
           run_command("pyenv exec pip install --upgrade pip")
           run_command("pyenv exec pip install -r" \

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -314,7 +314,7 @@ module Dependabot
         end
 
         def install_required_python
-          return if run_command("pyenv versions").include?(" #{python_version}")
+          return if run_command("pyenv versions").include?("\ #{python_version}")
 
           run_command("pyenv install -s #{python_version}")
           run_command("pyenv exec pip install --upgrade pip")

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -323,7 +323,7 @@ module Dependabot
             nil
           end
 
-          return if run_command("pyenv versions").include?("#{python_version}\n")
+          return if run_command("pyenv versions").include?("#{python_version}")
 
           requirements_path = NativeHelpers.python_requirements_path
           run_command("pyenv install -s #{python_version}")

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -323,7 +323,7 @@ module Dependabot
             nil
           end
 
-          return if run_command("pyenv versions").include?("#{python_version}")
+          return if run_command("pyenv versions").include?(python_version.to_s)
 
           requirements_path = NativeHelpers.python_requirements_path
           run_command("pyenv install -s #{python_version}")

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -323,7 +323,7 @@ module Dependabot
             nil
           end
 
-          return if run_command("pyenv versions").include?(python_version)
+          return if run_command("pyenv versions").include?(" #{python_version}")
 
           requirements_path = NativeHelpers.python_requirements_path
           run_command("pyenv install -s #{python_version}")

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -323,7 +323,7 @@ module Dependabot
             nil
           end
 
-          return if run_command("pyenv versions").include?(" #{python_version}")
+          return if run_command("pyenv versions").include?("\ #{python_version}")
 
           requirements_path = NativeHelpers.python_requirements_path
           run_command("pyenv install -s #{python_version}")

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -323,7 +323,7 @@ module Dependabot
             nil
           end
 
-          return if run_command("pyenv versions").include?(python_version.to_s)
+          return if run_command("pyenv versions").include?(python_version)
 
           requirements_path = NativeHelpers.python_requirements_path
           run_command("pyenv install -s #{python_version}")


### PR DESCRIPTION
## Context

There are many ways to specify an alternate pypi index in Python depending on the package manager, for the most part we attempt to parse these settings from pyproject.toml, pip.conf, and requirements.txt settings.  If the project specifies an alternate index url we shouldn't call the public pypi.org index.

There are a number of calls we make to pypi.org to retrieve data that is only available there (primarily the `<package name>/json` metadata endpoint).  These calls currently cause PR creation to fail if pypi.org is unavailable or otherwise blocked/firewalled.  We should be able to generate a PR given a private index even if pypi.org is unavailable.

## Approach

There are 3 classes of issues I found in attempting to run updates without pypi.org access:
1) Failures to get metadata from pypi.org resulted in failed PR creation
2) Our python version detection was failing to detect already installed python versions resulting in extra attempts to install python and pip from pypi.org
3) pip-compile is not properly injecting an alternate index url provided in a requirements.txt file

I've added a couple rescues to catch timeouts so failed attempts to reach pypi.org do not crash pr creation.  These could probably be expanded further to include other network errors (SocketError maybe?)

Calls to `pyenv versions` were always failing to find installed python for pipenv and pip-compile as they were expecting a newline which is no longer in the output.  This "fix" only resolves the issue if the repo is using a version of python we have pre-installed.

I have not attempted to address point 3 above yet, I added a partial solution of exposing the `main_url` from `IndexFinder` via a new public method on `IndexFinder` and this worked, however it would require a larger change to properly set this in context with `replaces_base` and I feel there might be better options to explore around parsing the exact command pip-compile recommends from the requirements.txt file.  Since pip-compile supports multiple source files (requirements.in, setup.py, and pyproject.toml) we should probably take a more holistic approach here. 