### PR TITLE
Fix error when parsing Gitlab changelogs

### DIFF
--- a/common/lib/dependabot/source.rb
+++ b/common/lib/dependabot/source.rb
@@ -21,8 +21,8 @@ module Dependabot
     GITLAB_SOURCE = %r{
       (?<provider>gitlab)
       (?:\.com)[/:]
-      (?<repo>(?!\.git|/tree|/blob)[\w./-]+?)(?:\.git)?
-      (?:(?:/tree|/blob)/(?<branch>[^/]+)/(?<directory>.*)[\#|/].*)?$
+      (?<repo>[^/]+/(?:(?!\.git)[^/])+((?!/tree|/blob/|/-)/[^/]+)?)
+      (?:(?:/tree|/blob)/(?<branch>[^/]+)/(?<directory>.*)[\#|/].*)?
     }x.freeze
 
     BITBUCKET_SOURCE = %r{

--- a/common/spec/dependabot/source_spec.rb
+++ b/common/spec/dependabot/source_spec.rb
@@ -256,6 +256,13 @@ RSpec.describe Dependabot::Source do
       its(:directory) { is_expected.to eq("dir") }
     end
 
+    context "with a GitLab changelog link" do
+      let(:url) { "https://gitlab.com/oauth-xx/oauth2/-/tree/v2.0.9/CHANGELOG.md" }
+      its(:provider) { is_expected.to eq("gitlab") }
+      its(:repo) { is_expected.to eq("oauth-xx/oauth2") }
+      its(:directory) { is_expected.to be_nil }
+    end
+
     context "with a GitLab subgroup URL" do
       let(:url) { "https://gitlab.com/org/group/abc/blob/master/dir/readme.md" }
       its(:provider) { is_expected.to eq("gitlab") }


### PR DESCRIPTION
This bug was causing Dependabot to not be able to create PRs to bump the oauth2 ruby gem.

This is a fairly popular Ruby gem. It's hosted a gitlab.com, and uses gemspec metadata to declare how to find it's changelog.

The URL it uses is `https://gitlab.com/oauth-xx/oauth2/-/tree/v2.0.9/CHANGELOG.md`, which Dependabot was not parsing properly, causing runtime errors.

This is a regression from 49d1a13fca921000b8f9a76612a67d9098431ebd.

Before, when trying to create a PR bump the oauth2 rubygem, you would get:

```
🌍 https://rubygems.org/api/v1/gems/oauth2.json
🌍 https://gitlab.com/oauth-xx/oauth2/-/tree/v2.0.9.git/info/refs
/home/dependabot/dependabot-core/common/lib/dependabot/git_metadata_fetcher.rb:68:in `fetch_upload_pack_for': Server error at https://gitlab.com/oauth-xx/oauth2/-/tree/v2.0.9/: Internal server error (RuntimeError)
	from /home/dependabot/dependabot-core/common/lib/dependabot/git_metadata_fetcher.rb:17:in `upload_pack'
	from /home/dependabot/dependabot-core/common/lib/dependabot/git_metadata_fetcher.rb:23:in `tags'
	from /home/dependabot/dependabot-core/common/lib/dependabot/metadata_finders/base/commits_finder.rb:177:in `fetch_dependency_tags'
	from /home/dependabot/dependabot-core/common/lib/dependabot/metadata_finders/base/commits_finder.rb:169:in `dependency_tags'
	from /home/dependabot/dependabot-core/common/lib/dependabot/metadata_finders/base/commits_finder.rb:60:in `new_tag'
	from /home/dependabot/dependabot-core/common/lib/dependabot/metadata_finders/base/changelog_finder.rb:151:in `tag_for_new_version'
	from /home/dependabot/dependabot-core/common/lib/dependabot/metadata_finders/base/changelog_finder.rb:106:in `relevant_tag_changelog'
	from /home/dependabot/dependabot-core/common/lib/dependabot/metadata_finders/base/changelog_finder.rb:70:in `changelog'
	from /home/dependabot/dependabot-core/common/lib/dependabot/metadata_finders/base/changelog_finder.rb:33:in `changelog_url'
	from /home/dependabot/dependabot-core/common/lib/dependabot/metadata_finders/base.rb:40:in `changelog_url'
	from /usr/local/lib/ruby/3.1.0/forwardable.rb:238:in `changelog_url'
	from /home/dependabot/dependabot-core/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb:81:in `changelog_cascade'
	from /home/dependabot/dependabot-core/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb:39:in `to_s'
	from /home/dependabot/dependabot-core/common/lib/dependabot/pull_request_creator/message_builder.rb:395:in `metadata_cascades_for_dep'
	from /home/dependabot/dependabot-core/common/lib/dependabot/pull_request_creator/message_builder.rb:365:in `metadata_cascades'
	from /home/dependabot/dependabot-core/common/lib/dependabot/pull_request_creator/message_builder.rb:50:in `pr_message'
	from /home/dependabot/dependabot-core/common/lib/dependabot/pull_request_creator/message_builder.rb:64:in `message'
	from bin/dry-run.rb:797:in `block in <main>'
	from bin/dry-run.rb:661:in `each'
	from bin/dry-run.rb:661:in `<main>'
```

After:

```
🌍 https://rubygems.org/api/v1/gems/oauth2.json
🌍 https://gitlab.com/oauth-xx/oauth2/raw/main/CHANGELOG.md
🌍 https://gitlab.com/oauth-xx/oauth2.git/info/refs
Pull Request Title: Bump oauth2 from 2.0.8 to 2.0.9
--description--
Bumps [oauth2](https://gitlab.com/oauth-xx/oauth2) from 2.0.8 to 2.0.9.
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://gitlab.com/oauth-xx/oauth2/blob/main/CHANGELOG.md">oauth2's changelog</a>.</em></p>
<blockquote>
<h2>[2.0.9] - 2022-09-16 ([tag][2.0.9t])</h2>
<h3>Added</h3>
<ul>
<li>More specs (<a href="https://github.com/pboling"><code>@​pboling</code></a>)</li>
</ul>
<h3>Changed</h3>
<ul>
<li>Complete migration to main branch as default (<a href="https://github.com/pboling"><code>@​pboling</code></a>)</li>
<li>Complete migration to Gitlab, updating all links, and references in VCS-managed files (<a href="https://github.com/pboling"><code>@​pboling</code></a>)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://gitlab.com/oauth-xx/oauth2/commit/8c88ad2f309374599ac56cd253fb93e3ad81cf07"><code>8c88ad2</code></a> 🔖 Prepare release 2.0.9</li>
<li><a href="https://gitlab.com/oauth-xx/oauth2/commit/39f0f2a5eb73e6045a758c1a8d0a9dbfec61c889"><code>39f0f2a</code></a> ✏️ Correct typos in CHANGELOG.md</li>
<li><a href="https://gitlab.com/oauth-xx/oauth2/commit/bbd243110ee0f345693e0ed4d4f4ef13021483cb"><code>bbd2431</code></a> 🔖 Prepare release 2.0.9</li>
<li><a href="https://gitlab.com/oauth-xx/oauth2/commit/e9d70c9f385675583491c44b6928cad27c08bb2b"><code>e9d70c9</code></a> ✏️ Correct typos in CHANGELOG.md</li>
<li><a href="https://gitlab.com/oauth-xx/oauth2/commit/1e81b62048ec85b861994844d092ee4eef2c2c3c"><code>1e81b62</code></a> 🔧 Migration from Github to Gitlab</li>
<li><a href="https://gitlab.com/oauth-xx/oauth2/commit/ef8c2c1d24eb4cdf5f4f2c74c3e125d3d23a9cf8"><code>ef8c2c1</code></a> 🔧 Migration from Github to Gitlab</li>
<li><a href="https://gitlab.com/oauth-xx/oauth2/commit/10d9a8374e08bb15938168c6b7c3ef74aae68ee5"><code>10d9a83</code></a> ✅ More tests</li>
<li><a href="https://gitlab.com/oauth-xx/oauth2/commit/5e405dcecbb24a37ce92204225c0c321520698f7"><code>5e405dc</code></a> 🔧 Migration from Github to Gitlab</li>
<li><a href="https://gitlab.com/oauth-xx/oauth2/commit/272edd68f594d457ab02da85c40179f0e93521da"><code>272edd6</code></a> ⬆️ Allow rack v3</li>
<li><a href="https://gitlab.com/oauth-xx/oauth2/commit/260a8bb225f9bbfb529c22ca6bd802a9cd907f71"><code>260a8bb</code></a> 🔧 Complete migration from master to main branch</li>
<li>Additional commits viewable in <a href="https://gitlab.com/oauth-xx/oauth2/compare/v2.0.8...v2.0.9">compare view</a></li>
</ul>
</details>
<br />

--/description--
--commit--
Bump oauth2 from 2.0.8 to 2.0.9

Bumps [oauth2](https://gitlab.com/oauth-xx/oauth2) from 2.0.8 to 2.0.9.
- [Release notes](https://gitlab.com/oauth-xx/oauth2/tags)
- [Changelog](https://gitlab.com/oauth-xx/oauth2/blob/main/CHANGELOG.md)
- [Commits](https://gitlab.com/oauth-xx/oauth2/compare/v2.0.8...v2.0.9)
--/commit--
```

Fixes https://github.com/dependabot/dependabot-core/issues/5789.
