### PR TITLE
Bump Dart to 2.18.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -273,7 +273,7 @@ ENV PUB_CACHE=/opt/dart/pub-cache \
   PATH="${PATH}:/opt/dart/dart-sdk/bin"
 
 # https://dart.dev/get-dart/archive
-ARG DART_VERSION=2.18.4
+ARG DART_VERSION=2.18.5
 # TODO Dart now publishes SHA256 checksums for their releases, we should validate against those.
 RUN DART_ARCH=${TARGETARCH} \
   && if [ "$TARGETARCH" = "amd64" ]; then DART_ARCH=x64; fi \


### PR DESCRIPTION
While working on the pub security update I happened to notice that `2.18.5` dropped yesterday.