### PR TITLE
No public url call when public registry is disabled

### DIFF
--- a/nuget/lib/dependabot/nuget/metadata_finder.rb
+++ b/nuget/lib/dependabot/nuget/metadata_finder.rb
@@ -122,10 +122,7 @@ module Dependabot
                  find { |r| r&.fetch(:source) }&.fetch(:source)
 
         if source&.key?(:nuspec_url)
-          source.fetch(:nuspec_url) ||
-            "https://api.nuget.org/v3-flatcontainer/" \
-            "#{dependency.name.downcase}/#{dependency.version}/" \
-            "#{dependency.name.downcase}.nuspec"
+          source.fetch(:nuspec_url)
         end
       end
 

--- a/nuget/lib/dependabot/nuget/metadata_finder.rb
+++ b/nuget/lib/dependabot/nuget/metadata_finder.rb
@@ -126,15 +126,6 @@ module Dependabot
             "https://api.nuget.org/v3-flatcontainer/" \
             "#{dependency.name.downcase}/#{dependency.version}/" \
             "#{dependency.name.downcase}.nuspec"
-        elsif source&.key?(:nuspec_url)
-          source.fetch("nuspec_url") ||
-            "https://api.nuget.org/v3-flatcontainer/" \
-            "#{dependency.name.downcase}/#{dependency.version}/" \
-            "#{dependency.name.downcase}.nuspec"
-        else
-          "https://api.nuget.org/v3-flatcontainer/" \
-            "#{dependency.name.downcase}/#{dependency.version}/" \
-            "#{dependency.name.downcase}.nuspec"
         end
       end
 

--- a/nuget/lib/dependabot/nuget/metadata_finder.rb
+++ b/nuget/lib/dependabot/nuget/metadata_finder.rb
@@ -121,9 +121,7 @@ module Dependabot
         source = dependency.requirements.
                  find { |r| r&.fetch(:source) }&.fetch(:source)
 
-        if source&.key?(:nuspec_url)
-          source.fetch(:nuspec_url)
-        end
+        return source.fetch(:nuspec_url) if source&.key?(:nuspec_url)
       end
 
       def dependency_source_url

--- a/nuget/spec/dependabot/nuget/metadata_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/metadata_finder_spec.rb
@@ -59,15 +59,6 @@ RSpec.describe Dependabot::Nuget::MetadataFinder do
       )
     end
 
-    context "with a github link in the nuspec" do
-      it { is_expected.to eq("https://github.com/dotnet/core-setup") }
-
-      it "caches the call to nuget" do
-        2.times { source_url }
-        expect(WebMock).to have_requested(:get, nuget_url).once
-      end
-    end
-
     context "with a source" do
       let(:source) do
         {
@@ -94,7 +85,7 @@ RSpec.describe Dependabot::Nuget::MetadataFinder do
         expect(WebMock).to have_requested(:get, nuget_url).once
       end
 
-      context "that has a source_url" do
+      context "that has a source_url only" do
         let(:source) do
           {
             type: "nuget_repo",
@@ -117,13 +108,7 @@ RSpec.describe Dependabot::Nuget::MetadataFinder do
           }
         end
 
-        let(:nuget_url) do
-          "https://api.nuget.org/v3-flatcontainer/" \
-            "microsoft.extensions.dependencymodel/2.1.0/" \
-            "microsoft.extensions.dependencymodel.nuspec"
-        end
-
-        it { is_expected.to eq("https://github.com/dotnet/core-setup") }
+        it { is_expected.to eq(nil) }
       end
 
       context "with details in the credentials (but no token)" do


### PR DESCRIPTION
## Context

When pubic registry is disabled in the Nuget, it still tries to make a call to public registry url (`https://api.nuget.org/v3-flatcontainer/nuget.versioning/6.2.1/nuget.versioning.nuspec`) to get the nuspec file if no nuspec file url is provided.

## Solution

Earlier, in the `dependency_nuspec_url` function of the metadata finder, a default public nuspec url was added if the source was missing or if the source was present but had no nuspec file. I have removed the injection of the default public nuspec url when there is either no source or no nuspec url specified in the source.

Even without my change from this PR, when nuspec url was nil in source, the metadata finder was calling the default nuspec url and returning 404.

## Note
Nuspec file: A .nuspec file is an XML manifest that contains package metadata. This manifest is used both to build the package and to provide information to consumers. The manifest is always included in a package. [[ref](https://learn.microsoft.com/en-us/nuget/reference/nuspec)]