### PR TITLE
Add Azure DevOps support for creating a PR with assigned reviewers

### DIFF
--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -172,7 +172,8 @@ module Dependabot
 
       # rubocop:disable Metrics/ParameterLists
       def create_pull_request(pr_name, source_branch, target_branch,
-                              pr_description, labels, work_item = nil)
+                              pr_description, labels,
+                              reviewers = nil, assignees = nil, work_item = nil)
         pr_description = truncate_pr_description(pr_description)
 
         content = {
@@ -181,6 +182,7 @@ module Dependabot
           title: pr_name,
           description: pr_description,
           labels: labels.map { |label| { name: label } },
+          reviewers: pr_reviewers(reviewers, assignees),
           workItemRefs: [{ id: work_item }]
         }
 
@@ -322,6 +324,13 @@ module Dependabot
 
         message = JSON.parse(response.body).fetch("message", nil)
         message&.include?("TF401289")
+      end
+
+      def pr_reviewers(reviewers, assignees)
+        return [] unless reviewers || assignees
+
+        pr_reviewers = reviewers&.map { |r_id| { id: r_id, isRequired: true } } || []
+        pr_reviewers + (assignees&.map { |r_id| { id: r_id, isRequired: false } } || [])
       end
 
       attr_reader :auth_header

--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -176,6 +176,8 @@ module Dependabot
         pr_name: message.pr_name,
         author_details: author_details,
         labeler: labeler,
+        reviewers: reviewers,
+        assignees: assignees,
         work_item: provider_metadata&.fetch(:work_item, nil)
       )
     end

--- a/common/lib/dependabot/pull_request_creator/azure.rb
+++ b/common/lib/dependabot/pull_request_creator/azure.rb
@@ -8,11 +8,11 @@ module Dependabot
     class Azure
       attr_reader :source, :branch_name, :base_commit, :credentials,
                   :files, :commit_message, :pr_description, :pr_name,
-                  :author_details, :labeler, :work_item
+                  :author_details, :labeler, :reviewers, :assignees, :work_item
 
       def initialize(source:, branch_name:, base_commit:, credentials:,
                      files:, commit_message:, pr_description:, pr_name:,
-                     author_details:, labeler:, work_item: nil)
+                     author_details:, labeler:, reviewers: nil, assignees: nil, work_item: nil)
         @source         = source
         @branch_name    = branch_name
         @base_commit    = base_commit
@@ -23,6 +23,8 @@ module Dependabot
         @pr_name        = pr_name
         @author_details = author_details
         @labeler        = labeler
+        @reviewers      = reviewers
+        @assignees      = assignees
         @work_item      = work_item
       end
 
@@ -79,6 +81,8 @@ module Dependabot
           source.branch || default_branch,
           pr_description,
           labeler.labels_for_pr,
+          reviewers,
+          assignees,
           work_item
         )
       end

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -282,6 +282,8 @@ RSpec.describe Dependabot::PullRequestCreator do
             pr_name: "PR name",
             author_details: author_details,
             labeler: instance_of(described_class::Labeler),
+            reviewers: reviewers,
+            assignees: assignees,
             work_item: 123
           ).and_return(dummy_creator)
         expect(dummy_creator).to receive(:create)


### PR DESCRIPTION
Allows [creating a PR ](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/create?view=azure-devops-rest-6.0&tabs=HTTP) for Azure DevOps and assigning directly a 
- required reviewer (reviewer)
- optional reviewer (assignee)

by providing the ids of the identities to be assigned.

just for completeness, the identity Id can be retrieved in scripts:
- Azure DevOps Services using the [Graph API](https://learn.microsoft.com/en-us/rest/api/azure/devops/graph/subject-query/query?view=azure-devops-rest-6.1), [Stackoverflow](https://stackoverflow.com/a/70268220)
- Azure DevOps Server using the [Identities API](https://learn.microsoft.com/en-us/rest/api/azure/devops/ims/identities/read-identities?view=azure-devops-server-rest-6.0&tabs=HTTP) using a `searchFilter` for e.g. a `MailAddress` 