### PR TITLE
Expose composer error message when not resolvable

### DIFF
--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -301,7 +301,7 @@ module Dependabot
             # If there *is* a lockfile we can't confidently distinguish between
             # cases where we can't install and cases where we can't update. For
             # now, we therefore just ignore the dependency.
-            nil
+            raise Dependabot::DependencyFileNotResolvable, sanitized_message
           elsif error.message.include?("URL required authentication") ||
                 error.message.include?("403 Forbidden")
             source = error.message.match(%r{https?://(?<source>[^/]+)/}).named_captures.fetch("source")


### PR DESCRIPTION
Expose the underlying composer error message when a dependency is not resolvable.

While debugging a customer issue, we ran into the problem that the error output from the `composer` helper was being swallowed: https://github.com/dependabot/dependabot-core/blob/b911f9dfe1e11d19edcafb11e83d305758c97f85/composer/lib/dependabot/composer/update_checker/version_resolver.rb#L295-L304

The underlying error:
```
Your requirements could not be resolved to an installable set of packages. (Dependabot::SharedHelpers::HelperSubprocessFailed)
  Problem 1
    - php-amqplib/php-amqplib v2.11.3 conflicts with php[7.4.0].
    - php-amqplib/php-amqplib v2.11.3 conflicts with php[7.4.0].
    - Installation request for php 7.4.0 -> satisfiable by php[7.4.0].
    - Installation request for php-amqplib/php-amqplib (locked at v2.11.3, required as ^2.6) -> satisfiable by php-amqplib/php-amqplib[v2.11.3].
```

Swallowing the error makes it hard for users to figure what's going on.

The original motivation for swallowing was in the early days of Dependabot Preview, it opened issues for exceptions raised in the updater/core which has forced us to suppress certain errors that might be spammy or intermittent, e.g. resolvability errors. In version updates we no longer create issues so attaching errors to the last update job means we can attach any number of errors to highlight potential issues without spamming users.

Fix https://github.com/dependabot/dependabot-core/issues/6289