### PR TITLE
Fix NuGet packages.config parsing

### DIFF
--- a/nuget/lib/dependabot/nuget/file_updater/packages_config_declaration_finder.rb
+++ b/nuget/lib/dependabot/nuget/file_updater/packages_config_declaration_finder.rb
@@ -8,8 +8,8 @@ module Dependabot
     class FileUpdater
       class PackagesConfigDeclarationFinder
         DECLARATION_REGEX =
-          %r{<package [^>]*?/>|
-             <package [^>]*?[^/]>.*?</package>}mx
+          %r{<package\s[^>]*?/>|
+             <package\s[^>]*?[^/]>.*?</package>}mx
 
         attr_reader :dependency_name, :declaring_requirement,
                     :packages_config

--- a/nuget/spec/dependabot/nuget/file_updater/packages_config_declaration_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater/packages_config_declaration_finder_spec.rb
@@ -74,13 +74,13 @@ RSpec.describe namespace::PackagesConfigDeclarationFinder do
       end
 
       context "and the node is empty" do
-        let(:dependency_name) { "NUnit" }
+        let(:dependency_name) { "WebActivatorEx" }
 
         it "finds the declaration" do
           expect(declaration_strings.count).to eq(1)
 
           expect(declaration_strings.first).
-            to eq('<package id="NUnit" version="3.13.0" ' \
+            to eq('<package id="WebActivatorEx" version="2.1.0" ' \
                   'targetFramework="net46"></package>')
         end
       end

--- a/nuget/spec/dependabot/nuget/file_updater/packages_config_declaration_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater/packages_config_declaration_finder_spec.rb
@@ -72,6 +72,18 @@ RSpec.describe namespace::PackagesConfigDeclarationFinder do
           expect(declaration_strings.count).to eq(0)
         end
       end
+
+      context "and the node is empty" do
+        let(:dependency_name) { "NUnit" }
+
+        it "finds the declaration" do
+          expect(declaration_strings.count).to eq(1)
+
+          expect(declaration_strings.first).
+            to eq('<package id="NUnit" version="3.13.0" '\
+                  'targetFramework="net46"></package>')
+        end
+      end
     end
   end
 end

--- a/nuget/spec/dependabot/nuget/file_updater/packages_config_declaration_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater/packages_config_declaration_finder_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe namespace::PackagesConfigDeclarationFinder do
           expect(declaration_strings.count).to eq(1)
 
           expect(declaration_strings.first).
-            to eq('<package id="NUnit" version="3.13.0" '\
+            to eq('<package id="NUnit" version="3.13.0" ' \
                   'targetFramework="net46"></package>')
         end
       end

--- a/nuget/spec/dependabot/nuget/file_updater/packages_config_declaration_finder_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater/packages_config_declaration_finder_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe namespace::PackagesConfigDeclarationFinder do
 
       context "and the node is empty" do
         let(:dependency_name) { "WebActivatorEx" }
+        let(:declaring_requirement_string) { "2.1.0" }
 
         it "finds the declaration" do
           expect(declaration_strings.count).to eq(1)

--- a/nuget/spec/fixtures/packages_configs/packages.config
+++ b/nuget/spec/fixtures/packages_configs/packages.config
@@ -9,5 +9,5 @@
   <package id="NuGet.Server" version="2.11.2" targetFramework="net46" />
   <package id="RouteMagic" version="1.3" targetFramework="net46" />
   <package id="WebActivatorEx" version="2.1.0" targetFramework="net46" />
+  <package id="NUnit" version="3.13.0" targetFramework="net46"></package>
 </packages>
-

--- a/nuget/spec/fixtures/packages_configs/packages.config
+++ b/nuget/spec/fixtures/packages_configs/packages.config
@@ -10,3 +10,4 @@
   <package id="RouteMagic" version="1.3" targetFramework="net46" />
   <package id="WebActivatorEx" version="2.1.0" targetFramework="net46"></package>
 </packages>
+

--- a/nuget/spec/fixtures/packages_configs/packages.config
+++ b/nuget/spec/fixtures/packages_configs/packages.config
@@ -8,6 +8,5 @@
   <package id="NuGet.Core" version="2.11.1" targetFramework="net46" />
   <package id="NuGet.Server" version="2.11.2" targetFramework="net46" />
   <package id="RouteMagic" version="1.3" targetFramework="net46" />
-  <package id="WebActivatorEx" version="2.1.0" targetFramework="net46" />
-  <package id="NUnit" version="3.13.0" targetFramework="net46"></package>
+  <package id="WebActivatorEx" version="2.1.0" targetFramework="net46"></package>
 </packages>


### PR DESCRIPTION
Since pattern whitespace is being ignored via the `x` flag, the string `<packages>` incorrectly matches the second part of the regex (`<package\s[^>]*?[^/]>.*?</package>`) when "package" isn't a self-closing element.

For example:

```xml
<packages>
  <package id="mypackage" version="0.0.0"></package>
</packages>
```

will match:

```
<packages>
  <package id="mypackage" version="0.0.0"></package>
```

This commit makes the space explicit so that `<packages>` no longer matches.