### PR TITLE
Update helm charts beyond `values.yaml`

### DIFF
--- a/docker/lib/dependabot/docker/file_fetcher.rb
+++ b/docker/lib/dependabot/docker/file_fetcher.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dependabot/docker/utils/helpers"
 require "dependabot/experiments"
 require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
@@ -9,7 +10,6 @@ module Dependabot
     class FileFetcher < Dependabot::FileFetchers::Base
       YAML_REGEXP = /^[^\.]+\.ya?ml$/i
       DOCKER_REGEXP = /dockerfile/i
-      HELM_REGEXP = /values[\-a-zA-Z_0-9]*\.ya?ml$/i
 
       def self.required_files_in?(filenames)
         filenames.any? { |f| f.match?(DOCKER_REGEXP) } or
@@ -86,7 +86,7 @@ module Dependabot
       def correctly_encoded_yamlfiles
         candidate_files = yamlfiles.select { |f| f.content.valid_encoding? }
         candidate_files.select do |f|
-          if f.type == "file" && f.name.match?(HELM_REGEXP)
+          if f.type == "file" && Utils.likely_helm_chart?(f)
             true
           else
             # This doesn't handle multi-resource files, but it shouldn't matter, since the first resource

--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dependabot/docker/utils/helpers"
 require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
 require "dependabot/errors"
@@ -152,7 +153,7 @@ module Dependabot
       end
 
       def updated_yaml_content(file)
-        updated_content = file.name == "values.yaml" ? update_helm(file) : update_image(file)
+        updated_content = Utils.likely_helm_chart?(file) ? update_helm(file) : update_image(file)
 
         raise "Expected content to change!" if updated_content == file.content
 

--- a/docker/lib/dependabot/docker/utils/helpers.rb
+++ b/docker/lib/dependabot/docker/utils/helpers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Dependabot
+  module Docker
+    module Utils
+      HELM_REGEXP = /values[\-a-zA-Z_0-9]*\.ya?ml$/i
+
+      def self.likely_helm_chart?(file)
+        file.name.match?(HELM_REGEXP)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The docker updater for helm charts was hardcoded to `"values.yaml"`.

But we should support the full range of filenames supported in the file fetcher... for example, in the wild we saw this failing to update `"arc-values.yaml"` because of this hardcoding.