### PR TITLE
Tolerate running `dry-run.rb` without `docker-dev-shell`

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -37,7 +37,7 @@
 # rubocop:disable Style/GlobalVars
 
 require "etc"
-unless Etc.getpwuid(Process.uid).name == "dependabot"
+unless Etc.getpwuid(Process.uid).name == "dependabot" || ENV["ALLOW_DRY_RUN_STANDALONE"] == "true"
   puts <<~INFO
     bin/dry-run.rb is only supported in a development container.
 


### PR DESCRIPTION
I actually run `dry-run.rb` without `docker-dev-shell` quite often, specifically in those ecosystem where I know I have everything I need, or when I'm confident I can troubleshoot any issues.

With the current situation I have to keep stashing and unstashing a patch to remove this whole block when I need to. Instead I could live with a warning every time I run this, but that allows me to avoid all this dance.

I also think this is less important now that our main entry point to reproduce issues is the [CLI](https://github.com/dependabot/cli).

Thoughts? 