### PR TITLE
Don't repeat dependency names in PR title

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -78,8 +78,12 @@ module Dependabot
               "#{from_version_msg(old_library_requirement(dependencies.first))}" \
               "to #{new_library_requirement(dependencies.first)}"
           else
-            names = dependencies.map(&:name)
-            "requirements for #{names[0..-2].join(', ')} and #{names[-1]}"
+            names = dependencies.map(&:name).uniq
+            if names.count == 1
+              "requirements for #{names.first}"
+            else
+              "requirements for #{names[0..-2].join(', ')} and #{names[-1]}"
+            end
           end
       end
 
@@ -104,8 +108,12 @@ module Dependabot
               "#{from_version_msg(previous_version(dependency))}" \
               "to #{new_version(dependency)}"
           else
-            names = dependencies.map(&:name)
-            "#{names[0..-2].join(', ')} and #{names[-1]}"
+            names = dependencies.map(&:name).uniq
+            if names.count == 1
+              names.first
+            else
+              "#{names[0..-2].join(', ')} and #{names[-1]}"
+            end
           end
       end
 

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -87,6 +87,7 @@ module Dependabot
           end
       end
 
+      # rubocop:disable Metrics/AbcSize
       def application_pr_name
         pr_name = "bump "
         pr_name = pr_name.capitalize if pr_name_prefixer.capitalize_first_word?
@@ -116,6 +117,7 @@ module Dependabot
             end
           end
       end
+      # rubocop:enable Metrics/AbcSize
 
       def pr_name_prefix
         pr_name_prefixer.pr_name_prefix

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -217,8 +217,19 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with two dependencies" do
-          let(:dependencies) { [dependency, dependency] }
-          it { is_expected.to eq("Bump business and business") }
+          let(:dependency2) do
+            Dependabot::Dependency.new(
+              name: "business2",
+              version: "1.5.0",
+              previous_version: "1.4.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependencies) { [dependency, dependency2] }
+
+          it { is_expected.to eq("Bump business and business2") }
 
           context "for a Maven property update" do
             let(:dependency) do
@@ -297,9 +308,35 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
+        context "with two dependencies with the same name" do
+          let(:dependencies) { [dependency, dependency] }
+          it { is_expected.to eq("Bump business") }
+        end
+
         context "with three dependencies" do
-          let(:dependencies) { [dependency, dependency, dependency] }
-          it { is_expected.to eq("Bump business, business and business") }
+          let(:dependency2) do
+            Dependabot::Dependency.new(
+              name: "business2",
+              version: "1.5.0",
+              previous_version: "1.4.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency3) do
+            Dependabot::Dependency.new(
+              name: "business3",
+              version: "1.5.0",
+              previous_version: "1.4.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependencies) { [dependency, dependency2, dependency3] }
+
+          it { is_expected.to eq("Bump business, business2 and business3") }
         end
 
         context "with a directory specified" do
@@ -643,20 +680,55 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with two dependencies" do
-          let(:dependencies) { [dependency, dependency] }
+          let(:dependency2) do
+            Dependabot::Dependency.new(
+              name: "business2",
+              version: "1.5.0",
+              previous_version: "1.4.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependencies) { [dependency, dependency2] }
 
           it "includes both dependencies" do
             expect(pr_name).
-              to eq("Update requirements for business and business")
+              to eq("Update requirements for business and business2")
           end
         end
 
+        context "with two dependencies with the same name" do
+          let(:dependencies) { [dependency, dependency] }
+          it { is_expected.to eq("Update requirements for business") }
+        end
+
         context "with three dependencies" do
-          let(:dependencies) { [dependency, dependency, dependency] }
+          let(:dependency2) do
+            Dependabot::Dependency.new(
+              name: "business2",
+              version: "1.5.0",
+              previous_version: "1.4.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependency3) do
+            Dependabot::Dependency.new(
+              name: "business3",
+              version: "1.5.0",
+              previous_version: "1.4.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependencies) { [dependency, dependency2, dependency3] }
 
           it "includes all three dependencies" do
             expect(pr_name).
-              to eq("Update requirements for business, business and business")
+              to eq("Update requirements for business, business2 and business3")
           end
         end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -309,7 +309,17 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with two dependencies with the same name" do
-          let(:dependencies) { [dependency, dependency] }
+          let(:dependency2) do
+            Dependabot::Dependency.new(
+              name: "business",
+              version: "2.3.0",
+              previous_version: "2.1.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependencies) { [dependency, dependency2] }
           it { is_expected.to eq("Bump business") }
         end
 
@@ -699,7 +709,17 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "with two dependencies with the same name" do
-          let(:dependencies) { [dependency, dependency] }
+          let(:dependency2) do
+            Dependabot::Dependency.new(
+              name: "business",
+              version: "2.3.0",
+              previous_version: "2.1.0",
+              package_manager: "dummy",
+              requirements: [],
+              previous_requirements: []
+            )
+          end
+          let(:dependencies) { [dependency, dependency2] }
           it { is_expected.to eq("Update requirements for business") }
         end
 


### PR DESCRIPTION
This improves the PR title to only mention a dependency once if it's being updated to multiple versions.

ex: https://github.com/dependabot/dependabot-core/issues/5880

Fix https://github.com/dependabot/dependabot-core/issues/5888