### PR TITLE
submodule cloning may not be important to the job, ignore errors

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -26,11 +26,11 @@ module Dependabot
         Dependabot::Clients::CodeCommit::NotFound
       ].freeze
 
-      GIT_SUBMODULE_ERROR_REGEX1 =
+      GIT_SUBMODULE_INACCESSIBLE_ERROR =
         /^fatal: unable to access '(?<url>.*)': The requested URL returned error: (?<code>\d+)$/
-      GIT_SUBMODULE_ERROR_REGEX2 =
+      GIT_SUBMODULE_CLONE_ERROR =
         /^fatal: clone of '(?<url>.*)' into submodule path '.*' failed$/
-      GIT_SUBMODULE_ERROR_REGEX = /(#{GIT_SUBMODULE_ERROR_REGEX1})|(#{GIT_SUBMODULE_ERROR_REGEX2})/
+      GIT_SUBMODULE_ERROR_REGEX = /(#{GIT_SUBMODULE_INACCESSIBLE_ERROR})|(#{GIT_SUBMODULE_CLONE_ERROR})/
 
       def self.required_files_in?(_filename_array)
         raise NotImplementedError

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -26,8 +26,11 @@ module Dependabot
         Dependabot::Clients::CodeCommit::NotFound
       ].freeze
 
-      GIT_SUBMODULE_ERROR_REGEX =
+      GIT_SUBMODULE_ERROR_REGEX1 =
         /^fatal: unable to access '(?<url>.*)': The requested URL returned error: (?<code>\d+)$/
+      GIT_SUBMODULE_ERROR_REGEX2 =
+        /^fatal: clone of '(?<url>.*)' into submodule path '.*' failed$/
+      GIT_SUBMODULE_ERROR_REGEX = /(#{GIT_SUBMODULE_ERROR_REGEX1})|(#{GIT_SUBMODULE_ERROR_REGEX2})/
 
       def self.required_files_in?(_filename_array)
         raise NotImplementedError
@@ -604,7 +607,7 @@ module Dependabot
               CMD
             )
           rescue SharedHelpers::HelperSubprocessFailed => e
-            raise unless e.message.match?(GIT_SUBMODULE_ERROR_REGEX) && e.message.include?("submodule")
+            raise unless GIT_SUBMODULE_ERROR_REGEX && e.message.downcase.include?("submodule")
 
             submodule_cloning_failed = true
             match = e.message.match(GIT_SUBMODULE_ERROR_REGEX)
@@ -613,7 +616,7 @@ module Dependabot
 
             # Submodules might be in the repo but unrelated to dependencies,
             # so ignoring this error to try the update anyway since the base repo exists.
-            Dependabot.logger.error("Cloning of submodule failed: #{url} error: #{code}")
+            Dependabot.logger.error("Cloning of submodule failed: #{url} error: #{code || 'unknown'}")
           end
 
           if source.commit

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -1569,6 +1569,9 @@ RSpec.describe Dependabot::FileFetchers::Base do
         let(:repo) do
           "dependabot-fixtures/go-modules-app-with-inaccessible-submodules"
         end
+        let(:branch) do
+          "with-git-urls"
+        end
 
         it "does not raise an error" do
           clone_repo_contents


### PR DESCRIPTION
In #6172 I missed that having SCP-style URLs in the `.gitmodules` would have a different error message.

So this checks for both error messages and ignores so that the update can attempt to proceed in the event the submodules were not important to the update.