### PR TITLE
Allow file fetchers to opt into loading git submodules

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -47,6 +47,10 @@ module Dependabot
       def go_sum
         @go_sum ||= fetch_file_if_present("go.sum")
       end
+
+      def recurse_submodules_when_cloning?
+        true
+      end
     end
   end
 end

--- a/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
@@ -59,4 +59,15 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
         to raise_error(Dependabot::DependencyFileNotFound)
     end
   end
+
+  context "when dependencies are git submodules" do
+    let(:repo) { "dependabot-fixtures/go-modules-app-with-git-submodules" }
+    let(:branch) { "main" }
+    let(:submodule_contents_path) { File.join(repo_contents_path, "examplelib") }
+
+    it "clones them" do
+      expect { file_fetcher_instance.files }.to_not raise_error
+      expect(`ls -1 #{submodule_contents_path}`.split).to include("go.mod")
+    end
+  end
 end


### PR DESCRIPTION
## Context

Closes https://github.com/dependabot/dependabot-core/issues/5975

Repos are always git-cloned with `--no-recurse-submodules`. This can be problematic if a dependency lives in a git submodule and dependency resolution requires reading from it. For my use case, this is showing up when using go modules.

## What's Changing

This PR adds `#recurse_submodules_when_cloning?` to `Dependabot::FileFetchers::Base`. If it returns a truthy value, repos are git-cloned with [`--recurse-submodules`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---recurse-submodulesltpathspecgt) and [`--shallow-submodules`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---no-shallow-submodules); if it returns a falsy value, `--no-recurse-submodules` is used (the current behavior).

The default implementation of the method returns false, preserving the existing behavior for all file fetchers. Subclasses of `Dependabot::FileFetchers::Base` may override to opt into the behavior, and this PR does so for the go modules file fetcher.

The change also extends the behavior to the git-fetch and git-reset operations if `source.commit` is present (i.e., for testing). The relevant options used are [`git fetch --recurse-submodules=on-demand`](https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---recurse-submodulesyeson-demandno) and [`git reset --recurse-submodules`](https://git-scm.com/docs/git-reset#Documentation/git-reset.txt---no-recurse-submodules).

## How to Review

I recommend reviewing this PR by commit:

0b1f0978c93a890174a68731bf220dd7d6745f15: I noticed that `Dependabot::FileFetchers::Base` declares some methods "private" (ruby `private`, prefixed with underscore) under a comment heading that says they should not be used by subclasses, but some "protected" (ruby `private`, no underscore) methods were mixed in with these under the same comment. This commit moves the protected methods above the comment, which makes the overall diff appear larger than what's actually changing.

41bac21d56c5cfd2c35adec5030ad2987442ea32: adds `#recurse_submodules_when_cloning?` and integrates it into `#_clone_repo_contents`.

 2f8a624d74de0ee214954894e5a64ac5f1ce0e05: overrides `#recurse_submodules_when_cloning?` for the `go_modules` file fetcher in order to opt into the behavior.