### PR TITLE
Check if existing python requirement is satisfied before modifying

### DIFF
--- a/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
@@ -38,8 +38,11 @@ module Dependabot
 
         def update_python_requirement(requirement)
           pyproject_object = TomlRB.parse(@pyproject_content)
-          if pyproject_object.dig("tool", "poetry", "dependencies", "python")
-            pyproject_object["tool"]["poetry"]["dependencies"]["python"] = "~#{requirement}"
+          if (python_specification = pyproject_object.dig("tool", "poetry", "dependencies", "python"))
+            python_req = Python::Requirement.new(python_specification)
+            unless python_req.satisfied_by?(requirement)
+              pyproject_object["tool"]["poetry"]["dependencies"]["python"] = "~#{requirement}"
+            end
           end
           TomlRB.dump(pyproject_object)
         end


### PR DESCRIPTION
## Context
Reported https://github.com/dependabot/dependabot-core/issues/6226 we are inadvertently updating the python project and causing the poetry resolver to change behavior based on the python version specified in `pyproject.toml`.

## Approach
This change checks the existing python version specification against the python version we're going to use to see that the existing requirement is satisfied by the python version under which we're running. If the python requirement is satisfied by this version, we do not change `pyproject.toml`. This preserves the earlier behavior introduced in #6191 to widen this requirement if the repository specifies a specific python version eg. `3.10.6`. In this case we need to widen the python requirement to `~3.10` so that poetry will not error out when we try to run under python 3.10.8 (or any other later patch version in the 3.10 series)