### PR TITLE
Install composer in a way that does not use `COPY --from`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,8 +141,6 @@ RUN [ "$TARGETARCH" != "amd64" ] \
 
 # Install PHP and Composer
 ENV COMPOSER_ALLOW_SUPERUSER=1
-COPY --from=composer:1.10.26 /usr/bin/composer /usr/local/bin/composer1
-COPY --from=composer:2.3.9 /usr/bin/composer /usr/local/bin/composer
 RUN add-apt-repository ppa:ondrej/php \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -174,6 +172,10 @@ RUN add-apt-repository ppa:ondrej/php \
     php7.4-zmq \
     php7.4-mcrypt \
   && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer1 --version=1.10.26
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=2.3.9
+
 USER dependabot
 # Perform a fake `composer update` to warm ~/dependabot/.cache/composer/repo
 # with historic data (we don't care about package files here)


### PR DESCRIPTION
I observed that many times buildkit cache is not being hit, triggering a rebuild of the whole dependabot-core image, in situations where it would not seem necessary.

One hypothesis is that this is due to the `COPY --from` usage when installing composer, since I recall issues with that not playing well with buildkit cache.

I want to try a different way of installing composer, in order to verify whether this is the culprit and this speeds up our CI.