### PR TITLE
Revert "Remove no longer needed custom fingerprints"

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -32,7 +32,7 @@ module Dependabot
             SharedHelpers.with_git_configured(credentials: credentials) do
               # Shell out to Cargo, which handles everything for us, and does
               # so without doing an install (so it's fast).
-              run_shell_command("cargo update -p #{dependency_spec}")
+              run_shell_command("cargo update -p #{dependency_spec}", fingerprint: "cargo update -p <dependency_spec>")
             end
 
             updated_lockfile = File.read("Cargo.lock")
@@ -135,7 +135,7 @@ module Dependabot
           %(name = "#{dependency.name}"\nversion = "#{dependency.version}")
         end
 
-        def run_shell_command(command)
+        def run_shell_command(command, fingerprint:)
           start = Time.now
           command = SharedHelpers.escape_command(command)
           stdout, process = Open3.capture2e(command)
@@ -149,6 +149,7 @@ module Dependabot
             message: stdout,
             error_context: {
               command: command,
+              fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: process.to_s
             }

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -134,11 +134,12 @@ module Dependabot
         # so without doing an install (so it's fast).
         def run_cargo_update_command
           run_cargo_command(
-            "cargo update -p #{dependency_spec} --verbose"
+            "cargo update -p #{dependency_spec} --verbose",
+            fingerprint: "cargo update -p <dependency_spec> --verbose"
           )
         end
 
-        def run_cargo_command(command)
+        def run_cargo_command(command, fingerprint: nil)
           start = Time.now
           command = SharedHelpers.escape_command(command)
           stdout, process = Open3.capture2e(command)
@@ -152,6 +153,7 @@ module Dependabot
             message: stdout,
             error_context: {
               command: command,
+              fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: process.to_s
             }

--- a/common/lib/dependabot/file_updaters/vendor_updater.rb
+++ b/common/lib/dependabot/file_updaters/vendor_updater.rb
@@ -23,7 +23,8 @@ module Dependabot
           # rubocop:enable Performance/DeletePrefix
 
           status = SharedHelpers.run_shell_command(
-            "git status --untracked-files all --porcelain v1 #{relative_dir}"
+            "git status --untracked-files all --porcelain v1 #{relative_dir}",
+            fingerprint: "git status --untracked-files all --porcelain v1 <relative_dir>"
           )
           changed_paths = status.split("\n").map(&:split)
           changed_paths.map do |type, path|

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -59,11 +59,12 @@ module Dependabot
         super(message)
         @error_class = error_class || ""
         @error_context = error_context
+        @fingerprint = error_context[:fingerprint] || error_context[:command]
         @trace = trace
       end
 
       def raven_context
-        { extra: @error_context.except(:stderr_output) }
+        { fingerprint: [@fingerprint], extra: @error_context.except(:stderr_output, :fingerprint) }
       end
     end
 
@@ -189,7 +190,8 @@ module Dependabot
       run_shell_command(
         "git config --global credential.helper " \
         "'!#{credential_helper_path} --file #{Dir.pwd}/git.store'",
-        allow_unsafe_shell_command: true
+        allow_unsafe_shell_command: true,
+        fingerprint: "git config --global credential.helper '<helper_command>'"
       )
 
       # see https://github.blog/2022-04-12-git-security-vulnerability-announced/
@@ -294,7 +296,7 @@ module Dependabot
       FileUtils.mv(backup_path, GIT_CONFIG_GLOBAL_PATH)
     end
 
-    def self.run_shell_command(command, allow_unsafe_shell_command: false, env: {})
+    def self.run_shell_command(command, allow_unsafe_shell_command: false, env: {}, fingerprint: nil)
       start = Time.now
       cmd = allow_unsafe_shell_command ? command : escape_command(command)
       stdout, process = Open3.capture2e(env || {}, cmd)
@@ -306,6 +308,7 @@ module Dependabot
 
       error_context = {
         command: cmd,
+        fingerprint: fingerprint,
         time_taken: time_taken,
         process_exit_value: process.to_s
       }

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -252,7 +252,8 @@ module Dependabot
 
       def find_container_branch(sha)
         branches_including_ref = SharedHelpers.run_shell_command(
-          "git branch --remotes --contains #{sha}"
+          "git branch --remotes --contains #{sha}",
+          fingerprint: "git branch --remotes --contains <sha>"
         ).split("\n").map { |branch| branch.strip.gsub("origin/", "") }
 
         current_branch = branches_including_ref.find { |branch| branch.start_with?("HEAD -> ") }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -206,7 +206,18 @@ module Dependabot
             "--package-lock-only"
           ].join(" ")
 
-          SharedHelpers.run_shell_command(command)
+          fingerprint = [
+            "npm",
+            "install",
+            "<install_args>",
+            "--force",
+            "--dry-run",
+            "false",
+            "--ignore-scripts",
+            "--package-lock-only"
+          ].join(" ")
+
+          SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
           { lockfile_basename => File.read(lockfile_basename) }
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -157,7 +157,8 @@ module Dependabot
             end
 
             Helpers.run_yarn_command(
-              "yarn up -R #{updates.join(' ')} #{yarn_berry_args}".strip
+              "yarn up -R #{updates.join(' ')} #{yarn_berry_args}".strip,
+              fingerprint: "yarn up -R <dependency_names> #{yarn_berry_args}".strip
             )
           end
           { yarn_lock.name => File.read(yarn_lock.name) }
@@ -173,9 +174,9 @@ module Dependabot
           update = "#{dep.name}@#{dep.version}"
 
           commands = [
-            "yarn add #{update} #{yarn_berry_args}".strip,
-            "yarn dedupe #{dep.name} #{yarn_berry_args}".strip,
-            "yarn remove #{dep.name} #{yarn_berry_args}".strip
+            ["yarn add #{update} #{yarn_berry_args}".strip, "yarn add <update> #{yarn_berry_args}".strip],
+            ["yarn dedupe #{dep.name} #{yarn_berry_args}".strip, "yarn dedupe <dep_name> #{yarn_berry_args}".strip],
+            ["yarn remove #{dep.name} #{yarn_berry_args}".strip, "yarn remove <dep_name> #{yarn_berry_args}".strip]
           ]
 
           Helpers.run_yarn_commands(*commands)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -85,13 +85,13 @@ module Dependabot
       # contain malicious code.
       def self.run_yarn_commands(*commands)
         setup_yarn_berry
-        commands.each { |cmd| SharedHelpers.run_shell_command(cmd) }
+        commands.each { |cmd, fingerprint| SharedHelpers.run_shell_command(cmd, fingerprint: fingerprint) }
       end
 
       # Run a single yarn command returning stdout/stderr
-      def self.run_yarn_command(command)
+      def self.run_yarn_command(command, fingerprint: nil)
         setup_yarn_berry
-        SharedHelpers.run_shell_command(command)
+        SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
       end
 
       def self.dependencies_with_all_versions_metadata(dependency_set)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
@@ -32,7 +32,18 @@ module Dependabot
           "--package-lock-only"
         ].join(" ")
 
-        SharedHelpers.run_shell_command(command)
+        fingerprint = [
+          "npm",
+          "update",
+          "<dependency_names>",
+          "--force",
+          "--dry-run",
+          "false",
+          "--ignore-scripts",
+          "--package-lock-only"
+        ].join(" ")
+
+        SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
       end
     end
   end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -117,7 +117,8 @@ module Dependabot
           SharedHelpers.with_git_configured(credentials: credentials) do
             Dir.chdir(path) do
               Helpers.run_yarn_command(
-                "yarn up -R #{dependency.name} #{Helpers.yarn_berry_args}".strip
+                "yarn up -R #{dependency.name} #{Helpers.yarn_berry_args}".strip,
+                fingerprint: "yarn up -R <dependency_name> #{Helpers.yarn_berry_args}".strip
               )
               { lockfile_name => File.read(lockfile_name) }
             end

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -198,11 +198,12 @@ module Dependabot
         # Using `--no-interaction` avoids asking for passwords.
         def run_poetry_update_command
           run_poetry_command(
-            "pyenv exec poetry update #{dependency.name} --lock --no-interaction"
+            "pyenv exec poetry update #{dependency.name} --lock --no-interaction",
+            fingerprint: "pyenv exec poetry update <dependency_name> --lock --no-interaction"
           )
         end
 
-        def run_poetry_command(command)
+        def run_poetry_command(command, fingerprint: nil)
           start = Time.now
           command = SharedHelpers.escape_command(command)
           stdout, process = Open3.capture2e(command)
@@ -216,6 +217,7 @@ module Dependabot
             message: stdout,
             error_context: {
               command: command,
+              fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: process.to_s
             }

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -77,9 +77,11 @@ module Dependabot
                   # Shell out to pip-compile.
                   # This is slow, as pip-compile needs to do installs.
                   options = pip_compile_options(filename)
+                  options_fingerprint = pip_compile_options_fingerprint(options)
 
                   run_pip_compile_command(
-                    "pyenv exec pip-compile -v #{options} -P #{dependency.name} #{filename}"
+                    "pyenv exec pip-compile -v #{options} -P #{dependency.name} #{filename}",
+                    fingerprint: "pyenv exec pip-compile -v #{options_fingerprint} -P <dependency_name> <filename>"
                   )
 
                   next if dependency.top_level?
@@ -93,7 +95,8 @@ module Dependabot
                   # update_not_possible.
                   write_original_manifest_files
                   run_pip_compile_command(
-                    "pyenv exec pip-compile #{options} #{filename}"
+                    "pyenv exec pip-compile #{options} #{filename}",
+                    fingerprint: "pyenv exec pip-compile #{options_fingerprint} <filename>"
                   )
                 end
 
@@ -186,9 +189,11 @@ module Dependabot
 
               filenames_to_compile.each do |filename|
                 options = pip_compile_options(filename)
+                options_fingerprint = pip_compile_options_fingerprint(options)
 
                 run_pip_compile_command(
-                  "pyenv exec pip-compile #{options} #{filename}"
+                  "pyenv exec pip-compile #{options} #{filename}",
+                  fingerprint: "pyenv exec pip-compile #{options_fingerprint} <filename>"
                 )
               end
 
@@ -208,7 +213,7 @@ module Dependabot
           end
         end
 
-        def run_command(command, env: python_env)
+        def run_command(command, env: python_env, fingerprint:)
           start = Time.now
           command = SharedHelpers.escape_command(command)
           stdout, process = Open3.capture2e(env, command)
@@ -220,6 +225,7 @@ module Dependabot
             message: stdout,
             error_context: {
               command: command,
+              fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: process.to_s
             }
@@ -228,6 +234,16 @@ module Dependabot
 
         def new_resolver_supported?
           python_version >= Python::Version.new("3.7")
+        end
+
+        def pip_compile_options_fingerprint(options)
+          options.sub(
+            /--output-file=\S+/, "--output-file=<output_file>"
+          ).sub(
+            /--index-url=\S+/, "--index-url=<index_url>"
+          ).sub(
+            /--extra-index-url=\S+/, "--extra-index-url=<extra_index_url>"
+          )
         end
 
         def pip_compile_options(filename)
@@ -257,12 +273,13 @@ module Dependabot
             end
         end
 
-        def run_pip_compile_command(command)
+        def run_pip_compile_command(command, fingerprint:)
           run_command(
-            "pyenv local #{Helpers.python_major_minor(python_version)}"
+            "pyenv local #{Helpers.python_major_minor(python_version)}",
+            fingerprint: "pyenv local <python_major_minor>"
           )
 
-          run_command(command)
+          run_command(command, fingerprint: fingerprint)
         end
 
         def python_env

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -165,7 +165,8 @@ module Dependabot
         # Using `--no-interaction` avoids asking for passwords.
         def run_poetry_update_command
           run_poetry_command(
-            "pyenv exec poetry update #{dependency.name} --lock --no-interaction"
+            "pyenv exec poetry update #{dependency.name} --lock --no-interaction",
+            fingerprint: "pyenv exec poetry update <dependency_name> --lock --no-interaction"
           )
         end
 
@@ -333,7 +334,7 @@ module Dependabot
           poetry_lock || pyproject_lock
         end
 
-        def run_poetry_command(command)
+        def run_poetry_command(command, fingerprint: nil)
           start = Time.now
           command = SharedHelpers.escape_command(command)
           stdout, process = Open3.capture2e(command)
@@ -347,6 +348,7 @@ module Dependabot
             message: stdout,
             error_context: {
               command: command,
+              fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: process.to_s
             }

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -174,7 +174,8 @@ module Dependabot
             File.write(".terraform.lock.hcl", lockfile_hash_removed)
 
             SharedHelpers.run_shell_command(
-              "terraform providers lock -platform=#{arch} #{provider_source} -no-color"
+              "terraform providers lock -platform=#{arch} #{provider_source} -no-color",
+              fingerprint: "terraform providers lock -platform=<arch> <provider_source> -no-color"
             )
 
             updated_lockfile = File.read(".terraform.lock.hcl")
@@ -231,7 +232,8 @@ module Dependabot
           File.write(".terraform.lock.hcl", lockfile_dependency_removed)
 
           SharedHelpers.run_shell_command(
-            "terraform providers lock #{platforms} #{provider_source}"
+            "terraform providers lock #{platforms} #{provider_source}",
+            fingerprint: "terraform providers lock <platforms> <provider_source>"
           )
 
           updated_lockfile = File.read(".terraform.lock.hcl")

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -854,7 +854,7 @@ module Dependabot
           # info such as file contents or paths. This information is already
           # in the job logs, so we send a breadcrumb to Sentry to retrieve those
           # instead.
-          msg = "Subprocess `#{error.error_context[:command]}` failed to run. Check the job logs for error messages"
+          msg = "Subprocess #{error.raven_context[:fingerprint]} failed to run. Check the job logs for error messages"
           sanitized_error = SubprocessFailed.new(msg, raven_context: error.raven_context)
           sanitized_error.set_backtrace(error.backtrace)
           Raven.capture_exception(sanitized_error, raven_context)


### PR DESCRIPTION
This reverts commit 05f2c7c8ecfa4c222d59431d999833503f267cbd, reversing changes made to 5a4f0857df455c0d478a74cf9dda5e8a2b15b09d.

Sentry is getting confused about which stack trace frames are in-app vs outside-app. So it's merging unrelated exceptions together.

I think we should be able to tweak Sentry config to do the right thing but for now I'll revert the PR.