### PR TITLE
Create a merge-queue script

### DIFF
--- a/bin/merge-queue.rb
+++ b/bin/merge-queue.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "open3"
+
+module MergeQueue
+  extend self
+
+  def add(*pr_list)
+    git!("fetch", "origin", "main")
+
+    unless git?("checkout", "origin/merge-train")
+      git("checkout", "-b", "merge-train", "origin/main")
+      new_merge_train = true
+    end
+
+    pr_list.each do |pr|
+      gh!("pr", "checkout", pr)
+      pr_branch, _ = git("rev-parse", "--abbrev-ref", "HEAD")
+      git!("checkout", "merge-train")
+      git!("merge", "--ff", "--no-edit", pr_branch.strip)
+    end
+
+    git!("push", "origin", "merge-train")
+
+    if new_merge_train
+      gh!("pr", "create", "--title", "Current Merge Train", "--body", ":steam_locomotive:", "--repo", "dependabot/dependabot-core")
+    end
+  end
+
+  private
+
+  def gh!(*cmd)
+    run_cmd!("gh", *cmd)
+  end
+
+  def git!(*cmd)
+    run_cmd!("git", *cmd)
+  end
+
+  def git?(*cmd)
+    _, status = git(*cmd)
+
+    status.success?
+  end
+
+  def git(*cmd)
+    run_cmd("git", *cmd)
+  end
+
+  def run_cmd!(*cmd)
+    output, status = run_cmd(*cmd)
+    raise output unless status.success?
+  end
+
+  def run_cmd(*cmd)
+    puts cmd.join(" ") if ENV["VERBOSE"]
+    output, status = Open3.capture2e(*cmd)
+    puts output if ENV["VERBOSE"]
+    [output, status]
+  end
+end
+
+MergeQueue.add(*ARGV)


### PR DESCRIPTION
To ease creation of a "Current merge train" PR.

I used it to generate #5938.

To use it:

```
$ bin/merge-queue.rb <pr1> ... <prN>
```

If a merge queue PR already exists, PRs are added to it. Otherwise, it creates a new merge queue PR.

What do you think?