### PR TITLE
Added useful error message when image not found

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -224,6 +224,7 @@ module Dependabot
         @tags_from_registry ||=
           begin
             client = docker_registry_client
+
             client.tags(docker_repo_name, auto_paginate: true).fetch("tags")
           rescue *transient_docker_errors
             attempt ||= 1

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -234,7 +234,7 @@ module Dependabot
             retry
           end
       rescue DockerRegistry2::NotFound
-        raise DockerRegistry2::NotFound, "404 Not Found. Image https://#{registry_hostname}/#{repo} not found"
+        raise DockerRegistry2::NotFound, "Image not found: https://#{registry_hostname}/#{docker_repo_name}"
       rescue DockerRegistry2::RegistryAuthenticationException,
              RestClient::Forbidden
         raise PrivateSourceAuthenticationFailure, registry_hostname

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -225,7 +225,7 @@ module Dependabot
           begin
             client = docker_registry_client
             repo = docker_repo_name
-            client.tags(repo, auto_paginate: true).fetch("tags")
+            client.tags(docker_repo_name, auto_paginate: true).fetch("tags")
           rescue *transient_docker_errors
             attempt ||= 1
             attempt += 1

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -224,8 +224,8 @@ module Dependabot
         @tags_from_registry ||=
           begin
             client = docker_registry_client
-
-            client.tags(docker_repo_name, auto_paginate: true).fetch("tags")
+            repo = docker_repo_name
+            client.tags(repo, auto_paginate: true).fetch("tags")
           rescue *transient_docker_errors
             attempt ||= 1
             attempt += 1
@@ -233,6 +233,8 @@ module Dependabot
 
             retry
           end
+      rescue DockerRegistry2::NotFound
+        raise DockerRegistry2::NotFound, "404 Not Found. Image https://#{registry_hostname}/#{repo} not found"
       rescue DockerRegistry2::RegistryAuthenticationException,
              RestClient::Forbidden
         raise PrivateSourceAuthenticationFailure, registry_hostname

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -224,7 +224,6 @@ module Dependabot
         @tags_from_registry ||=
           begin
             client = docker_registry_client
-            repo = docker_repo_name
             client.tags(docker_repo_name, auto_paginate: true).fetch("tags")
           rescue *transient_docker_errors
             attempt ||= 1

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -284,20 +284,6 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     end
 
     context "when image is not found" do
-      let(:dependency_name) { "ubuntu" }
-      let(:dependency) do
-        Dependabot::Dependency.new(
-          name: dependency_name,
-          version: version,
-          requirements: [{
-            requirement: nil,
-            groups: [],
-            file: "Dockerfile",
-            source: { tag: "17.10" }
-          }],
-          package_manager: "docker"
-        )
-      end
       let(:tags_fixture_name) { "ubuntu_no_latest.json" }
 
       context "with replaces-base set to true" do

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to eq("17.04") }
     end
 
-    context "when tag is not found" do
+    context "when image is not found" do
       let(:dependency_name) { "ubuntu" }
       let(:dependency) do
         Dependabot::Dependency.new(

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
           error_class = DockerRegistry2::NotFound
           expect { checker.latest_version }.
             to raise_error(error_class) do |error|
-              expect(error.message).to eq("404 Not Found. Image https://registry-host.io:5000/ubuntu not found")
+              expect(error.message).to eq("Image not found: https://registry-host.io:5000/ubuntu")
             end
         end
       end


### PR DESCRIPTION
## Context

When an image is not found in the private registry, it throws an exception of `DockerRegistry2::NotFound` and lot of stack trace but this info is not useful for the end user. 
```
updater | ERROR <job_500122728> Error processing myreg/ubuntu (DockerRegistry2::NotFound)
updater | ERROR <job_500122728> 404 Not Found
updater | ERROR <job_500122728> /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/docker_registry2-1.12.0/lib/registry/registry.rb:285:in `rescue in doreq'
updater | ERROR <job_500122728> /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/docker_registry2-1.12.0/lib/registry/registry.rb:269:in `doreq'
updater | ERROR <job_500122728> /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/docker_registry2-1.12.0/lib/registry/registry.rb:26:in `doget'

```
Error logs: https://github.com/dsp-testing/docker-firewalled-testing/network/updates/500122728

## Approach
I'm using a rescue block to catch the "DockerRegistry2::NotFound" exception and throwing it with useful error message when a Dependabot tries to retrieve an image from the registry but it doesn't exist there.