### PR TITLE
Downgrade RubyGems to 3.3.7 to match Ruby 3.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,8 @@ RUN if ! getent group "$USER_GID"; then groupadd --gid "$USER_GID" dependabot ; 
 
 ARG RUBY_VERSION=3.1.2
 ARG RUBY_INSTALL_VERSION=0.8.3
-
-ARG RUBYGEMS_SYSTEM_VERSION=3.3.22
+# Generally simplest to pin RUBYGEMS_SYSTEM_VERSION to the version that default ships with RUBY_VERSION.
+ARG RUBYGEMS_SYSTEM_VERSION=3.3.7
 
 ARG BUNDLER_V1_VERSION=1.17.3
 # When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.files        = []
 
   spec.required_ruby_version = ">= 3.1.0"
-  spec.required_rubygems_version = ">= 3.3.22"
+  spec.required_rubygems_version = ">= 3.3.7"
 
   spec.add_dependency "activesupport", ">= 6.0.0"
   spec.add_dependency "aws-sdk-codecommit", "~> 1.28"


### PR DESCRIPTION
We use `dependabot-core` as a library in a few internal projects. After the bump to `3.3.22`, they started complaining with the following error:
```
dependabot-common-0.213.0 requires rubygems version >= 3.3.22, which is
incompatible with the current version, 3.3.7
```

RubyGems `3.3.7` is the version shipped with `ruby:3.1.2`.

While we could patch all those places to update their system RubyGems, it's a bit of a game of whack-a-mole, and adds minimal value.

So instead, relax the constraint slightly so that those versions work. I don't mind forcing folks to upgrade to the newest Ruby, but as long as they do that, then there's no need for us to be forcing them to futz around further.

Downgrading the version used in the Dockerfile was optional, but I thought better to keep that in sync with what most consumers of the library will be using.