### PR TITLE
Never change version precision of actions chosen by users

### DIFF
--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -98,23 +98,13 @@ module Dependabot
           latest_tags = git_commit_checker.local_tags_for_latest_version_commit_sha
 
           # Find the latest version with the same precision as the pinned version.
-          # Falls back to a version with the closest precision if no exact match.
-          current_dots = dependency.version.split(".").length
-          latest_tags.max do |a, b|
-            next a[:version] <=> b[:version] unless shortened_semver_version_eq?(a[:version], b[:version])
-
-            a_dots = a[:version].to_s.split(".").length
-            b_dots = b[:version].to_s.split(".").length
-            a_diff = (a_dots - current_dots).abs
-            b_diff = (b_dots - current_dots).abs
-            next -(a_diff <=> b_diff) unless a_diff == b_diff
-
-            # preference to a less specific version if we have a tie
-            next 1 if a_dots < current_dots
-
-            -1
-          end
+          current_precision = precision(dependency.version)
+          latest_tags.select { |tag| precision(tag[:version].to_s) == current_precision }.max_by { |tag| tag[:version] }
         end
+      end
+
+      def precision(version)
+        version.split(".").length
       end
 
       def updated_source
@@ -191,13 +181,6 @@ module Dependabot
         return false unless base_split.length <= other_split.length
 
         other_split[0..base_split.length - 1] == base_split
-      end
-
-      def shortened_semver_version_eq?(base_version, other_version)
-        base = base_version.to_s
-        other = other_version.to_s
-
-        shortened_semver_eq?(base, other) || shortened_semver_eq?(other, base)
       end
 
       def find_container_branch(sha)

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -303,8 +303,8 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         let(:reference) { "v1" }
         let(:latest_versions) { ["2.1", "2.1.0"] }
 
-        it "chooses the closest precision version" do
-          expect(subject).to eq(Dependabot::GithubActions::Version.new("2.1"))
+        it "does not choose a version with different precision" do
+          expect(subject).to be_nil
         end
       end
 
@@ -312,8 +312,8 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         let(:reference) { "v1.0" }
         let(:latest_versions) { ["2", "2.1.0"] }
 
-        it "choses the lower precision version when equidistant" do
-          expect(subject).to eq(Dependabot::GithubActions::Version.new("2"))
+        it "does not choose a version with different precision" do
+          expect(subject).to be_nil
         end
       end
 
@@ -321,17 +321,17 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         let(:reference) { "v1.0.0" }
         let(:latest_versions) { ["2", "2.1"] }
 
-        it "chooses the closest precision version" do
-          expect(subject).to eq(Dependabot::GithubActions::Version.new("2.1"))
+        it "does not choose a version with different precision" do
+          expect(subject).to be_nil
         end
       end
 
-      context "when a lower version is tagged to the same commit" do
+      context "using the full version" do
         let(:reference) { "v1.0.0" }
         let(:latest_versions) { ["1.0.5", "2", "2.1"] }
 
-        it "chooses the closest precision of the latest version" do
-          expect(subject).to eq(Dependabot::GithubActions::Version.new("2.1"))
+        it "chooses a higher version with the same precision" do
+          expect(subject).to eq(Dependabot::GithubActions::Version.new("1.0.5"))
         end
       end
     end


### PR DESCRIPTION
Never changing the existing version precision is our default behavior, however there's one edge case where Dependabot may actually propose a PR changing the precision.

This is only in the interim between the time where a new major version of the action has been released, but the action's author has not yet created a new major version tag pointing to the new release.

If Dependabot happens to run between the above two events, it will create a PR changing the precision from vX to vX.Y.Z, just because it's unable to find any versions with the same precision.

I think this in never what users expect, and it introduces inconsistent behavior in Dependabot, not dependent of the state of the manifest files, but on external circumstances which is confusing. On top of that, the issue will be automatically "fixed" next time Dependabot runs, once the actions author has created the proper major version tag.

I'm aware that I'm changing expectations of existing specs here, but I don't think this is intended after all. These specs where initially added [here](https://github.com/dependabot/dependabot-core/pull/4953), precisely to fix "precision being changed" issues. The few specs that I'm tweaking I think may have been added to have a nice fallback behavior when tags with the same precision are not available. However, in practice users still don't want this since the valid edge cases where this happens are only temporary.

So I think it's best to simplify this code to filter out versions not fully matching existing precision, and then choose the latest over what's left.

Fixes #5887.
Closes #2304.