### PR TITLE
Fix accidental downgrades in Bundler PRs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN if ! getent group "$USER_GID"; then groupadd --gid "$USER_GID" dependabot ; 
 
 ### RUBY
 
+# When bumping Ruby minor, need to also add the previos version to `bundler/helpers/v{1,2}/monkey_patches/definition_ruby_version_patch.rb`
 ARG RUBY_VERSION=3.1.2
 ARG RUBY_INSTALL_VERSION=0.8.3
 # Generally simplest to pin RUBYGEMS_SYSTEM_VERSION to the version that default ships with RUBY_VERSION.

--- a/bundler/helpers/v1/monkey_patches/definition_ruby_version_patch.rb
+++ b/bundler/helpers/v1/monkey_patches/definition_ruby_version_patch.rb
@@ -11,8 +11,9 @@ module BundlerDefinitionRubyVersionPatch
           Gem::Specification.new("ruby\0", requested_version)
       end
 
-      sources.metadata_source.specs <<
-        Gem::Specification.new("ruby\0", "2.5.3p105")
+      %w(2.5.3p105 2.6.10p210 2.7.6p219 3.0.4p208).each do |version|
+        sources.metadata_source.specs << Gem::Specification.new("ruby\0", version)
+      end
     end
   end
 end

--- a/bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb
@@ -10,8 +10,9 @@ module BundlerDefinitionRubyVersionPatch
         Gem::Specification.new("Ruby\0", requested_version)
     end
 
-    sources.metadata_source.specs <<
-      Gem::Specification.new("Ruby\0", "2.5.3")
+    %w(2.5.3 2.6.10 2.7.6 3.0.4).each do |version|
+      sources.metadata_source.specs << Gem::Specification.new("Ruby\0", version)
+    end
 
     super
   end


### PR DESCRIPTION
Dependabot monkeypatches Bundler to allow resolving for arbitrary rubies, not just for the running Ruby. However, when no Ruby information is provided via either `gemspec` files or `ruby` Gemfile directive, Dependabot was only allowing to resolve either to Ruby 2.5, or to the running Ruby 3.1.

In some situations, it can happen that resolving on Ruby 3.1 is not possible, while resolving on Ruby 2.5 is possible but requires downgrading some lock file dependencies.

To avoid this problem, let's add the missing rubies to our list of rubies Dependabot can resolve to.

NOTE: I spent some time trying to write specs for this, but it turned out pretty tricky. In the end, I added a note in the Dockerfile to avoid falling out of sync again here. Also, I will look into porting this functionality to Bundler so that Dependabot does not need to monkey patch it, and thus leads to more consistent results.

Fixes https://github.com/dependabot/dependabot-core/issues/5926.