### PR TITLE
fix(bitbucket): Fixed file path not correct when creating commit

### DIFF
--- a/common/lib/dependabot/clients/bitbucket.rb
+++ b/common/lib/dependabot/clients/bitbucket.rb
@@ -113,8 +113,7 @@ module Dependabot
         }
 
         files.each do |file|
-          absolute_path = file.name.start_with?("/") ? file.name : "/" + file.name
-          parameters[absolute_path] = file.content
+          parameters[file.path] = file.content
         end
 
         body = encode_form_parameters(parameters)


### PR DESCRIPTION
Closes #6216

Before my change: [ceb626f5bab804b96798bd558bdb41d07f69bfe3
](https://bitbucket.org/james-lucas/dependabot-core-reproduction/commits/ceb626f5bab804b96798bd558bdb41d07f69bfe3)

After my change: [f54e4c0ad71ccbbf9a3859c53fb81a24648a0892](https://bitbucket.org/james-lucas/dependabot-core-reproduction/commits/f54e4c0ad71ccbbf9a3859c53fb81a24648a0892)

As it says in the issue bitbucket expects the path to file in the post request (docs [here](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#application-x-www-form-urlencoded)) `file.name` does not include the path, so simply swapped to use `file.path` instead and dropped the `.start_with?("/")` as `file.path` returned the path prefixed with `/`