### PR TITLE
Add support for custom pom.xml names for the child maven modules

### DIFF
--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -11,7 +11,7 @@ module Dependabot
                         "profile > modules > module"
 
       def self.required_files_in?(filenames)
-        (%w(pom.xml) - filenames).empty?
+        filenames.include?("pom.xml")
       end
 
       def self.required_files_message
@@ -66,7 +66,7 @@ module Dependabot
           name_parts = [
             base_path,
             relative_path,
-            relative_path.end_with?("pom.xml") ? nil : "pom.xml"
+            relative_path.end_with?(".xml") ? nil : "pom.xml"
           ].compact.reject(&:empty?)
           path = Pathname.new(File.join(*name_parts)).cleanpath.to_path
 
@@ -126,7 +126,7 @@ module Dependabot
         name_parts = [
           File.dirname(pom.name),
           relative_parent_path,
-          relative_parent_path.end_with?("pom.xml", "pom_parent.xml") ? nil : "pom.xml"
+          relative_parent_path.end_with?(".xml") ? nil : "pom.xml"
         ].compact.reject(&:empty?)
 
         Pathname.new(File.join(*name_parts)).cleanpath.to_path

--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -272,7 +272,9 @@ module Dependabot
 
       def pomfiles
         @pomfiles ||=
-          dependency_files.select { |f| f.name.end_with?("pom.xml", "pom_parent.xml") }
+          dependency_files.select do |f|
+            f.name.end_with?(".xml") && !f.name.end_with?("extensions.xml")
+          end
       end
 
       def extensionfiles

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -13,6 +13,7 @@ module Dependabot
       def self.updated_files_regex
         [
           /^pom\.xml$/, %r{/pom\.xml$},
+          /.*\.xml$/, %r{/.*\.xml$},
           /^extensions.\.xml$/, %r{/extensions\.xml$}
         ]
       end
@@ -31,7 +32,7 @@ module Dependabot
           )
         end
 
-        updated_files.select! { |f| f.name.end_with?("pom.xml", "pom_parent.xml", "extensions.xml") }
+        updated_files.select! { |f| f.name.end_with?(".xml") }
         updated_files.reject! { |f| dependency_files.include?(f) }
 
         raise "No files changed!" if updated_files.none?

--- a/maven/spec/dependabot/maven/file_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/file_fetcher_spec.rb
@@ -29,6 +29,40 @@ RSpec.describe Dependabot::Maven::FileFetcher do
     }]
   end
 
+  describe ".required_files_in?" do
+    subject { described_class.required_files_in?(filenames) }
+
+    context "with only a pom.xml" do
+      let(:filenames) { %w(pom.xml) }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with pom.xml and any other valid .xml" do
+      let(:filenames) { %w(pom.xml othermodule.xml) }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with only an extensions.xml" do
+      let(:filenames) { %w(extensions.xml) }
+      it { is_expected.to eq(false) }
+    end
+
+    context "with an extensions.xml and a valid pom.xml file" do
+      let(:filenames) { %w(extensions.xml pom.xml) }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a non .xml file" do
+      let(:filenames) { %w(nonxml.txt) }
+      it { is_expected.to eq(false) }
+    end
+
+    context "with no files passed" do
+      let(:filenames) { %w() }
+      it { is_expected.to eq(false) }
+    end
+  end
+
   before do
     allow(file_fetcher_instance).to receive(:commit).and_return("sha")
 
@@ -323,6 +357,90 @@ RSpec.describe Dependabot::Maven::FileFetcher do
           ).once
         end
       end
+    end
+  end
+
+  context "with a multimodule custom named child poms" do
+    before do
+      stub_request(:get, File.join(url, "pom.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "contents_java_multimodule_different_pom_names.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, "submodule-one/pom.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "contents_java_basic_pom.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, "submodule-three/some-other-name.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "contents_java_basic_pom.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, "submodule-two/notpom.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "contents_java_basic_pom.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, ".mvn/extensions.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 404
+        )
+    end
+
+    it "fetches the child poms with different names" do
+      expect(file_fetcher_instance.files.count).to eq(4)
+      expect(file_fetcher_instance.files.map(&:name)).
+        to match_array(
+          %w(pom.xml submodule-one/pom.xml submodule-three/some-other-name.xml submodule-two/notpom.xml)
+        )
+    end
+  end
+
+  context "with a parent pom with custom name" do
+    before do
+      stub_request(:get, File.join(url, "pom.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "contents_java_parent_pom_custom_name.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, "parentpom.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "contents_java_basic_pom.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, ".mvn/extensions.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 404
+        )
+    end
+
+    it "fetches the parent pom" do
+      expect(file_fetcher_instance.files.count).to eq(2)
+      expect(file_fetcher_instance.files.map(&:name)).
+        to match_array(
+          %w(pom.xml parentpom.xml)
+        )
     end
   end
 end

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -828,6 +828,99 @@ RSpec.describe Dependabot::Maven::FileUpdater do
       end
     end
 
+    context "with a multimodule custom named child poms" do
+      let(:dependency_files) do
+        [
+          multimodule_custom_pom, submodule_one_pom, submodule_two_pom, submodule_three_pom
+        ]
+      end
+      let(:multimodule_custom_pom) do
+        Dependabot::DependencyFile.new(
+          name: "pom.xml",
+          content: fixture("poms", "multimodule_custom_modules.xml")
+        )
+      end
+      let(:submodule_one_pom) do
+        Dependabot::DependencyFile.new(
+          name: "submodule-one/pom.xml",
+          content: fixture("poms", "multimodule_custom_modules_submodule_one_pom.xml")
+        )
+      end
+      let(:submodule_two_pom) do
+        Dependabot::DependencyFile.new(
+          name: "submodule-two/notpom.xml",
+          content: fixture("poms", "multimodule_custom_modules_submodule_two_pom.xml")
+        )
+      end
+      let(:submodule_three_pom) do
+        Dependabot::DependencyFile.new(
+          name: "submodule-three/some-other-name.xml",
+          content: fixture("poms", "multimodule_custom_modules_submodule_three_pom.xml")
+        )
+      end
+
+      context "for a dependency in a normal and custom named pom" do
+        let(:dependencies) do
+          [
+            Dependabot::Dependency.new(
+              name: "org.apache.httpcomponents:httpclient",
+              version: "4.0",
+              requirements: [{
+                requirement: "4.5.13",
+                file: "submodule-one/pom.xml",
+                groups: [],
+                source: nil,
+                metadata: {
+                  packaging_type: "jar"
+                }
+              }],
+              previous_requirements: [{
+                requirement: "4.0",
+                file: "submodule-one/pom.xml",
+                groups: [],
+                source: nil,
+                metadata: {
+                  packaging_type: "jar"
+                }
+              }],
+              package_manager: "maven"
+            ),
+            Dependabot::Dependency.new(
+              name: "org.springframework:spring-core",
+              version: "4.3.11.RELEASE",
+              requirements: [{
+                requirement: "5.0.0.RELEASE",
+                file: "submodule-three/some-other-name.xml",
+                groups: [],
+                source: nil,
+                metadata: {
+                  packaging_type: "jar"
+                }
+              }],
+              previous_requirements: [{
+                requirement: "4.3.11.RELEASE",
+                file: "submodule-three/some-other-name.xml",
+                groups: [],
+                source: nil,
+                metadata: {
+                  packaging_type: "jar"
+                }
+              }],
+              package_manager: "maven"
+            )
+          ]
+        end
+
+        it "updates the version in both pom-s" do
+          expect(updated_files.map(&:name)).to eq(%w(submodule-one/pom.xml submodule-three/some-other-name.xml))
+          expect(updated_files.first.content).
+            to include("<version>4.5.13</version>")
+          expect(updated_files.last.content).
+            to include("<version>5.0.0.RELEASE</version>")
+        end
+      end
+    end
+
     context "with a remote parent" do
       let(:pom) do
         Dependabot::DependencyFile.new(
@@ -874,6 +967,87 @@ RSpec.describe Dependabot::Maven::FileUpdater do
         it "updates the version of the parent in the POM" do
           expect(updated_files.first.content).
             to include("<version>2.6.1</version>")
+        end
+      end
+    end
+
+    context "with a parent pom having own dependencies" do
+      let(:dependency_files) do
+        [
+          pom, parent_pom
+        ]
+      end
+      let(:pom) do
+        Dependabot::DependencyFile.new(
+          name: "pom.xml",
+          content: fixture("poms", "inheritance_custom_named_pom.xml")
+        )
+      end
+      let(:parent_pom) do
+        Dependabot::DependencyFile.new(
+          name: "parentpom.xml",
+          content: fixture("poms", "inheritance_custom_named_parent_pom.xml")
+        )
+      end
+
+      context "for a dependencies in a pom and its parent do" do
+        let(:dependencies) do
+          [
+            Dependabot::Dependency.new(
+              name: "org.apache.httpcomponents:httpclient",
+              version: "4.0",
+              requirements: [{
+                requirement: "4.5.13",
+                file: "pom.xml",
+                groups: [],
+                source: nil,
+                metadata: {
+                  packaging_type: "jar"
+                }
+              }],
+              previous_requirements: [{
+                requirement: "4.0",
+                file: "pom.xml",
+                groups: [],
+                source: nil,
+                metadata: {
+                  packaging_type: "jar"
+                }
+              }],
+              package_manager: "maven"
+            ),
+            Dependabot::Dependency.new(
+              name: "org.springframework:spring-aop",
+              version: "4.0.5.RELEASE",
+              requirements: [{
+                requirement: "5.0.0.RELEASE",
+                file: "parentpom.xml",
+                groups: [],
+                source: nil,
+                metadata: {
+                  packaging_type: "jar"
+                }
+              }],
+              previous_requirements: [{
+                requirement: "4.0.5.RELEASE",
+                file: "parentpom.xml",
+                groups: [],
+                source: nil,
+                metadata: {
+                  packaging_type: "jar"
+                }
+              }],
+              package_manager: "maven"
+            )
+          ]
+        end
+
+        it "updates the version in both pom and its parent" do
+          expect(updated_files.map(&:name)).to eq(%w(pom.xml parentpom.xml))
+          expect(updated_files.first.content).
+            to include("<version>4.5.13</version>")
+          expect(updated_files.last.content).
+            to include("<version>5.0.0.RELEASE</version>")
         end
       end
     end

--- a/maven/spec/fixtures/github/contents_java_multimodule_different_pom_names.json
+++ b/maven/spec/fixtures/github/contents_java_multimodule_different_pom_names.json
@@ -1,0 +1,18 @@
+{
+  "name": "pom.xml",
+  "path": "pom.xml",
+  "sha": "5e65c9c171f071ee8a49d2003a911706d9429b80",
+  "size": 829,
+  "url": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/pom.xml?ref=main",
+  "html_url": "https://github.com/soulus13/dependabot-maven-test/blob/main/pom.xml",
+  "git_url": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/5e65c9c171f071ee8a49d2003a911706d9429b80",
+  "download_url": "https://raw.githubusercontent.com/soulus13/dependabot-maven-test/main/pom.xml",
+  "type": "file",
+  "content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHByb2pl\nY3QgeG1sbnM9Imh0dHA6Ly9tYXZlbi5hcGFjaGUub3JnL1BPTS80LjAuMCIK\nICAgICAgICAgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hN\nTFNjaGVtYS1pbnN0YW5jZSIKICAgICAgICAgeHNpOnNjaGVtYUxvY2F0aW9u\nPSJodHRwOi8vbWF2ZW4uYXBhY2hlLm9yZy9QT00vNC4wLjAgaHR0cDovL21h\ndmVuLmFwYWNoZS5vcmcveHNkL21hdmVuLTQuMC4wLnhzZCI+CiAgICA8bW9k\nZWxWZXJzaW9uPjQuMC4wPC9tb2RlbFZlcnNpb24+CgogICAgPGdyb3VwSWQ+\nb3JnLmV4YW1wbGU8L2dyb3VwSWQ+CiAgICA8YXJ0aWZhY3RJZD5tYXZlbi10\nZXN0PC9hcnRpZmFjdElkPgogICAgPHZlcnNpb24+MS4wLVNOQVBTSE9UPC92\nZXJzaW9uPgoKICAgIDxwcm9wZXJ0aWVzPgogICAgICAgIDxtYXZlbi5jb21w\naWxlci5zb3VyY2U+ODwvbWF2ZW4uY29tcGlsZXIuc291cmNlPgogICAgICAg\nIDxtYXZlbi5jb21waWxlci50YXJnZXQ+ODwvbWF2ZW4uY29tcGlsZXIudGFy\nZ2V0PgogICAgICAgIDxwcm9qZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPlVU\nRi04PC9wcm9qZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPgogICAgPC9wcm9w\nZXJ0aWVzPgoKICAgIDxtb2R1bGVzPgogICAgICAgIDxtb2R1bGU+c3VibW9k\ndWxlLW9uZTwvbW9kdWxlPgogICAgICAgIDxtb2R1bGU+c3VibW9kdWxlLXRo\ncmVlL3NvbWUtb3RoZXItbmFtZS54bWw8L21vZHVsZT4KICAgICAgICA8bW9k\ndWxlPnN1Ym1vZHVsZS10d28vbm90cG9tLnhtbDwvbW9kdWxlPgogICAgPC9t\nb2R1bGVzPgoKPC9wcm9qZWN0Pg==\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/pom.xml?ref=main",
+    "git": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/5e65c9c171f071ee8a49d2003a911706d9429b80",
+    "html": "https://github.com/soulus13/dependabot-maven-test/blob/main/pom.xml"
+  }
+}

--- a/maven/spec/fixtures/github/contents_java_parent_pom_custom_name.json
+++ b/maven/spec/fixtures/github/contents_java_parent_pom_custom_name.json
@@ -1,0 +1,18 @@
+{
+  "name": "pom.xml",
+  "path": "submodule-one/pom.xml",
+  "sha": "81f12b6f6a6da42d3f4eca2f7e514ef861ee99b7",
+  "size": 1073,
+  "url": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/submodule-one/pom.xml?ref=main",
+  "html_url": "https://github.com/soulus13/dependabot-maven-test/blob/main/submodule-one/pom.xml",
+  "git_url": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/81f12b6f6a6da42d3f4eca2f7e514ef861ee99b7",
+  "download_url": "https://raw.githubusercontent.com/soulus13/dependabot-maven-test/main/submodule-one/pom.xml",
+  "type": "file",
+  "content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHByb2pl\nY3QgeG1sbnM9Imh0dHA6Ly9tYXZlbi5hcGFjaGUub3JnL1BPTS80LjAuMCIK\nICAgICAgICAgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hN\nTFNjaGVtYS1pbnN0YW5jZSIKICAgICAgICAgeHNpOnNjaGVtYUxvY2F0aW9u\nPSJodHRwOi8vbWF2ZW4uYXBhY2hlLm9yZy9QT00vNC4wLjAgaHR0cDovL21h\ndmVuLmFwYWNoZS5vcmcveHNkL21hdmVuLTQuMC4wLnhzZCI+CiAgICA8bW9k\nZWxWZXJzaW9uPjQuMC4wPC9tb2RlbFZlcnNpb24+CgogICAgPHBhcmVudD4K\nICAgICAgICA8Z3JvdXBJZD5vcmcuZXhhbXBsZTwvZ3JvdXBJZD4KICAgICAg\nICA8YXJ0aWZhY3RJZD5tYXZlbi10ZXN0LXN1Ym1vZHVsZS1vbmUtcGFyZW50\nPC9hcnRpZmFjdElkPgogICAgICAgIDx2ZXJzaW9uPjEuMC1TTkFQU0hPVDwv\ndmVyc2lvbj4KICAgICAgICA8cmVsYXRpdmVQYXRoPnBhcmVudHBvbS54bWw8\nL3JlbGF0aXZlUGF0aD4KICAgIDwvcGFyZW50PgoKICAgIDxhcnRpZmFjdElk\nPm1hdmVuLXRlc3Qtc3VibW9kdWxlLW9uZTwvYXJ0aWZhY3RJZD4KICAgIDx2\nZXJzaW9uPjEuMC1TTkFQU0hPVDwvdmVyc2lvbj4KCiAgICA8cHJvcGVydGll\ncz4KICAgICAgICA8bWF2ZW4uY29tcGlsZXIuc291cmNlPjg8L21hdmVuLmNv\nbXBpbGVyLnNvdXJjZT4KICAgICAgICA8bWF2ZW4uY29tcGlsZXIudGFyZ2V0\nPjg8L21hdmVuLmNvbXBpbGVyLnRhcmdldD4KICAgICAgICA8cHJvamVjdC5i\ndWlsZC5zb3VyY2VFbmNvZGluZz5VVEYtODwvcHJvamVjdC5idWlsZC5zb3Vy\nY2VFbmNvZGluZz4KICAgIDwvcHJvcGVydGllcz4KCiAgICA8ZGVwZW5kZW5j\naWVzPgogICAgICAgIDxkZXBlbmRlbmN5PgogICAgICAgICAgICA8Z3JvdXBJ\nZD5vcmcuYXBhY2hlLmh0dHBjb21wb25lbnRzPC9ncm91cElkPgogICAgICAg\nICAgICA8YXJ0aWZhY3RJZD5odHRwY2xpZW50PC9hcnRpZmFjdElkPgogICAg\nICAgICAgICA8dmVyc2lvbj40LjA8L3ZlcnNpb24+CiAgICAgICAgPC9kZXBl\nbmRlbmN5PgogICAgPC9kZXBlbmRlbmNpZXM+CjwvcHJvamVjdD4=\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/submodule-one/pom.xml?ref=main",
+    "git": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/81f12b6f6a6da42d3f4eca2f7e514ef861ee99b7",
+    "html": "https://github.com/soulus13/dependabot-maven-test/blob/main/submodule-one/pom.xml"
+  }
+}

--- a/maven/spec/fixtures/poms/inheritance_custom_named_parent_pom.xml
+++ b/maven/spec/fixtures/poms/inheritance_custom_named_parent_pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <packaging>pom</packaging>
+
+  <groupId>org.example</groupId>
+  <artifactId>maven-test-submodule-one-parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+      <version>4.0.5.RELEASE</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/maven/spec/fixtures/poms/inheritance_custom_named_pom.xml
+++ b/maven/spec/fixtures/poms/inheritance_custom_named_pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.example</groupId>
+    <artifactId>maven-test-submodule-one-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>parentpom.xml</relativePath>
+  </parent>
+
+  <artifactId>maven-test-submodule-one</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/maven/spec/fixtures/poms/inheritance_pom_no_parent_with_namespace_present.xml
+++ b/maven/spec/fixtures/poms/inheritance_pom_no_parent_with_namespace_present.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.example</groupId>
+        <artifactId>maven-test-no-parent-artifact</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>./parent</relativePath>
+    </parent>
+
+    <artifactId>maven-test-submodule-three</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+            <version>4.0.3.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+            <version>2.9.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/spec/fixtures/poms/multimodule_custom_modules.xml
+++ b/maven/spec/fixtures/poms/multimodule_custom_modules.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>maven-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>submodule-one</module>
+        <module>submodule-three/some-other-name.xml</module>
+        <module>submodule-two/notpom.xml</module>
+    </modules>
+
+</project>

--- a/maven/spec/fixtures/poms/multimodule_custom_modules_submodule_one_pom.xml
+++ b/maven/spec/fixtures/poms/multimodule_custom_modules_submodule_one_pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>maven-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/spec/fixtures/poms/multimodule_custom_modules_submodule_three_pom.xml
+++ b/maven/spec/fixtures/poms/multimodule_custom_modules_submodule_three_pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>maven-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>4.3.11.RELEASE</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/spec/fixtures/poms/multimodule_custom_modules_submodule_two_pom.xml
+++ b/maven/spec/fixtures/poms/multimodule_custom_modules_submodule_two_pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>maven-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+            <version>4.0.3.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+            <version>2.9.0</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
Extended on the multi-module review support, allowing for the custom pom.xml names be used for the pom-s in child modules. With that PR they would be able to have various names, with the only limitation being that they must end with .xml. 
This PR should, hopefully, address a part of the https://github.com/dependabot/dependabot-core/issues/4425 issue.