### PR TITLE
only replace url for private pipenv source

### DIFF
--- a/python/lib/dependabot/python/file_updater/pipfile_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_preparer.rb
@@ -21,7 +21,7 @@ module Dependabot
           pipfile_object = TomlRB.parse(pipfile_content)
 
           pipfile_object["source"] =
-            pipfile_sources.reject { |h| h["url"].include?("${") } +
+            pipfile_sources.filter_map { |h| sub_auth_url(h, credentials) } +
             config_variable_sources(credentials)
 
           TomlRB.dump(pipfile_object)
@@ -112,6 +112,22 @@ module Dependabot
           @pipfile_sources ||=
             TomlRB.parse(pipfile_content).fetch("source", []).
             map { |h| h.dup.merge("url" => h["url"].gsub(%r{/*$}, "") + "/") }
+        end
+
+        def sub_auth_url(source, credentials)
+          if source["url"].include?("${")
+            base_url = source["url"].sub(/\${.*}@/, "")
+
+            source_cred = credentials.
+                          select { |cred| cred["type"] == "python_index" }.
+                          find { |c| c["index-url"].sub(/\${.*}@/, "") == base_url }
+
+            return nil if source_cred.nil?
+
+            source["url"] = AuthedUrlBuilder.authed_url(credential: source_cred)
+          end
+
+          source
         end
 
         def config_variable_sources(credentials)

--- a/python/spec/dependabot/python/file_updater/pipfile_preparer_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pipfile_preparer_spec.rb
@@ -158,5 +158,31 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfilePreparer do
           to include("https://username:password@pypi.posrip.com/pypi/")
       end
     end
+
+    context "with auth details provided in Pipfile" do
+      let(:credentials) do
+        [{
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "token"
+        }, {
+          "type" => "python_index",
+          "index-url" => "https://pypi.posrip.com/pypi/",
+          "token" => "username:password"
+        }]
+      end
+
+      let(:pipfile_fixture_name) { "private_source_auth" }
+
+      it "keeps source config" do
+        expect(updated_content).to include(
+          "[[source]]\n" \
+          "name = \"pypi\"\n" \
+          "url = \"https://username:password@pypi.posrip.com/pypi/\"\n" \
+          "verify_ssl = true\n"
+        )
+      end
+    end
   end
 end

--- a/python/spec/fixtures/pipfiles/private_source_auth
+++ b/python/spec/fixtures/pipfiles/private_source_auth
@@ -1,0 +1,10 @@
+[[source]]
+url = "https://${ENV_USER}:${ENV_PASSWORD}@pypi.posrip.com/pypi/"
+verify_ssl = true
+name = "pypi"
+
+[dev-packages]
+pytest = "==3.4.0"
+
+[packages]
+requests = "==2.18.0"


### PR DESCRIPTION
Instead of filtering out private pipenv sources completely, and inserting the urls from the Dependabot credentials configuration (which removes other parts of the pipenv source configuration, e.g. the source name), only replace the url with the new authed url.

This should fix https://github.com/dependabot/dependabot-core/issues/6157