### PR TITLE
Added support for Azure in git_submodules

### DIFF
--- a/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
@@ -702,7 +702,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
 
     context "with a azure repo" do
       let(:service_pack_url) do
-        "https://dev.azure.com/contoso/MyProject/_git/business.git/info/refs" \
+        "https://dev.azure.com/contoso/MyProject/_git/business/info/refs" \
           "?service=git-upload-pack"
       end
 
@@ -1077,7 +1077,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
           )
         end
         let(:service_pack_url) do
-          "https://dev.azure.com/contoso/MyProject/_git/business.git/info/refs" \
+          "https://dev.azure.com/contoso/MyProject/_git/business/info/refs" \
             "?service=git-upload-pack"
         end
 

--- a/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb
+++ b/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb
@@ -54,6 +54,8 @@ module Dependabot
                when "gitlab"
                  tmp_path = path.gsub(%r{^/*}, "")
                  gitlab_client.get_file(repo, tmp_path, commit).blob_id
+               when "azure"
+                 azure_client.fetch_file_contents(commit, path)
                else raise "Unsupported provider '#{source.provider}'."
                end
 
@@ -63,7 +65,9 @@ module Dependabot
           directory: directory,
           type: "submodule"
         )
-      rescue Octokit::NotFound, Gitlab::Error::NotFound
+      rescue Octokit::NotFound,
+             Gitlab::Error::NotFound,
+             Dependabot::Clients::Azure::NotFound
         raise Dependabot::DependencyFileNotFound, path
       end
 

--- a/git_submodules/spec/dependabot/git_submodules/metadata_finder_spec.rb
+++ b/git_submodules/spec/dependabot/git_submodules/metadata_finder_spec.rb
@@ -64,6 +64,11 @@ RSpec.describe Dependabot::GitSubmodules::MetadataFinder do
       it { is_expected.to eq("https://bitbucket.org/example/manifesto") }
     end
 
+    context "when the URL is an azure one" do
+      let(:url) { "https://contoso@dev.azure.com/contoso/MyProject/_git/manifesto" }
+      it { is_expected.to eq("https://dev.azure.com/contoso/MyProject/_git/manifesto") }
+    end
+
     context "when the URL is from an unknown host" do
       let(:url) { "https://example.com/example/manifesto.git" }
       it { is_expected.to be_nil }
@@ -90,6 +95,16 @@ RSpec.describe Dependabot::GitSubmodules::MetadataFinder do
           to eq("https://bitbucket.org/example/manifesto/branches/" \
                 "compare/cd8274d15fa3ae2ab983129fb037999f264ba9a7" \
                 "..7638417db6d59f3c431d3e1f261cc637155684cd")
+      end
+    end
+
+    context "when the URL is an azure one" do
+      let(:url) { "https://contoso@dev.azure.com/contoso/MyProject/_git/manifesto" }
+      it do
+        is_expected.
+          to eq("https://dev.azure.com/contoso/MyProject/_git/manifesto/branchCompare" \
+                "?baseVersion=GC7638417db6d59f3c431d3e1f261cc637155684cd" \
+                "&targetVersion=GCcd8274d15fa3ae2ab983129fb037999f264ba9a7")
       end
     end
 


### PR DESCRIPTION
Support `git_submodules` from Azure DevOps. All the code was present but not set up.

Changes in #6304 and #6306 helped a great deal too in handling submodule URLs for Azure DevOps:

```bash
[submodule "another-repo"]
	path = another-repo
	url = https://contoso@dev.azure.com/contoso/MyProject/_git/another-repo
```

The suffix `.git` does not in Azure DevOps. For GitHub and GitLab, it works with and without the suffix hence removed it just when getting the `git-upload-pack` in `service_pack_uri(...)`. For `dev.azure.com` and `*.visualstudio.com`, this suffix is skipped.

Fixes: #6340 
Fixes: #5756