### PR TITLE
make Octokit read_timeout configurable

### DIFF
--- a/common/lib/dependabot/clients/github_with_retries.rb
+++ b/common/lib/dependabot/clients/github_with_retries.rb
@@ -6,16 +6,21 @@ module Dependabot
   module Clients
     class GithubWithRetries
       DEFAULT_OPEN_TIMEOUT_IN_SECONDS = 2
+      DEFAULT_READ_TIMEOUT_IN_SECONDS = 5
 
       def self.open_timeout_in_seconds
         ENV.fetch("DEPENDABOT_OPEN_TIMEOUT_IN_SECONDS", DEFAULT_OPEN_TIMEOUT_IN_SECONDS).to_i
+      end
+
+      def self.read_timeout_in_seconds
+        ENV.fetch("DEPENDABOT_READ_TIMEOUT_IN_SECONDS", DEFAULT_READ_TIMEOUT_IN_SECONDS).to_i
       end
 
       DEFAULT_CLIENT_ARGS = {
         connection_options: {
           request: {
             open_timeout: open_timeout_in_seconds,
-            timeout: 5
+            timeout: read_timeout_in_seconds
           }
         }
       }.freeze

--- a/common/spec/dependabot/clients/github_with_retries_spec.rb
+++ b/common/spec/dependabot/clients/github_with_retries_spec.rb
@@ -68,4 +68,22 @@ RSpec.describe Dependabot::Clients::GithubWithRetries do
       end
     end
   end
+
+  describe ".read_timeout_in_seconds" do
+    context "when DEPENDABOT_READ_TIMEOUT_IN_SECONDS is set" do
+      it "returns the provided value" do
+        override_value = 10
+        stub_const("ENV", ENV.to_hash.merge("DEPENDABOT_READ_TIMEOUT_IN_SECONDS" => override_value))
+
+        expect(described_class.read_timeout_in_seconds).to eq(override_value)
+      end
+    end
+
+    context "when ENV does not provide an override" do
+      it "falls back to a default value" do
+        expect(described_class.read_timeout_in_seconds).
+          to eq(described_class::DEFAULT_READ_TIMEOUT_IN_SECONDS)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Same as #4964 but for the read timeout.

We'd like to bump the read timeout up a bit to fix some timeout issues, so making it configurable with an environment variable.