### PR TITLE
Fix `lockfile-only` versioning strategy not creating some updates that are expected (v2)

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -115,7 +115,6 @@ $options = {
   cache_steps: [],
   write: false,
   clone: false,
-  lockfile_only: false,
   reject_external_code: false,
   requirements_update_strategy: nil,
   commit: nil,
@@ -186,15 +185,11 @@ option_parse = OptionParser.new do |opts|
     $options[:write] = true
   end
 
-  opts.on("--lockfile-only", "Only update the lockfile") do |_value|
-    $options[:lockfile_only] = true
-  end
-
   opts.on("--reject-external-code", "Reject external code") do |_value|
     $options[:reject_external_code] = true
   end
 
-  opts_req_desc = "Options: auto, widen_ranges, bump_versions or " \
+  opts_req_desc = "Options: lockfile_only, auto, widen_ranges, bump_versions or " \
                   "bump_versions_if_necessary"
   opts.on("--requirements-update-strategy STRATEGY", opts_req_desc) do |value|
     value = nil if value == "auto"
@@ -695,7 +690,7 @@ dependencies.each do |dep|
   puts " => latest allowed version is #{latest_allowed_version || dep.version}"
 
   requirements_to_unlock =
-    if $options[:lockfile_only] || !checker.requirements_unlocked_or_can_be?
+    if !checker.requirements_unlocked_or_can_be?
       if checker.can_update?(requirements_to_unlock: :none) then :none
       else
         :update_not_possible

--- a/bundler/lib/dependabot/bundler/update_checker.rb
+++ b/bundler/lib/dependabot/bundler/update_checker.rb
@@ -73,8 +73,10 @@ module Dependabot
       end
 
       def requirements_unlocked_or_can_be?
-        dependency.requirements.
-          select { |r| requirement_class.new(r[:requirement]).specific? }.
+        return true if requirements_unlocked?
+        return false if requirements_update_strategy == :lockfile_only
+
+        dependency.specific_requirements.
           all? do |req|
             file = dependency_files.find { |f| f.name == req.fetch(:file) }
             updated = FileUpdater::RequirementReplacer.new(
@@ -108,6 +110,10 @@ module Dependabot
       end
 
       private
+
+      def requirements_unlocked?
+        dependency.specific_requirements.none?
+      end
 
       def latest_version_resolvable_with_full_unlock?
         return false unless latest_version

--- a/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
@@ -9,7 +9,7 @@ module Dependabot
         class UnfixableRequirement < StandardError; end
 
         ALLOWED_UPDATE_STRATEGIES =
-          %i(bump_versions bump_versions_if_necessary).freeze
+          %i(lockfile_only bump_versions bump_versions_if_necessary).freeze
 
         def initialize(requirements:, update_strategy:, updated_source:,
                        latest_version:, latest_resolvable_version:)
@@ -27,6 +27,8 @@ module Dependabot
         end
 
         def updated_requirements
+          return requirements if update_strategy == :lockfile_only
+
           requirements.map do |req|
             if req[:file].include?(".gemspec")
               update_gemspec_requirement(req)

--- a/bundler/spec/dependabot/bundler/update_checker/requirements_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/requirements_updater_spec.rb
@@ -505,5 +505,13 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::RequirementsUpdater do
         end
       end
     end
+
+    context "when lockfile_only configured" do
+      let(:update_strategy) { :lockfile_only }
+
+      it "does not change any requirements" do
+        expect(updated_requirements).to eq(requirements)
+      end
+    end
   end
 end

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       dependency_files: dependency_files,
       credentials: credentials,
       ignored_versions: ignored_versions,
-      security_advisories: security_advisories
+      security_advisories: security_advisories,
+      requirements_update_strategy: requirements_update_strategy
     )
   end
   let(:credentials) do
@@ -33,6 +34,7 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
   let(:directory) { "/" }
   let(:ignored_versions) { [] }
   let(:security_advisories) { [] }
+  let(:requirements_update_strategy) { nil }
 
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -1795,6 +1797,12 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
       end
 
       it { is_expected.to eq(true) }
+
+      context "and with the lockfile-only requirements update strategy set" do
+        let(:requirements_update_strategy) { :lockfile_only }
+
+        it { is_expected.to eq(true) }
+      end
     end
 
     context "with a sub-dependency" do
@@ -1820,6 +1828,12 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
         let(:req) { "> 1.0.0, < 1.5.0" }
 
         it { is_expected.to eq(true) }
+      end
+
+      context "but with the lockfile-only requirements update strategy set" do
+        let(:requirements_update_strategy) { :lockfile_only }
+
+        it { is_expected.to eq(false) }
       end
     end
 

--- a/cargo/lib/dependabot/cargo/update_checker.rb
+++ b/cargo/lib/dependabot/cargo/update_checker.rb
@@ -76,6 +76,10 @@ module Dependabot
       end
 
       def requirements_update_strategy
+        # If passed in as an option (in the base class) honour that option
+        return @requirements_update_strategy.to_sym if @requirements_update_strategy
+
+        # Otherwise, widen ranges for libraries and bump versions for apps
         library? ? :bump_versions_if_necessary : :bump_versions
       end
 

--- a/cargo/lib/dependabot/cargo/update_checker.rb
+++ b/cargo/lib/dependabot/cargo/update_checker.rb
@@ -75,6 +75,10 @@ module Dependabot
         ).updated_requirements
       end
 
+      def requirements_unlocked_or_can_be?
+        requirements_update_strategy != :lockfile_only
+      end
+
       def requirements_update_strategy
         # If passed in as an option (in the base class) honour that option
         return @requirements_update_strategy.to_sym if @requirements_update_strategy

--- a/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
@@ -18,7 +18,7 @@ module Dependabot
 
         VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-*]+)*/
         ALLOWED_UPDATE_STRATEGIES =
-          %i(bump_versions bump_versions_if_necessary).freeze
+          %i(lockfile_only bump_versions bump_versions_if_necessary).freeze
 
         def initialize(requirements:, updated_source:, update_strategy:,
                        target_version:)
@@ -34,6 +34,8 @@ module Dependabot
         end
 
         def updated_requirements
+          return requirements if update_strategy == :lockfile_only
+
           # NOTE: Order is important here. The FileUpdater needs the updated
           # requirement at index `i` to correspond to the previous requirement
           # at the same index.

--- a/cargo/spec/dependabot/cargo/update_checker/requirements_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/requirements_updater_spec.rb
@@ -363,5 +363,13 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::RequirementsUpdater do
         end
       end
     end
+
+    context "for a lockfile_only strategy" do
+      let(:update_strategy) { :lockfile_only }
+
+      it "does not change any requirements" do
+        expect(updater.updated_requirements).to eq(requirements)
+      end
+    end
   end
 end

--- a/cargo/spec/dependabot/cargo/update_checker_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker_spec.rb
@@ -23,13 +23,15 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
       credentials: credentials,
       ignored_versions: ignored_versions,
       raise_on_ignored: raise_on_ignored,
-      security_advisories: security_advisories
+      security_advisories: security_advisories,
+      requirements_update_strategy: requirements_update_strategy
     )
   end
 
   let(:ignored_versions) { [] }
   let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
+  let(:requirements_update_strategy) { nil }
   let(:credentials) do
     [{
       "type" => "git_source",
@@ -481,6 +483,18 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
             }]
           )
       end
+    end
+  end
+
+  context "#requirements_unlocked_or_can_be?" do
+    subject { checker.requirements_unlocked_or_can_be? }
+
+    it { is_expected.to eq(true) }
+
+    context "with the lockfile-only requirements update strategy set" do
+      let(:requirements_update_strategy) { :lockfile_only }
+
+      it { is_expected.to eq(false) }
     end
   end
 end

--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -199,6 +199,10 @@ module Dependabot
       self == other
     end
 
+    def specific_requirements
+      requirements.select { |r| requirement_class.new(r[:requirement]).specific? }
+    end
+
     def requirement_class
       Utils.requirement_class_for_package_manager(package_manager)
     end

--- a/composer/lib/dependabot/composer/update_checker.rb
+++ b/composer/lib/dependabot/composer/update_checker.rb
@@ -68,6 +68,10 @@ module Dependabot
         ).updated_requirements
       end
 
+      def requirements_unlocked_or_can_be?
+        requirements_update_strategy != :lockfile_only
+      end
+
       def requirements_update_strategy
         # If passed in as an option (in the base class) honour that option
         return @requirements_update_strategy.to_sym if @requirements_update_strategy

--- a/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
+++ b/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
@@ -19,7 +19,7 @@ module Dependabot
         OR_SEPARATOR = /(?<=[a-zA-Z0-9*])[\s,]*\|\|?\s*/
         SEPARATOR = /(?:#{AND_SEPARATOR})|(?:#{OR_SEPARATOR})/
         ALLOWED_UPDATE_STRATEGIES =
-          %i(widen_ranges bump_versions bump_versions_if_necessary).freeze
+          %i(lockfile_only widen_ranges bump_versions bump_versions_if_necessary).freeze
 
         def initialize(requirements:, update_strategy:,
                        latest_resolvable_version:)
@@ -35,6 +35,7 @@ module Dependabot
         end
 
         def updated_requirements
+          return requirements if update_strategy == :lockfile_only
           return requirements unless latest_resolvable_version
 
           requirements.map { |req| updated_requirement(req) }

--- a/composer/spec/dependabot/composer/update_checker/requirements_updater_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/requirements_updater_spec.rb
@@ -705,5 +705,13 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
         end
       end
     end
+
+    context "with lockfile_only as the update strategy" do
+      let(:update_strategy) { :lockfile_only }
+
+      it "does not update any requirements" do
+        expect(updater.updated_requirements).to eq(requirements)
+      end
+    end
   end
 end

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
       credentials: credentials,
       ignored_versions: ignored_versions,
       raise_on_ignored: raise_on_ignored,
-      security_advisories: security_advisories
+      security_advisories: security_advisories,
+      requirements_update_strategy: requirements_update_strategy
     )
   end
 
@@ -31,6 +32,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
   let(:ignored_versions) { [] }
   let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
+  let(:requirements_update_strategy) { nil }
   let(:dependency_name) { "monolog/monolog" }
   let(:dependency_version) { "1.0.1" }
   let(:requirements) do
@@ -869,6 +871,18 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
             }]
           )
       end
+    end
+  end
+
+  context "#requirements_unlocked_or_can_be?" do
+    subject { checker.requirements_unlocked_or_can_be? }
+
+    it { is_expected.to eq(true) }
+
+    context "with the lockfile-only requirements update strategy set" do
+      let(:requirements_update_strategy) { :lockfile_only }
+
+      it { is_expected.to eq(false) }
     end
   end
 end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -102,6 +102,10 @@ module Dependabot
           ).updated_requirements
       end
 
+      def requirements_unlocked_or_can_be?
+        requirements_update_strategy != :lockfile_only
+      end
+
       def requirements_update_strategy
         # If passed in as an option (in the base class) honour that option
         return @requirements_update_strategy.to_sym if @requirements_update_strategy

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
@@ -15,7 +15,7 @@ module Dependabot
       class RequirementsUpdater
         VERSION_REGEX = /[0-9]+(?:\.[A-Za-z0-9\-_]+)*/
         SEPARATOR = /(?<=[a-zA-Z0-9*])[\s|]+(?![\s|-])/
-        ALLOWED_UPDATE_STRATEGIES = %i(widen_ranges bump_versions bump_versions_if_necessary).freeze
+        ALLOWED_UPDATE_STRATEGIES = %i(lockfile_only widen_ranges bump_versions bump_versions_if_necessary).freeze
 
         def initialize(requirements:, updated_source:, update_strategy:,
                        latest_resolvable_version:)
@@ -32,6 +32,8 @@ module Dependabot
         end
 
         def updated_requirements
+          return requirements if update_strategy == :lockfile_only
+
           requirements.map do |req|
             req = req.merge(source: updated_source)
             next req unless latest_resolvable_version

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/requirements_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/requirements_updater_spec.rb
@@ -606,5 +606,13 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::RequirementsUpdater do
         end
       end
     end
+
+    context "for a requirement being left alone" do
+      let(:update_strategy) { :lockfile_only }
+
+      it "does not update any requirements" do
+        expect(updater.updated_requirements).to eq(requirements)
+      end
+    end
   end
 end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -30,11 +30,13 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       credentials: credentials,
       ignored_versions: ignored_versions,
       security_advisories: security_advisories,
+      requirements_update_strategy: requirements_update_strategy,
       options: options
     )
   end
   let(:ignored_versions) { [] }
   let(:security_advisories) { [] }
+  let(:requirements_update_strategy) { nil }
   let(:dependency_files) { project_dependency_files("npm6/no_lockfile") }
   let(:options) { {} }
 
@@ -1211,6 +1213,18 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           }
         )
       end
+    end
+  end
+
+  context "#requirements_unlocked_or_can_be?" do
+    subject { checker.requirements_unlocked_or_can_be? }
+
+    it { is_expected.to eq(true) }
+
+    context "with the lockfile-only requirements update strategy set" do
+      let(:requirements_update_strategy) { :lockfile_only }
+
+      it { is_expected.to eq(false) }
     end
   end
 

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -78,6 +78,10 @@ module Dependabot
         ).updated_requirements
       end
 
+      def requirements_unlocked_or_can_be?
+        requirements_update_strategy != :lockfile_only
+      end
+
       def requirements_update_strategy
         # If passed in as an option (in the base class) honour that option
         return @requirements_update_strategy.to_sym if @requirements_update_strategy

--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -30,6 +30,8 @@ module Dependabot
         end
 
         def updated_requirements
+          return requirements if update_strategy == :lockfile_only
+
           requirements.map do |req|
             case req[:file]
             when /setup\.(?:py|cfg)$/ then updated_setup_requirement(req)

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -649,6 +649,14 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
           end
         end
       end
+
+      context "when asked to not change requirements" do
+        let(:update_strategy) { :lockfile_only }
+
+        it "does not update any requirements" do
+          expect(updated_requirements).to eq(requirements)
+        end
+      end
     end
   end
 end

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Dependabot::Python::UpdateChecker do
       credentials: credentials,
       ignored_versions: ignored_versions,
       raise_on_ignored: raise_on_ignored,
-      security_advisories: security_advisories
+      security_advisories: security_advisories,
+      requirements_update_strategy: requirements_update_strategy
     )
   end
   let(:credentials) do
@@ -35,6 +36,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
   let(:ignored_versions) { [] }
   let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
+  let(:requirements_update_strategy) { nil }
   let(:dependency_files) { [requirements_file] }
   let(:pipfile) do
     Dependabot::DependencyFile.new(
@@ -749,6 +751,18 @@ RSpec.describe Dependabot::Python::UpdateChecker do
           }]
         )
       end
+    end
+  end
+
+  context "#requirements_unlocked_or_can_be?" do
+    subject { checker.requirements_unlocked_or_can_be? }
+
+    it { is_expected.to eq(true) }
+
+    context "with the lockfile-only requirements update strategy set" do
+      let(:requirements_update_strategy) { :lockfile_only }
+
+      it { is_expected.to eq(false) }
     end
   end
 end

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -94,11 +94,14 @@ module Dependabot
       @existing_group_pull_requests   = attributes.fetch(:existing_group_pull_requests, [])
       @experiments                    = attributes.fetch(:experiments, {})
       @ignore_conditions              = attributes.fetch(:ignore_conditions)
-      @lockfile_only                  = attributes.fetch(:lockfile_only)
       @package_manager                = attributes.fetch(:package_manager)
       @reject_external_code           = attributes.fetch(:reject_external_code, false)
       @repo_contents_path             = attributes.fetch(:repo_contents_path, nil)
-      @requirements_update_strategy   = attributes.fetch(:requirements_update_strategy)
+
+      @requirements_update_strategy   = build_update_strategy(
+        **attributes.slice(:requirements_update_strategy, :lockfile_only)
+      )
+
       @security_advisories            = attributes.fetch(:security_advisories)
       @security_updates_only          = attributes.fetch(:security_updates_only)
       @source                         = build_source(attributes.fetch(:source))
@@ -125,10 +128,6 @@ module Dependabot
       return nil unless clone?
 
       @repo_contents_path
-    end
-
-    def lockfile_only?
-      @lockfile_only
     end
 
     def updating_a_pull_request?
@@ -304,6 +303,12 @@ module Dependabot
         name_normaliser.call(name1),
         name_normaliser.call(name2)
       )
+    end
+
+    def build_update_strategy(requirements_update_strategy:, lockfile_only:)
+      return requirements_update_strategy unless requirements_update_strategy.nil?
+
+      lockfile_only ? "lockfile_only" : nil
     end
 
     def build_source(source_details)

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -196,7 +196,7 @@ module Dependabot
       end
 
       def requirements_to_unlock(checker)
-        if job.lockfile_only? || !checker.requirements_unlocked_or_can_be?
+        if !checker.requirements_unlocked_or_can_be?
           if checker.can_update?(requirements_to_unlock: :none) then :none
           else
             :update_not_possible

--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -217,7 +217,7 @@ module Dependabot
         end
 
         def requirements_to_unlock(checker)
-          if job.lockfile_only? || !checker.requirements_unlocked_or_can_be?
+          if !checker.requirements_unlocked_or_can_be?
             if checker.can_update?(requirements_to_unlock: :none) then :none
             else
               :update_not_possible

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -144,7 +144,7 @@ module Dependabot
         # rubocop:enable Metrics/MethodLength
 
         def requirements_to_unlock(checker)
-          if job.lockfile_only? || !checker.requirements_unlocked_or_can_be?
+          if !checker.requirements_unlocked_or_can_be?
             if checker.can_update?(requirements_to_unlock: :none) then :none
             else
               :update_not_possible

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -172,7 +172,7 @@ module Dependabot
         end
 
         def requirements_to_unlock(checker)
-          if job.lockfile_only? || !checker.requirements_unlocked_or_can_be?
+          if !checker.requirements_unlocked_or_can_be?
             if checker.can_update?(requirements_to_unlock: :none) then :none
             else
               :update_not_possible

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -196,7 +196,7 @@ module Dependabot
         end
 
         def requirements_to_unlock(checker)
-          if job.lockfile_only? || !checker.requirements_unlocked_or_can_be?
+          if !checker.requirements_unlocked_or_can_be?
             if checker.can_update?(requirements_to_unlock: :none) then :none
             else
               :update_not_possible

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Dependabot::Job do
         "username" => "x-access-token",
         "password" => "github-token"
       }],
-      lockfile_only: false,
+      lockfile_only: lockfile_only,
       requirements_update_strategy: nil,
       update_subdependencies: false,
       updating_a_pull_request: false,
@@ -47,6 +47,7 @@ RSpec.describe Dependabot::Job do
   let(:dependencies) { nil }
   let(:security_advisories) { [] }
   let(:package_manager) { "bundler" }
+  let(:lockfile_only) { false }
   let(:security_updates_only) { false }
   let(:allowed_updates) do
     [
@@ -91,6 +92,14 @@ RSpec.describe Dependabot::Job do
     it "will register its dependency groups" do
       expect_any_instance_of(described_class).to receive(:register_dependency_groups)
       new_update_job
+    end
+  end
+
+  context "when lockfile_only is passed as true" do
+    let(:lockfile_only) { true }
+
+    it "infers a lockfile_only requirements_update_strategy" do
+      expect(subject.requirements_update_strategy).to eq("lockfile_only")
     end
   end
 

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -206,6 +206,23 @@ RSpec.describe Dependabot::Updater do
       end
     end
 
+    context "when lockfile_only is set in the job" do
+      it "still tries to unlock requirements of dependencies" do
+        checker = stub_update_checker
+        allow(checker).to receive(:requirements_unlocked_or_can_be?).and_return(true)
+
+        job = build_job(lockfile_only: true)
+        service = build_service
+        updater = build_updater(service: service, job: job)
+
+        expect(Dependabot.logger).
+          to receive(:info).
+          with("Requirements to unlock own")
+
+        updater.run
+      end
+    end
+
     context "when no dependencies are allowed" do
       it "logs the current and latest versions" do
         job = build_job(
@@ -2342,7 +2359,8 @@ RSpec.describe Dependabot::Updater do
 
   def build_job(requested_dependencies: nil, allowed_updates: default_allowed_updates, # rubocop:disable Metrics/MethodLength
                 existing_pull_requests: [], ignore_conditions: [], security_advisories: [],
-                experiments: {}, updating_a_pull_request: false, security_updates_only: false, dependency_groups: [])
+                experiments: {}, updating_a_pull_request: false, security_updates_only: false, dependency_groups: [],
+                lockfile_only: false)
     Dependabot::Job.new(
       id: 1,
       token: "token",
@@ -2372,7 +2390,7 @@ RSpec.describe Dependabot::Updater do
           "secret" => "codes"
         }
       ],
-      lockfile_only: false,
+      lockfile_only: lockfile_only,
       requirements_update_strategy: nil,
       update_subdependencies: false,
       updating_a_pull_request: updating_a_pull_request,


### PR DESCRIPTION
Trying to retry #5581, but in a correct way now.

Fixes #5569.