### PR TITLE
Rescue socket errors for poetry library detection

### DIFF
--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -292,7 +292,7 @@ module Dependabot
 
         pypi_info = JSON.parse(index_response.body)["info"] || {}
         pypi_info["summary"] == library_details["description"]
-      rescue Excon::Error::Timeout
+      rescue Excon::Error::Timeout, Excon::Error::Socket
         false
       rescue URI::InvalidURIError
         false


### PR DESCRIPTION
We need to handle socket errors as well as timeouts to allow poetry updates to continue if pypi.org is unavailable.
