### PR TITLE
Remove dependencies from manifest before install

### DIFF
--- a/npm_and_yarn/helpers/lib/npm/index.js
+++ b/npm_and_yarn/helpers/lib/npm/index.js
@@ -1,9 +1,12 @@
 const conflictingDependencyParser = require("./conflicting-dependency-parser");
 const vulnerabilityAuditor = require("./vulnerability-auditor");
+const removeDependenciesFromManifest = require("./remove-dependencies-from-manifest");
 
 module.exports = {
   findConflictingDependencies:
     conflictingDependencyParser.findConflictingDependencies,
   vulnerabilityAuditor:
     vulnerabilityAuditor.findVulnerableDependencies,
+  removeDependenciesFromManifest:
+    removeDependenciesFromManifest.removeDependenciesFromManifest,
 };

--- a/npm_and_yarn/helpers/lib/npm/remove-dependencies-from-manifest.js
+++ b/npm_and_yarn/helpers/lib/npm/remove-dependencies-from-manifest.js
@@ -1,0 +1,55 @@
+const fs = require("fs");
+const path = require("path");
+
+const dependencyTypes = [
+  "dependencies", 
+  "devDependencies", 
+  "peerDependencies", 
+  "optionalDependencies"
+];
+
+// Removes all dependencies matching on name
+function removeDependenciesFromManifest(directory, manifestName, dependencies) {
+  const readFile = (fileName) =>
+    fs.readFileSync(path.join(directory, fileName)).toString();
+
+  manifest = readFile(manifestName);
+  const manifestObject = JSON.parse(manifest);
+
+  const updatedManifestObject = dependencyTypes.map((dependencyType) => {
+    if (manifestObject?.dependencyType !== undefined) {
+      manifestObject.dependencyType = _removeDependenciesFromManifest(
+        manifestObject[dependencyType],
+        dependencies.map((dep) => dep.name)
+      );
+    }
+  });
+
+  fs.writeFileSync(
+    path.join(directory, manifestName),
+    JSON.stringify(updatedManifestObject)
+  );
+}
+
+
+function _removeDependenciesFromManifest(manifestObject, dependenciesToRemove) {
+  dependencyTypes.map((dependencyType) => {
+    let dependencies = Object.entries(manifest.dependencyType).reduce(
+      (acc, [depName, packageValue]) => {
+        if (!dependenciesToRemove.includes(depName)) {
+          acc[depName] = _removeDependenciesFromLockfile(
+            packageValue,
+            dependenciesToRemove
+          );
+        }
+
+        return acc;
+      },
+      {}
+    );
+  });
+
+  return Object.assign({}, manifestObject, { dependencies });
+}
+
+module.exports = removeDependenciesFromManifest;

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -222,6 +222,14 @@ module Dependabot
         end
 
         def run_npm8_subdependency_updater(sub_dependencies:)
+          # NOTE: this won't remove the dependencies from the lockfile,
+          # but the lockfile information for the previous requirements will get overwritten
+          # once the npm8_subdependency_update_command runs
+          SharedHelpers.run_helper_subprocess(
+            command: self.helper_path,
+            function: "npm:removeDependenciesFromManifest",
+            args: [Dir.pwd, package_json, sub_dependencies]
+          )
           dependency_names = sub_dependencies.map(&:name)
           SharedHelpers.run_shell_command(NativeHelpers.npm8_subdependency_update_command(dependency_names))
           { lockfile_basename => File.read(lockfile_basename) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
@@ -15,6 +15,19 @@ module Dependabot
       end
 
       def self.npm8_subdependency_update_command(dependency_names)
+        # eventually this should be set based on the SharedHelper result
+        dependency_type = "production"
+        def dependency_type_to_flag(dependency_type)
+          case dependency_type
+          when "production"
+            "--save"
+          when "dev"
+            "--save-dev"
+          when "optional"
+            "--save-optional"
+          end
+        end
+
         # NOTE: npm options
         # - `--force` ignores checks for platform (os, cpu) and engines
         # - `--dry-run=false` the updater sets a global .npmrc with dry-run: true to
@@ -29,7 +42,8 @@ module Dependabot
           "--dry-run",
           "false",
           "--ignore-scripts",
-          "--package-lock-only"
+          "--package-lock-only",
+          dependency_type_to_flag(dependency_type)
         ].join(" ")
       end
     end


### PR DESCRIPTION
In newer versions of npm, peerDependencies are automatically installed which can lead to conflicts when trying to update dependencies. While the old behavior of not downloading and resolving the peerDependency tree can be enabled with the `--legacy-peer-deps` flag, instead this commit opts to remove the previous version of a dependencies being updated from a the `package.json` file before the newer versions of the dependencies are installed, which means the peer dependency tree for those specific dependencies are not considered and will not conflict.