### PR TITLE
Pass `raven_context` to Sentry on failed subprocess exceptions

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -64,7 +64,7 @@ module Dependabot
       end
 
       def raven_context
-        { fingerprint: [@command], extra: @error_context }
+        { fingerprint: [@command], extra: @error_context.except(:stderr_output) }
       end
     end
 

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -33,7 +33,15 @@ require "wildcard_matcher"
 # rubocop:disable Metrics/ClassLength
 module Dependabot
   class Updater
-    class SubprocessFailed < StandardError; end
+    class SubprocessFailed < StandardError
+      attr_reader :raven_context
+
+      def initialize(message, raven_context:)
+        super(message)
+
+        @raven_context = raven_context
+      end
+    end
 
     # These are errors that halt the update run and are handled in the main
     # backend. They do *not* raise a sentry.
@@ -848,7 +856,7 @@ module Dependabot
           # instead.
           msg = "Dependency update process failed, please check the job logs"
           Raven.capture_exception(
-            SubprocessFailed.new(msg),
+            SubprocessFailed.new(msg, raven_context: error.raven_context),
             raven_context
           )
 


### PR DESCRIPTION
So that we get proper differentiation of exceptions according to the subprocess that failed to run.

Sentry-raven will look into `#raven_context` of the passed exception and deep merge it into the passed context. However, the passed exception here is `SubprocessFailed` which does not define any `raven_context`. It's `HelperSubprocessFailed` defining it, so we should pass over that information to `SubprocessFailed`.

This is what I meant at https://github.com/dependabot/dependabot-core/pull/6253#discussion_r1040094395.

Completely untested.