### PR TITLE
Make dry-run script twice as fast

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -679,6 +679,11 @@ dependencies.each do |dep|
     next
   end
 
+  if checker.up_to_date?
+    puts "    (no update needed as it's already up-to-date)"
+    next
+  end
+
   if checker.vulnerable?
     if checker.lowest_security_fix_version
       puts " => earliest available non-vulnerable version is " \
@@ -694,11 +699,6 @@ dependencies.each do |dep|
                              checker.latest_resolvable_version
                            end
   puts " => latest allowed version is #{latest_allowed_version || dep.version}"
-
-  if checker.up_to_date?
-    puts "    (no update needed as it's already up-to-date)"
-    next
-  end
 
   requirements_to_unlock =
     if $options[:lockfile_only] || !checker.requirements_unlocked_or_can_be?


### PR DESCRIPTION
Check whether up to date after figuring latest version.

Before, on a standard Python update:

```
$ time bin/dry-run.rb pip LeeeeT/valtypes --cache files
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
=> reading dependency files from cache manifest: ./dry-run/LeeeeT/valtypes/cache-manifest-pip.json
=> parsing dependency files
=> updating 11 dependencies: pre-commit, isort, sort-all, black, pyproject-flake8, mypy, pyright, pytest, pytest-cov, mkdocs-material, jinja2

=== pre-commit ()
 => checking for updates 1/11
🌍 https://pypi.org/simple/pre-commit/
 => latest available version is 2.20.0
 => latest allowed version is 2.20.0
    (no update needed as it's already up-to-date)

(...)

=== jinja2 (3.1.0)
 => checking for updates 11/11
🌍 https://pypi.org/simple/jinja2/
 => latest available version is 3.1.2
🌍 https://pypi.org/simple/jinja2/
 => latest allowed version is 3.1.2
 => requirements to unlock: own
 => requirements update strategy: bump_versions
 => updating jinja2 from 3.1.0 to 3.1.2

    ± docs/requirements.txt
    ~~~
    2c2
    < Jinja2==3.1.0
    ---
    > Jinja2==3.1.2
    ~~~
🌍 Total requests made: '24'

real	1m0.863s
user	0m35.599s
sys	0m7.230s
```

After this change:

```
$ time bin/dry-run.rb pip LeeeeT/valtypes --cache files
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
=> reading dependency files from cache manifest: ./dry-run/LeeeeT/valtypes/cache-manifest-pip.json
=> parsing dependency files
=> updating 11 dependencies: pre-commit, isort, sort-all, black, pyproject-flake8, mypy, pyright, pytest, pytest-cov, mkdocs-material, jinja2

=== pre-commit ()
 => checking for updates 1/11
🌍 https://pypi.org/simple/pre-commit/
 => latest available version is 2.20.0
    (no update needed as it's already up-to-date)

(...)

=== jinja2 (3.1.0)
 => checking for updates 11/11
🌍 https://pypi.org/simple/jinja2/
 => latest available version is 3.1.2
🌍 https://pypi.org/simple/jinja2/
 => latest allowed version is 3.1.2
 => requirements to unlock: own
 => requirements update strategy: bump_versions
 => updating jinja2 from 3.1.0 to 3.1.2

    ± docs/requirements.txt
    ~~~
    2c2
    < Jinja2==3.1.0
    ---
    > Jinja2==3.1.2
    ~~~
🌍 Total requests made: '24'

real	0m27.956s
user	0m9.490s
sys	0m3.146s
```

So, more than 50% speed up.

And I think this also matches more closely what the real updater does.
