### PR TITLE
Run `go mod vendor` with `-e` flag

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -148,7 +148,7 @@ module Dependabot
         def run_go_vendor
           return unless vendor?
 
-          command = "go mod vendor"
+          command = "go mod vendor -e"
           _, stderr, status = Open3.capture3(environment, command)
           handle_subprocess_error(stderr) unless status.success?
         end


### PR DESCRIPTION
I've seen some customer reports of Go updates failing with a generic `Dependabot::DependabotError` error in `GoModUpdater#update_files`. I noticed that we run `go mod tidy -e` (with `-e` flag) and then `go mod vendor` (without the `-e` flag). From `go help mod vendor`:

> The -e flag causes vendor to attempt to proceed despite errors
encountered while loading packages.

This PR adds the `-e` flag to match the behavior of our `go mod tidy` invocation in the hopes of resolving the underlying issue of failed update jobs.