### PR TITLE
Make specs time zone independent

### DIFF
--- a/common/spec/dependabot/pull_request_creator/github_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/github_spec.rb
@@ -672,7 +672,7 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
             "\n" \
             "Commit msg"
         end
-        before { allow(Time).to receive(:now).and_return(Time.new(2001, 1, 1)) }
+        before { allow(Time).to receive(:now).and_return(Time.new(2001, 1, 1, 0, 0, 0, "+00:00")) }
 
         it "passes the author details and signature to GitHub" do
           creator.create

--- a/common/spec/dependabot/pull_request_updater/github_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/github_spec.rb
@@ -503,7 +503,7 @@ RSpec.describe Dependabot::PullRequestUpdater::Github do
             "- [Commits](https://github.com/gocardless/business/compare/" \
             "v3.0.0...v1.5.0)"
         end
-        before { allow(Time).to receive(:now).and_return(Time.new(2001, 1, 1)) }
+        before { allow(Time).to receive(:now).and_return(Time.new(2001, 1, 1, 0, 0, 0, "+00:00")) }
 
         it "passes the author details and signature to GitHub" do
           updater.update


### PR DESCRIPTION
I was being a bad boy and running `common/` specs outside of the development container and got a couple of failures.

Failures were due to my specific timezone.

This PR makes specs timezone independent.