### PR TITLE
Add Security Update Support for Pub

### DIFF
--- a/pub/README.md
+++ b/pub/README.md
@@ -8,10 +8,10 @@ Dart (pub) support for [`dependabot-core`][core-repo].
    * `dart pub` in general doesn't read versions numbers from git, so upgrade logic is limited to upgrading to what the 'ref' is pointing to.
    * If you pin to a specific revision in `pubspec.yaml` dependabot will not find upgrades.
    * If you give a branch in `pubspec.yaml` dependabot will upgrade to the
-     latest revision that branch is pointing to, and update pubspec.lock
+     latest revision that branch is pointing to, and update `pubspec.lock`
      accordingly.
- - No support for security advisory integration.
- - If the version found is ignored (by dependabot config) no update will happen (even if, an earlier version could be used)
+ - Security updates currently bump to the latest version. If the latest version is vulnerable, no update will happen (even if an earlier version could be used). Changing the upgrade strategy to use the minimum non-vulnerable version is tracked in https://github.com/dependabot/dependabot-core/issues/5391.
+ - If the version found is ignored (by dependabot config) no update will happen (even if an earlier version could be used)
  - Limited metadata support (just retrieves the repository link).
  - No support for auhtentication of private package repositories (mostly a configuration issue).
  - `updated_dependencies_after_full_unlock` only allows updating to a later version, if the latest version that is mutually compatible with other dependencies is the latest version of the said package. This is a dependabot limitation.


### PR DESCRIPTION
This implements basic security update support for Pub.

For now, it's a naive implementation that bumps to the latest available version, and then filters it out if it's vulnerable.

In other ecosystems, we only bump to the minimum version required to get a non-vulnerable version.

We're currently discussing with the `Pub` team how best to do that over in `https://github.com/dependabot/dependabot-core/issues/5391`, but that will come later.