### PR TITLE
Bump pipenv to 2022.11.5

### DIFF
--- a/python/helpers/requirements.txt
+++ b/python/helpers/requirements.txt
@@ -2,7 +2,7 @@ pip>=21.3.1,<22.4.0  # Range maintains py36 support TODO: Review python 3.6 supp
 pip-tools>=6.4.0,<6.9.1  # Range maintains py36 support TODO: Review python 3.6 support in April 2023 (eol ubuntu 18.04)
 flake8==5.0.4
 hashin==0.17.0
-pipenv==2022.4.8
+pipenv==2022.11.5
 pipfile==0.0.2
 poetry>=1.1.15,<1.3.0
 wheel==0.37.1

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -246,7 +246,7 @@ module Dependabot
         def run_command(command, env: {})
           start = Time.now
           command = SharedHelpers.escape_command(command)
-          stdout, process = Open3.capture2e(env, command)
+          stdout, _, process = Open3.capture3(env, command)
           time_taken = Time.now - start
 
           # Raise an error with the output from the shell session if Pipenv

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -233,12 +233,12 @@ module Dependabot
 
         def generate_updated_requirements_files
           req_content = run_pipenv_command(
-            "pyenv exec pipenv lock -r"
+            "pyenv exec pipenv requirements"
           )
           File.write("req.txt", req_content)
 
           dev_req_content = run_pipenv_command(
-            "pyenv exec pipenv lock -r -d"
+            "pyenv exec pipenv requirements --dev"
           )
           File.write("dev-req.txt", dev_req_content)
         end


### PR DESCRIPTION
I think this PR would fix #6091 if it was acceptable, because it includes https://github.com/pypa/pipenv/pull/5373 which I believe fixes exactly the issue reported at #6091.

However, it seems to introduce several other noise in manifest file diffs, although at least it's deterministic.

In addition to this, I _think_ it no longer works with Python 3.6 according to https://github.com/pypa/pipenv/issues/5406, so I guess we can't bump it just yet.

Fixes #6091.