### PR TITLE
Validate SHA256Sum for Dart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -271,15 +271,20 @@ ENV PUB_CACHE=/opt/dart/pub-cache \
 
 # https://dart.dev/get-dart/archive
 ARG DART_VERSION=2.18.5
-# TODO Dart now publishes SHA256 checksums for their releases, we should validate against those.
+
 RUN DART_ARCH=${TARGETARCH} \
   && if [ "$TARGETARCH" = "amd64" ]; then DART_ARCH=x64; fi \
-  && curl --connect-timeout 15 --retry 5 "https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/dartsdk-linux-${DART_ARCH}-release.zip" > "/tmp/dart-sdk.zip" \
+  && DART_EXE="dartsdk-linux-${DART_ARCH}-release.zip" \
+  && DOWNLOAD_URL="https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/${DART_EXE}" \
+  && curl --connect-timeout 15 --retry 5 "${DOWNLOAD_URL}" > "/tmp/${DART_EXE}" \
+  && curl --connect-timeout 15 --retry 5 "${DOWNLOAD_URL}.sha256sum" > "/tmp/${DART_EXE}.sha256sum" \
+  && cd /tmp/ \
+  && echo "$(cat /tmp/${DART_EXE}.sha256sum)" | sha256sum -c \
   && mkdir -p "$PUB_CACHE" \
   && chown dependabot:dependabot "$PUB_CACHE" \
-  && unzip "/tmp/dart-sdk.zip" -d "/opt/dart" > /dev/null \
+  && unzip "/tmp/${DART_EXE}" -d "/opt/dart" > /dev/null \
   && chmod -R o+rx "/opt/dart/dart-sdk" \
-  && rm "/tmp/dart-sdk.zip" \
+  && rm "/tmp/${DART_EXE}" \
   && dart --version
 
 COPY --chown=dependabot:dependabot LICENSE /home/dependabot

--- a/Dockerfile
+++ b/Dockerfile
@@ -270,7 +270,7 @@ ENV PUB_CACHE=/opt/dart/pub-cache \
   PATH="${PATH}:/opt/dart/dart-sdk/bin"
 
 # https://dart.dev/get-dart/archive
-ARG DART_VERSION=2.18.5
+ARG DART_VERSION=2.18.6
 
 RUN DART_ARCH=${TARGETARCH} \
   && if [ "$TARGETARCH" = "amd64" ]; then DART_ARCH=x64; fi \


### PR DESCRIPTION
Addresses #6131
This PR introduces changes to the Dart installation process. In addition to downloading the `zip` with the Dart SDK, the installation script now also downloads a `SHA256` hash file from the Dart project and verifies the downloaded zip. 

 - [x] Validate `SHA256` sums published by the Dart project. 
 - [x] Bump Dart from `1.8.5` -> `1.8.6`


