### PR TITLE
Respect custom directory for actions updates

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_fetcher.rb
+++ b/github_actions/lib/dependabot/github_actions/file_fetcher.rb
@@ -41,16 +41,22 @@ module Dependabot
       def workflow_files
         return @workflow_files if defined? @workflow_files
 
-        @workflow_files = [fetch_file_if_present("action.yml"), fetch_file_if_present("action.yaml")].compact
+        @workflow_files = []
 
         # In the special case where the root directory is defined we also scan
         # the .github/workflows/ folder.
-        return @workflow_files unless directory == "/"
+        if directory == "/"
+          @workflow_files += [fetch_file_if_present("action.yml"), fetch_file_if_present("action.yaml")].compact
+
+          workflows_dir = ".github/workflows"
+        else
+          workflows_dir = "."
+        end
 
         @workflow_files +=
-          repo_contents(dir: ".github/workflows", raise_errors: false).
+          repo_contents(dir: workflows_dir, raise_errors: false).
           select { |f| f.type == "file" && f.name.match?(/\.ya?ml$/) }.
-          map { |f| fetch_file_from_host(".github/workflows/#{f.name}") }
+          map { |f| fetch_file_from_host("#{workflows_dir}/#{f.name}") }
       end
 
       def referenced_local_workflow_files


### PR DESCRIPTION
While testing security updates for actions, I noticed that manual security update jobs are created with an explicit `directory` option passed with the `/.github/workflows` value.

But our updater currently does not support this.

Apparently, it used to, but that broke at some point.

Fixes https://github.com/dependabot/dependabot-core/issues/5047.