### PR TITLE
Revert lockfile-only changes

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -114,6 +114,7 @@ $options = {
   cache_steps: [],
   write: false,
   clone: false,
+  lockfile_only: false,
   reject_external_code: false,
   requirements_update_strategy: nil,
   commit: nil,
@@ -184,11 +185,15 @@ option_parse = OptionParser.new do |opts|
     $options[:write] = true
   end
 
+  opts.on("--lockfile-only", "Only update the lockfile") do |_value|
+    $options[:lockfile_only] = true
+  end
+
   opts.on("--reject-external-code", "Reject external code") do |_value|
     $options[:reject_external_code] = true
   end
 
-  opts_req_desc = "Options: lockfile_only, auto, widen_ranges, bump_versions or " \
+  opts_req_desc = "Options: auto, widen_ranges, bump_versions or " \
                   "bump_versions_if_necessary"
   opts.on("--requirements-update-strategy STRATEGY", opts_req_desc) do |value|
     value = nil if value == "auto"
@@ -696,7 +701,7 @@ dependencies.each do |dep|
   end
 
   requirements_to_unlock =
-    if !checker.requirements_unlocked_or_can_be?
+    if $options[:lockfile_only] || !checker.requirements_unlocked_or_can_be?
       if checker.can_update?(requirements_to_unlock: :none) then :none
       else
         :update_not_possible

--- a/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
@@ -9,7 +9,7 @@ module Dependabot
         class UnfixableRequirement < StandardError; end
 
         ALLOWED_UPDATE_STRATEGIES =
-          %i(lockfile_only bump_versions bump_versions_if_necessary).freeze
+          %i(bump_versions bump_versions_if_necessary).freeze
 
         def initialize(requirements:, update_strategy:, updated_source:,
                        latest_version:, latest_resolvable_version:)
@@ -27,8 +27,6 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == :lockfile_only
-
           requirements.map do |req|
             if req[:file].include?(".gemspec")
               update_gemspec_requirement(req)

--- a/bundler/spec/dependabot/bundler/update_checker/requirements_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/requirements_updater_spec.rb
@@ -505,13 +505,5 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::RequirementsUpdater do
         end
       end
     end
-
-    context "when lockfile_only configured" do
-      let(:update_strategy) { :lockfile_only }
-
-      it "does not change any requirements" do
-        expect(updated_requirements).to eq(requirements)
-      end
-    end
   end
 end

--- a/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
@@ -18,7 +18,7 @@ module Dependabot
 
         VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-*]+)*/.freeze
         ALLOWED_UPDATE_STRATEGIES =
-          %i(lockfile_only bump_versions bump_versions_if_necessary).freeze
+          %i(bump_versions bump_versions_if_necessary).freeze
 
         def initialize(requirements:, updated_source:, update_strategy:,
                        target_version:)
@@ -34,8 +34,6 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == :lockfile_only
-
           # NOTE: Order is important here. The FileUpdater needs the updated
           # requirement at index `i` to correspond to the previous requirement
           # at the same index.

--- a/cargo/spec/dependabot/cargo/update_checker/requirements_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/requirements_updater_spec.rb
@@ -363,13 +363,5 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::RequirementsUpdater do
         end
       end
     end
-
-    context "for a lockfile_only strategy" do
-      let(:update_strategy) { :lockfile_only }
-
-      it "does not change any requirements" do
-        expect(updater.updated_requirements).to eq(requirements)
-      end
-    end
   end
 end

--- a/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
+++ b/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
@@ -21,7 +21,7 @@ module Dependabot
         OR_SEPARATOR = /(?<=[a-zA-Z0-9*])[\s,]*\|\|?\s*/.freeze
         SEPARATOR = /(?:#{AND_SEPARATOR})|(?:#{OR_SEPARATOR})/.freeze
         ALLOWED_UPDATE_STRATEGIES =
-          %i(lockfile_only widen_ranges bump_versions bump_versions_if_necessary).freeze
+          %i(widen_ranges bump_versions bump_versions_if_necessary).freeze
 
         def initialize(requirements:, update_strategy:,
                        latest_resolvable_version:)
@@ -37,7 +37,6 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == :lockfile_only
           return requirements unless latest_resolvable_version
 
           requirements.map { |req| updated_requirement(req) }

--- a/composer/spec/dependabot/composer/update_checker/requirements_updater_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/requirements_updater_spec.rb
@@ -705,13 +705,5 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
         end
       end
     end
-
-    context "with lockfile_only as the update strategy" do
-      let(:update_strategy) { :lockfile_only }
-
-      it "does not update any requirements" do
-        expect(updater.updated_requirements).to eq(requirements)
-      end
-    end
   end
 end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
@@ -16,7 +16,7 @@ module Dependabot
         VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-_]+)*/.freeze
         SEPARATOR = /(?<=[a-zA-Z0-9*])[\s|]+(?![\s|-])/.freeze
         ALLOWED_UPDATE_STRATEGIES =
-          %i(lockfile_only widen_ranges bump_versions bump_versions_if_necessary).freeze
+          %i(widen_ranges bump_versions bump_versions_if_necessary).freeze
 
         def initialize(requirements:, updated_source:, update_strategy:,
                        latest_resolvable_version:)
@@ -33,8 +33,6 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == :lockfile_only
-
           requirements.map do |req|
             req = req.merge(source: updated_source)
             next req unless latest_resolvable_version

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/requirements_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/requirements_updater_spec.rb
@@ -606,13 +606,5 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
         end
       end
     end
-
-    context "for a requirement being left alone" do
-      let(:update_strategy) { :lockfile_only }
-
-      it "does not update any requirements" do
-        expect(updater.updated_requirements).to eq(requirements)
-      end
-    end
   end
 end

--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -30,8 +30,6 @@ module Dependabot
         end
 
         def updated_requirements
-          return requirements if update_strategy == :lockfile_only
-
           requirements.map do |req|
             case req[:file]
             when /setup\.(?:py|cfg)$/ then updated_setup_requirement(req)

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -635,14 +635,6 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           end
         end
       end
-
-      context "when asked to not change requirements" do
-        let(:update_strategy) { :lockfile_only }
-
-        it "does not update any requirements" do
-          expect(updated_requirements).to eq(requirements)
-        end
-      end
     end
   end
 end

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -26,7 +26,7 @@ module Dependabot
       @lockfile_only                = attributes.fetch(:lockfile_only)
       @package_manager              = attributes.fetch(:package_manager)
       @reject_external_code         = attributes.fetch(:reject_external_code, false)
-      @requirements_update_strategy = build_update_strategy(attributes.fetch(:requirements_update_strategy))
+      @requirements_update_strategy = attributes.fetch(:requirements_update_strategy)
       @security_advisories          = attributes.fetch(:security_advisories)
       @security_updates_only        = attributes.fetch(:security_updates_only)
       @source                       = build_source(attributes.fetch(:source))
@@ -41,6 +41,10 @@ module Dependabot
     def clone?
       vendor_dependencies? ||
         Dependabot::Utils.always_clone_for_package_manager?(@package_manager)
+    end
+
+    def lockfile_only?
+      @lockfile_only
     end
 
     def updating_a_pull_request?
@@ -154,12 +158,6 @@ module Dependabot
         name_normaliser.call(name1),
         name_normaliser.call(name2)
       )
-    end
-
-    def build_update_strategy(requirements_update_strategy)
-      return requirements_update_strategy unless requirements_update_strategy.nil?
-
-      @lockfile_only ? "lockfile_only" : nil
     end
 
     def build_source(source_details)

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -472,7 +472,7 @@ module Dependabot
     end
 
     def requirements_to_unlock(checker)
-      if !checker.requirements_unlocked_or_can_be?
+      if job.lockfile_only? || !checker.requirements_unlocked_or_can_be?
         if checker.can_update?(requirements_to_unlock: :none) then :none
         else
           :update_not_possible

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Dependabot::Job do
         "username" => "x-access-token",
         "password" => "github-token"
       }],
-      lockfile_only: lockfile_only,
+      lockfile_only: false,
       requirements_update_strategy: nil,
       update_subdependencies: false,
       updating_a_pull_request: false,
@@ -45,7 +45,6 @@ RSpec.describe Dependabot::Job do
   let(:dependencies) { nil }
   let(:security_advisories) { [] }
   let(:package_manager) { "bundler" }
-  let(:lockfile_only) { false }
   let(:security_updates_only) { false }
   let(:allowed_updates) do
     [
@@ -62,14 +61,6 @@ RSpec.describe Dependabot::Job do
   let(:experiments) { nil }
   let(:commit_message_options) { nil }
   let(:vendor_dependencies) { false }
-
-  context "when lockfile_only is passed as true" do
-    let(:lockfile_only) { true }
-
-    it "infers a lockfile_only requirements_update_strategy" do
-      expect(subject.requirements_update_strategy).to eq("lockfile_only")
-    end
-  end
 
   describe "#allowed_update?" do
     subject { job.allowed_update?(dependency) }

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -291,20 +291,6 @@ RSpec.describe Dependabot::Updater do
       end
     end
 
-    context "when lockfile_only is set in the job" do
-      let(:lockfile_only) { true }
-
-      it "still tries to unlock requirements of dependencies" do
-        allow(checker).
-          to receive(:can_update?).with(requirements_to_unlock: :own).
-          and_return(true)
-        expect(logger).
-          to receive(:info).
-          with("<job_1> Requirements to unlock own")
-        updater.run
-      end
-    end
-
     context "when no dependencies are allowed" do
       let(:allowed_updates) { [{ "dependency-name" => "typoed-dep-name" }] }
 


### PR DESCRIPTION
Revert "Merge pull request #5581 from dependabot/deivid-rodriguez/lockfile-only-bug"

This reverts commit 2f14e446f1cccb6e6d3983413ef07f6e96b0829b, reversing changes made to 5ae1a8c240a1cdc45545672200ac8f0f80323094.

This has caused some regressions, which are actually worse than the bug originally fixed.

I'm working on fixing those regressions right now, but I'd rather work on them without the pressure of those regressions hitting more people.

Closes #5892.
Tentatively closes #5890 .
Reopens #5569.