### PR TITLE
Remove superfluous `v` customization in test fixture

### DIFF
--- a/composer/spec/fixtures/packagist_response.json
+++ b/composer/spec/fixtures/packagist_response.json
@@ -1700,7 +1700,7 @@
                 "version": "1.22.0",
                 "version_normalized": "1.22.0.0"
             },
-            "v1.22.1": {
+            "1.22.1": {
                 "authors": [
                     {
                         "email": "j.boggiano@seld.be",


### PR DESCRIPTION
Historical context:
In https://github.com/dependabot/dependabot-core/commit/77406d5d220ce7c61c7d68d1bacb8b8fadf59277, support was added for version numbers that included a `"v"` prefix. At the time, the only packagist test fixture was this single file: https://github.com/dependabot/dependabot-core/tree/77406d5d220ce7c61c7d68d1bacb8b8fadf59277/spec/fixtures/php So to test this, Grey added a customization to force a `"v"` prefix on a version.

However, we now have a whole folder of packagist responses: https://github.com/dependabot/dependabot-core/tree/dc6584174b027b7313e1ccc92adae209417c8910/composer/spec/fixtures/packagist_responses

And several of those include `"v"` prefixes:
* https://github.com/dependabot/dependabot-core/blob/dc6584174b027b7313e1ccc92adae209417c8910/composer/spec/fixtures/packagist_responses/symfony--polyfill-mbstring.json#L875
* https://raw.githubusercontent.com/dependabot/dependabot-core/dc6584174b027b7313e1ccc92adae209417c8910/composer/spec/fixtures/packagist_responses/illuminate--console.json

And I confirmed that we do run tests against some of those: https://github.com/dependabot/dependabot-core/blob/dc6584174b027b7313e1ccc92adae209417c8910/composer/spec/dependabot/composer/file_updater_spec.rb#L94

So we no longer need this customization.

And tracking down these customizations has been a royal pain while working on https://github.com/dependabot/dependabot-core/issues/3010.

While retaining it is semi-harmless, explicitly removing this provides a `git blame` trail because in a future PR I'll be removing this generic `packagist_response.json` file completely in favor of using the explicit packagist response files.