### PR TITLE
Use git to fill in gemspec files

### DIFF
--- a/bundler/dependabot-bundler.gemspec
+++ b/bundler/dependabot-bundler.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
@@ -30,16 +28,5 @@ Gem::Specification.new do |spec|
 
   next unless File.exist?("../.gitignore")
 
-  ignores = File.readlines("../.gitignore").grep(/\S+/).map(&:chomp)
-
-  next unless File.directory?("lib")
-
-  prefix = "/" + File.basename(File.expand_path(__dir__)) + "/"
-  Find.find("lib", "helpers") do |path|
-    if ignores.any? { |i| File.fnmatch(i, prefix + path, File::FNM_DOTMATCH) }
-      Find.prune
-    else
-      spec.files << path unless File.directory?(path)
-    end
-  end
+  spec.files += `git -C #{__dir__} ls-files lib helpers -z`.split("\x0")
 end

--- a/cargo/dependabot-cargo.gemspec
+++ b/cargo/dependabot-cargo.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
 require "./lib/dependabot/version"
 
 Gem::Specification.new do |spec|
@@ -52,15 +51,5 @@ Gem::Specification.new do |spec|
 
   next unless File.exist?("../.gitignore")
 
-  ignores = File.readlines("../.gitignore").grep(/\S+/).map(&:chomp)
-
-  next unless File.directory?("lib")
-
-  Find.find("lib", "bin") do |path|
-    if ignores.any? { |i| File.fnmatch(i, "/" + path, File::FNM_DOTMATCH) }
-      Find.prune
-    else
-      spec.files << path unless File.directory?(path)
-    end
-  end
+  spec.files += `git -C #{__dir__} ls-files lib bin -z`.split("\x0")
 end

--- a/composer/dependabot-composer.gemspec
+++ b/composer/dependabot-composer.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
@@ -30,16 +28,5 @@ Gem::Specification.new do |spec|
 
   next unless File.exist?("../.gitignore")
 
-  ignores = File.readlines("../.gitignore").grep(/\S+/).map(&:chomp)
-
-  next unless File.directory?("lib") && File.directory?("helpers")
-
-  prefix = "/" + File.basename(File.expand_path(__dir__)) + "/"
-  Find.find("lib", "helpers") do |path|
-    if ignores.any? { |i| File.fnmatch(i, prefix + path, File::FNM_DOTMATCH) }
-      Find.prune
-    else
-      spec.files << path unless File.directory?(path)
-    end
-  end
+  spec.files += `git -C #{__dir__} ls-files lib helpers -z`.split("\x0")
 end

--- a/docker/dependabot-docker.gemspec
+++ b/docker/dependabot-docker.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")

--- a/elm/dependabot-elm.gemspec
+++ b/elm/dependabot-elm.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")

--- a/git_submodules/dependabot-git_submodules.gemspec
+++ b/git_submodules/dependabot-git_submodules.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")

--- a/github_actions/dependabot-github_actions.gemspec
+++ b/github_actions/dependabot-github_actions.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")

--- a/go_modules/dependabot-go_modules.gemspec
+++ b/go_modules/dependabot-go_modules.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
@@ -30,16 +28,5 @@ Gem::Specification.new do |spec|
 
   next unless File.exist?("../.gitignore")
 
-  ignores = File.readlines("../.gitignore").grep(/\S+/).map(&:chomp)
-
-  next unless File.directory?("lib") && File.directory?("helpers")
-
-  prefix = "/" + File.basename(File.expand_path(__dir__)) + "/"
-  Find.find("lib", "helpers") do |path|
-    if ignores.any? { |i| File.fnmatch(i, prefix + path, File::FNM_DOTMATCH) }
-      Find.prune
-    else
-      spec.files << path unless File.directory?(path)
-    end
-  end
+  spec.files += `git -C #{__dir__} ls-files lib helpers -z`.split("\x0")
 end

--- a/gradle/dependabot-gradle.gemspec
+++ b/gradle/dependabot-gradle.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")

--- a/hex/dependabot-hex.gemspec
+++ b/hex/dependabot-hex.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
@@ -30,16 +28,5 @@ Gem::Specification.new do |spec|
 
   next unless File.exist?("../.gitignore")
 
-  ignores = File.readlines("../.gitignore").grep(/\S+/).map(&:chomp)
-
-  next unless File.directory?("lib") && File.directory?("helpers")
-
-  prefix = "/" + File.basename(File.expand_path(__dir__)) + "/"
-  Find.find("lib", "helpers") do |path|
-    if ignores.any? { |i| File.fnmatch(i, prefix + path, File::FNM_DOTMATCH) }
-      Find.prune
-    else
-      spec.files << path unless File.directory?(path)
-    end
-  end
+  spec.files += `git -C #{__dir__} ls-files lib helpers -z`.split("\x0")
 end

--- a/maven/dependabot-maven.gemspec
+++ b/maven/dependabot-maven.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")

--- a/npm_and_yarn/dependabot-npm_and_yarn.gemspec
+++ b/npm_and_yarn/dependabot-npm_and_yarn.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
@@ -30,16 +28,5 @@ Gem::Specification.new do |spec|
 
   next unless File.exist?("../.gitignore")
 
-  ignores = File.readlines("../.gitignore").grep(/\S+/).map(&:chomp)
-
-  next unless File.directory?("lib") && File.directory?("helpers")
-
-  prefix = "/" + File.basename(File.expand_path(__dir__)) + "/"
-  Find.find("lib", "helpers") do |path|
-    if ignores.any? { |i| File.fnmatch(i, prefix + path, File::FNM_DOTMATCH) }
-      Find.prune
-    else
-      spec.files << path unless File.directory?(path)
-    end
-  end
+  spec.files += `git -C #{__dir__} ls-files lib helpers -z`.split("\x0")
 end

--- a/omnibus/dependabot-omnibus.gemspec
+++ b/omnibus/dependabot-omnibus.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")

--- a/pub/dependabot-pub.gemspec
+++ b/pub/dependabot-pub.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")

--- a/python/dependabot-python.gemspec
+++ b/python/dependabot-python.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
@@ -30,16 +28,5 @@ Gem::Specification.new do |spec|
 
   next unless File.exist?("../.gitignore")
 
-  ignores = File.readlines("../.gitignore").grep(/\S+/).map(&:chomp)
-
-  next unless File.directory?("lib") && File.directory?("helpers")
-
-  prefix = "/" + File.basename(File.expand_path(__dir__)) + "/"
-  Find.find("lib", "helpers") do |path|
-    if ignores.any? { |i| File.fnmatch(i, prefix + path, File::FNM_DOTMATCH) }
-      Find.prune
-    else
-      spec.files << path unless File.directory?(path)
-    end
-  end
+  spec.files += `git -C #{__dir__} ls-files lib helpers -z`.split("\x0")
 end

--- a/terraform/dependabot-terraform.gemspec
+++ b/terraform/dependabot-terraform.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "find"
-
 Gem::Specification.new do |spec|
   common_gemspec =
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
@@ -30,16 +28,5 @@ Gem::Specification.new do |spec|
 
   next unless File.exist?("../.gitignore")
 
-  ignores = File.readlines("../.gitignore").grep(/\S+/).map(&:chomp)
-
-  next unless File.directory?("lib") && File.directory?("helpers")
-
-  prefix = "/" + File.basename(File.expand_path(__dir__)) + "/"
-  Find.find("lib", "helpers") do |path|
-    if ignores.any? { |i| File.fnmatch(i, prefix + path, File::FNM_DOTMATCH) }
-      Find.prune
-    else
-      spec.files << path unless File.directory?(path)
-    end
-  end
+  spec.files += `git -C #{__dir__} ls-files lib helpers -z`.split("\x0")
 end


### PR DESCRIPTION
This is the result of running `time bundle exec rubocop --version` on my machine with the code in main:

```
$ time bundle exec rubocop --version
1.39.0
bundle exec rubocop --version  9,92s user 0,73s system 96% cpu 11,075 total
```

10 seconds, wait, what??

This is the result with this branch:

```
$ time bundle exec rubocop --version
1.39.0
bundle exec rubocop --version  0,56s user 0,30s system 94% cpu 0,909 total
```

Half a second seems more sensitive 😅.

To figure out why this is, we can add a `puts` statement in one of the gemspecs:

```diff
diff --git a/bundler/dependabot-bundler.gemspec b/bundler/dependabot-bundler.gemspec
index d8fa4822e..147ec9e55 100644
--- a/bundler/dependabot-bundler.gemspec
+++ b/bundler/dependabot-bundler.gemspec
@@ -42,4 +42,7 @@ Gem::Specification.new do |spec|
       spec.files << path unless File.directory?(path)
     end
   end
+
+  puts spec.files.size
+  puts spec.files.take(10)
 end
```

And running the above command we can see this:

```
$ time bundle exec rubocop --version     
12742
helpers/v1/.bundle/bin/bundle
helpers/v1/.bundle/bin/htmldiff
helpers/v1/.bundle/bin/irb
helpers/v1/.bundle/bin/ldiff
helpers/v1/.bundle/bin/rdbg
helpers/v1/.bundle/bin/rspec
helpers/v1/.bundle/bundler/gems/business-a1b78a929dac/.git/FETCH_HEAD
helpers/v1/.bundle/bundler/gems/business-a1b78a929dac/.git/HEAD
helpers/v1/.bundle/bundler/gems/business-a1b78a929dac/.git/ORIG_HEAD
helpers/v1/.bundle/bundler/gems/business-a1b78a929dac/.git/config
1.39.0
bundle exec rubocop --version  9,81s user 0,68s system 98% cpu 10,616 total
```

We're adding 12K files to the gem, including a bunch of generated files 😬.

The problem is that we're tryin to implement the `.gitignore` syntax in Ruby using just a few lines of code and... well, it doesn't really work.

With this PR, we use `git` itself that obviously knows how to handle `.gitignore`, and we get the result we expect:

```
$ time bundle exec rubocop --version     
78
helpers/v1/.gitignore
helpers/v1/Gemfile
helpers/v1/build
helpers/v1/lib/functions.rb
helpers/v1/lib/functions/conflicting_dependency_resolver.rb
helpers/v1/lib/functions/dependency_source.rb
helpers/v1/lib/functions/file_parser.rb
helpers/v1/lib/functions/force_updater.rb
helpers/v1/lib/functions/lockfile_updater.rb
helpers/v1/lib/functions/version_resolver.rb
1.39.0
bundle exec rubocop --version  0,56s user 0,30s system 96% cpu 0,888 total
```

I don't think this has ever bitten us when releasing production gems because we build them on a clean CI environment when the tree that we release matches a fresh clone and has nothing generated.

But this should avoid future issues in addition to speeding up my dev env.