### PR TITLE
Make `script/dependabot --help` actually work

### DIFF
--- a/script/dependabot
+++ b/script/dependabot
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-dependabot "$@" \
+dependabot \
   -v "$(pwd)"/.core-bash_history:/home/dependabot/.bash_history \
   -v "$(pwd)"/updater/bin:/home/dependabot/dependabot-updater/bin \
   -v "$(pwd)"/updater/lib:/home/dependabot/dependabot-updater/lib \
@@ -21,4 +21,5 @@ dependabot "$@" \
   -v "$(pwd)"/nuget:/home/dependabot/nuget \
   -v "$(pwd)"/pub:/home/dependabot/pub \
   -v "$(pwd)"/python:/home/dependabot/python \
-  -v "$(pwd)"/terraform:/home/dependabot/terraform
+  -v "$(pwd)"/terraform:/home/dependabot/terraform \
+  "$@"


### PR DESCRIPTION
Without this change I get

```
$ script/dependabot --help
Error: unknown command "/Users/deivid/Code/dependabot/dependabot-core/.core-bash_history:/home/dependabot/.bash_history" for "dependabot"
Run 'dependabot --help' for usage.
```

With this change

```
$ script/dependabot --help
Run Dependabot jobs from the command line.

Usage:
  dependabot [command]

Examples:
$ dependabot update go_modules rsc/quote --dry-run
$ dependabot test -f input.yml

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  test        Test scenarios
  update      Perform update job

Flags:
  -h, --help                   help for dependabot
      --proxy-image string     container image to use for the proxy (default "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest")
      --temp-dir string        path to the temporary directory for the job (default "tmp")
      --updater-image string   container image to use for the updater (default "ghcr.io/dependabot/dependabot-updater:latest")
  -v, --version                version for dependabot

Use "dependabot [command] --help" for more information about a command.
```