### PR TITLE
fix running as root in dependabot-action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ ARG USER_GID=$USER_UID
 RUN if ! getent group "$USER_GID"; then groupadd --gid "$USER_GID" dependabot ; \
      else GROUP_NAME=$(getent group $USER_GID | awk -F':' '{print $1}'); groupmod -n dependabot "$GROUP_NAME" ; fi \
   && useradd --uid "${USER_UID}" --gid "${USER_GID}" -m dependabot \
-  && mkdir -p /opt && chown dependabot:dependabot /opt
+  && mkdir -p /opt && chown dependabot:dependabot /opt && chgrp dependabot /etc/ssl/certs && chmod g+w /etc/ssl/certs
 
 
 ### RUBY


### PR DESCRIPTION
dependabot-action runs as root because it has to run `update-ca-certificates` which requires root access. By granting the `dependabot` user access to install certificates we can stop running as the root user, improving security of the container.

The `dependabot` user having write access to the certificates is not a problem since anyone able to execute commands on the container would be able to ignore certificate errors anyway.

I've tested this with the CLI and it works https://github.com/dependabot/cli/pull/46