### PR TITLE
fix hostname matching to be exact to avoid security issues

### DIFF
--- a/bundler/lib/dependabot/bundler/metadata_finder.rb
+++ b/bundler/lib/dependabot/bundler/metadata_finder.rb
@@ -215,10 +215,12 @@ module Dependabot
       def registry_auth_headers
         return {} unless new_source_type == "rubygems"
 
+        registry_host = URI(registry_url).host
+
         token =
           credentials.
           select { |cred| cred["type"] == "rubygems_server" }.
-          find { |cred| registry_url.include?(cred["host"]) }&.
+          find { |cred| registry_host == cred["host"] }&.
           fetch("token", nil)
 
         return {} unless token

--- a/bundler/spec/dependabot/bundler/metadata_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/metadata_finder_spec.rb
@@ -102,6 +102,11 @@ RSpec.describe Dependabot::Bundler::MetadataFinder do
             },
             {
               "type" => "rubygems_server",
+              "host" => "gems.greysteil.com.evil.com",
+              "token" => "secret:token"
+            },
+            {
+              "type" => "rubygems_server",
               "host" => "gems.greysteil.com",
               "token" => "secret:token"
             }

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -119,7 +119,8 @@ module Dependabot
         end
 
         def fetch_registry_versions_from_url(url)
-          cred = registry_credentials.find { |c| url.include?(c["registry"]) }
+          url_host = URI(url).host
+          cred = registry_credentials.find { |c| url_host == c["registry"] || url_host == URI(c["registry"]).host }
 
           response = Dependabot::RegistryClient.get(
             url: url,

--- a/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
@@ -293,6 +293,11 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
             "password" => "token"
           }, {
             "type" => "composer_repository",
+            "registry" => "php.fury.io.evil.com",
+            "username" => "user",
+            "password" => "pass"
+          }, {
+            "type" => "composer_repository",
             "registry" => "php.fury.io",
             "username" => "user",
             "password" => "pass"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -320,7 +320,7 @@ module Dependabot
           select { |cred| cred["type"] == "npm_registry" }.
           sort_by { |cred| cred["registry"].length }.
           find do |details|
-            return true if resolved_url_host == details["registry"]
+            next true if resolved_url_host == details["registry"]
 
             uri = if details["registry"]&.include?("://")
                     URI(details["registry"])

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -313,11 +313,22 @@ module Dependabot
       end
 
       def url_for_relevant_cred(resolved_url)
+        resolved_url_host = URI(resolved_url).host
+
         credential_matching_url =
           credentials.
           select { |cred| cred["type"] == "npm_registry" }.
           sort_by { |cred| cred["registry"].length }.
-          find { |details| resolved_url.include?(details["registry"]) }
+          find do |details|
+            return true if resolved_url_host == details["registry"]
+
+            uri = if details["registry"]&.include?("://")
+                    URI(details["registry"])
+                  else
+                    URI("https://#{details['registry']}")
+                  end
+            resolved_url_host == uri.host
+          end
 
         return unless credential_matching_url
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -321,11 +321,11 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
             context "with credentials" do
               let(:credentials) do
                 [{
-                   "type" => "npm_registry",
-                   "registry" =>
+                  "type" => "npm_registry",
+                  "registry" =>
                      "artifactory01.mydomain.com.evil.com/artifactory/api/npm/my-repo",
-                   "token" => "secret_token"
-                 },{
+                  "token" => "secret_token"
+                }, {
                   "type" => "npm_registry",
                   "registry" =>
                     "artifactory01.mydomain.com/artifactory/api/npm/my-repo",

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -321,6 +321,11 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
             context "with credentials" do
               let(:credentials) do
                 [{
+                   "type" => "npm_registry",
+                   "registry" =>
+                     "artifactory01.mydomain.com.evil.com/artifactory/api/npm/my-repo",
+                   "token" => "secret_token"
+                 },{
                   "type" => "npm_registry",
                   "registry" =>
                     "artifactory01.mydomain.com/artifactory/api/npm/my-repo",


### PR DESCRIPTION
More fixes like #6304. 

We want to do exact matches on hostname rather than substring match to avoid security issues.