### PR TITLE
nuget: keep version build identifiers out of manifests

### DIFF
--- a/nuget/lib/dependabot/nuget/version.rb
+++ b/nuget/lib/dependabot/nuget/version.rb
@@ -20,9 +20,8 @@ module Dependabot
       end
 
       def initialize(version)
-        @version_string = version.to_s
-
-        version = version.to_s.split("+").first if version.to_s.include?("+")
+        version = version.to_s.split("+").first || ""
+        @version_string = version
 
         super
       end
@@ -43,30 +42,24 @@ module Dependabot
       end
 
       def compare_release(other)
-        release_str = @version_string.split("-").first&.split("+")&.first || ""
-        other_release_str = other.to_s.split("-").first&.split("+")&.first || ""
+        release_str = @version_string.split("-").first || ""
+        other_release_str = other.to_s.split("-").first || ""
 
         Gem::Version.new(release_str).<=>(Gem::Version.new(other_release_str))
       end
 
       # rubocop:disable Metrics/PerceivedComplexity
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/AbcSize
       def compare_prerelease_part(other)
-        release_str = @version_string.split("-").first&.split("+")&.first || ""
+        release_str = @version_string.split("-").first || ""
         prerelease_string = @version_string.
                             sub(release_str, "").
-                            sub("-", "").
-                            split("+").
-                            first
+                            sub("-", "")
         prerelease_string = nil if prerelease_string == ""
 
-        other_release_str = other.to_s.split("-").first&.split("+")&.first || ""
+        other_release_str = other.to_s.split("-").first || ""
         other_prerelease_string = other.to_s.
                                   sub(other_release_str, "").
-                                  sub("-", "").
-                                  split("+").
-                                  first
+                                  sub("-", "")
         other_prerelease_string = nil if other_prerelease_string == ""
 
         return -1 if prerelease_string && !other_prerelease_string
@@ -86,10 +79,7 @@ module Dependabot
 
         0
       end
-
       # rubocop:enable Metrics/PerceivedComplexity
-      # rubocop:enable Metrics/CyclomaticComplexity
-      # rubocop:enable Metrics/AbcSize
 
       def compare_dot_separated_part(lhs, rhs)
         return -1 if lhs.nil?

--- a/nuget/spec/dependabot/nuget/update_checker/requirements_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/update_checker/requirements_updater_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Dependabot::Nuget::UpdateChecker::RequirementsUpdater do
         end
         let(:csproj_req_string) { "3.0.0-beta4.20207.4+07df2f07" }
         its([:requirement]) do
-          is_expected.to eq("3.0.0-beta4.20210.2+38fe3493")
+          is_expected.to eq("3.0.0-beta4.20210.2")
         end
       end
 

--- a/nuget/spec/dependabot/nuget/version_spec.rb
+++ b/nuget/spec/dependabot/nuget/version_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Dependabot::Nuget::Version do
 
     context "with build information" do
       let(:version_string) { "1.0.0+gc.1" }
-      it { is_expected.to eq "1.0.0+gc.1" }
+      it { is_expected.to eq "1.0.0" }
     end
 
     context "with a blank version" do
@@ -66,7 +66,7 @@ RSpec.describe Dependabot::Nuget::Version do
 
     context "with pre-release details" do
       let(:version_string) { "1.0.0-beta+abc.1" }
-      it { is_expected.to eq("1.0.0-beta+abc.1") }
+      it { is_expected.to eq("1.0.0-beta") }
     end
   end
 
@@ -102,7 +102,7 @@ RSpec.describe Dependabot::Nuget::Version do
         expect(described_class.new(v)).to eq v
       end
       it "should ignore the build identifier #{v}+build" do
-        expect(described_class.new(v)).to eq "#{v}+build"
+        expect(described_class.new(v)).to eq described_class.new("#{v}+build")
       end
     end
 


### PR DESCRIPTION
fixes #2310

We already don't consider NuGet build info when comparing versions. The next step is to not add the build info to versions bumped in the manifests which is what users expect, and how the native tooling behaves. 

By removing it immediately when parsing the version we ensure it won't appear when `to_s` is called.