### PR TITLE
Switch to `repo.packagist.org` to allow mirrors

### DIFF
--- a/composer/lib/dependabot/composer/metadata_finder.rb
+++ b/composer/lib/dependabot/composer/metadata_finder.rb
@@ -48,7 +48,7 @@ module Dependabot
       def packagist_listing
         return @packagist_listing unless @packagist_listing.nil?
 
-        response = Dependabot::RegistryClient.get(url: "https://packagist.org/p/#{dependency.name.downcase}.json")
+        response = Dependabot::RegistryClient.get(url: "https://repo.packagist.org/p/#{dependency.name.downcase}.json")
 
         return nil unless response.status == 200
 

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -108,7 +108,7 @@ module Dependabot
                  map { |url| url.gsub(%r{\/$}, "") + "/packages.json" }
 
           unless repositories.any? { |rep| rep["packagist.org"] == false }
-            urls << "https://packagist.org/p/#{dependency.name.downcase}.json"
+            urls << "https://repo.packagist.org/p/#{dependency.name.downcase}.json"
           end
 
           @registry_version_details = []

--- a/composer/spec/dependabot/composer/metadata_finder_spec.rb
+++ b/composer/spec/dependabot/composer/metadata_finder_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Dependabot::Composer::MetadataFinder do
 
   describe "#source_url" do
     subject(:source_url) { finder.source_url }
-    let(:packagist_url) { "https://packagist.org/p/monolog/monolog.json" }
+    let(:packagist_url) { "https://repo.packagist.org/p/monolog/monolog.json" }
 
     before do
       stub_request(:get, packagist_url).
@@ -68,14 +68,14 @@ RSpec.describe Dependabot::Composer::MetadataFinder do
           expect(WebMock).
             to have_requested(
               :get,
-              "https://packagist.org/p/monolog/monolog.json"
+              "https://repo.packagist.org/p/monolog/monolog.json"
             )
         end
       end
 
       context "when the package listing is for a different" do
         let(:dependency_name) { "monolog/something" }
-        let(:packagist_url) { "https://packagist.org/p/monolog/something.json" }
+        let(:packagist_url) { "https://repo.packagist.org/p/monolog/something.json" }
 
         it { is_expected.to be_nil }
       end
@@ -135,7 +135,7 @@ RSpec.describe Dependabot::Composer::MetadataFinder do
     end
 
     context "when the packagist link resolves to a redirect" do
-      let(:redirect_url) { "https://packagist.org/p/monolog/Monolog.json" }
+      let(:redirect_url) { "https://repo.packagist.org/p/monolog/Monolog.json" }
       let(:packagist_response) { fixture("packagist_response.json") }
 
       before do

--- a/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
@@ -40,14 +40,14 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
   before do
     sanitized_name = dependency_name.downcase.gsub("/", "--")
     fixture = fixture("packagist_responses", "#{sanitized_name}.json")
-    url = "https://packagist.org/p/#{dependency_name.downcase}.json"
+    url = "https://repo.packagist.org/p/#{dependency_name.downcase}.json"
     stub_request(:get, url).to_return(status: 200, body: fixture)
   end
 
   describe "#latest_version" do
     subject { finder.latest_version }
 
-    let(:packagist_url) { "https://packagist.org/p/monolog/monolog.json" }
+    let(:packagist_url) { "https://repo.packagist.org/p/monolog/monolog.json" }
     let(:packagist_response) { fixture("packagist_response.json") }
 
     before do
@@ -196,7 +196,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
           package_manager: "composer"
         )
       end
-      let(:packagist_url) { "https://packagist.org/p/monolog/something.json" }
+      let(:packagist_url) { "https://repo.packagist.org/p/monolog/something.json" }
 
       it { is_expected.to be_nil }
     end
@@ -221,7 +221,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
         expect(WebMock).
           to have_requested(
             :get,
-            "https://packagist.org/p/monolog/monolog.json"
+            "https://repo.packagist.org/p/monolog/monolog.json"
           )
       end
     end

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -43,14 +43,14 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
   before do
     sanitized_name = dependency_name.downcase.gsub("/", "--")
     fixture = fixture("packagist_responses", "#{sanitized_name}.json")
-    url = "https://packagist.org/p/#{dependency_name.downcase}.json"
+    url = "https://repo.packagist.org/p/#{dependency_name.downcase}.json"
     stub_request(:get, url).to_return(status: 200, body: fixture)
   end
 
   describe "#latest_version" do
     subject { checker.latest_version }
 
-    let(:packagist_url) { "https://packagist.org/p/monolog/monolog.json" }
+    let(:packagist_url) { "https://repo.packagist.org/p/monolog/monolog.json" }
     let(:packagist_response) { fixture("packagist_response.json") }
 
     before do
@@ -94,7 +94,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
 
     context "with a path source" do
       before do
-        stub_request(:get, "https://packagist.org/p/path_dep/path_dep.json").
+        stub_request(:get, "https://repo.packagist.org/p/path_dep/path_dep.json").
           to_return(status: 404)
       end
 
@@ -159,7 +159,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
   describe "#lowest_security_fix_version" do
     subject { checker.lowest_security_fix_version }
 
-    let(:packagist_url) { "https://packagist.org/p/monolog/monolog.json" }
+    let(:packagist_url) { "https://repo.packagist.org/p/monolog/monolog.json" }
     let(:packagist_response) { fixture("packagist_response.json") }
 
     before do
@@ -290,7 +290,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     context "with a path source" do
       let(:project_name) { "path_source" }
       before do
-        stub_request(:get, "https://packagist.org/p/path_dep/path_dep.json").
+        stub_request(:get, "https://repo.packagist.org/p/path_dep/path_dep.json").
           to_return(status: 404)
       end
 


### PR DESCRIPTION
Per https://github.com/dependabot/dependabot-core/issues/3010:
> Note that you currently use the packagist.org domain rather than the
> repo.packagist.org domain, which forbids you from using the official
> metadata mirrors. If dependabot runs in a US-based datacenter, using
> the repo.packagist.org domain would allow you to hit the mirror in
> Montreal instead of hitting a server in Europe, improving latency.
> Doing that switch is unrelated to the v1 vs v2 metadata change though
> (both are mirrored by packagist).

So this switches the two places we call out to `packagist.org` to use the new domain.