### PR TITLE
Use `elixir`'s `InvalidRequirementError`

### DIFF
--- a/hex/helpers/lib/check_update.exs
+++ b/hex/helpers/lib/check_update.exs
@@ -74,7 +74,7 @@ case UpdateChecker.run(dependency_name, credentials) do
     version = :erlang.term_to_binary({:ok, version})
     IO.write(:stdio, version)
 
-  {:error, %Hex.Version.InvalidRequirementError{} = error}  ->
+  {:error, %Version.InvalidRequirementError{} = error}  ->
     result = :erlang.term_to_binary({:error, "Invalid requirement: #{error.requirement}"})
     IO.write(:stdio, result)
 


### PR DESCRIPTION
As noted in https://github.com/dependabot/dependabot-core/issues/6009, Hex has no public API, so we should be using `elixir`'s built-in [`Version.InvalidRequirementError`](https://hexdocs.pm/elixir/Version.InvalidRequirementError.html) instead of `Hex.Version.InvalidRequirementError`.

Despite Hex not having a public API, we're still calling into it all over the place in this script, but that can't really be helped.

But this particular call can be updated, which will unblock bumping to Hex 2.0

Co-authored-by: @sorentwo
Co-authored-by: @tiagoefmoraes