### PR TITLE
Yarn Berry: Fixes subdependency security updates

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -121,10 +121,14 @@ module Dependabot
         end
 
         def run_yarn_berry_updater(path, lockfile_name)
-          Helpers.run_yarn_commands(
-            "yarn up -R #{dependency.name}",
-          )
-          { lockfile_name => File.read(lockfile_name) }
+          SharedHelpers.with_git_configured(credentials: credentials) do
+            Dir.chdir(path) do
+              Helpers.run_yarn_commands(
+                "yarn up -R #{dependency.name}"
+              )
+              { lockfile_name => File.read(lockfile_name) }
+            end
+          end
         end
 
         def run_npm_updater(path, lockfile_name, lockfile_content)


### PR DESCRIPTION
## Context
Version resolution for security updates was broken for yarn berry if there were any packages sourced from private registries, even if the private registry was correctly configured. Previously we were not performing version resolution with yarn berry for security updates, this still worked as long as yarn 1 could talk to all of the necessary registries.

## Approach
This PR adds specific version resolution calls for yarn berry to the subdependency version resolver so that it doesn't attempt to use yarn 1 when performing this resolution.

## Ongoing
This still requires that any package mentioned in yarn.lock or package.json is reachable by Dependabot. This means if there are packages sourced from private registries and Dependabot does not have access to those registries due to lack of configuration or incorrect configuration, a subdependency security update will still fail.