### PR TITLE
Yarn Berry: Adding a peer dependency checker

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -150,13 +150,13 @@ module Dependabot
           # the lockfile.
 
           command = if top_level_dependency_updates.all? { |dep| requirements_changed?(dep[:name]) }
-                      "yarn install#{Helpers.yarn_berry_args}"
+                      "yarn install #{Helpers.yarn_berry_args}".strip
                     else
                       updates = top_level_dependency_updates.collect do |dep|
                         dep[:requirements].map { |req| "#{dep[:name]}@#{req[:requirement]}" }.join(" ")
                       end
 
-                      "yarn up #{updates.join(' ')}#{Helpers.yarn_berry_args}"
+                      "yarn up #{updates.join(' ')} #{Helpers.yarn_berry_args}".strip
                     end
           Helpers.run_yarn_commands(command)
           { yarn_lock.name => File.read(yarn_lock.name) }
@@ -172,9 +172,9 @@ module Dependabot
           update = "#{dep.name}@#{dep.version}"
 
           Helpers.run_yarn_commands(
-            "yarn add #{update}#{Helpers.yarn_berry_args}",
-            "yarn dedupe #{dep.name}#{Helpers.yarn_berry_args}",
-            "yarn remove #{dep.name}#{Helpers.yarn_berry_args}"
+            "yarn add #{update} #{Helpers.yarn_berry_args}".strip,
+            "yarn dedupe #{dep.name} #{Helpers.yarn_berry_args}".strip,
+            "yarn remove #{dep.name} #{Helpers.yarn_berry_args}".strip
           )
           { yarn_lock.name => File.read(yarn_lock.name) }
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -50,11 +50,7 @@ module Dependabot
         end
       end
 
-      # Run any number of yarn commands while ensuring that `enableScripts` is
-      # set to false. Yarn commands should _not_ be ran outside of this helper
-      # to ensure that postinstall scripts are never executed, as they could
-      # contain malicious code.
-      def self.run_yarn_commands(*commands)
+      def self.setup_yarn_berry
         # Always disable immutable installs so yarn's CI detection doesn't prevent updates.
         SharedHelpers.run_shell_command("yarn config set enableImmutableInstalls false")
         # We never want to execute postinstall scripts, either set this config or mode=skip-build must be set
@@ -74,7 +70,19 @@ module Dependabot
             SharedHelpers.run_shell_command("yarn config set caFilePath #{ca_file_path}")
           end
         end
+      end
+      # Run any number of yarn commands while ensuring that `enableScripts` is
+      # set to false. Yarn commands should _not_ be ran outside of this helper
+      # to ensure that postinstall scripts are never executed, as they could
+      # contain malicious code.
+      def self.run_yarn_commands(*commands)
+        setup_yarn_berry
         commands.each { |cmd| SharedHelpers.run_shell_command(cmd) }
+      end
+
+      def self.run_yarn_command(command)
+        setup_yarn_berry
+        SharedHelpers.run_shell_command(command)
       end
 
       def self.dependencies_with_all_versions_metadata(dependency_set)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -44,9 +44,9 @@ module Dependabot
         if yarn_major_version == 2
           ""
         elsif yarn_major_version >= 3 && yarn_zero_install?
-          " --mode=skip-build"
+          "--mode=skip-build"
         else
-          " --mode=update-lockfile"
+          "--mode=update-lockfile"
         end
       end
 
@@ -63,14 +63,15 @@ module Dependabot
         if (https_proxy = ENV.fetch("HTTPS_PROXY", false))
           SharedHelpers.run_shell_command("yarn config set httpsProxy #{https_proxy}")
         end
-        if (ca_file_path = ENV.fetch("NODE_EXTRA_CA_CERTS", false))
-          if yarn_major_version >= 4
-            SharedHelpers.run_shell_command("yarn config set httpsCaFilePath #{ca_file_path}")
-          else
-            SharedHelpers.run_shell_command("yarn config set caFilePath #{ca_file_path}")
-          end
+        return unless (ca_file_path = ENV.fetch("NODE_EXTRA_CA_CERTS", false))
+
+        if yarn_major_version >= 4
+          SharedHelpers.run_shell_command("yarn config set httpsCaFilePath #{ca_file_path}")
+        else
+          SharedHelpers.run_shell_command("yarn config set caFilePath #{ca_file_path}")
         end
       end
+
       # Run any number of yarn commands while ensuring that `enableScripts` is
       # set to false. Yarn commands should _not_ be ran outside of this helper
       # to ensure that postinstall scripts are never executed, as they could
@@ -80,6 +81,7 @@ module Dependabot
         commands.each { |cmd| SharedHelpers.run_shell_command(cmd) }
       end
 
+      # Run a single yarn command returning stdout/stderr
       def self.run_yarn_command(command)
         setup_yarn_berry
         SharedHelpers.run_shell_command(command)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -339,7 +339,8 @@ module Dependabot
             credentials: credentials,
             dependency_files: dependency_files,
             latest_allowable_version: latest_version,
-            latest_version_finder: latest_version_finder
+            latest_version_finder: latest_version_finder,
+            repo_contents_path: repo_contents_path
           )
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -117,7 +117,7 @@ module Dependabot
           SharedHelpers.with_git_configured(credentials: credentials) do
             Dir.chdir(path) do
               Helpers.run_yarn_commands(
-                "yarn up -R #{dependency.name}#{Helpers.yarn_berry_args}"
+                "yarn up -R #{dependency.name} #{Helpers.yarn_berry_args}".strip
               )
               { lockfile_name => File.read(lockfile_name) }
             end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -343,7 +343,6 @@ module Dependabot
               else
                 raise
               end
-              debugger
               errors
             end.compact
           end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -498,6 +498,11 @@ module Dependabot
         end
 
         def run_yarn_berry_checker(path:, version:)
+          # This method mimics calling a native helper in order to comply with the caller's expectations
+          # Specifically we add the dependency at the specified updated version
+          # then check the output of the add command for Peer Dependency errors (Denoted by YN0060)
+          # If we find peer dependency issues, we raise HelperSubprocessFailed as
+          # the native helpers do.
           SharedHelpers.with_git_configured(credentials: credentials) do
             Dir.chdir(path) do
               output = Helpers.run_yarn_command(

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -325,27 +325,7 @@ module Dependabot
               path = Pathname.new(file.name).dirname
               run_checker(path: path, version: version)
             rescue SharedHelpers::HelperSubprocessFailed => e
-              errors = []
-              if e.message.match?(NPM6_PEER_DEP_ERROR_REGEX)
-                e.message.scan(NPM6_PEER_DEP_ERROR_REGEX) do
-                  errors << Regexp.last_match.named_captures
-                end
-              elsif e.message.match?(NPM8_PEER_DEP_ERROR_REGEX)
-                e.message.scan(NPM8_PEER_DEP_ERROR_REGEX) do
-                  errors << Regexp.last_match.named_captures
-                end
-              elsif e.message.match?(YARN_PEER_DEP_ERROR_REGEX)
-                e.message.scan(YARN_PEER_DEP_ERROR_REGEX) do
-                  errors << Regexp.last_match.named_captures
-                end
-              elsif e.message.match?(YARN_BERRY_PEER_DEP_ERROR_REGEX)
-                e.message.scan(YARN_BERRY_PEER_DEP_ERROR_REGEX) do
-                  errors << Regexp.last_match.named_captures
-                end
-              else
-                raise
-              end
-              errors
+              handle_peer_dependency_errors(e)
             end.compact
           end
         rescue SharedHelpers::HelperSubprocessFailed
@@ -353,6 +333,30 @@ module Dependabot
           # occurred should be properly handled by the FileUpdater. We
           # can slowly migrate error handling to this class over time.
           []
+        end
+
+        def handle_peer_dependency_errors(error)
+          errors = []
+          if error.message.match?(NPM6_PEER_DEP_ERROR_REGEX)
+            error.message.scan(NPM6_PEER_DEP_ERROR_REGEX) do
+              errors << Regexp.last_match.named_captures
+            end
+          elsif error.message.match?(NPM8_PEER_DEP_ERROR_REGEX)
+            error.message.scan(NPM8_PEER_DEP_ERROR_REGEX) do
+              errors << Regexp.last_match.named_captures
+            end
+          elsif error.message.match?(YARN_PEER_DEP_ERROR_REGEX)
+            error.message.scan(YARN_PEER_DEP_ERROR_REGEX) do
+              errors << Regexp.last_match.named_captures
+            end
+          elsif error.message.match?(YARN_BERRY_PEER_DEP_ERROR_REGEX)
+            error.message.scan(YARN_BERRY_PEER_DEP_ERROR_REGEX) do
+              errors << Regexp.last_match.named_captures
+            end
+          else
+            raise
+          end
+          errors
         end
 
         def unmet_peer_dependencies

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -511,7 +511,6 @@ module Dependabot
               if output.include?("YN0060")
                 raise SharedHelpers::HelperSubprocessFailed.new(
                   message: output,
-                  error_class: "JSON::ParserError",
                   error_context: {}
                 )
               end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
       dependency_files: dependency_files,
       credentials: credentials,
       latest_allowable_version: latest_allowable_version,
-      latest_version_finder: latest_version_finder
+      latest_version_finder: latest_version_finder,
+      repo_contents_path: nil
     )
   end
   let(:latest_version_finder) do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -875,7 +875,8 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           credentials: credentials,
           dependency_files: dependency_files,
           latest_version_finder: described_class::LatestVersionFinder,
-          latest_allowable_version: updated_version
+          latest_allowable_version: updated_version,
+          repo_contents_path: nil
         ).and_return(dummy_version_resolver)
       expect(dummy_version_resolver).
         to receive(:latest_resolvable_previous_version).
@@ -1314,7 +1315,8 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           credentials: credentials,
           dependency_files: dependency_files,
           latest_version_finder: described_class::LatestVersionFinder,
-          latest_allowable_version: Gem::Version.new("1.7.0")
+          latest_allowable_version: Gem::Version.new("1.7.0"),
+          repo_contents_path: nil
         ).and_return(dummy_version_resolver)
       expect(dummy_version_resolver).
         to receive(:dependency_updates_from_full_unlock).


### PR DESCRIPTION
## Context
Previous to this PR we were still running yarn classic to check for peer dependency issues created by a proposed version update. This was slow and probably could result in incorrect answers.

## Approach
I've added a yarn berry specific checker based on the output I could see after adding a dependency at a version that breaks a peer dependency request. This may be naive, and almost certainly does not catch all cases so I'd appreciate feedback around how to make this check more accurate. One specific shortcoming is that without making additional calls to `yarn explain` the versions of the the peer dependency mismatch are not available. In the short term this may cause us to fail to create a possible PR if we could have resolved an update to an earlier version.