### PR TITLE
Allow cargo versions with hypens in build identifiers

### DIFF
--- a/cargo/lib/dependabot/cargo/version.rb
+++ b/cargo/lib/dependabot/cargo/version.rb
@@ -12,7 +12,7 @@ module Dependabot
     class Version < Gem::Version
       VERSION_PATTERN = '[0-9]+(?>\.[0-9a-zA-Z]+)*' \
                         '(-[0-9A-Za-z-]+(\.[0-9a-zA-Z-]+)*)?' \
-                        '(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z]+)*)?'
+                        '(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?'
       ANCHORED_VERSION_PATTERN = /\A\s*(#{VERSION_PATTERN})?\s*\z/
 
       def initialize(version)

--- a/cargo/lib/dependabot/cargo/version.rb
+++ b/cargo/lib/dependabot/cargo/version.rb
@@ -12,7 +12,7 @@ module Dependabot
     class Version < Gem::Version
       VERSION_PATTERN = '[0-9]+(?>\.[0-9a-zA-Z]+)*' \
                         '(-[0-9A-Za-z-]+(\.[0-9a-zA-Z-]+)*)?' \
-                        '(\+[0-9a-zA-Z]+(\.[0-9a-zA-Z]+)*)?'
+                        '(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z]+)*)?'
       ANCHORED_VERSION_PATTERN = /\A\s*(#{VERSION_PATTERN})?\s*\z/
 
       def initialize(version)

--- a/cargo/spec/dependabot/cargo/version_spec.rb
+++ b/cargo/spec/dependabot/cargo/version_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe Dependabot::Cargo::Version do
       it { is_expected.to eq "1.0.0-pre1+something" }
     end
 
+    context "with a build version with hypens" do
+      let(:version_string) { "0.9.0+wasi-snapshot-preview1" }
+      it { is_expected.to eq "0.9.0+wasi-snapshot-preview1" }
+    end
+
     context "with a blank version" do
       let(:version_string) { "" }
       it { is_expected.to eq "" }
@@ -64,7 +69,7 @@ RSpec.describe Dependabot::Cargo::Version do
   describe "#correct?" do
     subject { described_class.correct?(version_string) }
 
-    valid = %w(1.0.0 1.0.0.pre1 1.0.0-pre1 1.0.0-pre1+something)
+    valid = %w(1.0.0 1.0.0.pre1 1.0.0-pre1 1.0.0-pre1+something 0.9.0+wasi-snapshot-preview1)
     valid.each do |version|
       context "with version #{version}" do
         let(:version_string) { version }

--- a/cargo/spec/dependabot/cargo/version_spec.rb
+++ b/cargo/spec/dependabot/cargo/version_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe Dependabot::Cargo::Version do
       it { is_expected.to eq "0.9.0+wasi-snapshot-preview1" }
     end
 
+    context "with a build version with hypens in multiple identifiers" do
+      let(:version_string) { "0.9.0+wasi-snapshot1.alpha-preview" }
+      it { is_expected.to eq "0.9.0+wasi-snapshot1.alpha-preview" }
+    end
+
     context "with a blank version" do
       let(:version_string) { "" }
       it { is_expected.to eq "" }
@@ -69,7 +74,8 @@ RSpec.describe Dependabot::Cargo::Version do
   describe "#correct?" do
     subject { described_class.correct?(version_string) }
 
-    valid = %w(1.0.0 1.0.0.pre1 1.0.0-pre1 1.0.0-pre1+something 0.9.0+wasi-snapshot-preview1)
+    valid = %w(1.0.0 1.0.0.pre1 1.0.0-pre1 1.0.0-pre1+something 0.9.0+wasi-snapshot-preview1
+               0.9.0+wasi-snapshot1.alpha-preview)
     valid.each do |version|
       context "with version #{version}" do
         let(:version_string) { version }


### PR DESCRIPTION
Cargo implements standard semantic versions as per https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field.

And standard semantic versioning allows hyphens in build identifiers as per https://semver.org/#spec-item-10.