### PR TITLE
need pull_request trigger for branch updates

### DIFF
--- a/.github/workflows/docker-branch-releases.yml
+++ b/.github/workflows/docker-branch-releases.yml
@@ -1,16 +1,22 @@
-name: Push docker branch images
+name: Push branch images
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   BASE_IMAGE: "ubuntu:20.04"
   UPDATER_IMAGE: "dependabot/updater"
   UPDATER_IMAGE_MIRROR: "ghcr.io/dependabot/dependabot-updater"
 on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - edited
   pull_request_review:
-    types: [submitted]
+    types:
+      - submitted
 
 jobs:
   push-updater-image:
-    name: Export dependabot-updater image to build artifacts
+    name: Deploy
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-fork-releases.yml
+++ b/.github/workflows/docker-fork-releases.yml
@@ -1,4 +1,4 @@
-name: Push docker fork images
+name: Push fork images
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   BASE_IMAGE: "ubuntu:20.04"
@@ -14,7 +14,7 @@ on:
 
 jobs:
   push-fork-image:
-    name: Build and push fork image
+    name: Deploy
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-main-releases.yml
+++ b/.github/workflows/docker-main-releases.yml
@@ -1,4 +1,4 @@
-name: Push docker branch images
+name: Push latest images
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   BASE_IMAGE: "ubuntu:20.04"
@@ -14,7 +14,7 @@ on:
 
 jobs:
   push-updater-image:
-    name: Release latest tag
+    name: Deploy
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
#6155 removed the pull_request trigger, but we need it since it triggers when we update a branch from master, for instance, or push a small change. That way we don't need to ask for reapproval in those cases. 

I **think** types: edited is the correct thing to put. We don't need the workflow to run when the PR opens, or closes, etc.

I also fixed the names of the latest release workflow being the same as the branch release workflow, which then got me carried away to make all the names shorter and more accurate. 