### PR TITLE
Fix crash when updating git dependencies

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/gemfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/gemfile_updater.rb
@@ -29,7 +29,7 @@ module Dependabot
 
             content = remove_gemfile_git_source(dependency, content) if remove_git_source?(dependency)
 
-            content = update_gemfile_git_pin(dependency, gemfile, content) if update_git_pin?(dependency)
+            content = update_gemfile_git_pin(dependency, gemfile, content) if update_git_pin?(dependency, gemfile)
           end
 
           content
@@ -81,10 +81,10 @@ module Dependabot
           new_gemfile_req[:source].nil?
         end
 
-        def update_git_pin?(dependency)
+        def update_git_pin?(dependency, file)
           new_gemfile_req =
             dependency.requirements.
-            find { |f| GEMFILE_FILENAMES.include?(f[:file]) }
+            find { |f| f[:file] == file.name }
           return false unless new_gemfile_req&.dig(:source, :type) == "git"
 
           # If the new requirement is a git dependency with a ref then there's

--- a/bundler/spec/dependabot/bundler/file_updater/gemfile_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/gemfile_updater_spec.rb
@@ -306,6 +306,20 @@ RSpec.describe Dependabot::Bundler::FileUpdater::GemfileUpdater do
         end
 
         it { is_expected.to eq(expected_string) }
+
+        context "but updating an evaled gemfile including a different git sourced dependency" do
+          let(:gemfile_body) do
+            %(gem "dependabot-test-other", git: "https://github.com/dependabot-fixtures/dependabot-other")
+          end
+
+          let(:gemfile) do
+            Dependabot::DependencyFile.new(content: gemfile_body, name: "Gemfile.included")
+          end
+
+          it "leaves the evaled gemfile untouched" do
+            is_expected.to eq(gemfile_body)
+          end
+        end
       end
 
       context "that should be removed" do


### PR DESCRIPTION
If there's an evaled gemfile that also includes git dependencies, it would result in a crash like the following:

```
Failure/Error:
  dependency.requirements.
  find { |f| f[:file] == file.name }.
  fetch(:source).fetch(:ref)

NoMethodError:
  undefined method `fetch' for nil:NilClass

              fetch(:source).fetch(:ref)
```

We need to check the Gemfile name being updated, not generic names when figuring out if we should update any git pins.