### PR TITLE
check for empty repo caused by network error

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -592,11 +592,12 @@ module Dependabot
                              " --no-recurse-submodules"
                            end
           clone_options << " --branch #{source.branch} --single-branch" if source.branch
-          SharedHelpers.run_shell_command(
+          stdout = SharedHelpers.run_shell_command(
             <<~CMD
               git clone #{clone_options.string} #{source.url} #{path}
             CMD
           )
+          raise Dependabot::RepoNotFound, source if stdout.include?("You appear to have cloned an empty repository.")
 
           if source.commit
             # This code will only be called for testing. Production will never pass a commit


### PR DESCRIPTION
Over the weekend Dependabot or GitHub was having some network errors with a strange error in cloned ecosystems. 

To reproduce the error I ran `dependabot update --dry-run go_modules rsc/quote --extra-hosts "github.com:127.0.0.1"`. The `extra-hosts` flag adds an `/etc/hosts` entry into the proxy, and since nothing is serving at 127.0.0.1:443 this causes the update to get a connection refused. The result is similar to what we saw over the weekend:

```
2022/11/15 12:51:31 [004] WARN: Cannot read TLS response from mitm'd server dial tcp 127.0.0.1:443: connect: connection refused
ERROR <job_cli> Error during file fetching; aborting
ERROR <job_cli> fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
<job_cli> Use '--' to separate paths from revisions, like this:
<job_cli> 'git <command> [<revision>...] -- [<file>...]'
<job_cli> HEAD
```

Adding the `--debug` flag to the CLI I can run a `git clone` manually reveals the issue:

```
$ git clone https://github.com/dependabot/dependabot-core.git
Cloning into 'dependabot-core'...
warning: You appear to have cloned an empty repository.
$ echo $?
0
```

My guess is the proxy is not handling the network error correctly, but we can work around this by checking for this warning text for now. This results in a more sensible output:

```
INFO <job_cli> Starting job processing
2022/11/15 12:48:21 [002] GET https://github.com:443/rsc/quote/info/refs?service=git-upload-pack
2022/11/15 12:48:21 [002] * authenticating git server request (host: github.com)
2022/11/15 12:48:21 [002] WARN: Cannot read TLS response from mitm'd server dial tcp 127.0.0.1:443: connect: connection refused
2022/11/15 12:48:21 [004] GET https://github.com:443/rsc/quote/HEAD
2022/11/15 12:48:21 [004] * authenticating git server request (host: github.com)
2022/11/15 12:48:21 [004] WARN: Cannot read TLS response from mitm'd server dial tcp 127.0.0.1:443: connect: connection refused
ERROR <job_cli> Error during file fetching; aborting
2022/11/15 12:48:31 [005] POST http://host.docker.internal:51283/update_jobs/cli/record_update_job_error
2022/11/15 12:48:31 [005] 200 http://host.docker.internal:51283/update_jobs/cli/record_update_job_error
2022/11/15 12:48:42 [006] PATCH http://host.docker.internal:51283/update_jobs/cli/mark_as_processed
2022/11/15 12:48:42 [006] 200 http://host.docker.internal:51283/update_jobs/cli/mark_as_processed
INFO <job_cli> Finished job processing
INFO Results:
Dependabot encountered '1' error(s) during execution, please check the logs for more details.
```