### PR TITLE
ignore - purely WIP CI testing: bump hex without changing location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -323,4 +323,4 @@ RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo
 ENV GIT_LFS_SKIP_SMUDGE=1
 
 # Pin to an earlier version of Hex. This must be run as dependabot
-RUN mix hex.install 1.0.1
+RUN mix hex.install 2.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -210,7 +210,7 @@ RUN cd /tmp \
 
 ### ELIXIR
 
-# Install Erlang and Elixir
+# Install Erlang, Elixir and Hex
 ENV PATH="$PATH:/usr/local/elixir/bin"
 # https://github.com/elixir-lang/elixir/releases
 ARG ELIXIR_VERSION=v1.14.1
@@ -225,6 +225,7 @@ RUN curl -sSLfO https://packages.erlang-solutions.com/erlang-solutions_2.0_all.d
   && echo "$ELIXIR_CHECKSUM  elixir-otp-${ERLANG_MAJOR_VERSION}.zip" | sha256sum -c - \
   && unzip -d /usr/local/elixir -x elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
   && rm -f elixir-otp-${ERLANG_MAJOR_VERSION}.zip erlang-solutions_2.0_all.deb \
+  && mix local.hex --force \
   && rm -rf /var/lib/apt/lists/*
 
 
@@ -288,8 +289,6 @@ RUN bash /opt/go_modules/helpers/build
 
 COPY --chown=dependabot:dependabot hex/helpers /opt/hex/helpers
 ENV MIX_HOME="/opt/hex/mix"
-# https://github.com/hexpm/hex/releases
-ENV HEX_VERSION="1.0.1"
 RUN bash /opt/hex/helpers/build
 
 COPY --chown=dependabot:dependabot pub/helpers /opt/pub/helpers
@@ -322,3 +321,6 @@ RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo
 # Disable automatic pulling of files stored with Git LFS
 # This avoids downloading large files not necessary for the dependabot scripts
 ENV GIT_LFS_SKIP_SMUDGE=1
+
+# Pin to an earlier version of Hex. This must be run as dependabot
+RUN mix hex.install 1.0.1

--- a/hex/helpers/build
+++ b/hex/helpers/build
@@ -10,14 +10,7 @@ fi
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/hex"
 mkdir -p "$install_dir"
 
-# Initial Hex install - will always be the latest available version
-mix local.hex --force --if-missing
-# Annoyingly, a specific Hex version cannot be specified during the initial install.
-# The only way to pin is to re-install.
-if [ -n "$HEX_VERSION" ]; then
-  mix hex.install "$HEX_VERSION"
-fi
-
+mix local.hex --force
 mix archive.install hex nerves_bootstrap --force
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
WIP purely for CI testing to see if somehow #6037 unexpectedly broke this upgrade causing the CI failures in #6026 