### PR TITLE
[Bitbucket] Handle Unauthorized error on current user endpoint

### DIFF
--- a/common/lib/dependabot/clients/bitbucket.rb
+++ b/common/lib/dependabot/clients/bitbucket.rb
@@ -171,6 +171,8 @@ module Dependabot
         base_url = "https://api.bitbucket.org/2.0/user?fields=uuid"
         response = get(base_url)
         JSON.parse(response.body).fetch("uuid")
+      rescue Unauthorized
+        [nil]
       end
 
       def default_reviewers(repo)

--- a/common/spec/fixtures/bitbucket/current_user_no_access.json
+++ b/common/spec/fixtures/bitbucket/current_user_no_access.json
@@ -1,0 +1,1 @@
+{"type": "error", "error": {"message": "Token is invalid or not supported for this endpoint."}}


### PR DESCRIPTION
If an access token is used that does not have access to the current_user endpoint, the default_reviewers method fails.

This PR prevents this failure.

See https://github.com/dependabot/dependabot-core/pull/6166#issuecomment-1338643047