### PR TITLE
Fix Maven inability to overwrite repository urls by ID

### DIFF
--- a/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
+++ b/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
@@ -24,6 +24,7 @@ module Dependabot
         # The Central Repository is included in the Super POM, which is
         # always inherited from.
         CENTRAL_REPO_URL = "https://repo.maven.apache.org/maven2"
+        SUPER_POM = { url: CENTRAL_REPO_URL, id: "central" }
 
         def initialize(dependency_files:, evaluate_properties: true)
           @dependency_files = dependency_files
@@ -36,26 +37,38 @@ module Dependabot
 
         # Collect all repository URLs from this POM and its parents
         def repository_urls(pom:, exclude_inherited: false)
-          repo_urls_in_pom =
-            Nokogiri::XML(pom.content).
-            css(REPOSITORY_SELECTOR).
-            map { |node| node.at_css("url").content.strip.gsub(%r{/$}, "") }.
-            reject { |url| contains_property?(url) && !evaluate_properties? }.
-            select { |url| url.start_with?("http") }.
-            map { |url| evaluated_value(url, pom) }
+          entries = gather_repository_urls(pom: pom, exclude_inherited: exclude_inherited)
+          ids = Set.new
+          entries.map do |entry|
+            next if entry[:id] && ids.include?(entry[:id])
 
-          return repo_urls_in_pom + [CENTRAL_REPO_URL] if exclude_inherited
-
-          unless (parent = parent_pom(pom, repo_urls_in_pom))
-            return repo_urls_in_pom + [CENTRAL_REPO_URL]
-          end
-
-          repo_urls_in_pom + repository_urls(pom: parent)
+            ids.add(entry[:id]) unless entry[:id].nil?
+            entry[:url]
+          end.uniq.compact
         end
 
         private
 
         attr_reader :dependency_files
+
+        def gather_repository_urls(pom:, exclude_inherited: false)
+          repos_in_pom =
+            Nokogiri::XML(pom.content).
+            css(REPOSITORY_SELECTOR).
+            map { |node| { url: node.at_css("url").content.strip, id: node.at_css("id").content.strip } }.
+            reject { |entry| contains_property?(entry[:url]) && !evaluate_properties? }.
+            select { |entry| entry[:url].start_with?("http") }.
+            map { |entry| { url: evaluated_value(entry[:url], pom).gsub(%r{/$}, ""), id: entry[:id] } }
+
+          return repos_in_pom + [SUPER_POM] if exclude_inherited
+
+          urls_in_pom = repos_in_pom.map { |repo| repo[:url] }
+          unless (parent = parent_pom(pom, urls_in_pom))
+            return repos_in_pom + [SUPER_POM]
+          end
+
+          repos_in_pom + gather_repository_urls(pom: parent)
+        end
 
         def evaluate_properties?
           @evaluate_properties

--- a/maven/spec/dependabot/maven/file_parser/repositories_finder_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser/repositories_finder_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe Dependabot::Maven::FileParser::RepositoriesFinder do
         )
       end
 
+      context "that overwrites central" do
+        let(:base_pom_fixture_name) { "overwrite_central_pom.xml" }
+
+        it "does not include central" do
+          expect(repository_urls).to eq(
+            %w(
+              https://example.com
+            )
+          )
+        end
+      end
+
       context "that use properties" do
         let(:base_pom_fixture_name) { "property_repo_pom.xml" }
 

--- a/maven/spec/fixtures/poms/overwrite_central_pom.xml
+++ b/maven/spec/fixtures/poms/overwrite_central_pom.xml
@@ -12,16 +12,13 @@
 
   <repositories>
     <repository>
-      <id>wrong</id>
-      <url>http://host:port/content/groups/public</url>
+      <id>central</id>
+      <url>https://example.com</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </repository>
   </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>wrong</id>
-      <url>http://host:port/content/groups/public</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
In Maven, it is possible to overwrite repository URLs defined elsewhere by defining a repository with the same ID, as long as the file has precedence according to the [order defined in the docs](https://maven.apache.org/guides/mini/guide-multiple-repositories.html#repository-order).

This is often used to define a different central repository to replace the default one inherited from the Super POM:

```xml
<repositories>
    <repository>
      <id>central</id>
      <url>https://example.com</url>
      <snapshots>
        <enabled>false</enabled>
      </snapshots>
    </repository>
  </repositories>
```

In this PR, I've tried to honor that behavior by gathering the IDs along with the URL and deduplicate by ID according to that precedence.

One caveat is that Maven differentiates between repository and pluginRepository. Our code does not, so if central is overwritten in a repository it will also overwrite it in pluginRepository. It seems somewhat unlikely that only one or the other is overwritten, so I think this is probably ok for now.