### PR TITLE
Bundler: use the replaces-base credential for metadata lookup

### DIFF
--- a/bundler/lib/dependabot/bundler/metadata_finder.rb
+++ b/bundler/lib/dependabot/bundler/metadata_finder.rb
@@ -196,10 +196,20 @@ module Dependabot
       end
 
       def registry_url
-        return "https://rubygems.org/" if new_source_type == "default"
+        return base_url if new_source_type == "default"
 
         info = dependency.requirements.filter_map { |r| r[:source] }.first
         info[:url] || info.fetch("url")
+      end
+
+      def base_url
+        return @base_url if defined?(@base_url)
+
+        credential = credentials.find do |cred|
+          cred["type"] == "rubygems_server" && cred["replaces-base"] == true
+        end
+        host = credential ? credential["host"] : "rubygems.org"
+        @base_url = "https://#{host}" + ("/" unless host.end_with?("/"))
       end
 
       def registry_auth_headers

--- a/bundler/spec/dependabot/bundler/metadata_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/metadata_finder_spec.rb
@@ -119,6 +119,40 @@ RSpec.describe Dependabot::Bundler::MetadataFinder do
         it { is_expected.to eq("https://github.com/gocardless/business") }
       end
 
+      context "with a replaces-base credential" do
+        before do
+          stub_request(:get, "https://gems.greysteil.com/api/v1/gems/business.json").
+            to_return(
+              status: 200,
+              body: fixture("ruby", "rubygems_response.json")
+            )
+        end
+
+        let(:source) do
+          { type: "default" }
+        end
+        let(:credentials) do
+          [
+            {
+              "type" => "rubygems_server",
+              "host" => "gems.greysteil.com",
+              "replaces-base" => true
+            }
+          ]
+        end
+
+        it "uses that domain instead" do
+          expect(finder.source_url).
+            to eq("https://github.com/gocardless/business")
+          expect(WebMock).
+            to have_requested(
+              :get,
+              "https://gems.greysteil.com/api/v1/gems/business.json"
+            )
+          expect(WebMock).to_not have_requested(:get, rubygems_gemspec_url)
+        end
+      end
+
       context "without a source" do
         let(:rubygems_response) do
           fixture("ruby", "rubygems_response_no_source.json")


### PR DESCRIPTION
When looking up metadata for Bundler, Dependabot would fall back to using rubygems.org even if the user had a private registry defined. 

This PR allows the user to define a host that replaces that with a private registry of their own by using the "replaces-base" setting in dependabot.yml. 
