### PR TITLE
Bump Node.js in bug report description field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -35,7 +35,7 @@ body:
   - type: input
     attributes:
       label: Language version
-      description: If applicable, specify the language version you're using (e.g., Node.js `14.1`, Ruby `3.1`, etc.)
+      description: If applicable, specify the language version you're using (e.g., Node.js `16.18`, Ruby `3.1`, etc.)
     validations:
       required: false
 


### PR DESCRIPTION
## Changes:

- Bump from Node.js `14.1` to `16.18`

## Context:

`16.18` is the latest Node.16 maintenance release.

You use Node `16` in your Dockerfile, so it seems good to match that in the bug report description.

https://github.com/dependabot/dependabot-core/blob/6da4eadd68fea6c0c9f4975ea17be2e957514576/Dockerfile#L114-L121