### PR TITLE
prevent trying to get a commit that can't exist

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -85,7 +85,11 @@ module Dependabot
       def clone_repo_contents
         @clone_repo_contents ||=
           _clone_repo_contents(target_directory: repo_contents_path)
-      rescue Dependabot::SharedHelpers::HelperSubprocessFailed
+      rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
+        if e.message.include?("fatal: Remote branch #{target_branch} not found in upstream origin")
+          raise Dependabot::BranchNotFound, target_branch
+        end
+
         raise Dependabot::RepoNotFound, source
       end
 

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -1553,6 +1553,16 @@ RSpec.describe Dependabot::FileFetchers::Base do
           expect { subject }.to raise_error(Dependabot::RepoNotFound)
         end
       end
+
+      context "when the branch can't be found" do
+        let(:branch) do
+          "notfound"
+        end
+
+        it "raises a not found error" do
+          expect { subject }.to raise_error(Dependabot::BranchNotFound)
+        end
+      end
     end
   end
 end

--- a/updater/lib/dependabot/file_fetcher_job.rb
+++ b/updater/lib/dependabot/file_fetcher_job.rb
@@ -57,6 +57,10 @@ module Dependabot
       return unless job.clone?
 
       file_fetcher.clone_repo_contents
+    rescue Dependabot::RepoNotFound, Dependabot::BranchNotFound
+      # base_commit_sha can't be reached, don't attempt to fetch it in the rescue
+      @base_commit_sha = "unknown"
+      raise
     end
 
     def base64_dependency_files

--- a/updater/spec/dependabot/file_fetcher_job_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_job_spec.rb
@@ -186,6 +186,27 @@ RSpec.describe Dependabot::FileFetcherJob do
         expect(Dir.exist?(Dependabot::Environment.repo_contents_path)).to be_truthy
         expect(Dir.empty?(Dependabot::Environment.repo_contents_path)).to be_truthy
       end
+
+      context "when the fetcher raises a BranchNotFound error while cloning" do
+        before do
+          allow_any_instance_of(Dependabot::GoModules::FileFetcher).
+            to receive(:clone_repo_contents).
+            and_raise(Dependabot::BranchNotFound, "my_branch")
+        end
+
+        it "tells the backend about the error (and doesn't re-raise it)" do
+          expect(api_client).
+            to receive(:record_update_job_error).
+            with(
+              job_id,
+              error_details: { "branch-name": "my_branch" },
+              error_type: "branch_not_found"
+            )
+          expect(api_client).to receive(:mark_job_as_processed)
+
+          expect { perform_job }.to output(/Error during file fetching; aborting/).to_stdout_from_any_process
+        end
+      end
     end
 
     context "when the connectivity check is enabled", vcr: true do


### PR DESCRIPTION
The change in #5937 caused Dependabot to begin raising an exception inside of the rescue for repositories that had a branch that didn't exist inside of their dependabot.yml.

What is happening is:
- The clone raises a HelperSubprocessFailed
- It gets turned into RepoNotFound
- The file_fetcher_job's rescue tries to call `mark_job_as_processed`
- But first it tries to get the `base_commit_sha` which... doesn't exist! So it also raises.

This fixes two issues:
- By setting @base_commit_sha to "unknown" when we know the clone failed, we can circumvent the second raise.
- By checking the error message for "remote brach X not found" we can raise the correct error so the UI is more helpful
