### PR TITLE
fix hex native helpers: v2.0.0 removed Hex.Version.InvalidRequirementError

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -315,3 +315,6 @@ RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar
 ENV PATH="$HOME/bin:$PATH"
 # Configure cargo to use git CLI so the above takes effect
 RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo/config.toml
+
+# Pin to an earlier version of Hex. This must be run as dependabot
+RUN mix hex.install 1.0.1


### PR DESCRIPTION
Our native helpers reference Hex.Version.InvalidRequirementError which comes from Hex itself, and since 2.0.0 was released it seems that struct is gone causing a compiler error. So I've pinned Dependabot to 1.0.1 until we can fix the issue and upgrade.