### PR TITLE
Add unit test for `docker` `DependencyFileNotFound`

### DIFF
--- a/docker/spec/dependabot/docker/file_fetcher_spec.rb
+++ b/docker/spec/dependabot/docker/file_fetcher_spec.rb
@@ -35,6 +35,23 @@ RSpec.describe Dependabot::Docker::FileFetcher do
 
   before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
 
+  context "with no Dockerfile or Kubernetes YAML file" do
+    before do
+      stub_request(:get, url + "?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "contents_no_docker_repo.json"),
+          headers: { "content-type" => "application/json" }
+        )
+    end
+
+    it "raises the expected error" do
+      expect { file_fetcher_instance.files }.
+        to raise_error(Dependabot::DependencyFileNotFound)
+    end
+  end
+
   context "with a Dockerfile" do
     before do
       stub_request(:get, url + "?ref=sha").

--- a/docker/spec/fixtures/github/contents_no_docker_repo.json
+++ b/docker/spec/fixtures/github/contents_no_docker_repo.json
@@ -1,0 +1,210 @@
+[
+  {
+    "name": ".circleci",
+    "path": ".circleci",
+    "sha": "a55330d23efd5d7a9f6de2f199025afaee1ec850",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/.circleci?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/tree/master/.circleci",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/a55330d23efd5d7a9f6de2f199025afaee1ec850",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/.circleci?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/a55330d23efd5d7a9f6de2f199025afaee1ec850",
+      "html": "https://github.com/dependabot/dependabot-core/tree/master/.circleci"
+    }
+  },
+  {
+    "name": ".editorconfig",
+    "path": ".editorconfig",
+    "sha": "90198c6fd1a76a01ccaa2bc945687b3fdf46401c",
+    "size": 198,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/.editorconfig?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/.editorconfig",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/90198c6fd1a76a01ccaa2bc945687b3fdf46401c",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/.editorconfig",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/.editorconfig?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/90198c6fd1a76a01ccaa2bc945687b3fdf46401c",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/.editorconfig"
+    }
+  },
+  {
+    "name": ".gitignore",
+    "path": ".gitignore",
+    "sha": "952d80d51793764e2b9761b39dd714d6529c9c89",
+    "size": 346,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/.gitignore?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/.gitignore",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/952d80d51793764e2b9761b39dd714d6529c9c89",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/.gitignore",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/.gitignore?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/952d80d51793764e2b9761b39dd714d6529c9c89",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/.gitignore"
+    }
+  },
+  {
+    "name": ".rubocop.yml",
+    "path": ".rubocop.yml",
+    "sha": "3610f39558406539335bcffbdcb6626ec30f8271",
+    "size": 746,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/.rubocop.yml?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/.rubocop.yml",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/3610f39558406539335bcffbdcb6626ec30f8271",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/.rubocop.yml",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/.rubocop.yml?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/3610f39558406539335bcffbdcb6626ec30f8271",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/.rubocop.yml"
+    }
+  },
+  {
+    "name": "CHANGELOG.md",
+    "path": "CHANGELOG.md",
+    "sha": "fc4a6a0790fc4a903ed2a0636f46b361ad6144c6",
+    "size": 114851,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/CHANGELOG.md?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/CHANGELOG.md",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/fc4a6a0790fc4a903ed2a0636f46b361ad6144c6",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/CHANGELOG.md",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/CHANGELOG.md?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/fc4a6a0790fc4a903ed2a0636f46b361ad6144c6",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/CHANGELOG.md"
+    }
+  },
+  {
+    "name": "CONTRIBUTING.md",
+    "path": "CONTRIBUTING.md",
+    "sha": "c60e1930968302a75220f8c09201450ff65e78f7",
+    "size": 2239,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/CONTRIBUTING.md?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/CONTRIBUTING.md",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/c60e1930968302a75220f8c09201450ff65e78f7",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/CONTRIBUTING.md",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/CONTRIBUTING.md?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/c60e1930968302a75220f8c09201450ff65e78f7",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/CONTRIBUTING.md"
+    }
+  },
+  {
+    "name": "Gemfile",
+    "path": "Gemfile",
+    "sha": "be173b205f70152dd1e0a0319f131e51c49eb9cd",
+    "size": 70,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/Gemfile?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/Gemfile",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/be173b205f70152dd1e0a0319f131e51c49eb9cd",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/Gemfile",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/Gemfile?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/be173b205f70152dd1e0a0319f131e51c49eb9cd",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/Gemfile"
+    }
+  },
+  {
+    "name": "LICENSE",
+    "path": "LICENSE",
+    "sha": "7c97dc80776f919c97e2ad78893ef196726c3521",
+    "size": 1554,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/LICENSE?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/LICENSE",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/7c97dc80776f919c97e2ad78893ef196726c3521",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/LICENSE",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/LICENSE?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/7c97dc80776f919c97e2ad78893ef196726c3521",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/LICENSE"
+    }
+  },
+  {
+    "name": "README.md",
+    "path": "README.md",
+    "sha": "d9e7b752b507ea93199b52a8866dabd26d0ddae7",
+    "size": 6078,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/README.md?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/README.md",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/d9e7b752b507ea93199b52a8866dabd26d0ddae7",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/README.md",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/README.md?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/d9e7b752b507ea93199b52a8866dabd26d0ddae7",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/README.md"
+    }
+  },
+  {
+    "name": "dependabot-core.gemspec",
+    "path": "dependabot-core.gemspec",
+    "sha": "70ca6dcb9506728ca235748d27fb871497c349a0",
+    "size": 1571,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/dependabot-core.gemspec?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/blob/main/dependabot-core.gemspec",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/70ca6dcb9506728ca235748d27fb871497c349a0",
+    "download_url": "https://raw.githubusercontent.com/dependabot/dependabot-core/master/dependabot-core.gemspec",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/dependabot-core.gemspec?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/blobs/70ca6dcb9506728ca235748d27fb871497c349a0",
+      "html": "https://github.com/dependabot/dependabot-core/blob/main/dependabot-core.gemspec"
+    }
+  },
+  {
+    "name": "helpers",
+    "path": "helpers",
+    "sha": "900f6c83a9611c92478918dfca8e541261912e8c",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/helpers?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/tree/master/helpers",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/900f6c83a9611c92478918dfca8e541261912e8c",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/helpers?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/900f6c83a9611c92478918dfca8e541261912e8c",
+      "html": "https://github.com/dependabot/dependabot-core/tree/master/helpers"
+    }
+  },
+  {
+    "name": "lib",
+    "path": "lib",
+    "sha": "8493ef79eb42da9d8aaa1e78dab729e3c08d22ee",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/lib?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/tree/master/lib",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/8493ef79eb42da9d8aaa1e78dab729e3c08d22ee",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/lib?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/8493ef79eb42da9d8aaa1e78dab729e3c08d22ee",
+      "html": "https://github.com/dependabot/dependabot-core/tree/master/lib"
+    }
+  },
+  {
+    "name": "spec",
+    "path": "spec",
+    "sha": "40e3fc7a0819fac4c3e30b0d4217ad11ffc2ceef",
+    "size": 0,
+    "url": "https://api.github.com/repos/dependabot/dependabot-core/contents/spec?ref=master",
+    "html_url": "https://github.com/dependabot/dependabot-core/tree/master/spec",
+    "git_url": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/40e3fc7a0819fac4c3e30b0d4217ad11ffc2ceef",
+    "download_url": null,
+    "type": "dir",
+    "_links": {
+      "self": "https://api.github.com/repos/dependabot/dependabot-core/contents/spec?ref=master",
+      "git": "https://api.github.com/repos/dependabot/dependabot-core/git/trees/40e3fc7a0819fac4c3e30b0d4217ad11ffc2ceef",
+      "html": "https://github.com/dependabot/dependabot-core/tree/master/spec"
+    }
+  }
+]


### PR DESCRIPTION
Add a unit test to guard against regressions resulting in bugs like https://github.com/dependabot/dependabot-core/pull/6142.

I didn't include this with the original PR because I was uncertain if it'd be affected by the removal of the `kubernetes_updates` feature flag in https://github.com/dependabot/dependabot-core/pull/6144.