### PR TITLE
Centralize pyenv install logic

### DIFF
--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -7,6 +7,7 @@ require "dependabot/python/file_fetcher"
 require "dependabot/python/file_parser/python_requirement_parser"
 require "dependabot/python/file_updater"
 require "dependabot/shared_helpers"
+require "dependabot/python/helpers"
 require "dependabot/python/native_helpers"
 require "dependabot/python/python_versions"
 require "dependabot/python/name_normaliser"
@@ -65,7 +66,7 @@ module Dependabot
         def compile_new_requirement_files
           SharedHelpers.in_a_temporary_directory do
             write_updated_dependency_files
-            install_required_python
+            Helpers.install_required_python(python_version)
 
             filenames_to_compile.each do |filename|
               # Shell out to pip-compile, generate a new set of requirements.
@@ -210,16 +211,6 @@ module Dependabot
             FileUtils.mkdir_p(Pathname.new(path).dirname)
             File.write(path, "[metadata]\nname = sanitized-package\n")
           end
-        end
-
-        def install_required_python
-          # The leading space is important
-          return if run_command("pyenv versions").include?(" #{python_version}")
-
-          run_command("pyenv install -s #{python_version}")
-          run_command("pyenv exec pip install --upgrade pip")
-          run_command("pyenv exec pip install -r " \
-                      "#{NativeHelpers.python_requirements_path}")
         end
 
         def sanitized_setup_file_content(file)

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -302,11 +302,7 @@ module Dependabot
             nil
           end
 
-          return if run_command("pyenv versions").include?("#{python_version}\n")
-
-          requirements_path = NativeHelpers.python_requirements_path
-          run_command("pyenv install -s #{python_version}")
-          run_command("pyenv exec pip install -r #{requirements_path}")
+          Helpers.install_required_python(python_version)
         end
 
         def sanitized_setup_file_content(file)

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -4,6 +4,7 @@ require "toml-rb"
 require "open3"
 require "dependabot/dependency"
 require "dependabot/shared_helpers"
+require "dependabot/python/helpers"
 require "dependabot/python/version"
 require "dependabot/python/requirement"
 require "dependabot/python/python_versions"
@@ -170,12 +171,7 @@ module Dependabot
               write_temporary_dependency_files(pyproject_content)
               add_auth_env_vars
 
-              if python_version && !pre_installed_python?(python_version)
-                run_poetry_command("pyenv install -s #{python_version}")
-                run_poetry_command("pyenv exec pip install --upgrade pip")
-                run_poetry_command("pyenv exec pip install -r" \
-                                   "#{NativeHelpers.python_requirements_path}")
-              end
+              Helpers.install_required_python(python_version)
 
               # use system git instead of the pure Python dulwich
               unless python_version&.start_with?("3.6")

--- a/python/lib/dependabot/python/helpers.rb
+++ b/python/lib/dependabot/python/helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "dependabot/logger"
 
 module Dependabot

--- a/python/lib/dependabot/python/helpers.rb
+++ b/python/lib/dependabot/python/helpers.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require "dependabot/logger"
+
+module Dependabot
+  module Python
+    module Helpers
+      def self.install_required_python(python_version)
+        # The leading space is important in the version check
+        return if SharedHelpers.run_shell_command("pyenv versions").include?(" #{python_version}")
+
+        Dependabot.logger.info("Installing required Python #{python_version}.")
+        SharedHelpers.run_shell_command("pyenv install -s #{python_version}")
+        SharedHelpers.run_shell_command("pyenv exec pip install --upgrade pip")
+        SharedHelpers.run_shell_command("pyenv exec pip install -r" \
+                                        "#{NativeHelpers.python_requirements_path}")
+      end
+    end
+  end
+end

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -11,6 +11,7 @@ require "dependabot/python/file_updater/requirement_replacer"
 require "dependabot/python/file_updater/setup_file_sanitizer"
 require "dependabot/python/version"
 require "dependabot/shared_helpers"
+require "dependabot/python/helpers"
 require "dependabot/python/native_helpers"
 require "dependabot/python/python_versions"
 require "dependabot/python/name_normaliser"
@@ -70,7 +71,7 @@ module Dependabot
             SharedHelpers.in_a_temporary_directory do
               SharedHelpers.with_git_configured(credentials: credentials) do
                 write_temporary_dependency_files(updated_req: requirement)
-                install_required_python
+                Helpers.install_required_python(python_version)
 
                 filenames_to_compile.each do |filename|
                   # Shell out to pip-compile.
@@ -317,16 +318,6 @@ module Dependabot
             FileUtils.mkdir_p(Pathname.new(file.name).dirname)
             File.write(file.name, file.content)
           end
-        end
-
-        def install_required_python
-          # The leading space is important
-          return if run_command("pyenv versions").include?(" #{python_version}")
-
-          run_command("pyenv install -s #{python_version}")
-          run_command("pyenv exec pip install --upgrade pip")
-          run_command("pyenv exec pip install -r" \
-                      "#{NativeHelpers.python_requirements_path}")
         end
 
         def sanitized_setup_file_content(file)

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -320,14 +320,7 @@ module Dependabot
             nil
           end
 
-          # The leading space is important
-          return if run_command("pyenv versions").include?(" #{python_version}")
-
-          requirements_path = NativeHelpers.python_requirements_path
-          run_command("pyenv install -s #{python_version}")
-          run_command("pyenv exec pip install --upgrade pip")
-          run_command("pyenv exec pip install -r " \
-                      "#{requirements_path}")
+          Helpers.install_required_python(python_version)
         end
 
         def sanitized_setup_file_content(file)

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -93,14 +93,7 @@ module Dependabot
                 write_temporary_dependency_files(updated_req: requirement)
                 add_auth_env_vars
 
-                if python_version && !pre_installed_python?(python_version)
-                  run_poetry_command("pyenv install -s #{python_version}")
-                  run_poetry_command("pyenv exec pip install --upgrade pip")
-                  run_poetry_command(
-                    "pyenv exec pip install -r " \
-                    "#{NativeHelpers.python_requirements_path}"
-                  )
-                end
+                Helpers.install_required_python(python_version)
 
                 # use system git instead of the pure Python dulwich
                 unless python_version&.start_with?("3.6")
@@ -346,7 +339,7 @@ module Dependabot
           stdout, process = Open3.capture2e(command)
           time_taken = Time.now - start
 
-          # Raise an error with the output from the shell session if Pipenv
+          # Raise an error with the output from the shell session if poetry
           # returns a non-zero status
           return if process.success?
 

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -82,7 +82,6 @@ module Dependabot
 
         private
 
-        # rubocop:disable Metrics/PerceivedComplexity
         def fetch_latest_resolvable_version_string(requirement:)
           @latest_resolvable_version_string ||= {}
           return @latest_resolvable_version_string[requirement] if @latest_resolvable_version_string.key?(requirement)
@@ -116,7 +115,6 @@ module Dependabot
               end
             end
         end
-        # rubocop:enable Metrics/PerceivedComplexity
 
         def fetch_version_from_parsed_lockfile(updated_lockfile)
           version =


### PR DESCRIPTION
## Context
As part of the work to allow Dependabot to work reliably when isolated from the internet some code cleanup has been identified.  This is the beginning of the work to limit the places where we make attempts to talk to the public internet

## Approach
I've added a new `helpers.rb` for python which will contain various methods which are currently copy/pasted between the various python package manager implementations.  The first method I've moved over is the method that installs new python versions via `pyenv install`.

## Ongoing
I am pretty sure the `python_version` and the methods it calls in the various implementations can also be moved to the new `helpers.rb` and I will be working on that next.