### PR TITLE
add Maven credential metadata to the URLs it searches for POM files

### DIFF
--- a/maven/lib/dependabot/maven/file_parser/property_value_finder.rb
+++ b/maven/lib/dependabot/maven/file_parser/property_value_finder.rb
@@ -17,8 +17,9 @@ module Dependabot
 
         DOT_SEPARATOR_REGEX = %r{\.(?!\d+([.\/_\-]|$)+)}.freeze
 
-        def initialize(dependency_files:)
+        def initialize(dependency_files:, credentials: [])
           @dependency_files = dependency_files
+          @credentials = credentials
         end
 
         def property_details(property_name:, callsite_pom:)
@@ -119,6 +120,7 @@ module Dependabot
           @repositories_finder ||=
             RepositoriesFinder.new(
               dependency_files: dependency_files,
+              credentials: @credentials,
               evaluate_properties: false
             )
         end

--- a/maven/spec/dependabot/maven/file_parser/repositories_finder_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser/repositories_finder_spec.rb
@@ -5,8 +5,13 @@ require "dependabot/dependency_file"
 require "dependabot/maven/file_parser/repositories_finder"
 
 RSpec.describe Dependabot::Maven::FileParser::RepositoriesFinder do
-  let(:finder) { described_class.new(dependency_files: dependency_files) }
-
+  let(:finder) do
+    described_class.new(
+      dependency_files: dependency_files,
+      credentials: credentials
+    )
+  end
+  let(:credentials) { [] }
   let(:dependency_files) { [base_pom] }
   let(:base_pom) do
     Dependabot::DependencyFile.new(
@@ -46,6 +51,25 @@ RSpec.describe Dependabot::Maven::FileParser::RepositoriesFinder do
           expect(repository_urls).to eq(
             %w(
               https://example.com
+            )
+          )
+        end
+      end
+
+      context "with credentials" do
+        let(:base_pom_fixture_name) { "basic_pom.xml" }
+        let(:credentials) do
+          [
+            { "type" => "maven_repository", "url" => "https://example.com" },
+            { "type" => "git_source", "url" => "https://github.com" } # ignored since it's not maven
+          ]
+        end
+
+        it "adds the credential urls first" do
+          expect(repository_urls).to eq(
+            %w(
+              https://example.com
+              https://repo.maven.apache.org/maven2
             )
           )
         end


### PR DESCRIPTION
Currently Dependabot uses any repository or pluginRepository URL it finds in the POM to search for parent POM files. However, there is no reason a child POM needs to have any repositories defined at all. It's fairly common for private/custom registries to only be defined in the parent which is published to the registry. 

The reason why this works locally for Maven users is they often have a `settings.xml` which defines what registry to use, but that file isn't typically checked in to git.

Dependabot users commonly try to put the registry in `dependabot.yml` as a hint to where it can find the parent POM.

This PR takes that hint and puts Maven registries defined in `dependabot.yml` at the front of the list of registries to check.