### PR TITLE
Bump Hex to `2.0.1`

### DIFF
--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -25,7 +25,7 @@ USER dependabot
 COPY --chown=dependabot:dependabot hex/helpers /opt/hex/helpers
 ENV MIX_HOME="/opt/hex/mix"
 # https://github.com/hexpm/hex/releases
-ENV HEX_VERSION="1.0.1"
+ENV HEX_VERSION="2.0.1"
 RUN bash /opt/hex/helpers/build
 
 COPY --chown=dependabot:dependabot hex /home/dependabot/hex


### PR DESCRIPTION
Bump Hex to `2.0.1`.

Fix https://github.com/dependabot/dependabot-core/issues/6009