### PR TITLE
local clone deletion not required due to action change

### DIFF
--- a/updater/lib/dependabot/file_fetcher_job.rb
+++ b/updater/lib/dependabot/file_fetcher_job.rb
@@ -26,7 +26,6 @@ module Dependabot
         end
         handle_file_fetcher_error(e)
         service.mark_job_as_processed(job_id, @base_commit_sha)
-        clear_repo_contents_path
         return
       end
 
@@ -99,17 +98,6 @@ module Dependabot
       @file_fetcher ||=
         Dependabot::FileFetchers.for_package_manager(job.package_manager).
         new(**args)
-    end
-
-    def clear_repo_contents_path
-      # Remove the contents of the repo_contents_path, as these files are owned
-      # by the root user and will cause a permission error if left in place when
-      # we try to remove the directory.
-      # The `secure` flag ensures that we do not remove any symlinks, which
-      # could be exploited.
-      return unless job.clone?
-
-      FileUtils.rm_rf("#{Environment.repo_contents_path}/.", secure: true)
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -87,8 +87,6 @@ module Dependabot
       # OOM errors are special cased so that we stop the update run early
       error = { "error-type": RUN_HALTING_ERRORS.fetch(e.class) }
       record_error(error)
-    ensure
-      clear_repo_contents_path
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/PerceivedComplexity
@@ -779,17 +777,6 @@ module Dependabot
       logger_info("Telling backend to close pull request for " \
                   "#{job.dependencies.join(', ')} - #{reason_string}")
       service.close_pull_request(job_id, job.dependencies, reason)
-    end
-
-    def clear_repo_contents_path
-      # Remove the contents of the repo_contents_path, as these files are owned
-      # by the root user and will cause a permission error if left in place when
-      # we try to remove the directory.
-      # The `secure` flag ensures that we do not remove any symlinks, which
-      # could be exploited.
-      return unless repo_contents_path && Dir.exist?(repo_contents_path)
-
-      FileUtils.rm_rf("#{repo_contents_path}/.", secure: true)
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/updater/spec/dependabot/file_fetcher_job_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_job_spec.rb
@@ -174,19 +174,6 @@ RSpec.describe Dependabot::FileFetcherJob do
         expect(root_dir_entries).to include("main.go")
       end
 
-      it "cleans up any files left after the job errors" do
-        allow(job).to receive(:clone_repo_contents).and_wrap_original do |method, *args|
-          method.call(*args)
-          raise "Something went wrong"
-        end
-        expect(api_client).to receive(:mark_job_as_processed)
-
-        expect { perform_job }.to output(/Something went wrong/).to_stdout_from_any_process
-
-        expect(Dir.exist?(Dependabot::Environment.repo_contents_path)).to be_truthy
-        expect(Dir.empty?(Dependabot::Environment.repo_contents_path)).to be_truthy
-      end
-
       context "when the fetcher raises a BranchNotFound error while cloning" do
         before do
           allow_any_instance_of(Dependabot::GoModules::FileFetcher).

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -303,28 +303,6 @@ RSpec.describe Dependabot::Updater do
       end
     end
 
-    context "when the repo_contents_path is set and the job clones into it" do
-      let(:repo_contents_path) { Dir.mktmpdir("test_repo_dir") }
-
-      before do
-        File.write(File.join(repo_contents_path, "Gemfile"), <<~GEMFILE)
-          source "https://rubygems.org"
-          gem "dummy-pkg-a"
-        GEMFILE
-      end
-
-      after do
-        FileUtils.rm_rf(repo_contents_path)
-      end
-
-      it "cleans up any files left behind" do
-        updater.run
-
-        expect(Dir.exist?(repo_contents_path)).to be_truthy
-        expect(Dir.empty?(repo_contents_path)).to be_truthy
-      end
-    end
-
     context "for security only updates" do
       let(:security_updates_only) { true }
       let(:security_advisories) do


### PR DESCRIPTION
As the comment notes in the code below, originally this was added because of file permission issues when cleaning up after a job since the Dependabot Action runs as root. The other reason this is needed is the container runs fetch_files in one container, then update_files in another. Since the clone happens in fetch_files, the repo directory had to be mounted to avoid cloning twice.

So in https://github.com/github/dependabot-action/pull/319 I removed the need to mount the directory, so this code is no longer needed because the repo only exists inside the container which is removed on completion.
