### PR TITLE
Suppress Dependabot::Updater::SubprocessFailed

### DIFF
--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -843,14 +843,8 @@ module Dependabot
           }
         when Dependabot::SharedHelpers::HelperSubprocessFailed
           # If a helper subprocess has failed the error may include sensitive
-          # info such as file contents or paths. This information is already
-          # in the job logs, so we send a breadcrumb to Sentry to retrieve those
-          # instead.
-          msg = "Dependency update process failed, please check the job logs"
-          Raven.capture_exception(
-            SubprocessFailed.new(msg),
-            raven_context
-          )
+          # info such as file contents or paths, which is already available in
+          # the job logs.
 
           { "error-type": "unknown_error" }
         when *Octokit::RATE_LIMITED_ERRORS

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1652,13 +1652,6 @@ RSpec.describe Dependabot::Updater do
             )
           updater.run
         end
-
-        it "notifies Sentry with a breadcrumb to check the logs" do
-          expect(Raven).
-            to receive(:capture_exception).
-            with(instance_of(Dependabot::Updater::SubprocessFailed), anything)
-          updater.run
-        end
       end
 
       it "tells Sentry" do


### PR DESCRIPTION
Let's stop logging these errors to Sentry. 
We explicitly leave out error details because they may contain sensitive information, so continuing to post these errors won't help us learn anything new.