### PR TITLE
prevent "unknown" base_commit SHA from failing PR creation

### DIFF
--- a/updater/lib/dependabot/file_fetcher_job.rb
+++ b/updater/lib/dependabot/file_fetcher_job.rb
@@ -13,7 +13,9 @@ module Dependabot
       begin
         connectivity_check if ENV["ENABLE_CONNECTIVITY_CHECK"] == "1"
         clone_repo_contents
-        @base_commit_sha = file_fetcher.commit || "unknown"
+        @base_commit_sha = file_fetcher.commit
+        raise "base commit SHA not found" unless @base_commit_sha
+
         dependency_files
       rescue StandardError => e
         @base_commit_sha ||= "unknown"


### PR DESCRIPTION
We're noticing some PRs are failing to be created and have "unknown" set as the base_commit.

One way that could be happening is the `file_fetcher.commit` could be returning `nil`, which then gets set to "unknown". Then the update carries that values through the entire update posting PRs which will fail with a base commit of "unknown." We originally added the "unknown" in a few places in #5981 to fix an exception in the exception handler.

So I've removed the `|| "unknown"` and added a sanity check which will take us into the rescue. 

It seems like the only place `commit` could return `nil` is here: https://github.com/dependabot/dependabot-core/blob/db729c15d578e441825b8481ff2aa5973a5fa449/common/lib/dependabot/file_fetchers/base.rb#L88

I'm unsure why we would not want to throw in that situation. 🤔 