### PR TITLE
Add version catalog support for Gradle

### DIFF
--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -14,6 +14,10 @@ module Dependabot
       SUPPORTED_SETTINGS_FILE_NAMES =
         %w(settings.gradle settings.gradle.kts).freeze
 
+      # For now Gradle only supports libray .toml files in the main gradle folder
+      SUPPORTED_VERSION_CATALOG_FILE_PATH =
+        %w(/gradle/libs.versions.toml).freeze
+
       def self.required_files_in?(filenames)
         filenames.any? do |filename|
           SUPPORTED_BUILD_FILE_NAMES.include?(filename)
@@ -33,7 +37,7 @@ module Dependabot
       end
 
       def all_buildfiles_in_build(root_dir)
-        files = [buildfile(root_dir), settings_file(root_dir)].compact
+        files = [buildfile(root_dir), settings_file(root_dir), version_catalog_file(root_dir)].compact
         files += subproject_buildfiles(root_dir)
         files += dependency_script_plugins(root_dir)
         files + included_builds(root_dir).
@@ -82,6 +86,15 @@ module Dependabot
         end
       end
 
+      def version_catalog_file(root_dir)
+        return nil unless root_dir == "."
+
+        gradle_toml_file(root_dir)
+      rescue Dependabot::DependencyFileNotFound
+        # Catalog file is optional for Gradle
+        nil
+      end
+
       # rubocop:disable Metrics/PerceivedComplexity
       def dependency_script_plugins(root_dir)
         return [] unless buildfile(root_dir)
@@ -125,6 +138,10 @@ module Dependabot
         file = find_first(dir, SUPPORTED_BUILD_FILE_NAMES) || return
         @buildfile_name ||= File.basename(file.name)
         file
+      end
+
+      def gradle_toml_file(dir)
+        find_first(dir, SUPPORTED_VERSION_CATALOG_FILE_PATH)
       end
 
       def settings_file(dir)

--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -96,8 +96,10 @@ module Dependabot
 
           version_details = Gradle::Version.correct?(version) ? version : "$" + version["ref"]
           details = { group: group, name: name, version: version_details }
+          dependency = dependency_from(details_hash: details, buildfile: toml_file)
+          next unless dependency
 
-          dependency_set << dependency_from(details_hash: details, buildfile: toml_file)
+          dependency_set << dependency
         end
         dependency_set
       end

--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -79,7 +79,12 @@ module Dependabot
           next unless Gradle::Version.correct?(version) || (version.is_a?(Hash) && version.key?("ref"))
 
           version_details = version["ref"].nil? ? version : "$" + version["ref"]
-          group, name = declaration["module"].split(":")
+          group, name = if declaration["module"]
+                          declaration["module"].split(":")
+                        else
+                          [declaration["group"], declaration["name"]]
+                        end
+
           details = { group: group, name: name, version: version_details }
           dependency_set << dependency_from(details_hash: details, buildfile: toml_file)
         end

--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -85,6 +85,8 @@ module Dependabot
 
       def dependencies_for_declarations(declarations, toml_file, details_getter)
         dependency_set = DependencySet.new
+        return dependency_set unless declarations
+
         declarations.each do |_mod, declaration|
           version = declaration["version"]
           next if version.nil?

--- a/gradle/lib/dependabot/gradle/file_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater.rb
@@ -142,6 +142,8 @@ module Dependabot
           if dependency.name.include?(":")
             next false unless line.include?(dependency.name.split(":").first)
             next false unless line.include?(dependency.name.split(":").last)
+          elsif requirement.fetch(:file).end_with?(".toml")
+            next false unless line.include?(dependency.name)
           else
             name_regex_value = /['"]#{Regexp.quote(dependency.name)}['"]/
             name_regex = /(id|kotlin)(\s+#{name_regex_value}|\(#{name_regex_value}\))/

--- a/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
@@ -38,10 +38,17 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
     }]
   end
 
+  def stub_no_content_request(path)
+    stub_request(:get, File.join(url, path)).
+      with(headers: { "Authorization" => "token token" }).
+      to_return(status: 404)
+  end
+
   before { allow(file_fetcher_instance).to receive(:commit).and_return("sha") }
 
   context "with a basic buildfile" do
     before do
+      stub_no_content_request("gradle?ref=sha")
       stub_content_request("?ref=sha", "contents_java.json")
       stub_content_request("build.gradle?ref=sha", "contents_java_basic_buildfile.json")
     end
@@ -50,6 +57,19 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
       expect(file_fetcher_instance.files.count).to eq(1)
       expect(file_fetcher_instance.files.map(&:name)).
         to match_array(%w(build.gradle))
+    end
+
+    context "with version catalog" do
+      before do
+        stub_content_request("gradle?ref=sha", "content_gradle_toml.json")
+        stub_content_request("gradle/libs.versions.toml?ref=sha", "libs_versions_toml.json")
+      end
+
+      it "fetches the toml file" do
+        expect(file_fetcher_instance.files.count).to eq(2)
+        expect(file_fetcher_instance.files.map(&:name)).
+          to match_array(%w(build.gradle gradle/libs.versions.toml))
+      end
     end
 
     context "with a settings.gradle" do
@@ -78,6 +98,19 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
             to match_array(%w(build.gradle settings.gradle))
         end
       end
+
+      context "whith versions catalog" do
+        before do
+          stub_content_request("gradle?ref=sha", "content_gradle_toml.json")
+          stub_content_request("gradle/libs.versions.toml?ref=sha", "libs_versions_toml.json")
+        end
+
+        it "fetches the main buildfile and subproject buildfile and version catalog" do
+          expect(file_fetcher_instance.files.count).to eq(4)
+          expect(file_fetcher_instance.files.map(&:name)).
+            to match_array(%w(build.gradle settings.gradle app/build.gradle gradle/libs.versions.toml))
+        end
+      end
     end
 
     context "with included builds" do
@@ -95,6 +128,18 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
           it "fetches all buildfiles" do
             expect(file_fetcher_instance.files.map(&:name)).
               to match_array(%w(build.gradle buildSrc/build.gradle))
+          end
+
+          context "with version catalog" do
+            before do
+              stub_content_request("gradle?ref=sha", "content_gradle_toml.json")
+              stub_content_request("gradle/libs.versions.toml?ref=sha", "libs_versions_toml.json")
+            end
+
+            it "fetches all buildfiles and version catalog" do
+              expect(file_fetcher_instance.files.map(&:name)).
+                to match_array(%w(build.gradle buildSrc/build.gradle gradle/libs.versions.toml))
+            end
           end
         end
 
@@ -244,6 +289,18 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
         expect(file_fetcher_instance.files.map(&:name)).
           to match_array(%w(settings.gradle app/build.gradle))
       end
+
+      context "with version catalog" do
+        before do
+          stub_content_request("gradle?ref=sha", "content_gradle_toml.json")
+          stub_content_request("gradle/libs.versions.toml?ref=sha", "libs_versions_toml.json")
+        end
+
+        it "fetches the main buildfile, subproject buildfile and version catalog" do
+          expect(file_fetcher_instance.files.map(&:name)).
+            to match_array(%w(settings.gradle app/build.gradle gradle/libs.versions.toml))
+        end
+      end
     end
 
     context "with kotlin" do
@@ -279,6 +336,7 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
 
   context "with a script plugin" do
     before do
+      stub_no_content_request("gradle?ref=sha")
       stub_content_request("?ref=sha", "contents_java.json")
       stub_content_request("build.gradle?ref=sha", "contents_java_buildfile_with_script_plugins.json")
       stub_content_request("gradle/dependencies.gradle?ref=sha", "contents_java_simple_settings.json")
@@ -288,6 +346,18 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
       expect(file_fetcher_instance.files.count).to eq(2)
       expect(file_fetcher_instance.files.map(&:name)).
         to match_array(%w(build.gradle gradle/dependencies.gradle))
+    end
+
+    context "with version catalog" do
+      before do
+        stub_content_request("gradle?ref=sha", "content_gradle_toml.json")
+        stub_content_request("gradle/libs.versions.toml?ref=sha", "libs_versions_toml.json")
+      end
+
+      it "fetches the main buildfile, subproject buildfile and version catalog" do
+        expect(file_fetcher_instance.files.map(&:name)).
+          to match_array(%w(build.gradle gradle/dependencies.gradle gradle/libs.versions.toml))
+      end
     end
 
     context "that can't be found" do
@@ -311,6 +381,7 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
 
   context "with no required manifest files" do
     before do
+      stub_no_content_request("gradle?ref=sha")
       stub_request(:get, url + "?ref=sha").
         with(headers: { "Authorization" => "token token" }).
         to_return(

--- a/gradle/spec/dependabot/gradle/file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser_spec.rb
@@ -813,7 +813,7 @@ RSpec.describe Dependabot::Gradle::FileParser do
         )
       end
 
-      its(:length) { is_expected.to eq(30) }
+      its(:length) { is_expected.to eq(31) }
 
       describe "the first dependency" do
         subject(:dependency) { dependencies.first }
@@ -849,6 +849,26 @@ RSpec.describe Dependabot::Gradle::FileParser do
               groups: [],
               source: nil,
               metadata: { property_name: "espresso" }
+            }]
+          )
+        end
+      end
+
+      describe "dependency with group + name and referenced version" do
+        let(:dependency) do
+          dependencies.find { |dep| dep.name == "org.jetbrains.kotlin:kotlin-gradle-plugin" }
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.version).to eq("1.7.20")
+          expect(dependency.requirements).to eq(
+            [{
+              requirement: "1.7.20",
+              file: "gradle/libs.versions.toml",
+              groups: [],
+              source: nil,
+              metadata: { property_name: "kotlin" }
             }]
           )
         end

--- a/gradle/spec/dependabot/gradle/file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser_spec.rb
@@ -813,7 +813,7 @@ RSpec.describe Dependabot::Gradle::FileParser do
         )
       end
 
-      its(:length) { is_expected.to eq(31) }
+      its(:length) { is_expected.to eq(33) }
 
       describe "the first dependency" do
         subject(:dependency) { dependencies.first }
@@ -874,6 +874,32 @@ RSpec.describe Dependabot::Gradle::FileParser do
         end
       end
 
+      describe "plugin with explicit module and referenced version" do
+        let(:dependency) do
+          dependencies.find { |dep| dep.name == "org.jlleitschuh.gradle.ktlint" }
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.version).to eq("9.0.0")
+          expect(dependency.requirements).to eq(
+            [{
+              requirement: "10.0.0",
+              file: "gradle/libs.versions.toml",
+              groups: ["plugins"],
+              source: nil,
+              metadata: { property_name: "ktlint" }
+            }, {
+              requirement: "9.0.0",
+              file: "gradle/libs.versions.toml",
+              groups: ["plugins"],
+              source: nil,
+              metadata: nil
+            }]
+          )
+        end
+      end
+
       describe "non-referenced version dependency" do
         subject(:dependency) do
           dependencies.find { |d| d.name == "androidx.activity:activity-compose" }
@@ -914,7 +940,7 @@ RSpec.describe Dependabot::Gradle::FileParser do
           )
         end
 
-        its(:length) { is_expected.to eq(30) }
+        its(:length) { is_expected.to eq(31) }
 
         describe "the first dependency" do
           subject(:dependency) { dependencies.first }
@@ -943,8 +969,8 @@ RSpec.describe Dependabot::Gradle::FileParser do
           end
         end
 
-        describe "the last dependency" do
-          subject(:dependency) { dependencies.last }
+        describe "the last library dependency" do
+          subject(:dependency) { dependencies[-2] }
 
           it "has the right details" do
             expect(dependency).to be_a(Dependabot::Dependency)
@@ -957,6 +983,25 @@ RSpec.describe Dependabot::Gradle::FileParser do
                 groups: [],
                 source: nil,
                 metadata: { property_name: "espresso" }
+              }]
+            )
+          end
+        end
+
+        describe "the version catalog plugin" do
+          subject(:dependency) { dependencies.last }
+
+          it "has the right details" do
+            expect(dependency).to be_a(Dependabot::Dependency)
+            expect(dependency.name).to eq("org.jmailen.kotlinter")
+            expect(dependency.version).to eq("3.11.0")
+            expect(dependency.requirements).to eq(
+              [{
+                requirement: "3.11.0",
+                file: "gradle/libs.versions.toml",
+                groups: ["plugins"],
+                source: nil,
+                metadata: nil
               }]
             )
           end

--- a/gradle/spec/dependabot/gradle/file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser_spec.rb
@@ -1008,5 +1008,29 @@ RSpec.describe Dependabot::Gradle::FileParser do
         end
       end
     end
+
+    describe "parse only version catalog file that contains only libraries" do
+      let(:files) { [version_catalog] }
+      let(:version_catalog) do
+        Dependabot::DependencyFile.new(
+          name: "gradle/libs.versions.toml",
+          content: fixture("version_catalog_file", "libs.versions.only.libraries.toml")
+        )
+      end
+
+      its(:length) { is_expected.to eq(11) }
+    end
+
+    describe "parse only version catalog file that contains only plugins" do
+      let(:files) { [version_catalog] }
+      let(:version_catalog) do
+        Dependabot::DependencyFile.new(
+          name: "gradle/libs.versions.toml",
+          content: fixture("version_catalog_file", "libs.versions.only.plugins.toml")
+        )
+      end
+
+      its(:length) { is_expected.to eq(2) }
+    end
   end
 end

--- a/gradle/spec/dependabot/gradle/file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser_spec.rb
@@ -813,7 +813,7 @@ RSpec.describe Dependabot::Gradle::FileParser do
         )
       end
 
-      its(:length) { is_expected.to eq(33) }
+      its(:length) { is_expected.to eq(35) }
 
       describe "the first dependency" do
         subject(:dependency) { dependencies.first }

--- a/gradle/spec/dependabot/gradle/file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser_spec.rb
@@ -813,7 +813,7 @@ RSpec.describe Dependabot::Gradle::FileParser do
         )
       end
 
-      its(:length) { is_expected.to eq(35) }
+      its(:length) { is_expected.to eq(36) }
 
       describe "the first dependency" do
         subject(:dependency) { dependencies.first }
@@ -897,6 +897,17 @@ RSpec.describe Dependabot::Gradle::FileParser do
               metadata: nil
             }]
           )
+        end
+      end
+
+      describe "dependency with short format and 'ref' in its version" do
+        let(:dependency) do
+          dependencies.find { |dep| dep.name == "com.mycompany:mylib-with-version-including-ref" }
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.version).to eq("1.4-ref")
         end
       end
 

--- a/gradle/spec/dependabot/gradle/file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser_spec.rb
@@ -941,6 +941,15 @@ RSpec.describe Dependabot::Gradle::FileParser do
         end
       end
 
+      describe "rich version dependency specified as a property is ignored" do
+        subject(:dependency) do
+          dependencies.find { |d| d.name == "com.util.juice:juice" }
+        end
+        it "has the right details" do
+          expect(dependency).to be(nil)
+        end
+      end
+
       context "with version catalog file containing dependency overlap with build file" do
         let(:files) { [buildfile, version_catalog_overlap] }
 

--- a/gradle/spec/dependabot/gradle/file_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater_spec.rb
@@ -568,6 +568,140 @@ RSpec.describe Dependabot::Gradle::FileUpdater do
             to include("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1")
         end
       end
+
+      context "with a version catalog" do
+        let(:buildfile) do
+          Dependabot::DependencyFile.new(
+            name: "gradle/libs.versions.toml",
+            content: fixture("version_catalog_file", "libs.versions.toml")
+          )
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "org.jmailen.kotlinter",
+            version: "3.12.0",
+            previous_version: "3.10.0",
+            requirements: [{
+              file: "gradle/libs.versions.toml",
+              requirement: "3.12.0",
+              groups: ["plugins"],
+              source: { type: "maven_repo", url: "https://plugins.gradle.org/m2" },
+              metadata: nil
+            }],
+            previous_requirements: [{
+              file: "gradle/libs.versions.toml",
+              requirement: "3.10.0",
+              groups: ["plugins"],
+              source: { type: "maven_repo", url: "https://plugins.gradle.org/m2" },
+              metadata: nil
+            }],
+            package_manager: "gradle"
+          )
+        end
+
+        subject(:updated_buildfile) do
+          updated_files.find { |f| f.name == "gradle/libs.versions.toml" }
+        end
+        its(:content) do
+          is_expected.to include(
+            'kotlinter = { id = "org.jmailen.kotlinter", version = "3.12.0" }'
+          )
+        end
+      end
+      context "with a version catalog with ref" do
+        let(:buildfile) do
+          Dependabot::DependencyFile.new(
+            name: "gradle/libs.versions.toml",
+            content: fixture("version_catalog_file", "libs.versions.toml")
+          )
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "org.jlleitschuh.gradle.ktlint",
+            version: "11.0.0",
+            previous_version: "10.0.0",
+            requirements: [{
+              file: "gradle/libs.versions.toml",
+              requirement: "11.0.0",
+              groups: ["plugins"],
+              source: { type: "maven_repo", url: "https://plugins.gradle.org/m2" },
+              metadata: { property_name: "ktlint" }
+            }],
+            previous_requirements: [{
+              file: "gradle/libs.versions.toml",
+              requirement: "10.0.0",
+              groups: ["plugins"],
+              source: { type: "maven_repo", url: "https://plugins.gradle.org/m2" },
+              metadata: { property_name: "ktlint" }
+            }],
+            package_manager: "gradle"
+          )
+        end
+
+        subject(:updated_buildfile) do
+          updated_files.find { |f| f.name == "gradle/libs.versions.toml" }
+        end
+        its(:content) do
+          is_expected.to include(
+            'ktlint = "11.0.0"'
+          )
+        end
+      end
+
+      context "with a version catalog with ref and non-ref mixed" do
+        let(:buildfile) do
+          Dependabot::DependencyFile.new(
+            name: "gradle/libs.versions.toml",
+            content: fixture("version_catalog_file", "libs.versions.toml")
+          )
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "org.jlleitschuh.gradle.ktlint",
+            version: "11.0.0",
+            previous_version: "9.0.0",
+            requirements: [{
+              file: "gradle/libs.versions.toml",
+              requirement: "11.0.0",
+              groups: ["plugins"],
+              source: { type: "maven_repo", url: "https://plugins.gradle.org/m2" },
+              metadata: { property_name: "ktlint" }
+            }, {
+              file: "gradle/libs.versions.toml",
+              requirement: "11.0.0",
+              groups: ["plugins"],
+              source: { type: "maven_repo", url: "https://plugins.gradle.org/m2" },
+              metadata: nil
+            }],
+            previous_requirements: [{
+              file: "gradle/libs.versions.toml",
+              requirement: "10.0.0",
+              groups: ["plugins"],
+              source: { type: "maven_repo", url: "https://plugins.gradle.org/m2" },
+              metadata: { property_name: "ktlint" }
+            }, {
+              file: "gradle/libs.versions.toml",
+              requirement: "9.0.0",
+              groups: ["plugins"],
+              source: { type: "maven_repo", url: "https://plugins.gradle.org/m2" },
+              metadata: nil
+            }],
+            package_manager: "gradle"
+          )
+        end
+
+        subject(:updated_buildfile) do
+          updated_files.find { |f| f.name == "gradle/libs.versions.toml" }
+        end
+        its(:content) do
+          is_expected.to include(
+            'ktlint = "11.0.0"'
+          )
+          is_expected.to include(
+            'ktlintUpdated = { id = "org.jlleitschuh.gradle.ktlint", version = "11.0.0" }'
+          )
+        end
+      end
     end
   end
 end

--- a/gradle/spec/fixtures/github/content_gradle_toml.json
+++ b/gradle/spec/fixtures/github/content_gradle_toml.json
@@ -1,0 +1,18 @@
+[
+    {
+      "name": "libs.versions.toml",
+      "path": "gradle/libs.versions.toml",
+      "sha": "61e2017c7cfb111d2c1ada6dc9508711ae02b5c1",
+      "size": 1470,
+      "url": "https://api.github.com/repos/bigandroidenergies/version_catalog/contents/gradle/libs.versions.toml?ref=main",
+      "html_url": "https://github.com/bigandroidenergies/version_catalog/blob/main/gradle/libs.versions.toml",
+      "git_url": "https://api.github.com/repos/bigandroidenergies/version_catalog/git/blobs/61e2017c7cfb111d2c1ada6dc9508711ae02b5c1",
+      "download_url": "https://raw.githubusercontent.com/bigandroidenergies/version_catalog/main/gradle/libs.versions.toml",
+      "type": "file",
+      "_links": {
+        "self": "https://api.github.com/repos/bigandroidenergies/version_catalog/contents/gradle/libs.versions.toml?ref=main",
+        "git": "https://api.github.com/repos/bigandroidenergies/version_catalog/git/blobs/61e2017c7cfb111d2c1ada6dc9508711ae02b5c1",
+        "html": "https://github.com/bigandroidenergies/version_catalog/blob/main/gradle/libs.versions.toml"
+      }
+    }
+  ]

--- a/gradle/spec/fixtures/github/libs_versions_toml.json
+++ b/gradle/spec/fixtures/github/libs_versions_toml.json
@@ -1,0 +1,18 @@
+{
+    "name": "libs.versions.toml",
+    "path": "gradle/libs.versions.toml",
+    "sha": "be86def0733c2cd34f58fb5bf4f051b989408f71",
+    "size": 1510,
+    "url": "https://api.github.com/repos/bigandroidenergies/version_catalog/contents/gradle/libs.versions.toml?ref=main",
+    "html_url": "https://github.com/bigandroidenergies/version_catalog/blob/main/gradle/libs.versions.toml",
+    "git_url": "https://api.github.com/repos/bigandroidenergies/version_catalog/git/blobs/be86def0733c2cd34f58fb5bf4f051b989408f71",
+    "download_url": "https://raw.githubusercontent.com/bigandroidenergies/version_catalog/main/gradle/libs.versions.toml",
+    "type": "file",
+    "content": "W3ZlcnNpb25zXQpjb3Jla3R4ID0gIjEuNy4wIgpsaWZlY3ljbGVSdW50aW1l\nID0gIjIuMy4xIgphY3Rpdml0eUNvbXBvc2UgPSAiMS4zLjEiCmNvbXBvc2VV\naSA9ICIxLjIuMCIKY29tcG9zZU1hdGVyaWFsID0gIjEuMi4wIgpqVW5pdFZl\ncnNpb24gPSAiNC4xMy4yIgphbmRyb2lkeEp1bml0ID0gIjEuMS4zIgplc3By\nZXNzbyA9ICIzLjUuMCIKCltsaWJyYXJpZXNdCmNvcmVrdHggPSB7IG1vZHVs\nZSA9ICJhbmRyb2lkeC5jb3JlOmNvcmUta3R4IiwgdmVyc2lvbi5yZWYgPSAi\nY29yZWt0eCIgfQpsaWZlY3ljbGVSdW50aW1lS3R4ID0geyBtb2R1bGUgPSAi\nYW5kcm9pZHgubGlmZWN5Y2xlOmxpZmVjeWNsZS1ydW50aW1lLWt0eCIsIHZl\ncnNpb24ucmVmID0gImxpZmVjeWNsZVJ1bnRpbWUiIH0KCmNvbXBvc2UtYWN0\naXZpdHkgPSB7IG1vZHVsZSA9ICJhbmRyb2lkeC5hY3Rpdml0eTphY3Rpdml0\neS1jb21wb3NlIiwgdmVyc2lvbi5yZWYgPSAiYWN0aXZpdHlDb21wb3NlIiB9\nCmNvbXBvc2UtdWkgPSB7IG1vZHVsZSA9ICJhbmRyb2lkeC5jb21wb3NlLnVp\nOnVpIiwgdmVyc2lvbi5yZWYgPSAiY29tcG9zZVVpIiB9CmNvbXBvc2UtdWkt\ndG9vbGluZyA9IHsgbW9kdWxlID0gImFuZHJvaWR4LmNvbXBvc2UudWk6dWkt\ndG9vbGluZy1wcmV2aWV3IiwgdmVyc2lvbi5yZWYgPSAiY29tcG9zZVVpIiB9\nCmNvbXBvc2UtbWF0ZXJpYWwgPSB7IG1vZHVsZSA9ICJhbmRyb2lkeC5jb21w\nb3NlLm1hdGVyaWFsOm1hdGVyaWFsIiwgdmVyc2lvbi5yZWYgPSAiY29tcG9z\nZU1hdGVyaWFsIiB9Cgp0ZXN0LWp1bml0ID0geyBtb2R1bGUgPSAianVuaXQ6\nanVuaXQiLCB2ZXJzaW9uLnJlZiA9ICJqVW5pdFZlcnNpb24iIH0KdGVzdC1h\nbmRvcmlkeC1qdW5pdCA9IHsgbW9kdWxlID0gImFuZHJvaWR4LnRlc3QuZXh0\nOmp1bml0IiwgdmVyc2lvbi5yZWYgPSAiYW5kcm9pZHhKdW5pdCIgfQp0ZXN0\nLWNvbXBvc2UtdWkgPSB7IG1vZHVsZSA9ICJhbmRyb2lkeC5jb21wb3NlLnVp\nOnVpLXRlc3QtanVuaXQ0IiwgdmVyc2lvbi5yZWYgPSAiY29tcG9zZVVpIiB9\nCnRlc3QtY29tcG9zZS11aS10b29saW5nID0geyBtb2R1bGUgPSAiYW5kcm9p\nZHguY29tcG9zZS51aTp1aS10b29saW5nIiwgdmVyc2lvbi5yZWYgPSAiY29t\ncG9zZVVpIiB9CnRlc3QtY29tcG9zZS1tYW5pZmVzdCA9IHsgbW9kdWxlID0g\nImFuZHJvaWR4LmNvbXBvc2UudWk6dWktdGVzdC1tYW5pZmVzdCIsIHZlcnNp\nb24ucmVmID0gImNvbXBvc2VVaSIgfQp0ZXN0LWVzcHJlc3NvLUNvcmUgPSB7\nIG1vZHVsZSA9ICJhbmRyb2lkeC50ZXN0LmVzcHJlc3NvOmVzcHJlc3NvLWNv\ncmUiLCB2ZXJzaW9uLnJlZiA9ICJlc3ByZXNzbyIgfQoKW2J1bmRsZXNdCmNv\nbXBvc2UgPSBbImNvbXBvc2UtYWN0aXZpdHkiLCAiY29tcG9zZS11aSIsICJj\nb21wb3NlLXVpLXRvb2xpbmciLCAiY29tcG9zZS1tYXRlcmlhbCJdCgpbcGx1\nZ2luc10Ka290bGludGVyID0geyBpZCA9ICJvcmcuam1haWxlbi5rb3RsaW50\nZXIiLCB2ZXJzaW9uID0gIjMuMTEuMCIgfQ==\n",
+    "encoding": "base64",
+    "_links": {
+        "self": "https://api.github.com/repos/bigandroidenergies/version_catalog/contents/gradle/libs.versions.toml?ref=main",
+        "git": "https://api.github.com/repos/bigandroidenergies/version_catalog/git/blobs/be86def0733c2cd34f58fb5bf4f051b989408f71",
+        "html": "https://github.com/bigandroidenergies/version_catalog/blob/main/gradle/libs.versions.toml"
+    }
+}

--- a/gradle/spec/fixtures/version_catalog_file/libs.versions.only.libraries.toml
+++ b/gradle/spec/fixtures/version_catalog_file/libs.versions.only.libraries.toml
@@ -1,0 +1,22 @@
+[versions]
+corektx = "1.7.0"
+lifecycleRuntime = "2.3.1"
+composeUi = "1.2.0"
+jUnitVersion = "4.13.2"
+androidxJunit = "1.1.3"
+espresso = "3.5.0"
+
+[libraries]
+corektx = { module = "androidx.core:core-ktx", version.ref = "corektx" }
+lifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntime" }
+
+compose-activity = { module = "androidx.activity:activity-compose", version = "1.3.1" }
+compose-ui = { module = "androidx.compose.ui:ui", version.ref = "composeUi" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "composeUi" }
+
+test-junit = { module = "junit:junit", version.ref = "jUnitVersion" }
+test-andoridx-junit = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
+test-compose-ui = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "composeUi" }
+test-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "composeUi" }
+test-compose-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "composeUi" }
+test-espresso-Core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }

--- a/gradle/spec/fixtures/version_catalog_file/libs.versions.only.plugins.toml
+++ b/gradle/spec/fixtures/version_catalog_file/libs.versions.only.plugins.toml
@@ -1,0 +1,7 @@
+[versions]
+ktlint = "10.0.0"
+
+[plugins]
+kotlinter = { id = "org.jmailen.kotlinter", version = "3.10.0" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+ktlintUpdated = { id = "org.jlleitschuh.gradle.ktlint", version = "9.0.0" }

--- a/gradle/spec/fixtures/version_catalog_file/libs.versions.overlapping.toml
+++ b/gradle/spec/fixtures/version_catalog_file/libs.versions.overlapping.toml
@@ -1,0 +1,31 @@
+[versions]
+corektx = "1.7.0"
+lifecycleRuntime = "2.3.1"
+composeUi = "1.2.0"
+jUnitVersion = "4.13.2"
+androidxJunit = "1.1.3"
+espresso = "3.5.0"
+coAikar = "0.5.0-SNAPSHOT"
+
+[libraries]
+coakir = { module = "co.aikar:acf-paper", version.ref = "coAikar" }
+corektx = { module = "androidx.core:core-ktx", version.ref = "corektx" }
+lifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntime" }
+
+compose-activity = { module = "androidx.activity:activity-compose", version = "1.3.1" }
+compose-ui = { module = "androidx.compose.ui:ui", version.ref = "composeUi" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "composeUi" }
+compose-material = { module = "androidx.compose.material:material", version = { strictly = "[1.2.0, 1.3.1[", prefer="1.3.0" } }
+
+test-junit = { module = "junit:junit", version.ref = "jUnitVersion" }
+test-andoridx-junit = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
+test-compose-ui = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "composeUi" }
+test-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "composeUi" }
+test-compose-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "composeUi" }
+test-espresso-Core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+
+[bundles]
+compose = ["compose-activity", "compose-ui", "compose-ui-tooling", "compose-material"]
+
+[plugins]
+kotlinter = { id = "org.jmailen.kotlinter", version = "3.11.0" }

--- a/gradle/spec/fixtures/version_catalog_file/libs.versions.toml
+++ b/gradle/spec/fixtures/version_catalog_file/libs.versions.toml
@@ -1,0 +1,29 @@
+[versions]
+corektx = "1.7.0"
+lifecycleRuntime = "2.3.1"
+composeUi = "1.2.0"
+jUnitVersion = "4.13.2"
+androidxJunit = "1.1.3"
+espresso = "3.5.0"
+
+[libraries]
+corektx = { module = "androidx.core:core-ktx", version.ref = "corektx" }
+lifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntime" }
+
+compose-activity = { module = "androidx.activity:activity-compose", version = "1.3.1" }
+compose-ui = { module = "androidx.compose.ui:ui", version.ref = "composeUi" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "composeUi" }
+compose-material = { module = "androidx.compose.material:material", version = { strictly = "[1.2.0, 1.3.1[", prefer="1.3.0" } }
+
+test-junit = { module = "junit:junit", version.ref = "jUnitVersion" }
+test-andoridx-junit = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
+test-compose-ui = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "composeUi" }
+test-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "composeUi" }
+test-compose-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "composeUi" }
+test-espresso-Core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+
+[bundles]
+compose = ["compose-activity", "compose-ui", "compose-ui-tooling", "compose-material"]
+
+[plugins]
+kotlinter = { id = "org.jmailen.kotlinter", version = "3.11.0" }

--- a/gradle/spec/fixtures/version_catalog_file/libs.versions.toml
+++ b/gradle/spec/fixtures/version_catalog_file/libs.versions.toml
@@ -26,6 +26,8 @@ test-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.r
 test-compose-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "composeUi" }
 test-espresso-Core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 
+my-lib = "com.mycompany:mylib:1.4"
+
 [bundles]
 compose = ["compose-activity", "compose-ui", "compose-ui-tooling", "compose-material"]
 
@@ -33,3 +35,5 @@ compose = ["compose-activity", "compose-ui", "compose-ui-tooling", "compose-mate
 kotlinter = { id = "org.jmailen.kotlinter", version = "3.10.0" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 ktlintUpdated = { id = "org.jlleitschuh.gradle.ktlint", version = "9.0.0" }
+
+short-notation = "some.plugin.id:1.4"

--- a/gradle/spec/fixtures/version_catalog_file/libs.versions.toml
+++ b/gradle/spec/fixtures/version_catalog_file/libs.versions.toml
@@ -27,6 +27,7 @@ test-compose-manifest = { module = "androidx.compose.ui:ui-test-manifest", versi
 test-espresso-Core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 
 my-lib = "com.mycompany:mylib:1.4"
+my-lib-with-version-including-ref = "com.mycompany:mylib-with-version-including-ref:1.4-ref"
 
 [bundles]
 compose = ["compose-activity", "compose-ui", "compose-ui-tooling", "compose-material"]

--- a/gradle/spec/fixtures/version_catalog_file/libs.versions.toml
+++ b/gradle/spec/fixtures/version_catalog_file/libs.versions.toml
@@ -6,6 +6,7 @@ composeUi = "1.2.0"
 jUnitVersion = "4.13.2"
 androidxJunit = "1.1.3"
 espresso = "3.5.0"
+ktlint = "10.0.0"
 
 [libraries]
 corektx = { module = "androidx.core:core-ktx", version.ref = "corektx" }
@@ -29,4 +30,6 @@ test-espresso-Core = { module = "androidx.test.espresso:espresso-core", version.
 compose = ["compose-activity", "compose-ui", "compose-ui-tooling", "compose-material"]
 
 [plugins]
-kotlinter = { id = "org.jmailen.kotlinter", version = "3.11.0" }
+kotlinter = { id = "org.jmailen.kotlinter", version = "3.10.0" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+ktlintUpdated = { id = "org.jlleitschuh.gradle.ktlint", version = "9.0.0" }

--- a/gradle/spec/fixtures/version_catalog_file/libs.versions.toml
+++ b/gradle/spec/fixtures/version_catalog_file/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+kotlin = "1.7.20"
 corektx = "1.7.0"
 lifecycleRuntime = "2.3.1"
 composeUi = "1.2.0"
@@ -9,6 +10,8 @@ espresso = "3.5.0"
 [libraries]
 corektx = { module = "androidx.core:core-ktx", version.ref = "corektx" }
 lifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntime" }
+
+kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 
 compose-activity = { module = "androidx.activity:activity-compose", version = "1.3.1" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "composeUi" }

--- a/gradle/spec/fixtures/version_catalog_file/libs.versions.toml
+++ b/gradle/spec/fixtures/version_catalog_file/libs.versions.toml
@@ -7,6 +7,7 @@ jUnitVersion = "4.13.2"
 androidxJunit = "1.1.3"
 espresso = "3.5.0"
 ktlint = "10.0.0"
+juice = { strictly = "3.0" }
 
 [libraries]
 corektx = { module = "androidx.core:core-ktx", version.ref = "corektx" }
@@ -28,6 +29,8 @@ test-espresso-Core = { module = "androidx.test.espresso:espresso-core", version.
 
 my-lib = "com.mycompany:mylib:1.4"
 my-lib-with-version-including-ref = "com.mycompany:mylib-with-version-including-ref:1.4-ref"
+
+juice = { module = "com.util.juice:juice", version.ref="juice" }
 
 [bundles]
 compose = ["compose-activity", "compose-ui", "compose-ui-tooling", "compose-material"]


### PR DESCRIPTION
Hello from the GitHub [Android mobile team](https://github.com/mobile)!

As part of a client apps hackathon we decided to give it a shot and add [version catalog](https://docs.gradle.org/current/userguide/platforms.html) support for Gradle projects.

This functionality has been requested by some users here: https://github.com/dependabot/dependabot-core/issues/3121, and we are planning to start using version catalog as well as soon as Dependabot supports it :P.

We have added support for version catalogs defined using a `toml` file ([more info](https://docs.gradle.org/current/userguide/platforms.html#sub:conventional-dependencies-toml)), for libraries and plugins using value versions and referenced versions, so this changes add support for **a** toml file like:

```
[versions]
corektx = "1.7.0"
lifecycleRuntime = "2.3.1"
composeUi = "1.2.0"
jUnitVersion = "4.13.2"
androidxJunit = "1.1.3"
espresso = "3.5.0"

[libraries]
corektx = { module = "androidx.core:core-ktx", version.ref = "corektx" }
lifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntime" }

compose-activity = { module = "androidx.activity:activity-compose", version = "1.3.1" }
compose-ui = { module = "androidx.compose.ui:ui", version.ref = "composeUi" }
compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "composeUi" }
compose-material = { module = "androidx.compose.material:material", version = { strictly = "[1.2.0, 1.3.1[", prefer="1.3.0" } }

test-junit = { module = "junit:junit", version.ref = "jUnitVersion" }
test-andoridx-junit = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
test-compose-ui = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "composeUi" }
test-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "composeUi" }
test-compose-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "composeUi" }
test-espresso-Core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }

[bundles]
compose = ["compose-activity", "compose-ui", "compose-ui-tooling", "compose-material"]

[plugins]
kotlinter = { id = "org.jmailen.kotlinter", version = "3.11.0" }
```

### Testing

 In order to guide our development we have used the steps defined in [here](https://github.com/dependabot/dependabot-core#dry-run-script) to use the dry-run script pointing to [this](https://github.com/bigandroidenergies/version_catalog) test repo we created.

### Note

We realize that this code won't reach the quality bar to be considered as a candidate to be merged (Ruby is not our field of expertise), but we will be more than happy to react to your feedback and keep working on it!

### BIG THANKS
To @jurre who has been helping us on this task, sharing advices, techniques and ideas!

Closes #3121.