### PR TITLE
Raise `DependencyFileNotFound` for missing files

### DIFF
--- a/docker/lib/dependabot/docker/file_fetcher.rb
+++ b/docker/lib/dependabot/docker/file_fetcher.rb
@@ -40,8 +40,9 @@ module Dependabot
           )
         elsif incorrectly_encoded_dockerfiles.none? && incorrectly_encoded_yamlfiles.none?
           raise(
-            Dependabot::DependabotError,
-            "Found neither Kubernetes YAML nor Dockerfiles in #{directory}"
+            Dependabot::DependencyFileNotFound,
+            File.join(directory, "Dockerfile"),
+            "Found neither Dockerfiles nor Kubernetes YAML in #{directory}"
           )
         elsif incorrectly_encoded_dockerfiles.none?
           raise(


### PR DESCRIPTION
`DependencyFileNotFound` is treated by our internal monitoring as a user configuration error, and not something we need to act on. Additionally, we surface a nice clean error banner to the user.

`DependabotError` is treated as an unknown error that requires further investigation, so it's causing our internal alerts to flap when users don't have a manifest file... for example, users sometimes assume the `docker` check is recursive so they specify it as `"/"`, but it's not so it raises this error.

This is a super quick PR that we can get deployed to stop our alerts flapping. I'm working on a larger refactor of this section of code that also removes the feature flag and adds a unit test to ensure the proper exception is raised.