### PR TITLE
Install hex only once, the specific version we want

### DIFF
--- a/hex/helpers/build
+++ b/hex/helpers/build
@@ -10,14 +10,11 @@ fi
 install_dir="$DEPENDABOT_NATIVE_HELPERS_PATH/hex"
 mkdir -p "$install_dir"
 
-# Initial Hex install - will always be the latest available version
-mix local.hex --force --if-missing
-# Annoyingly, a specific Hex version cannot be specified during the initial install.
-# The only way to pin is to re-install.
-if [ -n "$HEX_VERSION" ]; then
-  mix hex.install "$HEX_VERSION"
-fi
+mix local.hex "$HEX_VERSION" --force --if-missing
 
+# Install deps necessary for Elixir projects using Nerves extensions
+# The `hex` arg isn't re-installing hex, but rather telling
+# mix that nerves_bootstrap is a hex package.
 mix archive.install hex nerves_bootstrap --force
 
 helpers_dir="$(dirname "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
Prior to Elixir `1.14.0`, we couldn't specify the `hex` version during the initial install, causing two problems:
1. Brittle code, because if the latest `hex` version was broken, we couldn't workaround it.
2. Duplicated install, wasting space and time.

We're now able to specify the version during install, so let's do that instead. Many thanks to @sorentwo for clarifying in  https://github.com/hexpm/hex/issues/962.

Additionally, when I was first looking at this code, I was very confused thinking that the line:
```shell
mix archive.install hex nerves_bootstrap --force
```
resulted in installing both `hex` and `nerves_bootstrap`, ie, we were installing it a third time. 

But after reading `mix help archive.install` I realized that the `hex` arg is simply indicating that `nerves_bootstrap` is a hex package.

Fix https://github.com/dependabot/dependabot-core/issues/6046.