### PR TITLE
Remove no longer needed custom fingerprints

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -32,7 +32,7 @@ module Dependabot
             SharedHelpers.with_git_configured(credentials: credentials) do
               # Shell out to Cargo, which handles everything for us, and does
               # so without doing an install (so it's fast).
-              run_shell_command("cargo update -p #{dependency_spec}", fingerprint: "cargo update -p <dependency_spec>")
+              run_shell_command("cargo update -p #{dependency_spec}")
             end
 
             updated_lockfile = File.read("Cargo.lock")
@@ -135,7 +135,7 @@ module Dependabot
           %(name = "#{dependency.name}"\nversion = "#{dependency.version}")
         end
 
-        def run_shell_command(command, fingerprint:)
+        def run_shell_command(command)
           start = Time.now
           command = SharedHelpers.escape_command(command)
           stdout, process = Open3.capture2e(command)
@@ -149,7 +149,6 @@ module Dependabot
             message: stdout,
             error_context: {
               command: command,
-              fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: process.to_s
             }

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -134,12 +134,11 @@ module Dependabot
         # so without doing an install (so it's fast).
         def run_cargo_update_command
           run_cargo_command(
-            "cargo update -p #{dependency_spec} --verbose",
-            fingerprint: "cargo update -p <dependency_spec> --verbose"
+            "cargo update -p #{dependency_spec} --verbose"
           )
         end
 
-        def run_cargo_command(command, fingerprint: nil)
+        def run_cargo_command(command)
           start = Time.now
           command = SharedHelpers.escape_command(command)
           stdout, process = Open3.capture2e(command)
@@ -153,7 +152,6 @@ module Dependabot
             message: stdout,
             error_context: {
               command: command,
-              fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: process.to_s
             }

--- a/common/lib/dependabot/file_updaters/vendor_updater.rb
+++ b/common/lib/dependabot/file_updaters/vendor_updater.rb
@@ -23,8 +23,7 @@ module Dependabot
           # rubocop:enable Performance/DeletePrefix
 
           status = SharedHelpers.run_shell_command(
-            "git status --untracked-files all --porcelain v1 #{relative_dir}",
-            fingerprint: "git status --untracked-files all --porcelain v1 <relative_dir>"
+            "git status --untracked-files all --porcelain v1 #{relative_dir}"
           )
           changed_paths = status.split("\n").map(&:split)
           changed_paths.map do |type, path|

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -252,8 +252,7 @@ module Dependabot
 
       def find_container_branch(sha)
         branches_including_ref = SharedHelpers.run_shell_command(
-          "git branch --remotes --contains #{sha}",
-          fingerprint: "git branch --remotes --contains <sha>"
+          "git branch --remotes --contains #{sha}"
         ).split("\n").map { |branch| branch.strip.gsub("origin/", "") }
 
         current_branch = branches_including_ref.find { |branch| branch.start_with?("HEAD -> ") }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -206,18 +206,7 @@ module Dependabot
             "--package-lock-only"
           ].join(" ")
 
-          fingerprint = [
-            "npm",
-            "install",
-            "<install_args>",
-            "--force",
-            "--dry-run",
-            "false",
-            "--ignore-scripts",
-            "--package-lock-only"
-          ].join(" ")
-
-          SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
+          SharedHelpers.run_shell_command(command)
           { lockfile_basename => File.read(lockfile_basename) }
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -157,8 +157,7 @@ module Dependabot
             end
 
             Helpers.run_yarn_command(
-              "yarn up -R #{updates.join(' ')} #{yarn_berry_args}".strip,
-              fingerprint: "yarn up -R <dependency_names> #{yarn_berry_args}".strip
+              "yarn up -R #{updates.join(' ')} #{yarn_berry_args}".strip
             )
           end
           { yarn_lock.name => File.read(yarn_lock.name) }
@@ -174,9 +173,9 @@ module Dependabot
           update = "#{dep.name}@#{dep.version}"
 
           commands = [
-            ["yarn add #{update} #{yarn_berry_args}".strip, "yarn add <update> #{yarn_berry_args}".strip],
-            ["yarn dedupe #{dep.name} #{yarn_berry_args}".strip, "yarn dedupe <dep_name> #{yarn_berry_args}".strip],
-            ["yarn remove #{dep.name} #{yarn_berry_args}".strip, "yarn remove <dep_name> #{yarn_berry_args}".strip]
+            "yarn add #{update} #{yarn_berry_args}".strip,
+            "yarn dedupe #{dep.name} #{yarn_berry_args}".strip,
+            "yarn remove #{dep.name} #{yarn_berry_args}".strip
           ]
 
           Helpers.run_yarn_commands(*commands)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -85,13 +85,13 @@ module Dependabot
       # contain malicious code.
       def self.run_yarn_commands(*commands)
         setup_yarn_berry
-        commands.each { |cmd, fingerprint| SharedHelpers.run_shell_command(cmd, fingerprint: fingerprint) }
+        commands.each { |cmd| SharedHelpers.run_shell_command(cmd) }
       end
 
       # Run a single yarn command returning stdout/stderr
-      def self.run_yarn_command(command, fingerprint: nil)
+      def self.run_yarn_command(command)
         setup_yarn_berry
-        SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
+        SharedHelpers.run_shell_command(command)
       end
 
       def self.dependencies_with_all_versions_metadata(dependency_set)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
@@ -32,18 +32,7 @@ module Dependabot
           "--package-lock-only"
         ].join(" ")
 
-        fingerprint = [
-          "npm",
-          "update",
-          "<dependency_names>",
-          "--force",
-          "--dry-run",
-          "false",
-          "--ignore-scripts",
-          "--package-lock-only"
-        ].join(" ")
-
-        SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
+        SharedHelpers.run_shell_command(command)
       end
     end
   end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -117,8 +117,7 @@ module Dependabot
           SharedHelpers.with_git_configured(credentials: credentials) do
             Dir.chdir(path) do
               Helpers.run_yarn_command(
-                "yarn up -R #{dependency.name} #{Helpers.yarn_berry_args}".strip,
-                fingerprint: "yarn up -R <dependency_name> #{Helpers.yarn_berry_args}".strip
+                "yarn up -R #{dependency.name} #{Helpers.yarn_berry_args}".strip
               )
               { lockfile_name => File.read(lockfile_name) }
             end

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -72,24 +72,17 @@ module Dependabot
               # Shell out to pip-compile, generate a new set of requirements.
               # This is slow, as pip-compile needs to do installs.
               options = pip_compile_options(filename)
-              options_fingerprint = pip_compile_options_fingerprint(options)
 
               name_part = "pyenv exec pip-compile " \
                           "#{options} -P " \
                           "#{dependency.name}"
-              fingerprint_name_part = "pyenv exec pip-compile " \
-                                      "#{options_fingerprint} -P " \
-                                      "<dependency_name>"
-
               version_part = "#{dependency.version} #{filename}"
-              fingerprint_version_part = "<dependency_version> <filename>"
 
               # Don't escape pyenv `dep-name==version` syntax
               run_pip_compile_command(
                 "#{SharedHelpers.escape_command(name_part)}==" \
                 "#{SharedHelpers.escape_command(version_part)}",
-                allow_unsafe_shell_command: true,
-                fingerprint: "#{fingerprint_name_part}==#{fingerprint_version_part}"
+                allow_unsafe_shell_command: true
               )
             end
 
@@ -147,7 +140,7 @@ module Dependabot
           ).updated_dependency_files
         end
 
-        def run_command(cmd, env: python_env, allow_unsafe_shell_command: false, fingerprint:)
+        def run_command(cmd, env: python_env, allow_unsafe_shell_command: false)
           start = Time.now
           command = if allow_unsafe_shell_command
                       cmd
@@ -167,23 +160,20 @@ module Dependabot
             message: stdout,
             error_context: {
               command: command,
-              fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: process.to_s
             }
           )
         end
 
-        def run_pip_compile_command(command, allow_unsafe_shell_command: false, fingerprint:)
+        def run_pip_compile_command(command, allow_unsafe_shell_command: false)
           run_command(
-            "pyenv local #{Helpers.python_major_minor(python_version)}",
-            fingerprint: "pyenv local <python_major_minor>"
+            "pyenv local #{Helpers.python_major_minor(python_version)}"
           )
 
           run_command(
             command,
-            allow_unsafe_shell_command: allow_unsafe_shell_command,
-            fingerprint: fingerprint
+            allow_unsafe_shell_command: allow_unsafe_shell_command
           )
         end
 
@@ -401,16 +391,6 @@ module Dependabot
             named_captures.fetch("separator")
 
           current_separator || default_separator
-        end
-
-        def pip_compile_options_fingerprint(options)
-          options.sub(
-            /--output-file=\S+/, "--output-file=<output_file>"
-          ).sub(
-            /--index-url=\S+/, "--index-url=<index_url>"
-          ).sub(
-            /--extra-index-url=\S+/, "--extra-index-url=<extra_index_url>"
-          )
         end
 
         def pip_compile_options(filename)

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -198,12 +198,11 @@ module Dependabot
         # Using `--no-interaction` avoids asking for passwords.
         def run_poetry_update_command
           run_poetry_command(
-            "pyenv exec poetry update #{dependency.name} --lock --no-interaction",
-            fingerprint: "pyenv exec poetry update <dependency_name> --lock --no-interaction"
+            "pyenv exec poetry update #{dependency.name} --lock --no-interaction"
           )
         end
 
-        def run_poetry_command(command, fingerprint: nil)
+        def run_poetry_command(command)
           start = Time.now
           command = SharedHelpers.escape_command(command)
           stdout, process = Open3.capture2e(command)
@@ -217,7 +216,6 @@ module Dependabot
             message: stdout,
             error_context: {
               command: command,
-              fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: process.to_s
             }

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -165,8 +165,7 @@ module Dependabot
         # Using `--no-interaction` avoids asking for passwords.
         def run_poetry_update_command
           run_poetry_command(
-            "pyenv exec poetry update #{dependency.name} --lock --no-interaction",
-            fingerprint: "pyenv exec poetry update <dependency_name> --lock --no-interaction"
+            "pyenv exec poetry update #{dependency.name} --lock --no-interaction"
           )
         end
 
@@ -334,7 +333,7 @@ module Dependabot
           poetry_lock || pyproject_lock
         end
 
-        def run_poetry_command(command, fingerprint: nil)
+        def run_poetry_command(command)
           start = Time.now
           command = SharedHelpers.escape_command(command)
           stdout, process = Open3.capture2e(command)
@@ -348,7 +347,6 @@ module Dependabot
             message: stdout,
             error_context: {
               command: command,
-              fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: process.to_s
             }

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -174,8 +174,7 @@ module Dependabot
             File.write(".terraform.lock.hcl", lockfile_hash_removed)
 
             SharedHelpers.run_shell_command(
-              "terraform providers lock -platform=#{arch} #{provider_source} -no-color",
-              fingerprint: "terraform providers lock -platform=<arch> <provider_source> -no-color"
+              "terraform providers lock -platform=#{arch} #{provider_source} -no-color"
             )
 
             updated_lockfile = File.read(".terraform.lock.hcl")
@@ -232,8 +231,7 @@ module Dependabot
           File.write(".terraform.lock.hcl", lockfile_dependency_removed)
 
           SharedHelpers.run_shell_command(
-            "terraform providers lock #{platforms} #{provider_source}",
-            fingerprint: "terraform providers lock <platforms> <provider_source>"
+            "terraform providers lock #{platforms} #{provider_source}"
           )
 
           updated_lockfile = File.read(".terraform.lock.hcl")

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -854,7 +854,7 @@ module Dependabot
           # info such as file contents or paths. This information is already
           # in the job logs, so we send a breadcrumb to Sentry to retrieve those
           # instead.
-          msg = "Subprocess #{error.raven_context[:fingerprint]} failed to run. Check the job logs for error messages"
+          msg = "Subprocess #{error.error_context[:command]} failed to run. Check the job logs for error messages"
           sanitized_error = SubprocessFailed.new(msg, raven_context: error.raven_context)
           sanitized_error.set_backtrace(error.backtrace)
           Raven.capture_exception(sanitized_error, raven_context)

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -854,7 +854,7 @@ module Dependabot
           # info such as file contents or paths. This information is already
           # in the job logs, so we send a breadcrumb to Sentry to retrieve those
           # instead.
-          msg = "Subprocess #{error.error_context[:command]} failed to run. Check the job logs for error messages"
+          msg = "Subprocess `#{error.error_context[:command]}` failed to run. Check the job logs for error messages"
           sanitized_error = SubprocessFailed.new(msg, raven_context: error.raven_context)
           sanitized_error.set_backtrace(error.backtrace)
           Raven.capture_exception(sanitized_error, raven_context)


### PR DESCRIPTION
This PR removes most of my recent changes 😆

Sentry groups events by stacktrace, and now we have a stacktrace for subprocess failed errors, so I believe Sentry should be able to group properly by default?

Also, I believe this is more correct because the same command may end up being run in different code locations, and those would be different errors.