### PR TITLE
Upgrade Bundler to 2.3.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ ARG RUBYGEMS_SYSTEM_VERSION=3.3.7
 
 ARG BUNDLER_V1_VERSION=1.17.3
 # When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
-ARG BUNDLER_V2_VERSION=2.3.22
+ARG BUNDLER_V2_VERSION=2.3.25
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
 # Allow gem installs as the dependabot user
 ENV BUNDLE_PATH=".bundle" \

--- a/bundler/helpers/v2/monkey_patches/definition_bundler_version_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/definition_bundler_version_patch.rb
@@ -6,9 +6,7 @@ require "bundler/definition"
 # version available to us is the one we're using).
 module BundlerDefinitionBundlerVersionPatch
   def expanded_dependencies
-    @expanded_dependencies ||=
-      expand_dependencies(dependencies + metadata_dependencies, @remote).
-      reject { |d| d.name == "bundler" }
+    @expanded_dependencies ||= (dependencies + metadata_dependencies).reject { |d| d.name == "bundler" }
   end
 end
 

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -330,4 +330,4 @@ DEPENDENCIES
   webmock (~> 3.18)
 
 BUNDLED WITH
-   2.3.22
+   2.3.25


### PR DESCRIPTION
Recently I've been experiencing an issue where Dependabot has stopped working and always [times out](https://github.com/Homebrew/brew/network/updates/499334214).

I've looked into why that was happening and it's a Bundler bug that was [fixed](https://github.com/rubygems/rubygems/pull/5698) in 2.3.24. Dependabot is however still using 2.3.22.

I've tested this change locally and it fixed the issue for me. `dependabot update` always hung before but now succeeeds.

The fix upstream changed some methods a bit, so I've updated a monkey-patch accordingly.