### PR TITLE
Helm supports both `.yml` and `.yaml`

### DIFF
--- a/docker/lib/dependabot/docker/file_fetcher.rb
+++ b/docker/lib/dependabot/docker/file_fetcher.rb
@@ -9,7 +9,7 @@ module Dependabot
     class FileFetcher < Dependabot::FileFetchers::Base
       YAML_REGEXP = /^[^\.]+\.ya?ml$/i
       DOCKER_REGEXP = /dockerfile/i
-      HELM_REGEXP = /values[\-a-zA-Z_0-9]*\.yaml/i
+      HELM_REGEXP = /values[\-a-zA-Z_0-9]*\.ya?ml$/i
 
       def self.required_files_in?(filenames)
         filenames.any? { |f| f.match?(DOCKER_REGEXP) } or

--- a/docker/spec/dependabot/docker/file_fetcher_spec.rb
+++ b/docker/spec/dependabot/docker/file_fetcher_spec.rb
@@ -271,10 +271,14 @@ RSpec.describe Dependabot::Docker::FileFetcher do
 
     context "with a Helm values file" do
       matching_filenames = [
+        "other-values.yml",
         "other-values.yaml",
+        "values.yml",
         "values.yaml",
-        "values2.yaml",
-        "values_other.yaml"
+        "values_other.yml",
+        "values_other.yaml",
+        "values2.yml",
+        "values2.yaml"
       ]
 
       before do
@@ -301,7 +305,7 @@ RSpec.describe Dependabot::Docker::FileFetcher do
       let(:options) { { kubernetes_updates: true } }
 
       it "fetches the values.yaml" do
-        expect(file_fetcher_instance.files.count).to eq(4)
+        expect(file_fetcher_instance.files.count).to eq(matching_filenames.length)
         expect(file_fetcher_instance.files.map(&:name)).
           to match_array(matching_filenames)
       end

--- a/docker/spec/fixtures/github/contents_helm_repo.json
+++ b/docker/spec/fixtures/github/contents_helm_repo.json
@@ -96,8 +96,8 @@
     }
   },
   {
-    "name": "values.yaml",
-    "path": "values.yaml",
+    "name": "other-values.yml",
+    "path": "other-values.yml",
     "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",
     "size": 4927,
     "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
@@ -128,8 +128,72 @@
     }
   },
   {
+    "name": "values.yml",
+    "path": "values.yml",
+    "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",
+    "size": 4927,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/Dockerfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile"
+    }
+  },
+  {
+    "name": "values.yaml",
+    "path": "values.yaml",
+    "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",
+    "size": 4927,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/Dockerfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile"
+    }
+  },
+  {
+    "name": "values_other.yml",
+    "path": "values_other.yml",
+    "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",
+    "size": 4927,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/Dockerfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile"
+    }
+  },
+  {
     "name": "values_other.yaml",
     "path": "values_other.yaml",
+    "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",
+    "size": 4927,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/Dockerfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/311f9743315183cc6751313cb251cfeb3de45c1a",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/Dockerfile"
+    }
+  },
+  {
+    "name": "values2.yml",
+    "path": "values2.yml",
     "sha": "311f9743315183cc6751313cb251cfeb3de45c1a",
     "size": 4927,
     "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Dockerfile?ref=master",
@@ -272,4 +336,3 @@
     }
   }
 ]
-

--- a/docker/spec/fixtures/github/contents_values_yaml.json
+++ b/docker/spec/fixtures/github/contents_values_yaml.json
@@ -16,4 +16,3 @@
     "html": "https://github.com/dependabot/dependabot-core/blob/main/values.yaml"
   }
 }
-


### PR DESCRIPTION
While pairing with `@bdragon`, he noticed this check is only looking for `*.yaml` files. However, we suspect Helm also supports `.yml` files.

I found mention of `values.yml` in their documentation: https://v2.helm.sh/docs/developing_charts/#chart-development-tips-and-tricks

So we should support it as well.

Co-authored-by: Bryan Dragon <bdragon@github.com>