### PR TITLE
Maven: fix forgetting repositories seen in earlier POMs

### DIFF
--- a/maven/spec/dependabot/maven/file_parser/repositories_finder_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser/repositories_finder_spec.rb
@@ -65,6 +65,45 @@ RSpec.describe Dependabot::Maven::FileParser::RepositoriesFinder do
         )
       end
 
+      it "remembers what it's seen" do
+        custom_pom = Dependabot::DependencyFile.new(
+          name: "pom.xml",
+          content: fixture("poms", "custom_repositories_pom.xml")
+        )
+        expect(finder.repository_urls(pom: custom_pom)).to eq(
+          %w(
+            http://scala-tools.org/repo-releases
+            http://repository.jboss.org/maven2
+            http://plugin-repository.jboss.org/maven2
+            https://repo.maven.apache.org/maven2
+          )
+        )
+        base_pom = Dependabot::DependencyFile.new(
+          name: "pom.xml",
+          content: fixture("poms", "basic_pom.xml")
+        )
+        expect(finder.repository_urls(pom: base_pom)).to eq(
+          %w(
+            http://scala-tools.org/repo-releases
+            http://repository.jboss.org/maven2
+            http://plugin-repository.jboss.org/maven2
+            https://repo.maven.apache.org/maven2
+          )
+        )
+        overwrite_central_pom = Dependabot::DependencyFile.new(
+          name: "pom.xml",
+          content: fixture("poms", "overwrite_central_pom.xml")
+        )
+        expect(finder.repository_urls(pom: overwrite_central_pom)).to eq(
+          %w(
+            http://scala-tools.org/repo-releases
+            http://repository.jboss.org/maven2
+            http://plugin-repository.jboss.org/maven2
+            https://example.com
+          )
+        )
+      end
+
       context "that overwrites central" do
         let(:base_pom_fixture_name) { "overwrite_central_pom.xml" }
 


### PR DESCRIPTION
In project where POMs have grandparents (the POM's parent has a parent) we're seeing Dependabot forget about repositories it has seen in previous POMs. So it will start off well querying for a parent in a custom repository, but then forget about that and try to get the grandparent from Maven Central where it doesn't exist.

This PR adds tracking for URLs seen in POM files so that Dependabot can find the grandparent.

I was careful to keep the central repo URL out of the list of known URLs because if we have `[custom1, central]` in the first POM and `[custom2, central]` in the second, that would add up to `[custom1, central, custom2]` which is not the ideal order.

I tested this locally and it fixes #4168 and #5543. It also makes Dependabot "just work" in more cases now!