### PR TITLE
Actually consider development dependencies (v2)

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -20,8 +20,6 @@ gemspec path: "../pub"
 gemspec path: "../python"
 gemspec path: "../terraform"
 
-gem "rubocop", group: :development
-
 # Visual Studio Code integration
 gem "reek", group: :development
 gem "ruby-debug-ide", group: :development


### PR DESCRIPTION
As can be seen in [CI logs](https://github.com/dependabot/dependabot-core/actions/runs/3319718684/jobs/5485230152):

```
(...)
Installing simplecov-console 0.9.1
Fetching rubocop 1.37.1
Installing rubocop 1.37.1
Fetching aws-sdk-codecommit 1.51.0
Installing aws-sdk-codecommit 1.51.0
(...)
```

#5969 did not fix the issue since it's still installing the latest RuboCop.

I think this is an issue in Bundler, but let's add a workaround for it.

Currently, if you add a development dependency to a Gemfile through a gemspec, with the `gemspec` DSL, and later on in the Gemfile you explicitly add it again, Bundler will silently prefer the latter specification even if the former is more restrictive.

I think Bundler should either warn, or prefer the most restrictive one, but to avoid this issue we can remove the duplicated dependency specification.