### PR TITLE
Improve subprocess failed error aggregation

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -32,7 +32,7 @@ module Dependabot
             SharedHelpers.with_git_configured(credentials: credentials) do
               # Shell out to Cargo, which handles everything for us, and does
               # so without doing an install (so it's fast).
-              run_shell_command("cargo update -p #{dependency_spec}")
+              run_shell_command("cargo update -p #{dependency_spec}", fingerprint: "cargo update -p <dependency_spec>")
             end
 
             updated_lockfile = File.read("Cargo.lock")
@@ -135,7 +135,7 @@ module Dependabot
           %(name = "#{dependency.name}"\nversion = "#{dependency.version}")
         end
 
-        def run_shell_command(command)
+        def run_shell_command(command, fingerprint:)
           start = Time.now
           command = SharedHelpers.escape_command(command)
           stdout, process = Open3.capture2e(command)
@@ -149,6 +149,7 @@ module Dependabot
             message: stdout,
             error_context: {
               command: command,
+              fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: process.to_s
             }

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -43,9 +43,7 @@ module Dependabot
             write_temporary_dependency_files
 
             SharedHelpers.with_git_configured(credentials: credentials) do
-              # Shell out to Cargo, which handles everything for us, and does
-              # so without doing an install (so it's fast).
-              run_cargo_command("cargo update -p #{dependency_spec} --verbose")
+              run_cargo_update_command
             end
 
             updated_version = fetch_version_from_new_lockfile
@@ -132,7 +130,16 @@ module Dependabot
           spec
         end
 
-        def run_cargo_command(command)
+        # Shell out to Cargo, which handles everything for us, and does
+        # so without doing an install (so it's fast).
+        def run_cargo_update_command
+          run_cargo_command(
+            "cargo update -p #{dependency_spec} --verbose",
+            fingerprint: "cargo update -p <dependency_spec> --verbose"
+          )
+        end
+
+        def run_cargo_command(command, fingerprint: nil)
           start = Time.now
           command = SharedHelpers.escape_command(command)
           stdout, process = Open3.capture2e(command)
@@ -146,6 +153,7 @@ module Dependabot
             message: stdout,
             error_context: {
               command: command,
+              fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: process.to_s
             }
@@ -291,7 +299,7 @@ module Dependabot
             write_temporary_dependency_files(prepared: false)
 
             SharedHelpers.with_git_configured(credentials: credentials) do
-              run_cargo_command("cargo update -p #{dependency_spec} --verbose")
+              run_cargo_update_command
             end
           end
 

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -59,12 +59,12 @@ module Dependabot
         super(message)
         @error_class = error_class || ""
         @error_context = error_context
-        @command = error_context[:command]
+        @fingerprint = error_context[:fingerprint] || error_context[:command]
         @trace = trace
       end
 
       def raven_context
-        { fingerprint: [@command], extra: @error_context.except(:stderr_output) }
+        { fingerprint: [@fingerprint], extra: @error_context.except(:stderr_output, :fingerprint) }
       end
     end
 

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -185,7 +185,7 @@ module Dependabot
                 run_poetry_command("pyenv exec poetry config experimental.system-git-client true")
               end
 
-              run_poetry_command(poetry_update_command)
+              run_poetry_update_command
 
               return File.read("poetry.lock") if File.exist?("poetry.lock")
 
@@ -196,11 +196,14 @@ module Dependabot
 
         # Using `--lock` avoids doing an install.
         # Using `--no-interaction` avoids asking for passwords.
-        def poetry_update_command
-          "pyenv exec poetry update #{dependency.name} --lock --no-interaction"
+        def run_poetry_update_command
+          run_poetry_command(
+            "pyenv exec poetry update #{dependency.name} --lock --no-interaction",
+            fingerprint: "pyenv exec poetry update <dependency_name> --lock --no-interaction"
+          )
         end
 
-        def run_poetry_command(command)
+        def run_poetry_command(command, fingerprint: nil)
           start = Time.now
           command = SharedHelpers.escape_command(command)
           stdout, process = Open3.capture2e(command)
@@ -214,6 +217,7 @@ module Dependabot
             message: stdout,
             error_context: {
               command: command,
+              fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: process.to_s
             }


### PR DESCRIPTION
For dynamic commands including things like the name of a dependency, we want to make sure we aggregate all errors together, no matter what the name of the dependency is.