### PR TITLE
Pass subprocess failed errors to the backend

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -53,7 +53,7 @@ module Dependabot
     end
 
     class HelperSubprocessFailed < Dependabot::DependabotError
-      attr_reader :error_class, :error_context, :trace
+      attr_reader :error_class, :error_context, :command, :trace
 
       def initialize(message:, error_context:, error_class: nil, trace: nil)
         super(message)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -95,6 +95,9 @@ module Dependabot
         rescue SharedHelpers::HelperSubprocessFailed => e
           log_helper_subprocess_failure(dependency, e)
           fix_unavailable
+
+          # Re-raise so the error is sent to the backend
+          raise
         end
         # rubocop:enable Metrics/MethodLength
 
@@ -171,7 +174,7 @@ module Dependabot
           builder << "\n" << context[:trace]
 
           msg = builder.string
-          Dependabot.logger.info(msg) # TODO: is this the right log level?
+          Dependabot.logger.info(msg)
         end
       end
     end

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -843,14 +843,8 @@ module Dependabot
           }
         when Dependabot::SharedHelpers::HelperSubprocessFailed
           # If a helper subprocess has failed the error may include sensitive
-          # info such as file contents or paths. This information is already
-          # in the job logs, so we send a breadcrumb to Sentry to retrieve those
-          # instead.
-          msg = "Dependency update process failed, please check the job logs"
-          Raven.capture_exception(
-            SubprocessFailed.new(msg),
-            raven_context
-          )
+          # info such as file contents or paths, which is already available in
+          # the job logs.
 
           { "error-type": "unknown_error" }
         when *Octokit::RATE_LIMITED_ERRORS

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1652,13 +1652,6 @@ RSpec.describe Dependabot::Updater do
             )
           updater.run
         end
-
-        it "notifies Sentry with a breadcrumb to check the logs" do
-          expect(Raven).
-            to receive(:capture_exception).
-            with(instance_of(Dependabot::Updater::SubprocessFailed), anything)
-          updater.run
-        end
       end
 
       it "tells Sentry" do


### PR DESCRIPTION
Let's pass subprocess failed errors to the Api backend so we can aggregate information about the errors better.

30c0639bb27185067a47e7bbd2a62e76355d141c re-raises a subprocess failed error in the npm vulnerability auditor that was previously only being logged to the job log.