### PR TITLE
[POC] Check if go packages use vulnerable call for security updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -203,6 +203,7 @@ RUN cd /tmp \
   && rm go-${TARGETARCH}.tar.gz
 
 
+
 ### ELIXIR
 
 # Install Erlang, Elixir and Hex
@@ -303,6 +304,9 @@ RUN bash /opt/terraform/helpers/build
 ENV PATH="$PATH:/opt/terraform/bin:/opt/python/bin:/opt/go_modules/bin"
 
 ENV HOME="/home/dependabot"
+
+ENV PATH="/home/dependabot/go/bin:$PATH"
+RUN go install golang.org/x/vuln/cmd/govulncheck@latest
 
 WORKDIR ${HOME}
 

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "json"
+ "json"
 require "dependabot/utils"
 require "dependabot/security_advisory"
 

--- a/go_modules/spec/fixtures/projects/vulnerable_function_called/go.mod
+++ b/go_modules/spec/fixtures/projects/vulnerable_function_called/go.mod
@@ -1,0 +1,7 @@
+module github.com/dependabot/vgotest
+
+go 1.19
+
+require github.com/theupdateframework/go-tuf v0.3.1
+
+require github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect

--- a/go_modules/spec/fixtures/projects/vulnerable_function_called/go.sum
+++ b/go_modules/spec/fixtures/projects/vulnerable_function_called/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/secure-systems-lab/go-securesystemslib v0.4.0 h1:b23VGrQhTA8cN2CbBw7/FulN9fTtqYUdS5+Oxzt+DUE=
+github.com/secure-systems-lab/go-securesystemslib v0.4.0/go.mod h1:FGBZgq2tXWICsxWQW1msNf49F0Pf2Op5Htayx335Qbs=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/theupdateframework/go-tuf v0.3.1 h1:NkjMlCuLcDpHNtsWXY4lTmbbQQ5nOM7JSBbOKEEiI1c=
+github.com/theupdateframework/go-tuf v0.3.1/go.mod h1:lhHZ3Vt2pdAh15h0Cc6gWdlI+Okn2ZznD3q/cNjd5jw=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 h1:/pEO3GD/ABYAjuakUS6xSEmmlyVS4kxBNkeA9tLJiTI=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go_modules/spec/fixtures/projects/vulnerable_function_called/main.go
+++ b/go_modules/spec/fixtures/projects/vulnerable_function_called/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"time"
+
+	"github.com/theupdateframework/go-tuf/pkg/keys"
+	"github.com/theupdateframework/go-tuf/sign"
+	"github.com/theupdateframework/go-tuf/verify"
+)
+
+type signedMeta struct {
+	Type    string    `json:"_type"`
+	Expires time.Time `json:"expires"`
+	Version int64     `json:"version"`
+}
+
+func main() {
+	ver := int64(10)
+	exp := time.Now().Add(-time.Hour)
+	k, _ := keys.GenerateEd25519Key()
+	s, _ := sign.Marshal(&signedMeta{Type: "", Version: ver, Expires: exp}, k)
+
+	db := verify.NewDB()
+	db.Verify(s, "root", ver)
+}

--- a/go_modules/spec/fixtures/projects/vulnerable_function_not_called/go.mod
+++ b/go_modules/spec/fixtures/projects/vulnerable_function_not_called/go.mod
@@ -1,0 +1,7 @@
+module github.com/dependabot/vgotest
+
+go 1.19
+
+require github.com/theupdateframework/go-tuf v0.3.1
+
+require github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect

--- a/go_modules/spec/fixtures/projects/vulnerable_function_not_called/go.sum
+++ b/go_modules/spec/fixtures/projects/vulnerable_function_not_called/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/secure-systems-lab/go-securesystemslib v0.4.0 h1:b23VGrQhTA8cN2CbBw7/FulN9fTtqYUdS5+Oxzt+DUE=
+github.com/secure-systems-lab/go-securesystemslib v0.4.0/go.mod h1:FGBZgq2tXWICsxWQW1msNf49F0Pf2Op5Htayx335Qbs=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/theupdateframework/go-tuf v0.3.1 h1:NkjMlCuLcDpHNtsWXY4lTmbbQQ5nOM7JSBbOKEEiI1c=
+github.com/theupdateframework/go-tuf v0.3.1/go.mod h1:lhHZ3Vt2pdAh15h0Cc6gWdlI+Okn2ZznD3q/cNjd5jw=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 h1:/pEO3GD/ABYAjuakUS6xSEmmlyVS4kxBNkeA9tLJiTI=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go_modules/spec/fixtures/projects/vulnerable_function_not_called/main.go
+++ b/go_modules/spec/fixtures/projects/vulnerable_function_not_called/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/theupdateframework/go-tuf/verify"
+)
+
+func main() {
+	// the vulnerable package is imported an used, but the vulnerable function not
+	// called
+	verify.NewDB()
+}


### PR DESCRIPTION
This introduces a check for go security updates that checks if the package being updated is using a known vulnerable call for that package using [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)

Govulncheck has a few limitations; one being that it does not take into account function calls made using reflection.

The approach taken here also does not take into account the specific CVE that we're checking (as that data is not easily available right now, but it could be), and it also does not take into account if the go vulnerability database has vulnerable function information available for this package.