### PR TITLE
Use only python major.minor version

### DIFF
--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -198,7 +198,7 @@ module Dependabot
           end
 
           # Overwrite the .python-version with updated content
-          File.write(".python-version", python_version)
+          File.write(".python-version", Helpers.python_major_minor(python_version))
 
           setup_files.each do |file|
             path = file.name

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -221,7 +221,7 @@ module Dependabot
           end
 
           # Overwrite the .python-version with updated content
-          File.write(".python-version", python_version) if python_version
+          File.write(".python-version", Helpers.python_major_minor(python_version)) if python_version
 
           # Overwrite the pyproject with updated content
           File.write("pyproject.toml", pyproject_content)

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -298,7 +298,7 @@ module Dependabot
           end
 
           # Overwrite the .python-version with updated content
-          File.write(".python-version", python_version)
+          File.write(".python-version", Helpers.python_major_minor(python_version))
 
           setup_files.each do |file|
             path = file.name

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -202,7 +202,7 @@ module Dependabot
           end
 
           # Overwrite the .python-version with updated content
-          File.write(".python-version", python_version) if python_version
+          File.write(".python-version", Helpers.python_major_minor(python_version)) if python_version
 
           # Overwrite the pyproject with updated content
           if update_pyproject


### PR DESCRIPTION
Bugfix for pre-compiled python. I originally missed a couple places where we set the full version instead of just `major.minor`