### PR TITLE
Ignore URLs in Actions

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -17,7 +17,7 @@ module Dependabot
       require "dependabot/file_parsers/base/dependency_set"
 
       GITHUB_REPO_REFERENCE = %r{
-        (?<owner>[\w.-]+)/
+        ^(?<owner>[\w.-]+)/
         (?<repo>[\w.-]+)
         (?<path>/[^\@]+)?
         @(?<ref>.+)

--- a/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
@@ -158,6 +158,16 @@ RSpec.describe Dependabot::GithubActions::FileParser do
       end
     end
 
+    context "with a Docker url reference" do
+      subject(:dependency) { dependencies.first }
+      let(:workflow_file_fixture_name) { "docker_reference.yml" }
+
+      it "ignores the Docker url reference" do
+        expect(dependencies.count).to be(0)
+        expect(dependency).to be_nil
+      end
+    end
+
     context "with a semver tag pinned to a commit" do
       let(:workflow_file_fixture_name) { "pinned_source.yml" }
       let(:service_pack_url) do

--- a/github_actions/spec/fixtures/workflow_files/docker_reference.yml
+++ b/github_actions/spec/fixtures/workflow_files/docker_reference.yml
@@ -1,0 +1,8 @@
+
+on: [push]
+
+name: Integration
+jobs:
+  chore:
+    steps:
+    - uses: docker://ghcr.io/actions/checkout@master


### PR DESCRIPTION
Dependabot currently supports version updates for Actions that are referenced as a GitHub repository. There is a [feature request](https://github.com/dependabot/dependabot-core/issues/5819) to support image/container URLs in GitHub Actions, which will require checking which versions of the Action are available on the registry.

In the mean time, Dependabot should stop trying to parse these URLs as a reference to a GitHub repo and ignore them.

This PR accomplishes this by anchoring the `GITHUB_REPO_REFERENCE` regex to the start of the line.