### PR TITLE
Don't try to update path dependencies

### DIFF
--- a/bundler/helpers/v1/lib/functions/file_parser.rb
+++ b/bundler/helpers/v1/lib/functions/file_parser.rb
@@ -13,7 +13,7 @@ module Functions
     def parsed_gemfile(gemfile_name:)
       Bundler::Definition.build(gemfile_name, nil, {}).
         dependencies.select(&:current_platform?).
-        reject { |dep| dep.source.is_a?(Bundler::Source::Gemspec) }.
+        reject { |dep| local_sources.include?(dep.source.class) }.
         map { |dep| serialize_bundler_dependency(dep) }
     end
 
@@ -103,9 +103,15 @@ module Functions
         NilClass,
         Bundler::Source::Rubygems,
         Bundler::Source::Git,
-        Bundler::Source::Path,
-        Bundler::Source::Gemspec,
+        *local_sources,
         Bundler::Source::Metadata
+      ]
+    end
+
+    def local_sources
+      [
+        Bundler::Source::Path,
+        Bundler::Source::Gemspec
       ]
     end
   end

--- a/bundler/helpers/v2/lib/functions/file_parser.rb
+++ b/bundler/helpers/v2/lib/functions/file_parser.rb
@@ -13,7 +13,7 @@ module Functions
     def parsed_gemfile(gemfile_name:)
       Bundler::Definition.build(gemfile_name, nil, {}).
         dependencies.select(&:current_platform?).
-        reject { |dep| dep.source.is_a?(Bundler::Source::Gemspec) }.
+        reject { |dep| local_sources.include?(dep.source.class) }.
         map { |dep| serialize_bundler_dependency(dep) }
     end
 
@@ -103,9 +103,15 @@ module Functions
         NilClass,
         Bundler::Source::Rubygems,
         Bundler::Source::Git,
-        Bundler::Source::Path,
-        Bundler::Source::Gemspec,
+        *local_sources,
         Bundler::Source::Metadata
+      ]
+    end
+
+    def local_sources
+      [
+        Bundler::Source::Path,
+        Bundler::Source::Gemspec
       ]
     end
   end

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -392,11 +392,10 @@ RSpec.describe Dependabot::Bundler::FileParser do
         }]
       end
 
-      its(:length) { is_expected.to eq(5) }
+      its(:length) { is_expected.to eq(4) }
 
-      it "includes the path dependency" do
-        path_dep = dependencies.find { |dep| dep.name == "example" }
-        expect(path_dep.requirements).to eq(expected_requirements)
+      it "does not include the path dependency" do
+        expect(dependencies.map(&:name)).to_not include("example")
       end
 
       it "includes the path dependency's sub-dependency" do
@@ -409,8 +408,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
         let(:dependency_files) { bundler_project_dependency_files("version_specified_gemfile_specification") }
 
         it "includes the path dependency" do
-          path_dep = dependencies.find { |dep| dep.name == "example" }
-          expect(path_dep.requirements).to eq(expected_requirements)
+          expect(dependencies.map(&:name)).to_not include("example")
         end
       end
     end


### PR DESCRIPTION
Since by definition they're at the latest version.

There were actually specs positively checking for this, but I believe they may have been an oversight. They were introduced when adding support for updating subdpendencies at
b8010392313fa97dbbdb74792e3fafc7deb35d67, and I don't think this change regresses there.

I'm not sure if this could have any bad side effect, just opening it as a draft.

Fixes #5989.