### PR TITLE
Bump elixir and erlang so they don't conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -211,17 +211,18 @@ RUN cd /tmp \
 # Install Erlang, Elixir and Hex
 ENV PATH="$PATH:/usr/local/elixir/bin"
 # https://github.com/elixir-lang/elixir/releases
-ARG ELIXIR_VERSION=v1.13.4
-ARG ELIXIR_CHECKSUM=e64c714e80cd9657b8897d725f6d78f251d443082f6af5070caec863c18068c97af6bdda156c3b3390e0a2b84f77c2ad3378a42913f64bb583fb5251fa49e619
-ARG ERLANG_VERSION=1:24.2.1-1
+ARG ELIXIR_VERSION=v1.14.1
+ARG ELIXIR_CHECKSUM=40a880e817bc188469e0adf73f41acb82b6a5b9e5da5cbcb55d89d98dcafe5e5
+ARG ERLANG_MAJOR_VERSION=25
+ARG ERLANG_FULL_VERSION=1:${ERLANG_MAJOR_VERSION}.0.4-1
 RUN curl -sSLfO https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb \
   && dpkg -i erlang-solutions_2.0_all.deb \
   && apt-get update \
-  && apt-get install -y --no-install-recommends esl-erlang=${ERLANG_VERSION} \
-  && curl -sSLfO https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip \
-  && echo "$ELIXIR_CHECKSUM  Precompiled.zip" | sha512sum -c - \
-  && unzip -d /usr/local/elixir -x Precompiled.zip \
-  && rm -f Precompiled.zip erlang-solutions_2.0_all.deb \
+  && apt-get install -y --no-install-recommends esl-erlang=${ERLANG_FULL_VERSION} \
+  && curl -sSLfO https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
+  && echo "$ELIXIR_CHECKSUM  elixir-otp-${ERLANG_MAJOR_VERSION}.zip" | sha256sum -c - \
+  && unzip -d /usr/local/elixir -x elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
+  && rm -f elixir-otp-${ERLANG_MAJOR_VERSION}.zip erlang-solutions_2.0_all.deb \
   && mix local.hex --force \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The `1.13.x` series of Elixir wasn't precompiled to work with Erlang OTP 25.

The `1.14.x` series changed from a single pre-compiled binary to releasing separate versions compatible with OTP 23, 24, and 25.

So bump to Erlang OTP 25, and also to the Elixir version that's compiled with OTP 25.

Related:
* #5503 
* #5507 

Also, we may need to switch away from using the Erlang Solutions PPA to install Erlang via the default PPA, but I'm hopeful we won't need to do this...
* https://github.com/dependabot/dependabot-core/pull/5030#issuecomment-1296379546
* https://github.com/esl/packages/issues/15#issuecomment-1296378191
* https://github.com/elixir-lang/elixir-lang.github.com/pull/1637
* https://packages.ubuntu.com/jammy/erlang