### PR TITLE
Remove the `kubernetes_updates` feature flag

### DIFF
--- a/docker/lib/dependabot/docker/file_fetcher.rb
+++ b/docker/lib/dependabot/docker/file_fetcher.rb
@@ -22,27 +22,18 @@ module Dependabot
 
       private
 
-      def kubernetes_enabled?
-        Experiments.enabled?(:kubernetes_updates)
-      end
-
       def fetch_files
         fetched_files = []
         fetched_files += correctly_encoded_dockerfiles
-        fetched_files += correctly_encoded_yamlfiles if kubernetes_enabled?
+        fetched_files += correctly_encoded_yamlfiles
 
         return fetched_files if fetched_files.any?
 
-        if !kubernetes_enabled? && incorrectly_encoded_dockerfiles.none?
-          raise(
-            Dependabot::DependencyFileNotFound,
-            File.join(directory, "Dockerfile")
-          )
-        elsif incorrectly_encoded_dockerfiles.none? && incorrectly_encoded_yamlfiles.none?
+        if incorrectly_encoded_dockerfiles.none? && incorrectly_encoded_yamlfiles.none?
           raise(
             Dependabot::DependencyFileNotFound,
             File.join(directory, "Dockerfile"),
-            "Found neither Dockerfiles nor Kubernetes YAML in #{directory}"
+            "No Dockerfiles nor Kubernetes YAML found in #{directory}"
           )
         elsif incorrectly_encoded_dockerfiles.none?
           raise(

--- a/docker/spec/dependabot/docker/file_fetcher_spec.rb
+++ b/docker/spec/dependabot/docker/file_fetcher_spec.rb
@@ -182,9 +182,6 @@ RSpec.describe Dependabot::Docker::FileFetcher do
     end
 
     let(:kubernetes_fixture) { fixture("github", "contents_kubernetes.json") }
-    before do
-      Dependabot::Experiments.register(:kubernetes_updates, true)
-    end
 
     it "fetches the pod.yaml" do
       expect(file_fetcher_instance.files.count).to eq(1)
@@ -203,17 +200,6 @@ RSpec.describe Dependabot::Docker::FileFetcher do
 
     context "that has an non-kubernetes YAML" do
       let(:kubernetes_fixture) { fixture("github", "contents_other_yaml.json") }
-
-      it "raises a helpful error" do
-        expect { file_fetcher_instance.files }.
-          to raise_error(Dependabot::DependabotError)
-      end
-    end
-
-    context "with kubernetes not enabled" do
-      before do
-        Dependabot::Experiments.register(:kubernetes_updates, false)
-      end
 
       it "raises a helpful error" do
         expect { file_fetcher_instance.files }.
@@ -249,9 +235,6 @@ RSpec.describe Dependabot::Docker::FileFetcher do
 
     let(:kubernetes_fixture) { fixture("github", "contents_kubernetes.json") }
     let(:kubernetes_2_fixture) { fixture("github", "contents_kubernetes.json") }
-    before do
-      Dependabot::Experiments.register(:kubernetes_updates, true)
-    end
 
     it "fetches both YAMLs" do
       expect(file_fetcher_instance.files.count).to eq(2)
@@ -306,7 +289,6 @@ RSpec.describe Dependabot::Docker::FileFetcher do
       end
 
       let(:values_fixture) { fixture("github", "contents_values_yaml.json") }
-      let(:options) { { kubernetes_updates: true } }
 
       it "fetches the values.yaml" do
         expect(file_fetcher_instance.files.count).to eq(matching_filenames.length)


### PR DESCRIPTION
This has been rolled out 100%, so safe to remove.