### PR TITLE
Transform "No files changed!" unexpected error into expected one

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -158,6 +158,7 @@ module Dependabot
         return version_resolver.latest_version_resolvable_with_full_unlock? if dependency.top_level?
 
         return false unless security_advisories.any?
+        return false unless subdependency_version_resolver.latest_version_resolvable_with_full_unlock?
 
         vulnerability_audit["fix_available"]
       end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -52,6 +52,10 @@ module Dependabot
           nil
         end
 
+        def latest_version_resolvable_with_full_unlock?
+          !bundled_dependency?
+        end
+
         private
 
         attr_reader :dependency, :credentials, :dependency_files,


### PR DESCRIPTION
If a npm dependency is bundled, we can't really upgrade it unless the parent dependency is bumped.

This change should teach the update checker about that, so that unexpected security update errors show expected "upgrade is not possible" errors instead.