### PR TITLE
Bitbucket improvements

### DIFF
--- a/common/lib/dependabot/clients/bitbucket.rb
+++ b/common/lib/dependabot/clients/bitbucket.rb
@@ -156,7 +156,7 @@ module Dependabot
         decline_path = "#{repo}/pullrequests/#{pr_id}/decline"
         post(base_url + decline_path, "")
 
-        comment = "Dependabot declined pull request" if comment.nil?
+        comment = "Dependabot declined the pull request." if comment.nil?
 
         content = {
           content: {

--- a/common/spec/dependabot/clients/bitbucket_spec.rb
+++ b/common/spec/dependabot/clients/bitbucket_spec.rb
@@ -237,4 +237,67 @@ RSpec.describe Dependabot::Clients::Bitbucket do
       }
     end
   end
+
+  describe "#decline pull request" do
+    let(:default_decline_url) { api_base_url + repo + "/pullrequests/15/decline" }
+    let(:default_comment_url) { api_base_url + repo + "/pullrequests/15/comments" }
+
+    context "with provided comment" do
+      before do
+        stub_request(:post, default_decline_url).
+          with(
+            headers: {
+              "Authorization" => "Bearer #{access_token}",
+              "Accept" => "application/json"
+            }
+          ).
+          to_return(status: 200)
+
+        stub_request(:post, default_comment_url).
+          with(
+            body: "{\"content\":{\"raw\":\"Superseded by newer version\"}}",
+            headers: {
+              "Authorization" => "Bearer #{access_token}",
+              "Content-type" => "application/json"
+            }
+          ).
+          to_return(status: 201)
+      end
+
+      subject do
+        client.decline_pull_request(repo, 15, "Superseded by newer version")
+      end
+
+      specify { expect { subject }.to_not raise_error }
+    end
+
+    context "without provided comment" do
+      before do
+        stub_request(:post, default_decline_url).
+          with(
+            headers: {
+              "Authorization" => "Bearer #{access_token}",
+              "Accept" => "application/json"
+            }
+          ).
+          to_return(status: 200)
+
+        stub_request(:post, default_comment_url).
+          with(
+            body: "{\"content\":{\"raw\":\"Dependabot declined pull request\"}}",
+            headers: {
+              "Authorization" => "Bearer #{access_token}",
+              "Content-type" => "application/json"
+            }
+          ).
+          to_return(status: 201)
+      end
+
+      subject do
+        client.decline_pull_request(repo, 15)
+      end
+
+      specify { expect { subject }.to_not raise_error }
+    end
+  end
 end

--- a/common/spec/dependabot/clients/bitbucket_spec.rb
+++ b/common/spec/dependabot/clients/bitbucket_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe Dependabot::Clients::Bitbucket do
 
         stub_request(:post, default_comment_url).
           with(
-            body: "{\"content\":{\"raw\":\"Dependabot declined pull request\"}}",
+            body: "{\"content\":{\"raw\":\"Dependabot declined the pull request.\"}}",
             headers: {
               "Authorization" => "Bearer #{access_token}",
               "Content-type" => "application/json"

--- a/common/spec/fixtures/bitbucket/pull_requests_no_match.json
+++ b/common/spec/fixtures/bitbucket/pull_requests_no_match.json
@@ -1,0 +1,47 @@
+{
+  "values": [
+    {
+      "id": 7,
+      "title": "Pull request title",
+      "description": "Pull request description",
+      "state": "OPEN",
+      "author": {
+        "display_name": "Pull request Author"
+      },
+      "created_on": "2021-05-17T14:52:37.237653+00:00",
+      "updated_on": "2021-05-17T14:52:37.237653+00:00",
+      "destination": {
+        "branch": {
+          "name": "target_branch"
+        }
+      },
+      "source": {
+        "branch": {
+          "name": "branch_1"
+        }
+      }
+    },
+    {
+      "id": 25,
+      "title": "Second pull request",
+      "description": "Second pull request",
+      "state": "OPEN",
+      "author": {
+        "display_name": "Author"
+      },
+      "destination": {
+        "branch": {
+          "name": "branch_2"
+        }
+      },
+      "source": {
+        "branch": {
+          "name": "branch_3"
+        }
+      }
+    }
+  ],
+  "pagelen": 10,
+  "size": 2,
+  "page": 1
+}

--- a/common/spec/fixtures/bitbucket/pull_requests_with_match.json
+++ b/common/spec/fixtures/bitbucket/pull_requests_with_match.json
@@ -1,0 +1,47 @@
+{
+  "values": [
+    {
+      "id": 7,
+      "title": "Pull request title",
+      "description": "Pull request description",
+      "state": "OPEN",
+      "author": {
+        "display_name": "Pull request Author"
+      },
+      "created_on": "2021-05-17T14:52:37.237653+00:00",
+      "updated_on": "2021-05-17T14:52:37.237653+00:00",
+      "destination": {
+        "branch": {
+          "name": "target_branch"
+        }
+      },
+      "source": {
+        "branch": {
+          "name": "branch_1"
+        }
+      }
+    },
+    {
+      "id": 27,
+      "title": "Second pull request",
+      "description": "Second pull request",
+      "state": "OPEN",
+      "author": {
+        "display_name": "Author"
+      },
+      "destination": {
+        "branch": {
+          "name": "target_branch"
+        }
+      },
+      "source": {
+        "branch": {
+          "name": "source_branch"
+        }
+      }
+    }
+  ],
+  "pagelen": 10,
+  "size": 2,
+  "page": 1
+}


### PR DESCRIPTION
### Broaden the functionality of the pull_requests method.

This way the code can also be used to fetch more than one pull request and the state of the pull requests to fetch can be specified.

### Add decline pull request method

With this function it's possible to decline a pull request with a provided comment (a default comment is provided as fallback).