### PR TITLE
Re-enable two pending tests

### DIFF
--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -173,20 +173,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
 
         let(:dependency_files) { bundler_project_dependency_files("requires_bundler") }
 
-        pending "resolves version" do
-          expect(subject.version).to eq(Gem::Version.new("3.0.0"))
-        end
-      end
-
-      context "when bundled with v2 and requesting a version that requires bundler v1", :bundler_v2_only do
-        let(:dependency_name) { "guard-bundler" }
-        let(:requirement_string) { "~> 2.2.0" }
-
-        let(:dependency_files) { bundler_project_dependency_files("requires_bundler") }
-
-        pending "raises a DependencyFileNotResolvable error" do
-          expect { subject }.
-            to raise_error(Dependabot::DependencyFileNotResolvable)
+        it "resolves version" do
+          expect(subject[:version]).to eq(Gem::Version.new("3.0.0"))
         end
       end
 


### PR DESCRIPTION
Per the discussion in https://github.com/dependabot/dependabot-core/pull/3319#discussion_r599482825,
these only temporarily needed to be marked `pending` until
https://github.com/dependabot/dependabot-core/pull/3327 was merged.

From the first thread it looks like the intent was to remove the
`pending` marker, but that accidentally got overlooked.

So this removes the `pending` marker, and then fixes the failures:
1. The first was a straightforward change from method to hash value.
2. The second wasn't raising the expected error... However, this has
   been true since [this code was originally committed](https://github.com/dependabot/dependabot-core/pull/3319/files#r600526250)
   (once #3327 was merged to make the test work). So I deleted the test
   as it added no value.