### PR TITLE
Honor new dir selection logic in Github Actions error messages

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_fetcher.rb
+++ b/github_actions/lib/dependabot/github_actions/file_fetcher.rb
@@ -26,9 +26,16 @@ module Dependabot
         return fetched_files if fetched_files.any?
 
         if incorrectly_encoded_workflow_files.none?
+          expected_paths =
+            if directory == "/"
+              File.join(directory, "action.yml") + " or /.github/workflows/<anything>.yml"
+            else
+              File.join(directory, "<anything>.yml")
+            end
+
           raise(
             Dependabot::DependencyFileNotFound,
-            File.join(directory, "action.yml") + " or /.github/workflows/<anything>.yml"
+            expected_paths
           )
         else
           raise(


### PR DESCRIPTION
In #6189 I changed Actions logic to respect explicit directories being configured to fetch files from.

This PR changes the error message to follow the new logic.