### PR TITLE
Customize dependency full name

### DIFF
--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -6,6 +6,7 @@ module Dependabot
   class Dependency
     @production_checks = {}
     @display_name_builders = {}
+    @display_full_name_builders = {}
     @name_normalisers = {}
 
     def self.production_check_for_package_manager(package_manager)
@@ -25,6 +26,14 @@ module Dependabot
 
     def self.register_display_name_builder(package_manager, name_builder)
       @display_name_builders[package_manager] = name_builder
+    end
+
+    def self.display_full_name_builder_for_package_manager(package_manager)
+      @display_name_builders[package_manager]
+    end
+
+    def self.register_display_full_name_builder(package_manager, full_name_builder)
+      @display_name_builders[package_manager] = full_name_builder
     end
 
     def self.name_normaliser_for_package_manager(package_manager)
@@ -104,6 +113,14 @@ module Dependabot
       return name unless display_name_builder
 
       display_name_builder.call(name)
+    end
+
+    def display_full_name
+      display_full_name_builder =
+        self.class.display_full_name_builder_for_package_manager(package_manager)
+      return "#{name} #{version}" unless display_full_name_builder
+
+      display_full_name_builder.call(self)
     end
 
     # Returns all detected versions of the dependency. Only ecosystems that

--- a/github_actions/lib/dependabot/github_actions.rb
+++ b/github_actions/lib/dependabot/github_actions.rb
@@ -22,3 +22,6 @@ Dependabot::PullRequestCreator::Labeler.
 require "dependabot/dependency"
 Dependabot::Dependency.
   register_production_check("github_actions", ->(_) { true })
+
+Dependabot::Dependency.
+  register_display_full_name_builder("github_actions", ->(dep) { "#{dep.name}@#{dep.version}" })

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -507,7 +507,7 @@ module Dependabot
 
     def log_checking_for_update(dependency)
       logger_info(
-        "Checking if #{dependency.name} #{dependency.version} needs updating"
+        "Checking if #{dependency.display_full_name} needs updating"
       )
       log_ignore_conditions(dependency)
     end


### PR DESCRIPTION
This was suggested at https://github.com/dependabot/dependabot-core/issues/1985#issuecomment-1315815054.

Not sure if allowing customizing this per ecosystem is overkill, or if the `name@versio` notation makes sense for every ecosystem, or if it's just best to leave this as is.

Just opening a WIP for discussion.