### PR TITLE
Bump `RUBY_INSTALL_VERSION` to `0.8.5`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN if ! getent group "$USER_GID"; then groupadd --gid "$USER_GID" dependabot ; 
 
 # When bumping Ruby minor, need to also add the previous version to `bundler/helpers/v{1,2}/monkey_patches/definition_ruby_version_patch.rb`
 ARG RUBY_VERSION=3.1.2
-ARG RUBY_INSTALL_VERSION=0.8.3
+ARG RUBY_INSTALL_VERSION=0.8.5
 # Generally simplest to pin RUBYGEMS_SYSTEM_VERSION to the version that default ships with RUBY_VERSION.
 ARG RUBYGEMS_SYSTEM_VERSION=3.3.7
 


### PR DESCRIPTION
https://github.com/postmodern/ruby-install/tags

This may (or may not, I'm not sure) be helpful when bumping `ruby` to `3.1.3` / upcoming `3.2`...

I figured might as well bump it.