### PR TITLE
Don't fail if dependency with unknown vcs has local replacement

### DIFF
--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -307,6 +307,16 @@ RSpec.describe Dependabot::GoModules::FileParser do
       end
     end
 
+    context "that is not resolvable, but is locally replaced" do
+      let(:go_mod_content) do
+        fixture("projects", "unknown_vcs_local_replacement", "go.mod")
+      end
+
+      it "does not raise an error" do
+        expect { parser.parse }.not_to raise_error
+      end
+    end
+
     context "a monorepo" do
       let(:project_name) { "monorepo" }
       let(:repo_contents_path) { build_tmp_repo(project_name) }

--- a/go_modules/spec/fixtures/projects/unknown_vcs_local_replacement/go.mod
+++ b/go_modules/spec/fixtures/projects/unknown_vcs_local_replacement/go.mod
@@ -5,3 +5,7 @@ go 1.12
 require (
 	unknown.doesnotexist/vcs v0.0.0-00010101000000-000000000000
 )
+
+replace (
+	unknown.doesnotexist/vcs => ../monorepo/common
+)

--- a/go_modules/spec/fixtures/projects/unknown_vcs_local_replacement/main.go
+++ b/go_modules/spec/fixtures/projects/unknown_vcs_local_replacement/main.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	_ "unknown.doesnotexist/vcs"
+)
+
+func main() {
+}


### PR DESCRIPTION
Fixes #5949, so that if a project is using a module namespace that does not have an accessible version control system, and is using local replacements like a monorepo, dependabot will not fail to update the dependencies it can. Example:
```go
module company.com/vcs/service

go 1.12

require (
	company.com/vcs/gotool v0.0.0-00010101000000-000000000000
)

replace (
	company.com/vcs/gotool => ../monorepo/common
)
```

Updates the `go_modules` `file_parser` implementation such that: if dependabot encounters a `DependencyFileNotResolvable` error but the dependency has a local replacement available, it will not fail to update the remaining dependencies.

This case can occur in monorepos whose module paths are not a mapping to their version control system.

I've added the test scenario, and ran the tests locally as well as the dry-run script against a private repo where I was experiencing this issue initially and received the expected results. Please let me know if I should do anything more to contribute this change. 