### PR TITLE
Add support for Python 3.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,10 +105,10 @@ ENV PYENV_ROOT=/usr/local/.pyenv \
   PATH="/usr/local/.pyenv/bin:$PATH"
 RUN mkdir -p "$PYENV_ROOT" && chown dependabot:dependabot "$PYENV_ROOT"
 USER dependabot
-RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch v2.3.5 --single-branch --depth=1 /usr/local/.pyenv \
+RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch v2.3.6 --single-branch --depth=1 /usr/local/.pyenv \
   # This is the version of CPython that gets installed
-  && pyenv install 3.10.7 \
-  && pyenv global 3.10.7 \
+  && pyenv install 3.11.0 \
+  && pyenv global 3.11.0 \
   && rm -Rf /tmp/python-build*
 USER root
 

--- a/python/helpers/build
+++ b/python/helpers/build
@@ -18,4 +18,4 @@ cp -r \
   "$install_dir"
 
 cd "$install_dir"
-PYENV_VERSION=3.10.7 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"
+PYENV_VERSION=3.11.0 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"

--- a/python/lib/dependabot/python/python_versions.rb
+++ b/python/lib/dependabot/python/python_versions.rb
@@ -4,12 +4,13 @@ module Dependabot
   module Python
     module PythonVersions
       PRE_INSTALLED_PYTHON_VERSIONS = %w(
-        3.10.7
+        3.11.0
       ).freeze
 
       # Due to an OpenSSL issue we can only install the following versions in
       # the Dependabot container.
       SUPPORTED_VERSIONS = %w(
+        3.11.0
         3.10.7 3.10.6 3.10.5 3.10.4 3.10.3 3.10.2 3.10.1 3.10.0
         3.9.14 3.9.13 3.9.12 3.9.11 3.9.10 3.9.9 3.9.8 3.9.7 3.9.6 3.9.5 3.9.4 3.9.2 3.9.1 3.9.0
         3.8.14 3.8.13 3.8.12 3.8.11 3.8.10 3.8.9 3.8.8 3.8.7 3.8.6 3.8.5 3.8.4 3.8.3 3.8.2 3.8.1 3.8.0

--- a/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipenvVersionResolver do
                 to start_with("Dependabot detected the following Python")
               expect(error.message).to include("3.4.*")
               expect(error.message).
-                to include("supported in Dependabot: 3.10.7, 3.10.6, 3.10.5")
+                to include("supported in Dependabot: 3.11.0, 3.10.7, 3.10.6")
             end
         end
       end


### PR DESCRIPTION
It was just released on Oct. 24, 2022:
https://www.python.org/downloads/release/python-3110/

pyenv is providing 3.11 support was released today:
- https://github.com/pyenv/pyenv/releases/tag/v2.3.6
- https://github.com/Homebrew/homebrew-core/commit/c6ab2f5caf80d8558a1d76a88a5352aa4d318936