### PR TITLE
Create a permanent root Gemfile

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "*/bin/**/*"
     - "**/tmp/**/*"
     - "*/spec/fixtures/**/*"
+    - "dry-run/**/*"
   NewCops: enable
   SuggestExtensions: false
 Gemspec/DeprecatedAttributeAssignment:

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -39,8 +39,6 @@ WORKDIR ${CODE_DIR}
 
 RUN cd omnibus \
   && bundle install
-# Make omnibus gems available to bundler in root directory
-RUN echo 'eval_gemfile File.join(File.dirname(__FILE__), "omnibus/Gemfile")' > Gemfile
 
 ENV PATH="${CODE_DIR}/omnibus/$BUNDLE_BIN:$PATH"
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+eval_gemfile File.join(File.dirname(__FILE__), "omnibus/Gemfile")


### PR DESCRIPTION
For the same reasons this is useful in the development container, I'd like to also have it outside of the development container.

My use case is to quickly run RuboCop over the whole repo when making global changes across ecosystems.