### PR TITLE
Sanitize file names in `Dependabot::DependencyFile` initializer

### DIFF
--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -21,7 +21,7 @@ module Dependabot
     def initialize(name:, content:, directory: "/", type: "file",
                    support_file: false, symlink_target: nil,
                    content_encoding: ContentEncoding::UTF_8, deleted: false, operation: Operation::UPDATE)
-      @name = name
+      @name = sanitize_name(name)
       @content = content
       @directory = clean_directory(directory)
       @symlink_target = symlink_target
@@ -113,6 +113,12 @@ module Dependabot
     def clean_directory(directory)
       # Directory should always start with a `/`
       directory.sub(%r{^/*}, "/")
+    end
+
+    def sanitize_name(name)
+      # Ensure name is a relative path without relative path traversal
+      path = Pathname.new(name).cleanpath
+      File.join(path.split.reject { |c| c.root? || c.to_s == "." || c.to_s == ".." })
     end
   end
 end


### PR DESCRIPTION
Most package ecosystems have code to write dependency files into a temporary directory. Here's a representative example from `npm_and_yarn`:

https://github.com/dependabot/dependabot-core/blob/6a9c745252f7ff8389751b58133c851df6207b79/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/dependency_files_builder.rb#L16-L26

You can [find a few dozen instances of this pattern](https://github.com/search?q=repo%3Adependabot%2Fdependabot-core%20%22FileUtils.mkdir_p(Pathname.new(path).dirname)%22&type=code) in our codebase.

When `file.name` has a leading `/`, those calls to `FileUtils#mkdir_p` and `File.write` write to the root directory. This causes an `Errno::EACCES`. For example, when Dependabot runs an update job for a JavaScript project with a local path dependency it produces the error `"Permission denied @ rb_sysopen - /package.json"`.

This PR attempts to address this problem by sanitizing `Dependabot::DependencyFile` names in the initializer. With this change, any file names with an absolute path are translated into relative paths that will be written into temporary directories instead of attempting to be written to system root.