### PR TITLE
Cast source_url to string in terraform provider

### DIFF
--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -103,7 +103,7 @@ module Dependabot
           return nil unless response.status == 204
 
           source_url = response.headers.fetch("X-Terraform-Get")
-          source_url = URI.join(download_url, source_url) if
+          source_url = URI.join(download_url, source_url).to_s if
             source_url.start_with?("/", "./", "../")
           source_url = RegistryClient.get_proxied_source(source_url) if source_url
         when "provider", "providers"


### PR DESCRIPTION
It seems that https://github.com/dependabot/dependabot-core/commit/b4d66fa5ec88d6456a63fd1c04504ea9b325e586 introduced a bug where `URI` object would be passed in to `get_proxied_source` method. This results in raising `undefined method 'start_with?' for #<URI::HTTPS>`.

Convert `URI` to `String` for it to work correctly