### PR TITLE
Fix inconsistent docker updates with `-` suffixed images

### DIFF
--- a/docker/lib/dependabot/docker/version.rb
+++ b/docker/lib/dependabot/docker/version.rb
@@ -13,7 +13,7 @@ module Dependabot
       def initialize(version)
         release_part, update_part = version.split("_", 2)
 
-        @release_part = Gem::Version.new(release_part)
+        @release_part = Gem::Version.new(release_part.tr("-", "."))
 
         @update_part = Gem::Version.new(update_part&.start_with?(/[0-9]/) ? update_part : 0)
       end

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
       context "for an older version of the prefix" do
         let(:version) { "7.1-0.1" }
-        it { is_expected.to eq("7.1-0.3.1") }
+        it { is_expected.to eq("7.2-0.3.1") }
       end
     end
 


### PR DESCRIPTION
I'm not adding any specs because the spec that my changes broke illustrates perfectly the desired behavior.

Fixes #3929.
Fixes #4535.
Fixes #6169.