### PR TITLE
Bump `Dart` to `2.18.4`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -258,7 +258,9 @@ ENV PUB_CACHE=/opt/dart/pub-cache \
   PUB_ENVIRONMENT="dependabot" \
   PATH="${PATH}:/opt/dart/dart-sdk/bin"
 
-ARG DART_VERSION=2.17.0
+# https://dart.dev/get-dart/archive
+ARG DART_VERSION=2.18.4
+# TODO Dart now publishes SHA256 checksums for their releases, we should validate against those.
 RUN DART_ARCH=${TARGETARCH} \
   && if [ "$TARGETARCH" = "amd64" ]; then DART_ARCH=x64; fi \
   && curl --connect-timeout 15 --retry 5 "https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/dartsdk-linux-${DART_ARCH}-release.zip" > "/tmp/dart-sdk.zip" \


### PR DESCRIPTION
Bump to the latest release. I started to add the SHA256 validation, but it'll require refactoring how the unzipping works, so leaving that for later as the version bump is a step in the right direction for now.

Fix #6126 