### PR TITLE
Update `monolog/monolog` fixture to latest packagist response

### DIFF
--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
 
     context "when the user is ignoring the latest version" do
       let(:ignored_versions) { [">= 1.22.0.a, < 3.0"] }
-      it { is_expected.to eq(Gem::Version.new("1.21.0")) }
+      it { is_expected.to eq(Gem::Version.new("2.8.0")) }
     end
 
     context "without a lockfile" do
@@ -741,7 +741,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     subject { checker.preferred_resolvable_version }
 
     let(:ignored_versions) { [">= 1.22.0.a, < 3.0"] }
-    it { is_expected.to eq(Gem::Version.new("1.21.0")) }
+    it { is_expected.to eq(Gem::Version.new("2.8.0")) }
 
     context "with an insecure version" do
       let(:dependency_version) { "1.0.1" }

--- a/composer/spec/fixtures/packagist_responses/monolog--monolog.json
+++ b/composer/spec/fixtures/packagist_responses/monolog--monolog.json
@@ -1,2707 +1,6741 @@
 {
     "packages": {
+        "jean85/composer-provided-replaced-stub-package": {
+            "1.0.0": {
+                "name": "jean85/composer-provided-replaced-stub-package",
+                "description": "This is only a stub package used in the tests of jean85/pretty-package-versions",
+                "keywords": [],
+                "homepage": "",
+                "version": "1.0.0",
+                "version_normalized": "1.0.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Alessandro Lai",
+                        "email": "alessandro.lai85@gmail.com"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Jean85/composer-provided-replaced-stub-package.git",
+                    "type": "git",
+                    "reference": "a89d3f39a6149d33b6f6ebecc2f5f44fd4a2cf90"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Jean85/composer-provided-replaced-stub-package/zipball/a89d3f39a6149d33b6f6ebecc2f5f44fd4a2cf90",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "a89d3f39a6149d33b6f6ebecc2f5f44fd4a2cf90"
+                },
+                "type": "library",
+                "time": "2020-04-28T10:17:21+00:00",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 3820116
+            },
+            "dev-master": {
+                "name": "jean85/composer-provided-replaced-stub-package",
+                "description": "This is only a stub package used in the tests of jean85/pretty-package-versions",
+                "keywords": [],
+                "homepage": "",
+                "version": "dev-master",
+                "version_normalized": "9999999-dev",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Alessandro Lai",
+                        "email": "alessandro.lai85@gmail.com"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Jean85/composer-provided-replaced-stub-package.git",
+                    "type": "git",
+                    "reference": "a89d3f39a6149d33b6f6ebecc2f5f44fd4a2cf90"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Jean85/composer-provided-replaced-stub-package/zipball/a89d3f39a6149d33b6f6ebecc2f5f44fd4a2cf90",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "a89d3f39a6149d33b6f6ebecc2f5f44fd4a2cf90"
+                },
+                "type": "library",
+                "time": "2020-04-28T10:17:21+00:00",
+                "default-branch": true,
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 4108141
+            }
+        },
+        "jtl/connector-shopware": {
+            "2.11.0": {
+                "name": "jtl/connector-shopware",
+                "description": "Shopware 5 Connector based on jtl/connector",
+                "keywords": [
+                    "connector",
+                    "shopware",
+                    "jtl"
+                ],
+                "homepage": "http://www.jtl-software.de",
+                "version": "2.11.0",
+                "version_normalized": "2.11.0.0",
+                "license": [
+                    "LGPL-3.0-or-later"
+                ],
+                "authors": [
+                    {
+                        "name": "JTL-Software GmbH",
+                        "email": "info@jtl-software.de",
+                        "homepage": "http://www.jtl-software.de",
+                        "role": "Founder"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/jtl-software/connector-shopware5.git",
+                    "type": "git",
+                    "reference": "dbe81dc55bcfc250e210a40925817d3222910fee"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/jtl-software/connector-shopware5/zipball/dbe81dc55bcfc250e210a40925817d3222910fee",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "dbe81dc55bcfc250e210a40925817d3222910fee"
+                },
+                "type": "shopware-frontend-plugin",
+                "time": "2021-07-05T11:20:18+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "\\": "plugins/",
+                        "jtl\\Connector\\Shopware\\": "src/"
+                    }
+                },
+                "extra": {
+                    "installer-name": "jtlconnector"
+                },
+                "require": {
+                    "php": ">=7.1.3",
+                    "jtl/connector": "^3.3",
+                    "symfony/yaml": "^3.4",
+                    "phing/phing": "^2.16",
+                    "theiconic/name-parser": "^0.1.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.5"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 5338928
+            },
+            "2.11.1": {
+                "name": "jtl/connector-shopware",
+                "description": "Shopware 5 Connector based on jtl/connector",
+                "keywords": [
+                    "connector",
+                    "shopware",
+                    "jtl"
+                ],
+                "homepage": "http://www.jtl-software.de",
+                "version": "2.11.1",
+                "version_normalized": "2.11.1.0",
+                "license": [
+                    "LGPL-3.0-or-later"
+                ],
+                "authors": [
+                    {
+                        "name": "JTL-Software GmbH",
+                        "email": "info@jtl-software.de",
+                        "homepage": "http://www.jtl-software.de",
+                        "role": "Founder"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/jtl-software/connector-shopware5.git",
+                    "type": "git",
+                    "reference": "24bdf3c18175aff2369e97537b54e6a5c25ed353"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/jtl-software/connector-shopware5/zipball/24bdf3c18175aff2369e97537b54e6a5c25ed353",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "24bdf3c18175aff2369e97537b54e6a5c25ed353"
+                },
+                "type": "shopware-frontend-plugin",
+                "time": "2021-07-28T11:18:26+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "\\": "plugins/",
+                        "jtl\\Connector\\Shopware\\": "src/"
+                    }
+                },
+                "extra": {
+                    "installer-name": "jtlconnector"
+                },
+                "require": {
+                    "php": ">=7.1.3",
+                    "jtl/connector": "^3.3",
+                    "symfony/yaml": "^3.4",
+                    "phing/phing": "^2.16",
+                    "theiconic/name-parser": "^0.1.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.5"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 5397908
+            },
+            "2.12.0": {
+                "name": "jtl/connector-shopware",
+                "description": "Shopware 5 Connector based on jtl/connector",
+                "keywords": [
+                    "connector",
+                    "shopware",
+                    "jtl"
+                ],
+                "homepage": "http://www.jtl-software.de",
+                "version": "2.12.0",
+                "version_normalized": "2.12.0.0",
+                "license": [
+                    "LGPL-3.0-or-later"
+                ],
+                "authors": [
+                    {
+                        "name": "JTL-Software GmbH",
+                        "email": "info@jtl-software.de",
+                        "homepage": "http://www.jtl-software.de",
+                        "role": "Founder"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/jtl-software/connector-shopware5.git",
+                    "type": "git",
+                    "reference": "251789bd6529147b1f4db985833e67538c167a00"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/jtl-software/connector-shopware5/zipball/251789bd6529147b1f4db985833e67538c167a00",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "251789bd6529147b1f4db985833e67538c167a00"
+                },
+                "type": "shopware-frontend-plugin",
+                "time": "2021-09-01T09:22:38+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "\\": "plugins/",
+                        "jtl\\Connector\\Shopware\\": "src/"
+                    }
+                },
+                "extra": {
+                    "installer-name": "jtlconnector"
+                },
+                "require": {
+                    "php": ">=7.1.3",
+                    "jtl/connector": "^3.3",
+                    "symfony/yaml": "^3.4",
+                    "phing/phing": "^2.16",
+                    "theiconic/name-parser": "^0.1.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.5"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 5481542
+            },
+            "2.13.0": {
+                "name": "jtl/connector-shopware",
+                "description": "Shopware 5 Connector based on jtl/connector",
+                "keywords": [
+                    "connector",
+                    "shopware",
+                    "jtl"
+                ],
+                "homepage": "http://www.jtl-software.de",
+                "version": "2.13.0",
+                "version_normalized": "2.13.0.0",
+                "license": [
+                    "LGPL-3.0-or-later"
+                ],
+                "authors": [
+                    {
+                        "name": "JTL-Software GmbH",
+                        "email": "info@jtl-software.de",
+                        "homepage": "http://www.jtl-software.de",
+                        "role": "Founder"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/jtl-software/connector-shopware5.git",
+                    "type": "git",
+                    "reference": "1562b324c1f8a9eaa708164e27ba065e3c0f5faf"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/jtl-software/connector-shopware5/zipball/1562b324c1f8a9eaa708164e27ba065e3c0f5faf",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "1562b324c1f8a9eaa708164e27ba065e3c0f5faf"
+                },
+                "type": "shopware-frontend-plugin",
+                "time": "2021-11-16T10:25:23+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "\\": "plugins/",
+                        "jtl\\Connector\\Shopware\\": "src/"
+                    }
+                },
+                "extra": {
+                    "installer-name": "jtlconnector"
+                },
+                "require": {
+                    "php": ">=7.1.3",
+                    "jtl/connector": "^3.3",
+                    "symfony/yaml": "^3.4",
+                    "phing/phing": "^2.16",
+                    "theiconic/name-parser": "^0.1.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.5"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 5692106
+            },
+            "2.14.0": {
+                "name": "jtl/connector-shopware",
+                "description": "Shopware 5 Connector based on jtl/connector",
+                "keywords": [
+                    "connector",
+                    "shopware",
+                    "jtl"
+                ],
+                "homepage": "http://www.jtl-software.de",
+                "version": "2.14.0",
+                "version_normalized": "2.14.0.0",
+                "license": [
+                    "LGPL-3.0-or-later"
+                ],
+                "authors": [
+                    {
+                        "name": "JTL-Software GmbH",
+                        "email": "info@jtl-software.de",
+                        "homepage": "http://www.jtl-software.de",
+                        "role": "Founder"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/jtl-software/connector-shopware5.git",
+                    "type": "git",
+                    "reference": "31fb9f3b96f45aaf5d93d9e9bd6f2134944113d0"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/jtl-software/connector-shopware5/zipball/31fb9f3b96f45aaf5d93d9e9bd6f2134944113d0",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "31fb9f3b96f45aaf5d93d9e9bd6f2134944113d0"
+                },
+                "type": "shopware-frontend-plugin",
+                "time": "2022-02-01T13:49:41+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "\\": "plugins/",
+                        "jtl\\Connector\\Shopware\\": "src/"
+                    }
+                },
+                "extra": {
+                    "installer-name": "jtlconnector"
+                },
+                "require": {
+                    "php": ">=7.1.3",
+                    "jtl/connector": "^3.3",
+                    "symfony/yaml": "^3.4",
+                    "phing/phing": "^2.16",
+                    "theiconic/name-parser": "^0.1.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.5"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 5923865
+            },
+            "2.15.0": {
+                "name": "jtl/connector-shopware",
+                "description": "Shopware 5 Connector based on jtl/connector",
+                "keywords": [
+                    "connector",
+                    "shopware",
+                    "jtl"
+                ],
+                "homepage": "http://www.jtl-software.de",
+                "version": "2.15.0",
+                "version_normalized": "2.15.0.0",
+                "license": [
+                    "LGPL-3.0-or-later"
+                ],
+                "authors": [
+                    {
+                        "name": "JTL-Software GmbH",
+                        "email": "info@jtl-software.de",
+                        "homepage": "http://www.jtl-software.de",
+                        "role": "Founder"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/jtl-software/connector-shopware5.git",
+                    "type": "git",
+                    "reference": "4b9b622b4d8a2ff7878f20f92c63bf1a6172da0a"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/jtl-software/connector-shopware5/zipball/4b9b622b4d8a2ff7878f20f92c63bf1a6172da0a",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "4b9b622b4d8a2ff7878f20f92c63bf1a6172da0a"
+                },
+                "type": "shopware-frontend-plugin",
+                "time": "2022-05-25T12:05:52+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "\\": "plugins/",
+                        "jtl\\Connector\\Shopware\\": "src/"
+                    }
+                },
+                "extra": {
+                    "installer-name": "jtlconnector"
+                },
+                "require": {
+                    "php": ">=7.1.3",
+                    "jtl/connector": "^3.3",
+                    "symfony/yaml": "^3.4",
+                    "phing/phing": "^2.16",
+                    "theiconic/name-parser": "^0.1.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.5"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 6277953
+            },
+            "2.15.1": {
+                "name": "jtl/connector-shopware",
+                "description": "Shopware 5 Connector based on jtl/connector",
+                "keywords": [
+                    "connector",
+                    "shopware",
+                    "jtl"
+                ],
+                "homepage": "http://www.jtl-software.de",
+                "version": "2.15.1",
+                "version_normalized": "2.15.1.0",
+                "license": [
+                    "LGPL-3.0-or-later"
+                ],
+                "authors": [
+                    {
+                        "name": "JTL-Software GmbH",
+                        "email": "info@jtl-software.de",
+                        "homepage": "http://www.jtl-software.de",
+                        "role": "Founder"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/jtl-software/connector-shopware5.git",
+                    "type": "git",
+                    "reference": "7ec6b862587729a039b25035b092cf6c02b02f66"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/jtl-software/connector-shopware5/zipball/7ec6b862587729a039b25035b092cf6c02b02f66",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "7ec6b862587729a039b25035b092cf6c02b02f66"
+                },
+                "type": "shopware-frontend-plugin",
+                "time": "2022-07-12T07:37:59+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "\\": "plugins/",
+                        "jtl\\Connector\\Shopware\\": "src/"
+                    }
+                },
+                "extra": {
+                    "installer-name": "jtlconnector"
+                },
+                "require": {
+                    "php": ">=7.1.3",
+                    "jtl/connector": "^3.3",
+                    "symfony/yaml": "^3.4",
+                    "phing/phing": "^2.16",
+                    "theiconic/name-parser": "^0.1.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.5"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 6411819
+            },
+            "2.16.0": {
+                "name": "jtl/connector-shopware",
+                "description": "Shopware 5 Connector based on jtl/connector",
+                "keywords": [
+                    "connector",
+                    "shopware",
+                    "jtl"
+                ],
+                "homepage": "http://www.jtl-software.de",
+                "version": "2.16.0",
+                "version_normalized": "2.16.0.0",
+                "license": [
+                    "LGPL-3.0-or-later"
+                ],
+                "authors": [
+                    {
+                        "name": "JTL-Software GmbH",
+                        "email": "info@jtl-software.de",
+                        "homepage": "http://www.jtl-software.de",
+                        "role": "Founder"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/jtl-software/connector-shopware5.git",
+                    "type": "git",
+                    "reference": "515473d90dc4f1367fab704bc8e998f6ea8623d0"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/jtl-software/connector-shopware5/zipball/515473d90dc4f1367fab704bc8e998f6ea8623d0",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "515473d90dc4f1367fab704bc8e998f6ea8623d0"
+                },
+                "type": "shopware-frontend-plugin",
+                "time": "2022-09-13T11:46:13+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "\\": "plugins/",
+                        "jtl\\Connector\\Shopware\\": "src/"
+                    }
+                },
+                "extra": {
+                    "installer-name": "jtlconnector"
+                },
+                "require": {
+                    "php": ">=7.1.3",
+                    "jtl/connector": "^3.3",
+                    "symfony/yaml": "^3.4",
+                    "phing/phing": "^2.16",
+                    "theiconic/name-parser": "^0.1.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.5"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 6558112
+            },
+            "dev-bugfix/CO-2106_add_paypal_invoice_v2_support": {
+                "name": "jtl/connector-shopware",
+                "description": "Shopware 5 Connector based on jtl/connector",
+                "keywords": [
+                    "connector",
+                    "shopware",
+                    "jtl"
+                ],
+                "homepage": "http://www.jtl-software.de",
+                "version": "dev-bugfix/CO-2106_add_paypal_invoice_v2_support",
+                "version_normalized": "dev-bugfix/CO-2106_add_paypal_invoice_v2_support",
+                "license": [
+                    "LGPL-3.0-or-later"
+                ],
+                "authors": [
+                    {
+                        "name": "JTL-Software GmbH",
+                        "email": "info@jtl-software.de",
+                        "homepage": "http://www.jtl-software.de",
+                        "role": "Founder"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/jtl-software/connector-shopware5.git",
+                    "type": "git",
+                    "reference": "9d07bd2091cbab22ab6be02b81d848d6e63bd444"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/jtl-software/connector-shopware5/zipball/9d07bd2091cbab22ab6be02b81d848d6e63bd444",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "9d07bd2091cbab22ab6be02b81d848d6e63bd444"
+                },
+                "type": "shopware-frontend-plugin",
+                "time": "2022-09-08T07:57:19+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "\\": "plugins/",
+                        "jtl\\Connector\\Shopware\\": "src/"
+                    }
+                },
+                "extra": {
+                    "installer-name": "jtlconnector"
+                },
+                "require": {
+                    "php": ">=7.1.3",
+                    "jtl/connector": "^3.3",
+                    "symfony/yaml": "^3.4",
+                    "phing/phing": "^2.16",
+                    "theiconic/name-parser": "^0.1.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.5"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 6547907
+            },
+            "dev-bugfix/CO-2113_tax_group_not_used": {
+                "name": "jtl/connector-shopware",
+                "description": "Shopware 5 Connector based on jtl/connector",
+                "keywords": [
+                    "connector",
+                    "shopware",
+                    "jtl"
+                ],
+                "homepage": "http://www.jtl-software.de",
+                "version": "dev-bugfix/CO-2113_tax_group_not_used",
+                "version_normalized": "dev-bugfix/CO-2113_tax_group_not_used",
+                "license": [
+                    "LGPL-3.0-or-later"
+                ],
+                "authors": [
+                    {
+                        "name": "JTL-Software GmbH",
+                        "email": "info@jtl-software.de",
+                        "homepage": "http://www.jtl-software.de",
+                        "role": "Founder"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/jtl-software/connector-shopware5.git",
+                    "type": "git",
+                    "reference": "05656c7cfdf022463a5b48afb765b27fb8e1fe44"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/jtl-software/connector-shopware5/zipball/05656c7cfdf022463a5b48afb765b27fb8e1fe44",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "05656c7cfdf022463a5b48afb765b27fb8e1fe44"
+                },
+                "type": "shopware-frontend-plugin",
+                "time": "2022-09-12T06:56:12+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "\\": "plugins/",
+                        "jtl\\Connector\\Shopware\\": "src/"
+                    }
+                },
+                "extra": {
+                    "installer-name": "jtlconnector"
+                },
+                "require": {
+                    "php": ">=7.1.3",
+                    "jtl/connector": "^3.3",
+                    "symfony/yaml": "^3.4",
+                    "phing/phing": "^2.16",
+                    "theiconic/name-parser": "^0.1.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.5"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 6546029
+            },
+            "dev-feature/CI": {
+                "name": "jtl/connector-shopware",
+                "description": "Shopware 5 Connector based on jtl/connector",
+                "keywords": [
+                    "connector",
+                    "shopware",
+                    "jtl"
+                ],
+                "homepage": "http://www.jtl-software.de",
+                "version": "dev-feature/CI",
+                "version_normalized": "dev-feature/CI",
+                "license": [
+                    "LGPL-3.0-or-later"
+                ],
+                "authors": [
+                    {
+                        "name": "JTL-Software GmbH",
+                        "email": "info@jtl-software.de",
+                        "homepage": "http://www.jtl-software.de",
+                        "role": "Founder"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/jtl-software/connector-shopware5.git",
+                    "type": "git",
+                    "reference": "17e61188825c9a7fa06f833374b753a9fd555d86"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/jtl-software/connector-shopware5/zipball/17e61188825c9a7fa06f833374b753a9fd555d86",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "17e61188825c9a7fa06f833374b753a9fd555d86"
+                },
+                "type": "shopware-frontend-plugin",
+                "time": "2022-08-18T12:08:47+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "\\": "plugins/",
+                        "jtl\\Connector\\Shopware\\": "src/"
+                    }
+                },
+                "extra": {
+                    "installer-name": "jtlconnector"
+                },
+                "require": {
+                    "php": ">=7.1.3",
+                    "jtl/connector": "^3.3",
+                    "symfony/yaml": "^3.4",
+                    "phing/phing": "^2.16",
+                    "theiconic/name-parser": "^0.1.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.5"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 6531481
+            },
+            "dev-master": {
+                "name": "jtl/connector-shopware",
+                "description": "Shopware 5 Connector based on jtl/connector",
+                "keywords": [
+                    "connector",
+                    "shopware",
+                    "jtl"
+                ],
+                "homepage": "http://www.jtl-software.de",
+                "version": "dev-master",
+                "version_normalized": "9999999-dev",
+                "license": [
+                    "LGPL-3.0-or-later"
+                ],
+                "authors": [
+                    {
+                        "name": "JTL-Software GmbH",
+                        "email": "info@jtl-software.de",
+                        "homepage": "http://www.jtl-software.de",
+                        "role": "Founder"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/jtl-software/connector-shopware5.git",
+                    "type": "git",
+                    "reference": "515473d90dc4f1367fab704bc8e998f6ea8623d0"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/jtl-software/connector-shopware5/zipball/515473d90dc4f1367fab704bc8e998f6ea8623d0",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "515473d90dc4f1367fab704bc8e998f6ea8623d0"
+                },
+                "type": "shopware-frontend-plugin",
+                "time": "2022-09-13T11:46:13+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "\\": "plugins/",
+                        "jtl\\Connector\\Shopware\\": "src/"
+                    }
+                },
+                "extra": {
+                    "installer-name": "jtlconnector"
+                },
+                "default-branch": true,
+                "require": {
+                    "php": ">=7.1.3",
+                    "symfony/yaml": "^3.4",
+                    "phing/phing": "^2.16",
+                    "theiconic/name-parser": "^0.1.1",
+                    "jtl/connector": "^3.3"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.5"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 4047252
+            },
+            "dev-task/attribute_refactorings": {
+                "name": "jtl/connector-shopware",
+                "description": "Shopware 5 Connector based on jtl/connector",
+                "keywords": [
+                    "connector",
+                    "shopware",
+                    "jtl"
+                ],
+                "homepage": "http://www.jtl-software.de",
+                "version": "dev-task/attribute_refactorings",
+                "version_normalized": "dev-task/attribute_refactorings",
+                "license": [
+                    "LGPL-3.0-or-later"
+                ],
+                "authors": [
+                    {
+                        "name": "JTL-Software GmbH",
+                        "email": "info@jtl-software.de",
+                        "homepage": "http://www.jtl-software.de",
+                        "role": "Founder"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/jtl-software/connector-shopware5.git",
+                    "type": "git",
+                    "reference": "af20195040e30bfb5f94e1a0eb0a9fd18c3e547f"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/jtl-software/connector-shopware5/zipball/af20195040e30bfb5f94e1a0eb0a9fd18c3e547f",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "af20195040e30bfb5f94e1a0eb0a9fd18c3e547f"
+                },
+                "type": "shopware-frontend-plugin",
+                "time": "2021-08-30T07:49:42+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "\\": "plugins/",
+                        "jtl\\Connector\\Shopware\\": "src/"
+                    }
+                },
+                "extra": {
+                    "installer-name": "jtlconnector"
+                },
+                "require": {
+                    "php": ">=7.1.3",
+                    "jtl/connector": "^3.3",
+                    "symfony/yaml": "^3.4",
+                    "phing/phing": "^2.16",
+                    "theiconic/name-parser": "^0.1.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.5"
+                },
+                "replace": {
+                    "monolog/monolog": "*"
+                },
+                "uid": 5474722
+            }
+        },
         "monolog/monolog": {
             "1.0.0": {
-                "authors": [
-                    {
-                        "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
-                        "role": "Developer"
-                    }
-                ],
+                "name": "monolog/monolog",
                 "description": "Logging for PHP 5.3",
-                "dist": {
-                    "reference": "433b98d4218c181bae01865901aac045585e8a1a",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/433b98d4218c181bae01865901aac045585e8a1a"
-                },
-                "homepage": "http://github.com/Seldaek/monolog",
                 "keywords": [
                     "log",
                     "logging"
                 ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.0.0",
+                "version_normalized": "1.0.0.0",
                 "license": [
                     "MIT"
                 ],
-                "name": "monolog/monolog",
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "role": "Developer"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "433b98d4218c181bae01865901aac045585e8a1a"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/433b98d4218c181bae01865901aac045585e8a1a",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "433b98d4218c181bae01865901aac045585e8a1a"
+                },
+                "type": "library",
+                "time": "2011-07-07T16:21:02+00:00",
                 "require": {
                     "php": ">=5.3.0"
                 },
-                "source": {
-                    "reference": "433b98d4218c181bae01865901aac045585e8a1a",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
-                },
-                "time": "2011-07-07T16:21:02+00:00",
-                "type": "library",
-                "uid": 5151,
-                "version": "1.0.0",
-                "version_normalized": "1.0.0.0"
+                "uid": 5151
             },
             "1.0.0-RC1": {
-                "authors": [
-                    {
-                        "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
-                        "role": "Developer"
-                    }
-                ],
+                "name": "monolog/monolog",
                 "description": "Logging for PHP 5.3",
-                "dist": {
-                    "reference": "5e651a82b4b03d267da6084720ada0cd398c8d16",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5e651a82b4b03d267da6084720ada0cd398c8d16"
-                },
-                "homepage": "http://github.com/Seldaek/monolog",
                 "keywords": [
                     "log",
                     "logging"
                 ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.0.0-RC1",
+                "version_normalized": "1.0.0.0-RC1",
                 "license": [
                     "MIT"
                 ],
-                "name": "monolog/monolog",
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "role": "Developer"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "5e651a82b4b03d267da6084720ada0cd398c8d16"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5e651a82b4b03d267da6084720ada0cd398c8d16",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "5e651a82b4b03d267da6084720ada0cd398c8d16"
+                },
+                "type": "library",
+                "time": "2011-07-01T19:29:40+00:00",
                 "require": {
                     "php": ">=5.3.0"
                 },
-                "source": {
-                    "reference": "5e651a82b4b03d267da6084720ada0cd398c8d16",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
-                },
-                "time": "2011-07-01T19:29:40+00:00",
-                "type": "library",
-                "uid": 34388,
-                "version": "1.0.0-RC1",
-                "version_normalized": "1.0.0.0-RC1"
+                "uid": 34388
             },
             "1.0.1": {
-                "authors": [
-                    {
-                        "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
-                        "role": "Developer"
-                    }
-                ],
+                "name": "monolog/monolog",
                 "description": "Logging for PHP 5.3",
-                "dist": {
-                    "reference": "303b8a83c87d5c6d749926cf02620465a5dcd0f2",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/303b8a83c87d5c6d749926cf02620465a5dcd0f2"
-                },
-                "homepage": "http://github.com/Seldaek/monolog",
                 "keywords": [
                     "log",
                     "logging"
                 ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.0.1",
+                "version_normalized": "1.0.1.0",
                 "license": [
                     "MIT"
                 ],
-                "name": "monolog/monolog",
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be",
+                        "role": "Developer"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "303b8a83c87d5c6d749926cf02620465a5dcd0f2"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/303b8a83c87d5c6d749926cf02620465a5dcd0f2",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "303b8a83c87d5c6d749926cf02620465a5dcd0f2"
+                },
+                "type": "library",
+                "time": "2011-08-25T20:42:58+00:00",
                 "require": {
                     "php": ">=5.3.0"
                 },
-                "source": {
-                    "reference": "303b8a83c87d5c6d749926cf02620465a5dcd0f2",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
-                },
-                "time": "2011-08-25T20:42:58+00:00",
-                "type": "library",
-                "uid": 5152,
-                "version": "1.0.1",
-                "version_normalized": "1.0.1.0"
+                "uid": 5152
             },
             "1.0.2": {
+                "name": "monolog/monolog",
+                "description": "Logging for PHP 5.3",
+                "keywords": [
+                    "log",
+                    "logging"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.0.2",
+                "version_normalized": "1.0.2.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "b704c49a3051536f67f2d39f13568f74615b9922"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b704c49a3051536f67f2d39f13568f74615b9922",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "b704c49a3051536f67f2d39f13568f74615b9922"
+                },
+                "type": "library",
+                "time": "2011-10-24T09:39:02+00:00",
                 "autoload": {
                     "psr-0": {
                         "Monolog": "src/"
                     }
                 },
-                "description": "Logging for PHP 5.3",
-                "dist": {
-                    "reference": "b704c49a3051536f67f2d39f13568f74615b9922",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b704c49a3051536f67f2d39f13568f74615b9922"
-                },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0"
                 },
-                "source": {
-                    "reference": "b704c49a3051536f67f2d39f13568f74615b9922",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
-                },
-                "time": "2011-10-24T09:39:02+00:00",
-                "type": "library",
-                "uid": 5153,
-                "version": "1.0.2",
-                "version_normalized": "1.0.2.0"
+                "uid": 5153
             },
             "1.1.0": {
+                "name": "monolog/monolog",
+                "description": "Logging for PHP 5.3",
+                "keywords": [
+                    "log",
+                    "logging"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.1.0",
+                "version_normalized": "1.1.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "abc80e0db8ad31c03b373977fc997e980800f9c2"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/abc80e0db8ad31c03b373977fc997e980800f9c2",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "abc80e0db8ad31c03b373977fc997e980800f9c2"
+                },
+                "type": "library",
+                "time": "2012-04-23T16:27:40+00:00",
                 "autoload": {
                     "psr-0": {
                         "Monolog": "src/"
                     }
                 },
-                "description": "Logging for PHP 5.3",
-                "dist": {
-                    "reference": "abc80e0db8ad31c03b373977fc997e980800f9c2",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/abc80e0db8ad31c03b373977fc997e980800f9c2"
-                },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0"
                 },
                 "require-dev": {
                     "mlehner/gelf-php": "1.0.*"
                 },
-                "source": {
-                    "reference": "abc80e0db8ad31c03b373977fc997e980800f9c2",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
-                },
                 "suggest": {
                     "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server"
                 },
-                "time": "2012-04-23T16:27:40+00:00",
-                "type": "library",
-                "uid": 11074,
-                "version": "1.1.0",
-                "version_normalized": "1.1.0.0"
+                "uid": 11074
             },
             "1.10.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.10.0",
+                "version_normalized": "1.10.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "25b16e801979098cb2f120e697bfce454b18bf23"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/25b16e801979098cb2f120e697bfce454b18bf23",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "25b16e801979098cb2f120e697bfce454b18bf23"
+                },
+                "type": "library",
+                "time": "2014-06-04T16:30:04+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "25b16e801979098cb2f120e697bfce454b18bf23",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/25b16e801979098cb2f120e697bfce454b18bf23"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.10.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "~2.4, >2.4.8",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
                     "phpunit/phpunit": "~3.7.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "~0.5",
-                    "ruflin/elastica": "0.90.*"
-                },
-                "source": {
-                    "reference": "25b16e801979098cb2f120e697bfce454b18bf23",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "ruflin/elastica": "0.90.*",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "~2.4, >2.4.8"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
                     "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "raven/raven": "Allow sending log messages to a Sentry server",
-                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar"
                 },
-                "time": "2014-06-04T16:30:04+00:00",
-                "type": "library",
-                "uid": 183340,
-                "version": "1.10.0",
-                "version_normalized": "1.10.0.0"
+                "uid": 183340
             },
             "1.11.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.11.0",
+                "version_normalized": "1.11.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "ec3961874c43840e96da3a8a1ed20d8c73d7e5aa"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/ec3961874c43840e96da3a8a1ed20d8c73d7e5aa",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "ec3961874c43840e96da3a8a1ed20d8c73d7e5aa"
+                },
+                "type": "library",
+                "time": "2014-09-30T13:30:58+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "ec3961874c43840e96da3a8a1ed20d8c73d7e5aa",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/ec3961874c43840e96da3a8a1ed20d8c73d7e5aa"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.11.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "~2.4, >2.4.8",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
                     "phpunit/phpunit": "~3.7.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "~0.5",
                     "ruflin/elastica": "0.90.*",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "~2.4, >2.4.8",
                     "videlalvaro/php-amqplib": "~2.4"
                 },
-                "source": {
-                    "reference": "ec3961874c43840e96da3a8a1ed20d8c73d7e5aa",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
-                },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
                     "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "raven/raven": "Allow sending log messages to a Sentry server",
-                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
                     "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar"
                 },
-                "time": "2014-09-30T13:30:58+00:00",
-                "type": "library",
-                "uid": 243161,
-                "version": "1.11.0",
-                "version_normalized": "1.11.0.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 243161
             },
             "1.12.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.12.0",
+                "version_normalized": "1.12.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f"
+                },
+                "type": "library",
+                "time": "2014-12-29T21:29:35+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1fbe8c2641f2b163addf49cc5e18f144bec6b19f"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.12.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "~2.4, >2.4.8",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
                     "phpunit/phpunit": "~4.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "~0.5",
                     "ruflin/elastica": "0.90.*",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "~2.4, >2.4.8",
                     "videlalvaro/php-amqplib": "~2.4"
                 },
-                "source": {
-                    "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
-                },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
                     "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "raven/raven": "Allow sending log messages to a Sentry server",
-                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
                     "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar"
                 },
-                "time": "2014-12-29T21:29:35+00:00",
-                "type": "library",
-                "uid": 296518,
-                "version": "1.12.0",
-                "version_normalized": "1.12.0.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 296518
             },
             "1.13.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.13.0",
+                "version_normalized": "1.13.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "c41c218e239b50446fd883acb1ecfd4b770caeae"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c41c218e239b50446fd883acb1ecfd4b770caeae",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "c41c218e239b50446fd883acb1ecfd4b770caeae"
+                },
+                "type": "library",
+                "time": "2015-03-05T01:12:12+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "c41c218e239b50446fd883acb1ecfd4b770caeae",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c41c218e239b50446fd883acb1ecfd4b770caeae"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.13.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "~2.4, >2.4.8",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
                     "phpunit/phpunit": "~4.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "~0.5",
                     "ruflin/elastica": "0.90.*",
-                    "swiftmailer/swiftmailer": "~5.3",
-                    "videlalvaro/php-amqplib": "~2.4"
-                },
-                "source": {
-                    "reference": "c41c218e239b50446fd883acb1ecfd4b770caeae",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "~2.4, >2.4.8",
+                    "videlalvaro/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "~5.3"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
                     "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "raven/raven": "Allow sending log messages to a Sentry server",
-                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
                     "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar"
                 },
-                "time": "2015-03-05T01:12:12+00:00",
-                "type": "library",
-                "uid": 348286,
-                "version": "1.13.0",
-                "version_normalized": "1.13.0.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 348286
             },
             "1.13.1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.13.1",
+                "version_normalized": "1.13.1.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c31a2c4e8db5da8b46c74cf275d7f109c0f249ac",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac"
+                },
+                "type": "library",
+                "time": "2015-03-09T09:58:04+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c31a2c4e8db5da8b46c74cf275d7f109c0f249ac"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.13.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "~2.4, >2.4.8",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
                     "phpunit/phpunit": "~4.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "~0.5",
                     "ruflin/elastica": "0.90.*",
-                    "swiftmailer/swiftmailer": "~5.3",
-                    "videlalvaro/php-amqplib": "~2.4"
-                },
-                "source": {
-                    "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "~2.4, >2.4.8",
+                    "videlalvaro/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "~5.3"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
                     "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "raven/raven": "Allow sending log messages to a Sentry server",
-                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
                     "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar"
                 },
-                "time": "2015-03-09T09:58:04+00:00",
-                "type": "library",
-                "uid": 354135,
-                "version": "1.13.1",
-                "version_normalized": "1.13.1.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 354135
             },
             "1.14.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.14.0",
+                "version_normalized": "1.14.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "b287fbbe1ca27847064beff2bad7fb6920bf08cc"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b287fbbe1ca27847064beff2bad7fb6920bf08cc",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "b287fbbe1ca27847064beff2bad7fb6920bf08cc"
+                },
+                "type": "library",
+                "time": "2015-06-19T13:29:54+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "b287fbbe1ca27847064beff2bad7fb6920bf08cc",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b287fbbe1ca27847064beff2bad7fb6920bf08cc"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.14.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "~0.8",
                     "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "videlalvaro/php-amqplib": "~2.4",
                     "swiftmailer/swiftmailer": "~5.3",
-                    "videlalvaro/php-amqplib": "~2.4"
-                },
-                "source": {
-                    "reference": "b287fbbe1ca27847064beff2bad7fb6920bf08cc",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
-                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2015-06-19T13:29:54+00:00",
-                "type": "library",
-                "uid": 438539,
-                "version": "1.14.0",
-                "version_normalized": "1.14.0.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 438539
             },
             "1.15.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.15.0",
+                "version_normalized": "1.15.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "dc5150cc608f2334c72c3b6a553ec9668a4156b0"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/dc5150cc608f2334c72c3b6a553ec9668a4156b0",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "dc5150cc608f2334c72c3b6a553ec9668a4156b0"
+                },
+                "type": "library",
+                "time": "2015-07-12T13:54:09+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "dc5150cc608f2334c72c3b6a553ec9668a4156b0",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/dc5150cc608f2334c72c3b6a553ec9668a4156b0"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.15.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "~0.8",
                     "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "videlalvaro/php-amqplib": "~2.4",
                     "swiftmailer/swiftmailer": "~5.3",
-                    "videlalvaro/php-amqplib": "~2.4"
-                },
-                "source": {
-                    "reference": "dc5150cc608f2334c72c3b6a553ec9668a4156b0",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
-                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2015-07-12T13:54:09+00:00",
-                "type": "library",
-                "uid": 459596,
-                "version": "1.15.0",
-                "version_normalized": "1.15.0.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 459596
             },
             "1.16.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.16.0",
+                "version_normalized": "1.16.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "c0c0b4bee3aabce7182876b0d912ef2595563db7"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c0c0b4bee3aabce7182876b0d912ef2595563db7",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "c0c0b4bee3aabce7182876b0d912ef2595563db7"
+                },
+                "type": "library",
+                "time": "2015-08-09T17:44:44+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "c0c0b4bee3aabce7182876b0d912ef2595563db7",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c0c0b4bee3aabce7182876b0d912ef2595563db7"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.16.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "~0.8",
                     "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "videlalvaro/php-amqplib": "~2.4",
                     "swiftmailer/swiftmailer": "~5.3",
-                    "videlalvaro/php-amqplib": "~2.4"
-                },
-                "source": {
-                    "reference": "c0c0b4bee3aabce7182876b0d912ef2595563db7",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
-                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2015-08-09T17:44:44+00:00",
-                "type": "library",
-                "uid": 486369,
-                "version": "1.16.0",
-                "version_normalized": "1.16.0.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 486369
             },
             "1.17.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.17.0",
+                "version_normalized": "1.17.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "877ae631713cc961952df713ae785735b90df682"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/877ae631713cc961952df713ae785735b90df682",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "877ae631713cc961952df713ae785735b90df682"
+                },
+                "type": "library",
+                "time": "2015-08-30T11:40:25+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "877ae631713cc961952df713ae785735b90df682",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/877ae631713cc961952df713ae785735b90df682"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.16.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "~0.11",
                     "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "videlalvaro/php-amqplib": "~2.4",
                     "swiftmailer/swiftmailer": "~5.3",
-                    "videlalvaro/php-amqplib": "~2.4"
-                },
-                "source": {
-                    "reference": "877ae631713cc961952df713ae785735b90df682",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
-                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2015-08-30T11:40:25+00:00",
-                "type": "library",
-                "uid": 506342,
-                "version": "1.17.0",
-                "version_normalized": "1.17.0.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 506342
             },
             "1.17.1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.17.1",
+                "version_normalized": "1.17.1.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "0524c87587ab85bc4c2d6f5b41253ccb930a5422"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/0524c87587ab85bc4c2d6f5b41253ccb930a5422",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "0524c87587ab85bc4c2d6f5b41253ccb930a5422"
+                },
+                "type": "library",
+                "time": "2015-08-31T09:17:37+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "0524c87587ab85bc4c2d6f5b41253ccb930a5422",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/0524c87587ab85bc4c2d6f5b41253ccb930a5422"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.16.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "~0.11",
                     "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "videlalvaro/php-amqplib": "~2.4",
                     "swiftmailer/swiftmailer": "~5.3",
-                    "videlalvaro/php-amqplib": "~2.4"
-                },
-                "source": {
-                    "reference": "0524c87587ab85bc4c2d6f5b41253ccb930a5422",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
-                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2015-08-31T09:17:37+00:00",
-                "type": "library",
-                "uid": 507060,
-                "version": "1.17.1",
-                "version_normalized": "1.17.1.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 507060
             },
             "1.17.2": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.17.2",
+                "version_normalized": "1.17.2.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "bee7f0dc9c3e0b69a6039697533dca1e845c8c24"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bee7f0dc9c3e0b69a6039697533dca1e845c8c24",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "bee7f0dc9c3e0b69a6039697533dca1e845c8c24"
+                },
+                "type": "library",
+                "time": "2015-10-14T12:51:02+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "bee7f0dc9c3e0b69a6039697533dca1e845c8c24",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bee7f0dc9c3e0b69a6039697533dca1e845c8c24"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.16.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "jakub-onderka/php-parallel-lint": "0.9",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "^0.13",
                     "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "videlalvaro/php-amqplib": "~2.4",
                     "swiftmailer/swiftmailer": "~5.3",
-                    "videlalvaro/php-amqplib": "~2.4"
-                },
-                "source": {
-                    "reference": "bee7f0dc9c3e0b69a6039697533dca1e845c8c24",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
-                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2015-10-14T12:51:02+00:00",
-                "type": "library",
-                "uid": 550950,
-                "version": "1.17.2",
-                "version_normalized": "1.17.2.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 550950
             },
             "1.18.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.18.0",
+                "version_normalized": "1.18.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "e19b764b5c855580e8ffa7e615f72c10fd2f99cc"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e19b764b5c855580e8ffa7e615f72c10fd2f99cc",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "e19b764b5c855580e8ffa7e615f72c10fd2f99cc"
+                },
+                "type": "library",
+                "time": "2016-03-01T18:00:40+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "e19b764b5c855580e8ffa7e615f72c10fd2f99cc",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e19b764b5c855580e8ffa7e615f72c10fd2f99cc"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "2.0.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "jakub-onderka/php-parallel-lint": "0.9",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "^0.13",
                     "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "videlalvaro/php-amqplib": "~2.4",
                     "swiftmailer/swiftmailer": "~5.3",
-                    "videlalvaro/php-amqplib": "~2.4"
-                },
-                "source": {
-                    "reference": "e19b764b5c855580e8ffa7e615f72c10fd2f99cc",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
-                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2016-03-01T18:00:40+00:00",
-                "type": "library",
-                "uid": 719359,
-                "version": "1.18.0",
-                "version_normalized": "1.18.0.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 719359
             },
             "1.18.1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.18.1",
+                "version_normalized": "1.18.1.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "a5f2734e8c16f3aa21b3da09715d10e15b4d2d45"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/a5f2734e8c16f3aa21b3da09715d10e15b4d2d45",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "a5f2734e8c16f3aa21b3da09715d10e15b4d2d45"
+                },
+                "type": "library",
+                "time": "2016-03-13T16:08:35+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "a5f2734e8c16f3aa21b3da09715d10e15b4d2d45",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/a5f2734e8c16f3aa21b3da09715d10e15b4d2d45"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "2.0.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "jakub-onderka/php-parallel-lint": "0.9",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "^0.13",
                     "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "videlalvaro/php-amqplib": "~2.4",
                     "swiftmailer/swiftmailer": "~5.3",
-                    "videlalvaro/php-amqplib": "~2.4"
-                },
-                "source": {
-                    "reference": "a5f2734e8c16f3aa21b3da09715d10e15b4d2d45",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
-                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2016-03-13T16:08:35+00:00",
-                "type": "library",
-                "uid": 735276,
-                "version": "1.18.1",
-                "version_normalized": "1.18.1.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 735276
             },
             "1.18.2": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.18.2",
+                "version_normalized": "1.18.2.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "064b38c16790249488e7a8b987acf1c9d7383c09"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/064b38c16790249488e7a8b987acf1c9d7383c09",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "064b38c16790249488e7a8b987acf1c9d7383c09"
+                },
+                "type": "library",
+                "time": "2016-04-02T13:12:58+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "064b38c16790249488e7a8b987acf1c9d7383c09",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/064b38c16790249488e7a8b987acf1c9d7383c09"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "2.0.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "jakub-onderka/php-parallel-lint": "0.9",
-                    "php-amqplib/php-amqplib": "~2.4",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "^0.13",
                     "ruflin/elastica": ">=0.90 <3.0",
-                    "swiftmailer/swiftmailer": "~5.3"
-                },
-                "source": {
-                    "reference": "064b38c16790249488e7a8b987acf1c9d7383c09",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
-                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2016-04-02T13:12:58+00:00",
-                "type": "library",
-                "uid": 761695,
-                "version": "1.18.2",
-                "version_normalized": "1.18.2.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 761695
             },
             "1.19.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.19.0",
+                "version_normalized": "1.19.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5f56ed5212dc509c8dc8caeba2715732abb32dbf",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf"
+                },
+                "type": "library",
+                "time": "2016-04-12T18:29:35+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5f56ed5212dc509c8dc8caeba2715732abb32dbf"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "2.0.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "jakub-onderka/php-parallel-lint": "0.9",
-                    "php-amqplib/php-amqplib": "~2.4",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "^0.13",
                     "ruflin/elastica": ">=0.90 <3.0",
-                    "swiftmailer/swiftmailer": "~5.3"
-                },
-                "source": {
-                    "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
-                    "raven/raven": "Allow sending log messages to a Sentry server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2016-04-12T18:29:35+00:00",
-                "type": "library",
-                "uid": 775623,
-                "version": "1.19.0",
-                "version_normalized": "1.19.0.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 775623
             },
             "1.2.0": {
+                "name": "monolog/monolog",
+                "description": "Logging for PHP 5.3",
+                "keywords": [
+                    "log",
+                    "logging"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.2.0",
+                "version_normalized": "1.2.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "7940ae31ce4687d875d2bb5aa277bb3802203fe1"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/7940ae31ce4687d875d2bb5aa277bb3802203fe1",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "7940ae31ce4687d875d2bb5aa277bb3802203fe1"
+                },
+                "type": "library",
+                "time": "2012-08-18T17:27:13+00:00",
                 "autoload": {
                     "psr-0": {
                         "Monolog": "src/"
                     }
                 },
-                "description": "Logging for PHP 5.3",
-                "dist": {
-                    "reference": "7940ae31ce4687d875d2bb5aa277bb3802203fe1",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/7940ae31ce4687d875d2bb5aa277bb3802203fe1"
-                },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0"
                 },
                 "require-dev": {
                     "mlehner/gelf-php": "1.0.*"
                 },
-                "source": {
-                    "reference": "7940ae31ce4687d875d2bb5aa277bb3802203fe1",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
-                },
                 "suggest": {
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server"
+                    "ext-mongo": "Allow sending log messages to a MongoDB server"
                 },
-                "time": "2012-08-18T17:27:13+00:00",
-                "type": "library",
-                "uid": 17167,
-                "version": "1.2.0",
-                "version_normalized": "1.2.0.0"
+                "uid": 17167
             },
             "1.2.1": {
+                "name": "monolog/monolog",
+                "description": "Logging for PHP 5.3",
+                "keywords": [
+                    "log",
+                    "logging"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.2.1",
+                "version_normalized": "1.2.1.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "d16496318c3e08e3bccfc3866e104e49cf25488a"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/d16496318c3e08e3bccfc3866e104e49cf25488a",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "d16496318c3e08e3bccfc3866e104e49cf25488a"
+                },
+                "type": "library",
+                "time": "2012-08-29T11:53:20+00:00",
                 "autoload": {
                     "psr-0": {
                         "Monolog": "src/"
                     }
-                },
-                "description": "Logging for PHP 5.3",
-                "dist": {
-                    "reference": "d16496318c3e08e3bccfc3866e104e49cf25488a",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/d16496318c3e08e3bccfc3866e104e49cf25488a"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.3.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0"
                 },
                 "require-dev": {
                     "mlehner/gelf-php": "1.0.*"
                 },
-                "source": {
-                    "reference": "d16496318c3e08e3bccfc3866e104e49cf25488a",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
-                },
                 "suggest": {
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server"
+                    "ext-mongo": "Allow sending log messages to a MongoDB server"
                 },
-                "time": "2012-08-29T11:53:20+00:00",
-                "type": "library",
-                "uid": 17888,
-                "version": "1.2.1",
-                "version_normalized": "1.2.1.0"
+                "uid": 17888
             },
             "1.20.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.20.0",
+                "version_normalized": "1.20.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "55841909e2bcde01b5318c35f2b74f8ecc86e037"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/55841909e2bcde01b5318c35f2b74f8ecc86e037",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "55841909e2bcde01b5318c35f2b74f8ecc86e037"
+                },
+                "type": "library",
+                "time": "2016-07-02T14:02:10+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "55841909e2bcde01b5318c35f2b74f8ecc86e037",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/55841909e2bcde01b5318c35f2b74f8ecc86e037"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "2.0.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "jakub-onderka/php-parallel-lint": "0.9",
-                    "php-amqplib/php-amqplib": "~2.4",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
-                    "ruflin/elastica": ">=0.90 <3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "sentry/sentry": "^0.13",
-                    "swiftmailer/swiftmailer": "~5.3"
-                },
-                "source": {
-                    "reference": "55841909e2bcde01b5318c35f2b74f8ecc86e037",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "sentry/sentry": "Allow sending log messages to a Sentry server"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2016-07-02T14:02:10+00:00",
-                "type": "library",
-                "uid": 886205,
-                "version": "1.20.0",
-                "version_normalized": "1.20.0.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 886205
             },
             "1.21.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.21.0",
+                "version_normalized": "1.21.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f42fbdfd53e306bda545845e4dbfd3e72edb4952",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952"
+                },
+                "type": "library",
+                "time": "2016-07-29T03:23:52+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f42fbdfd53e306bda545845e4dbfd3e72edb4952"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "2.0.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "jakub-onderka/php-parallel-lint": "0.9",
-                    "php-amqplib/php-amqplib": "~2.4",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
-                    "ruflin/elastica": ">=0.90 <3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "sentry/sentry": "^0.13",
-                    "swiftmailer/swiftmailer": "~5.3"
-                },
-                "source": {
-                    "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "sentry/sentry": "Allow sending log messages to a Sentry server"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2016-07-29T03:23:52+00:00",
-                "type": "library",
-                "uid": 928751,
-                "version": "1.21.0",
-                "version_normalized": "1.21.0.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 928751
             },
             "1.22.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.22.0",
+                "version_normalized": "1.22.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "bad29cb8d18ab0315e6c477751418a82c850d558"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bad29cb8d18ab0315e6c477751418a82c850d558",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "bad29cb8d18ab0315e6c477751418a82c850d558"
+                },
+                "type": "library",
+                "time": "2016-11-26T00:15:39+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "bad29cb8d18ab0315e6c477751418a82c850d558",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bad29cb8d18ab0315e6c477751418a82c850d558"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "2.0.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "jakub-onderka/php-parallel-lint": "0.9",
-                    "php-amqplib/php-amqplib": "~2.4",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
-                    "ruflin/elastica": ">=0.90 <3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "sentry/sentry": "^0.13",
-                    "swiftmailer/swiftmailer": "~5.3"
-                },
-                "source": {
-                    "reference": "bad29cb8d18ab0315e6c477751418a82c850d558",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "sentry/sentry": "Allow sending log messages to a Sentry server"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2016-11-26T00:15:39+00:00",
-                "type": "library",
-                "uid": 1099516,
-                "version": "1.22.0",
-                "version_normalized": "1.22.0.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 1099516
             },
             "1.22.1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.22.1",
+                "version_normalized": "1.22.1.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1e044bc4b34e91743943479f1be7a1d5eb93add0",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0"
+                },
+                "type": "library",
+                "time": "2017-03-13T07:08:03+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1e044bc4b34e91743943479f1be7a1d5eb93add0"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "2.0.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
-                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "jakub-onderka/php-parallel-lint": "0.9",
-                    "php-amqplib/php-amqplib": "~2.4",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
-                    "ruflin/elastica": ">=0.90 <3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "sentry/sentry": "^0.13",
-                    "swiftmailer/swiftmailer": "~5.3"
-                },
-                "source": {
-                    "reference": "1e044bc4b34e91743943479f1be7a1d5eb93add0",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "~5.3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "sentry/sentry": "Allow sending log messages to a Sentry server"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2017-03-13T07:08:03+00:00",
-                "type": "library",
-                "uid": 1278871,
-                "version": "1.22.1",
-                "version_normalized": "1.22.1.0"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 1278871
             },
             "1.23.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.23.0",
+                "version_normalized": "1.23.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
+                        "homepage": "http://seld.be"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4"
+                },
+                "type": "library",
+                "time": "2017-06-19T01:22:40+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd8c787753b3a2ad11bc60c063cff1358a32a3b4"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "2.0.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.5",
+                    "graylog2/gelf-php": "~1.0",
+                    "sentry/sentry": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
+                },
                 "provide": {
                     "psr/log-implementation": "1.0.0"
                 },
+                "uid": 1451918
+            },
+            "1.24.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.24.0",
+                "version_normalized": "1.24.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "bfc9ebb28f97e7a24c45bdc3f0ff482e47bb0266"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bfc9ebb28f97e7a24c45bdc3f0ff482e47bb0266",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "bfc9ebb28f97e7a24c45bdc3f0ff482e47bb0266"
+                },
+                "type": "library",
+                "time": "2018-11-05T09:00:11+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "jakub-onderka/php-parallel-lint": "0.9",
-                    "php-amqplib/php-amqplib": "~2.4",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
-                    "ruflin/elastica": ">=0.90 <3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "sentry/sentry": "^0.13",
-                    "swiftmailer/swiftmailer": "^5.3|^6.0"
-                },
-                "source": {
-                    "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "sentry/sentry": "Allow sending log messages to a Sentry server"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
                 },
-                "time": "2017-06-19T01:22:40+00:00",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 2559895
+            },
+            "1.25.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.25.0",
+                "version_normalized": "1.25.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "c5dcc05defbaf8780c728c1ea31b1a0704d44f56"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c5dcc05defbaf8780c728c1ea31b1a0704d44f56",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "c5dcc05defbaf8780c728c1ea31b1a0704d44f56"
+                },
                 "type": "library",
-                "uid": 1451918,
-                "version": "1.23.0",
-                "version_normalized": "1.23.0.0"
+                "time": "2019-09-06T12:21:24+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.5",
+                    "graylog2/gelf-php": "~1.0",
+                    "sentry/sentry": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 3216012
+            },
+            "1.25.1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.25.1",
+                "version_normalized": "1.25.1.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "70e65a5470a42cfec1a7da00d30edb6e617e8dcf"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/70e65a5470a42cfec1a7da00d30edb6e617e8dcf",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "70e65a5470a42cfec1a7da00d30edb6e617e8dcf"
+                },
+                "type": "library",
+                "time": "2019-09-06T13:49:17+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.5",
+                    "graylog2/gelf-php": "~1.0",
+                    "sentry/sentry": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 3216902
+            },
+            "1.25.2": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.25.2",
+                "version_normalized": "1.25.2.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "d5e2fb341cb44f7e2ab639d12a1e5901091ec287"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/d5e2fb341cb44f7e2ab639d12a1e5901091ec287",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "d5e2fb341cb44f7e2ab639d12a1e5901091ec287"
+                },
+                "type": "library",
+                "time": "2019-11-13T10:00:05+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.5",
+                    "graylog2/gelf-php": "~1.0",
+                    "sentry/sentry": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 3374115
+            },
+            "1.25.3": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.25.3",
+                "version_normalized": "1.25.3.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "fa82921994db851a8becaf3787a9e73c5976b6f1"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fa82921994db851a8becaf3787a9e73c5976b6f1",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "fa82921994db851a8becaf3787a9e73c5976b6f1"
+                },
+                "type": "library",
+                "time": "2019-12-20T14:15:16+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.5",
+                    "graylog2/gelf-php": "~1.0",
+                    "sentry/sentry": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "jakub-onderka/php-parallel-lint": "0.9"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 3474855
+            },
+            "1.25.4": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.25.4",
+                "version_normalized": "1.25.4.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "3022efff205e2448b560c833c6fbbf91c3139168"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/3022efff205e2448b560c833c6fbbf91c3139168",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "3022efff205e2448b560c833c6fbbf91c3139168"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2020-05-22T07:31:27+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.5",
+                    "graylog2/gelf-php": "~1.0",
+                    "sentry/sentry": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "php-console/php-console": "^3.1.3",
+                    "php-parallel-lint/php-parallel-lint": "^1.0"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 3884781
+            },
+            "1.25.5": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.25.5",
+                "version_normalized": "1.25.5.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "1817faadd1846cd08be9a49e905dc68823bc38c0"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1817faadd1846cd08be9a49e905dc68823bc38c0",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "1817faadd1846cd08be9a49e905dc68823bc38c0"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2020-07-23T08:35:51+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.0.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.5",
+                    "graylog2/gelf-php": "~1.0",
+                    "sentry/sentry": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "php-console/php-console": "^3.1.3",
+                    "php-parallel-lint/php-parallel-lint": "^1.0"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 4293857
+            },
+            "1.26.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.26.0",
+                "version_normalized": "1.26.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "2209ddd84e7ef1256b7af205d0717fb62cfc9c33"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/2209ddd84e7ef1256b7af205d0717fb62cfc9c33",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "2209ddd84e7ef1256b7af205d0717fb62cfc9c33"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2020-12-14T12:56:38+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.5",
+                    "graylog2/gelf-php": "~1.0",
+                    "sentry/sentry": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpstan/phpstan": "^0.12.59"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 4746004
+            },
+            "1.26.1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.26.1",
+                "version_normalized": "1.26.1.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "c6b00f05152ae2c9b04a448f99c7590beb6042f5"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c6b00f05152ae2c9b04a448f99c7590beb6042f5",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "c6b00f05152ae2c9b04a448f99c7590beb6042f5"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2021-05-28T08:32:12+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.5",
+                    "graylog2/gelf-php": "~1.0",
+                    "sentry/sentry": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpstan/phpstan": "^0.12.59"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 5241893
+            },
+            "1.27.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.27.0",
+                "version_normalized": "1.27.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "52ebd235c1f7e0d5e1b16464b695a28335f8e44a"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/52ebd235c1f7e0d5e1b16464b695a28335f8e44a",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "52ebd235c1f7e0d5e1b16464b695a28335f8e44a"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-03-13T20:29:46+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.5",
+                    "graylog2/gelf-php": "~1.0",
+                    "sentry/sentry": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpstan/phpstan": "^0.12.59"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 6058157
+            },
+            "1.27.1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.27.1",
+                "version_normalized": "1.27.1.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "904713c5929655dc9b97288b69cfeedad610c9a1"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/904713c5929655dc9b97288b69cfeedad610c9a1",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "904713c5929655dc9b97288b69cfeedad610c9a1"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-06-09T08:53:42+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "require": {
+                    "php": ">=5.3.0",
+                    "psr/log": "~1.0"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "~4.5",
+                    "graylog2/gelf-php": "~1.0",
+                    "sentry/sentry": "^0.13",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "php-console/php-console": "^3.1.3",
+                    "phpstan/phpstan": "^0.12.59"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 6322715
             },
             "1.3.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.3.0",
+                "version_normalized": "1.3.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "25a97abf904120a386c546be11c3b58f1f9e6f37"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/25a97abf904120a386c546be11c3b58f1f9e6f37",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "25a97abf904120a386c546be11c3b58f1f9e6f37"
+                },
+                "type": "library",
+                "time": "2013-01-07T20:26:46+00:00",
                 "autoload": {
                     "psr-0": {
                         "Monolog": "src/"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "25a97abf904120a386c546be11c3b58f1f9e6f37",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/25a97abf904120a386c546be11c3b58f1f9e6f37"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.3.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "doctrine/couchdb": "dev-master",
                     "mlehner/gelf-php": "1.0.*",
-                    "raven/raven": "0.3.*"
-                },
-                "source": {
-                    "reference": "25a97abf904120a386c546be11c3b58f1f9e6f37",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "raven/raven": "0.3.*",
+                    "doctrine/couchdb": "dev-master"
                 },
                 "suggest": {
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                    "raven/raven": "Allow sending log messages to a Sentry server"
+                    "ext-mongo": "Allow sending log messages to a MongoDB server"
                 },
-                "time": "2013-01-07T20:26:46+00:00",
-                "type": "library",
-                "uid": 31072,
-                "version": "1.3.0",
-                "version_normalized": "1.3.0.0"
+                "uid": 31072
             },
             "1.3.1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.3.1",
+                "version_normalized": "1.3.1.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "47eb599b4aad36b66e818ed72ebf939e2fb311be"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/47eb599b4aad36b66e818ed72ebf939e2fb311be",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "47eb599b4aad36b66e818ed72ebf939e2fb311be"
+                },
+                "type": "library",
+                "time": "2013-01-11T10:23:20+00:00",
                 "autoload": {
                     "psr-0": {
                         "Monolog": "src/"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "47eb599b4aad36b66e818ed72ebf939e2fb311be",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/47eb599b4aad36b66e818ed72ebf939e2fb311be"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.3.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "doctrine/couchdb": "dev-master",
                     "mlehner/gelf-php": "1.0.*",
-                    "raven/raven": "0.3.*"
-                },
-                "source": {
-                    "reference": "47eb599b4aad36b66e818ed72ebf939e2fb311be",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "raven/raven": "0.3.*",
+                    "doctrine/couchdb": "dev-master"
                 },
                 "suggest": {
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                    "raven/raven": "Allow sending log messages to a Sentry server"
+                    "ext-mongo": "Allow sending log messages to a MongoDB server"
                 },
-                "time": "2013-01-11T10:23:20+00:00",
-                "type": "library",
-                "uid": 31615,
-                "version": "1.3.1",
-                "version_normalized": "1.3.1.0"
+                "uid": 31615
             },
             "1.4.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.4.0",
+                "version_normalized": "1.4.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "32fe28af60b4da9a5b0cef024138afacc0c01eeb"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/32fe28af60b4da9a5b0cef024138afacc0c01eeb",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "32fe28af60b4da9a5b0cef024138afacc0c01eeb"
+                },
+                "type": "library",
+                "time": "2013-02-13T18:06:51+00:00",
                 "autoload": {
                     "psr-0": {
                         "Monolog": "src/"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "32fe28af60b4da9a5b0cef024138afacc0c01eeb",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/32fe28af60b4da9a5b0cef024138afacc0c01eeb"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.4.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "doctrine/couchdb": "dev-master",
                     "mlehner/gelf-php": "1.0.*",
-                    "raven/raven": "0.3.*"
-                },
-                "source": {
-                    "reference": "32fe28af60b4da9a5b0cef024138afacc0c01eeb",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "raven/raven": "0.3.*",
+                    "doctrine/couchdb": "dev-master"
                 },
                 "suggest": {
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                    "raven/raven": "Allow sending log messages to a Sentry server"
+                    "ext-mongo": "Allow sending log messages to a MongoDB server"
                 },
-                "time": "2013-02-13T18:06:51+00:00",
-                "type": "library",
-                "uid": 37441,
-                "version": "1.4.0",
-                "version_normalized": "1.4.0.0"
+                "uid": 37441
             },
             "1.4.1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.4.1",
+                "version_normalized": "1.4.1.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "3295de82be06b3bbcd336983ddf8c50724430180"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/3295de82be06b3bbcd336983ddf8c50724430180",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "3295de82be06b3bbcd336983ddf8c50724430180"
+                },
+                "type": "library",
+                "time": "2013-04-01T10:04:58+00:00",
                 "autoload": {
                     "psr-0": {
                         "Monolog": "src/"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "3295de82be06b3bbcd336983ddf8c50724430180",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/3295de82be06b3bbcd336983ddf8c50724430180"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.4.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "doctrine/couchdb": "dev-master",
                     "mlehner/gelf-php": "1.0.*",
-                    "raven/raven": "0.3.*"
-                },
-                "source": {
-                    "reference": "3295de82be06b3bbcd336983ddf8c50724430180",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "raven/raven": "0.3.*",
+                    "doctrine/couchdb": "dev-master"
                 },
                 "suggest": {
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                    "raven/raven": "Allow sending log messages to a Sentry server"
+                    "ext-mongo": "Allow sending log messages to a MongoDB server"
                 },
-                "time": "2013-04-01T10:04:58+00:00",
-                "type": "library",
-                "uid": 46264,
-                "version": "1.4.1",
-                "version_normalized": "1.4.1.0"
+                "uid": 46264
             },
             "1.5.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.5.0",
+                "version_normalized": "1.5.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "583618d5cd2115a52101694aca87afb182b3e567"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/583618d5cd2115a52101694aca87afb182b3e567",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "583618d5cd2115a52101694aca87afb182b3e567"
+                },
+                "type": "library",
+                "time": "2013-04-23T10:09:48+00:00",
                 "autoload": {
                     "psr-0": {
                         "Monolog": "src/"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "583618d5cd2115a52101694aca87afb182b3e567",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/583618d5cd2115a52101694aca87afb182b3e567"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.4.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "doctrine/couchdb": "dev-master",
                     "mlehner/gelf-php": "1.0.*",
-                    "raven/raven": "0.3.*"
-                },
-                "source": {
-                    "reference": "583618d5cd2115a52101694aca87afb182b3e567",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "raven/raven": "0.3.*",
+                    "doctrine/couchdb": "dev-master"
                 },
                 "suggest": {
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                    "raven/raven": "Allow sending log messages to a Sentry server"
+                    "ext-mongo": "Allow sending log messages to a MongoDB server"
                 },
-                "time": "2013-04-23T10:09:48+00:00",
-                "type": "library",
-                "uid": 50373,
-                "version": "1.5.0",
-                "version_normalized": "1.5.0.0"
+                "uid": 50373
             },
             "1.6.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.6.0",
+                "version_normalized": "1.6.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "f72392d0e6eb855118f5a84e89ac2d257c704abd"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f72392d0e6eb855118f5a84e89ac2d257c704abd",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "f72392d0e6eb855118f5a84e89ac2d257c704abd"
+                },
+                "type": "library",
+                "time": "2013-07-28T22:38:30+00:00",
                 "autoload": {
                     "psr-0": {
                         "Monolog": "src/"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "f72392d0e6eb855118f5a84e89ac2d257c704abd",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f72392d0e6eb855118f5a84e89ac2d257c704abd"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.6.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "doctrine/couchdb": "dev-master",
                     "mlehner/gelf-php": "1.0.*",
-                    "raven/raven": "0.5.*"
-                },
-                "source": {
-                    "reference": "f72392d0e6eb855118f5a84e89ac2d257c704abd",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "raven/raven": "0.5.*",
+                    "doctrine/couchdb": "dev-master"
                 },
                 "suggest": {
+                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "raven/raven": "Allow sending log messages to a Sentry server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                    "raven/raven": "Allow sending log messages to a Sentry server"
+                    "ext-mongo": "Allow sending log messages to a MongoDB server"
                 },
-                "time": "2013-07-28T22:38:30+00:00",
-                "type": "library",
-                "uid": 72464,
-                "version": "1.6.0",
-                "version_normalized": "1.6.0.0"
+                "uid": 72464
             },
             "1.7.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.7.0",
+                "version_normalized": "1.7.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "6225b22de9dcf36546be3a0b2fa8e3d986153f57"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/6225b22de9dcf36546be3a0b2fa8e3d986153f57",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "6225b22de9dcf36546be3a0b2fa8e3d986153f57"
+                },
+                "type": "library",
+                "time": "2013-11-14T19:48:31+00:00",
                 "autoload": {
                     "psr-0": {
                         "Monolog": "src/"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "6225b22de9dcf36546be3a0b2fa8e3d986153f57",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/6225b22de9dcf36546be3a0b2fa8e3d986153f57"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.7.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "~2.4.8",
-                    "doctrine/couchdb": "dev-master",
-                    "mlehner/gelf-php": "1.0.*",
                     "phpunit/phpunit": "~3.7.0",
+                    "mlehner/gelf-php": "1.0.*",
                     "raven/raven": "0.5.*",
-                    "ruflin/elastica": "0.90.*"
-                },
-                "source": {
-                    "reference": "6225b22de9dcf36546be3a0b2fa8e3d986153f57",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "ruflin/elastica": "0.90.*",
+                    "doctrine/couchdb": "dev-master",
+                    "aws/aws-sdk-php": "~2.4.8"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
                     "mlehner/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "raven/raven": "Allow sending log messages to a Sentry server",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB"
                 },
-                "time": "2013-11-14T19:48:31+00:00",
-                "type": "library",
-                "uid": 101157,
-                "version": "1.7.0",
-                "version_normalized": "1.7.0.0"
+                "uid": 101157
             },
             "1.8.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.8.0",
+                "version_normalized": "1.8.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "392ef35fd470638e08d0160d6b1cbab63cb23174"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/392ef35fd470638e08d0160d6b1cbab63cb23174",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "392ef35fd470638e08d0160d6b1cbab63cb23174"
+                },
+                "type": "library",
+                "time": "2014-03-23T19:50:26+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "392ef35fd470638e08d0160d6b1cbab63cb23174",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/392ef35fd470638e08d0160d6b1cbab63cb23174"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.8.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "~2.4, >2.4.8",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
                     "phpunit/phpunit": "~3.7.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "~0.5",
-                    "ruflin/elastica": "0.90.*"
-                },
-                "source": {
-                    "reference": "392ef35fd470638e08d0160d6b1cbab63cb23174",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "ruflin/elastica": "0.90.*",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "~2.4, >2.4.8"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
                     "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "raven/raven": "Allow sending log messages to a Sentry server",
-                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar"
                 },
-                "time": "2014-03-23T19:50:26+00:00",
-                "type": "library",
-                "uid": 148914,
-                "version": "1.8.0",
-                "version_normalized": "1.8.0.0"
+                "uid": 148914
             },
             "1.9.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.9.0",
+                "version_normalized": "1.9.0.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "1afc39690e7414412face1f8cbf67b73db34485c"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1afc39690e7414412face1f8cbf67b73db34485c",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "1afc39690e7414412face1f8cbf67b73db34485c"
+                },
+                "type": "library",
+                "time": "2014-04-20T16:41:26+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "1afc39690e7414412face1f8cbf67b73db34485c",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1afc39690e7414412face1f8cbf67b73db34485c"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.9.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "~2.4, >2.4.8",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
                     "phpunit/phpunit": "~3.7.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "~0.5",
-                    "ruflin/elastica": "0.90.*"
-                },
-                "source": {
-                    "reference": "1afc39690e7414412face1f8cbf67b73db34485c",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "ruflin/elastica": "0.90.*",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "~2.4, >2.4.8"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
                     "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "raven/raven": "Allow sending log messages to a Sentry server",
-                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar"
                 },
-                "time": "2014-04-20T16:41:26+00:00",
-                "type": "library",
-                "uid": 161381,
-                "version": "1.9.0",
-                "version_normalized": "1.9.0.0"
+                "uid": 161381
             },
             "1.9.1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.9.1",
+                "version_normalized": "1.9.1.0",
+                "license": [
+                    "MIT"
+                ],
                 "authors": [
                     {
+                        "name": "Jordi Boggiano",
                         "email": "j.boggiano@seld.be",
                         "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano",
                         "role": "Developer"
                     }
                 ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "65026b610f8c19e61d7242f600530677b0466aac"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/65026b610f8c19e61d7242f600530677b0466aac",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "65026b610f8c19e61d7242f600530677b0466aac"
+                },
+                "type": "library",
+                "time": "2014-04-24T13:29:03+00:00",
                 "autoload": {
                     "psr-4": {
                         "Monolog\\": "src/Monolog"
                     }
-                },
-                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "65026b610f8c19e61d7242f600530677b0466aac",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/65026b610f8c19e61d7242f600530677b0466aac"
                 },
                 "extra": {
                     "branch-alias": {
                         "dev-master": "1.9.x-dev"
                     }
                 },
-                "homepage": "http://github.com/Seldaek/monolog",
-                "keywords": [
-                    "log",
-                    "logging",
-                    "psr-3"
-                ],
-                "license": [
-                    "MIT"
-                ],
-                "name": "monolog/monolog",
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "~2.4, >2.4.8",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
                     "phpunit/phpunit": "~3.7.0",
+                    "graylog2/gelf-php": "~1.0",
                     "raven/raven": "~0.5",
-                    "ruflin/elastica": "0.90.*"
-                },
-                "source": {
-                    "reference": "65026b610f8c19e61d7242f600530677b0466aac",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "ruflin/elastica": "0.90.*",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "~2.4, >2.4.8"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                    "ext-mongo": "Allow sending log messages to a MongoDB server",
                     "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "raven/raven": "Allow sending log messages to a Sentry server",
-                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongo": "Allow sending log messages to a MongoDB server",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar"
                 },
-                "time": "2014-04-24T13:29:03+00:00",
-                "type": "library",
-                "uid": 163177,
-                "version": "1.9.1",
-                "version_normalized": "1.9.1.0"
+                "uid": 163177
             },
             "1.x-dev": {
-                "authors": [
-                    {
-                        "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
-                    }
-                ],
-                "autoload": {
-                    "psr-4": {
-                        "Monolog\\": "src/Monolog"
-                    }
-                },
+                "name": "monolog/monolog",
                 "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd8c787753b3a2ad11bc60c063cff1358a32a3b4"
-                },
-                "extra": {
-                    "branch-alias": {
-                        "dev-master": "2.0.x-dev"
-                    }
-                },
-                "homepage": "http://github.com/Seldaek/monolog",
                 "keywords": [
                     "log",
                     "logging",
                     "psr-3"
                 ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "1.x-dev",
+                "version_normalized": "1.9999999.9999999.9999999-dev",
                 "license": [
                     "MIT"
                 ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "904713c5929655dc9b97288b69cfeedad610c9a1"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/904713c5929655dc9b97288b69cfeedad610c9a1",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "904713c5929655dc9b97288b69cfeedad610c9a1"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-06-09T08:53:42+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
                 },
                 "require": {
                     "php": ">=5.3.0",
                     "psr/log": "~1.0"
                 },
                 "require-dev": {
-                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
-                    "doctrine/couchdb": "~1.0@dev",
-                    "graylog2/gelf-php": "~1.0",
-                    "jakub-onderka/php-parallel-lint": "0.9",
-                    "php-amqplib/php-amqplib": "~2.4",
-                    "php-console/php-console": "^3.1.3",
                     "phpunit/phpunit": "~4.5",
-                    "phpunit/phpunit-mock-objects": "2.3.0",
+                    "graylog2/gelf-php": "~1.0",
                     "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "php-console/php-console": "^3.1.3",
+                    "php-amqplib/php-amqplib": "~2.4",
                     "sentry/sentry": "^0.13",
-                    "swiftmailer/swiftmailer": "^5.3|^6.0"
-                },
-                "source": {
-                    "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "phpstan/phpstan": "^0.12.59"
                 },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongo": "Allow sending log messages to a MongoDB server",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "sentry/sentry": "Allow sending log messages to a Sentry server"
                 },
-                "time": "2017-06-19T01:22:40+00:00",
-                "type": "library",
-                "uid": 627655,
-                "version": "1.x-dev",
-                "version_normalized": "1.9999999.9999999.9999999-dev"
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 627655
             },
-            "dev-master": {
-                "authors": [
-                    {
-                        "email": "j.boggiano@seld.be",
-                        "homepage": "http://seld.be",
-                        "name": "Jordi Boggiano"
-                    }
-                ],
-                "autoload": {
-                    "psr-4": {
-                        "Monolog\\": "src/Monolog"
-                    }
-                },
+            "2.0.0": {
+                "name": "monolog/monolog",
                 "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-                "dist": {
-                    "reference": "7b992836275e09ed63c63fe33ca9993e515e6c5d",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/7b992836275e09ed63c63fe33ca9993e515e6c5d"
-                },
-                "extra": {
-                    "branch-alias": {
-                        "dev-master": "2.0.x-dev"
-                    }
-                },
-                "homepage": "http://github.com/Seldaek/monolog",
                 "keywords": [
                     "log",
                     "logging",
                     "psr-3"
                 ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "2.0.0",
+                "version_normalized": "2.0.0.0",
                 "license": [
                     "MIT"
                 ],
-                "name": "monolog/monolog",
-                "provide": {
-                    "psr/log-implementation": "1.0.0"
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "68545165e19249013afd1d6f7485aecff07a2d22"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/68545165e19249013afd1d6f7485aecff07a2d22",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "68545165e19249013afd1d6f7485aecff07a2d22"
+                },
+                "type": "library",
+                "time": "2019-08-30T09:56:44+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.x-dev"
+                    }
                 },
                 "require": {
-                    "php": "^7.0",
+                    "php": "^7.2",
                     "psr/log": "^1.0.1"
                 },
                 "require-dev": {
                     "aws/aws-sdk-php": "^2.4.9 || ^3.0",
                     "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^6.0",
                     "graylog2/gelf-php": "^1.4.2",
                     "jakub-onderka/php-parallel-lint": "^0.9",
                     "php-amqplib/php-amqplib": "~2.4",
                     "php-console/php-console": "^3.1.3",
                     "phpspec/prophecy": "^1.6.1",
-                    "phpunit/phpunit": "^5.7",
+                    "phpunit/phpunit": "^8.3",
                     "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3",
                     "ruflin/elastica": ">=0.90 <3.0",
-                    "sentry/sentry": "^0.13",
                     "swiftmailer/swiftmailer": "^5.3|^6.0"
                 },
-                "source": {
-                    "reference": "7b992836275e09ed63c63fe33ca9993e515e6c5d",
-                    "type": "git",
-                    "url": "https://github.com/Seldaek/monolog.git"
-                },
                 "suggest": {
-                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                     "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
                     "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
-                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
                     "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
-                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                     "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                    "sentry/sentry": "Allow sending log messages to a Sentry server"
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols"
                 },
-                "time": "2017-06-19T10:29:40+00:00",
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 3198079
+            },
+            "2.0.0-beta1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "2.0.0-beta1",
+                "version_normalized": "2.0.0.0-beta1",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "0ad73a526f4b5e67312e94fb7f60c1bdefc284b9"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/0ad73a526f4b5e67312e94fb7f60c1bdefc284b9",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "0ad73a526f4b5e67312e94fb7f60c1bdefc284b9"
+                },
                 "type": "library",
-                "uid": 5154,
-                "version": "dev-master",
-                "version_normalized": "9999999-dev"
+                "time": "2018-12-08T17:16:32+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": "^7.1",
+                    "psr/log": "^1.0.1"
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^7.3",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "sentry/sentry": "^1.9",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "php-console/php-console": "^3.1.3",
+                    "jakub-onderka/php-parallel-lint": "^0.9",
+                    "predis/predis": "^1.1",
+                    "phpspec/prophecy": "^1.6.1",
+                    "elasticsearch/elasticsearch": "^6.0",
+                    "rollbar/rollbar": "^1.3"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "sentry/sentry": "Allow sending log messages to a Sentry server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 2625958
+            },
+            "2.0.0-beta2": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "2.0.0-beta2",
+                "version_normalized": "2.0.0.0-beta2",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "bf486002a08ca7cb156540e1a38c7be70fa8ed59"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bf486002a08ca7cb156540e1a38c7be70fa8ed59",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "bf486002a08ca7cb156540e1a38c7be70fa8ed59"
+                },
+                "type": "library",
+                "time": "2019-07-06T13:17:41+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": "^7.2",
+                    "psr/log": "^1.0.1"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^6.0",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "jakub-onderka/php-parallel-lint": "^0.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^7.5",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 3083761
+            },
+            "2.0.1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "2.0.1",
+                "version_normalized": "2.0.1.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "f9d56fd2f5533322caccdfcddbb56aedd622ef1c"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f9d56fd2f5533322caccdfcddbb56aedd622ef1c",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "f9d56fd2f5533322caccdfcddbb56aedd622ef1c"
+                },
+                "type": "library",
+                "time": "2019-11-13T10:27:43+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": "^7.2",
+                    "psr/log": "^1.0.1"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^6.0",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "jakub-onderka/php-parallel-lint": "^0.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^8.3",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 3374116
+            },
+            "2.0.2": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "2.0.2",
+                "version_normalized": "2.0.2.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "c861fcba2ca29404dc9e617eedd9eff4616986b8"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c861fcba2ca29404dc9e617eedd9eff4616986b8",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "c861fcba2ca29404dc9e617eedd9eff4616986b8"
+                },
+                "type": "library",
+                "time": "2019-12-20T14:22:59+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": "^7.2",
+                    "psr/log": "^1.0.1"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^6.0",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "jakub-onderka/php-parallel-lint": "^0.9",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^8.3",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 3474870
+            },
+            "2.1.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "2.1.0",
+                "version_normalized": "2.1.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "38914429aac460e8e4616c8cb486ecb40ec90bb1"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/38914429aac460e8e4616c8cb486ecb40ec90bb1",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "38914429aac460e8e4616c8cb486ecb40ec90bb1"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2020-05-22T08:12:19+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^6.0",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "php-parallel-lint/php-parallel-lint": "^1.0",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^8.5",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 3884939
+            },
+            "2.1.1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "http://github.com/Seldaek/monolog",
+                "version": "2.1.1",
+                "version_normalized": "2.1.1.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "http://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "f9eee5cec93dfb313a38b6b288741e84e53f02d5"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f9eee5cec93dfb313a38b6b288741e84e53f02d5",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "f9eee5cec93dfb313a38b6b288741e84e53f02d5"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2020-07-23T08:41:23+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-master": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^6.0",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "php-parallel-lint/php-parallel-lint": "^1.0",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^8.5",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3",
+                    "ruflin/elastica": ">=0.90 <3.0",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 4293858
+            },
+            "2.2.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "2.2.0",
+                "version_normalized": "2.2.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "1cb1cde8e8dd0f70cc0fe51354a59acad9302084"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1cb1cde8e8dd0f70cc0fe51354a59acad9302084",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "1cb1cde8e8dd0f70cc0fe51354a59acad9302084"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2020-12-14T13:15:25+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7",
+                    "mongodb/mongodb": "^1.8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^8.5",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3",
+                    "ruflin/elastica": ">=0.90 <7.0.1",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "phpstan/phpstan": "^0.12.59"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 4746005
+            },
+            "2.3.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "2.3.0",
+                "version_normalized": "2.3.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "df991fd88693ab703aa403413d83e15f688dae33"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/df991fd88693ab703aa403413d83e15f688dae33",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "df991fd88693ab703aa403413d83e15f688dae33"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2021-07-05T11:34:13+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7",
+                    "mongodb/mongodb": "^1.8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^8.5",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3",
+                    "ruflin/elastica": ">=0.90 <7.0.1",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "phpstan/phpstan": "^0.12.91"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 5338814
+            },
+            "2.3.1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "2.3.1",
+                "version_normalized": "2.3.1.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "9738e495f288eec0b187e310b7cdbbb285777dbe"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/9738e495f288eec0b187e310b7cdbbb285777dbe",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "9738e495f288eec0b187e310b7cdbbb285777dbe"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2021-07-14T11:56:39+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7",
+                    "mongodb/mongodb": "^1.8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^8.5",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3",
+                    "ruflin/elastica": ">=0.90 <7.0.1",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "phpstan/phpstan": "^0.12.91"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 5362706
+            },
+            "2.3.2": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "2.3.2",
+                "version_normalized": "2.3.2.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "71312564759a7db5b789296369c1a264efc43aad"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/71312564759a7db5b789296369c1a264efc43aad",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "71312564759a7db5b789296369c1a264efc43aad"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2021-07-23T07:42:52+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7",
+                    "mongodb/mongodb": "^1.8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^8.5",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3",
+                    "ruflin/elastica": ">=0.90 <7.0.1",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "phpstan/phpstan": "^0.12.91"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0"
+                },
+                "uid": 5384896
+            },
+            "2.3.3": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "2.3.3",
+                "version_normalized": "2.3.3.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "3962ebfe206ac7ce6c754c79e2fee0c64bf1818d"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/3962ebfe206ac7ce6c754c79e2fee0c64bf1818d",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "3962ebfe206ac7ce6c754c79e2fee0c64bf1818d"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2021-09-14T18:40:13+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1 || ^2.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7",
+                    "mongodb/mongodb": "^1.8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^8.5",
+                    "predis/predis": "^1.1",
+                    "ruflin/elastica": ">=0.90@dev",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "phpstan/phpstan": "^0.12.91"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0 || 2.0.0"
+                },
+                "uid": 5514876
+            },
+            "2.3.4": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "2.3.4",
+                "version_normalized": "2.3.4.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "437e7a1c50044b92773b361af77620efb76fff59"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/437e7a1c50044b92773b361af77620efb76fff59",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "437e7a1c50044b92773b361af77620efb76fff59"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2021-09-15T11:27:21+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7",
+                    "mongodb/mongodb": "^1.8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "php-amqplib/php-amqplib": "~2.4",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^8.5",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3",
+                    "ruflin/elastica": ">=0.90@dev",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "phpstan/phpstan": "^0.12.91"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+                },
+                "uid": 5517104
+            },
+            "2.3.5": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "2.3.5",
+                "version_normalized": "2.3.5.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "fd4380d6fc37626e2f799f29d91195040137eba9"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd4380d6fc37626e2f799f29d91195040137eba9",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "fd4380d6fc37626e2f799f29d91195040137eba9"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2021-10-01T21:08:31+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7",
+                    "mongodb/mongodb": "^1.8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "php-amqplib/php-amqplib": "~2.4 || ^3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^8.5",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3",
+                    "ruflin/elastica": ">=0.90@dev",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "phpstan/phpstan": "^0.12.91"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+                },
+                "uid": 5562332
+            },
+            "2.4.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "2.4.0",
+                "version_normalized": "2.4.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "d7fd7450628561ba697b7097d86db72662f54aef"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/d7fd7450628561ba697b7097d86db72662f54aef",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "d7fd7450628561ba697b7097d86db72662f54aef"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-03-14T12:44:37+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7",
+                    "mongodb/mongodb": "^1.8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "php-amqplib/php-amqplib": "~2.4 || ^3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^8.5",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3 || ^2 || ^3",
+                    "ruflin/elastica": ">=0.90@dev",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "phpstan/phpstan": "^0.12.91"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+                },
+                "uid": 6059678
+            },
+            "2.5.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "2.5.0",
+                "version_normalized": "2.5.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "4192345e260f1d51b365536199744b987e160edc"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/4192345e260f1d51b365536199744b987e160edc",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "4192345e260f1d51b365536199744b987e160edc"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-04-08T15:43:54+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7",
+                    "mongodb/mongodb": "^1.8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "php-amqplib/php-amqplib": "~2.4 || ^3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.6.1",
+                    "phpunit/phpunit": "^8.5",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3 || ^2 || ^3",
+                    "ruflin/elastica": ">=0.90@dev",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "phpstan/phpstan": "^0.12.91"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+                },
+                "uid": 6143493
+            },
+            "2.6.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "2.6.0",
+                "version_normalized": "2.6.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "247918972acd74356b0a91dfaa5adcaec069b6c0"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/247918972acd74356b0a91dfaa5adcaec069b6c0",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "247918972acd74356b0a91dfaa5adcaec069b6c0"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-05-10T09:36:00+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+                },
+                "require-dev": {
+                    "ext-json": "*",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7 || ^8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "guzzlehttp/guzzle": "^7.4",
+                    "guzzlehttp/psr7": "^2.2",
+                    "mongodb/mongodb": "^1.8",
+                    "php-amqplib/php-amqplib": "~2.4 || ^3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.15",
+                    "phpstan/phpstan": "^0.12.91",
+                    "phpunit/phpunit": "^8.5.14",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3 || ^2 || ^3",
+                    "ruflin/elastica": "^7",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "symfony/mailer": "^5.4 || ^6",
+                    "symfony/mime": "^5.4 || ^6"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+                },
+                "uid": 6231509
+            },
+            "2.7.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "2.7.0",
+                "version_normalized": "2.7.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "5579edf28aee1190a798bfa5be8bc16c563bd524"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5579edf28aee1190a798bfa5be8bc16c563bd524",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "5579edf28aee1190a798bfa5be8bc16c563bd524"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-06-09T08:59:12+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+                },
+                "require-dev": {
+                    "ext-json": "*",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7 || ^8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "guzzlehttp/guzzle": "^7.4",
+                    "guzzlehttp/psr7": "^2.2",
+                    "mongodb/mongodb": "^1.8",
+                    "php-amqplib/php-amqplib": "~2.4 || ^3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpspec/prophecy": "^1.15",
+                    "phpstan/phpstan": "^0.12.91",
+                    "phpunit/phpunit": "^8.5.14",
+                    "predis/predis": "^1.1",
+                    "rollbar/rollbar": "^1.3 || ^2 || ^3",
+                    "ruflin/elastica": "^7",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "symfony/mailer": "^5.4 || ^6",
+                    "symfony/mime": "^5.4 || ^6"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+                },
+                "uid": 6322756
+            },
+            "2.8.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "2.8.0",
+                "version_normalized": "2.8.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "720488632c590286b88b80e62aa3d3d551ad4a50"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/720488632c590286b88b80e62aa3d3d551ad4a50",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "720488632c590286b88b80e62aa3d3d551ad4a50"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-07-24T11:55:47+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+                },
+                "require-dev": {
+                    "ext-json": "*",
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7 || ^8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "guzzlehttp/guzzle": "^7.4",
+                    "guzzlehttp/psr7": "^2.2",
+                    "mongodb/mongodb": "^1.8",
+                    "php-amqplib/php-amqplib": "~2.4 || ^3",
+                    "phpspec/prophecy": "^1.15",
+                    "phpstan/phpstan": "^0.12.91",
+                    "phpunit/phpunit": "^8.5.14",
+                    "predis/predis": "^1.1 || ^2.0",
+                    "rollbar/rollbar": "^1.3 || ^2 || ^3",
+                    "ruflin/elastica": "^7",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "symfony/mailer": "^5.4 || ^6",
+                    "symfony/mime": "^5.4 || ^6"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+                },
+                "uid": 6443235
+            },
+            "2.x-dev": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "2.x-dev",
+                "version_normalized": "2.9999999.9999999.9999999-dev",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "1387e02612584ffa1a9e93384d2d63ba0a747e11"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1387e02612584ffa1a9e93384d2d63ba0a747e11",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "1387e02612584ffa1a9e93384d2d63ba0a747e11"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-10-14T15:01:04+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "2.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=7.2",
+                    "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+                },
+                "require-dev": {
+                    "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "mongodb/mongodb": "^1.8",
+                    "php-amqplib/php-amqplib": "~2.4 || ^3",
+                    "rollbar/rollbar": "^1.3 || ^2 || ^3",
+                    "swiftmailer/swiftmailer": "^5.3|^6.0",
+                    "phpstan/phpstan": "^0.12.91",
+                    "phpspec/prophecy": "^1.15",
+                    "symfony/mailer": "^5.4 || ^6",
+                    "symfony/mime": "^5.4 || ^6",
+                    "ext-json": "*",
+                    "elasticsearch/elasticsearch": "^7 || ^8",
+                    "guzzlehttp/guzzle": "^7.4",
+                    "guzzlehttp/psr7": "^2.2",
+                    "phpunit/phpunit": "^8.5.14",
+                    "ruflin/elastica": "^7",
+                    "predis/predis": "^1.1 || ^2.0",
+                    "graylog2/gelf-php": "^1.4.2 || ^2@dev"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+                },
+                "uid": 6123554
+            },
+            "3.0.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "3.0.0",
+                "version_normalized": "3.0.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "60ad5183b5e5d6c9d4047e9f3072d36071dcc161"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/60ad5183b5e5d6c9d4047e9f3072d36071dcc161",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "60ad5183b5e5d6c9d4047e9f3072d36071dcc161"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-05-10T10:39:55+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "3.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=8.1",
+                    "psr/log": "^2.0 || ^3.0"
+                },
+                "require-dev": {
+                    "ext-json": "*",
+                    "aws/aws-sdk-php": "^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7 || ^8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "guzzlehttp/guzzle": "^7.4",
+                    "guzzlehttp/psr7": "^2.2",
+                    "mongodb/mongodb": "^1.8",
+                    "php-amqplib/php-amqplib": "~2.4 || ^3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpstan/phpstan": "^1.4",
+                    "phpstan/phpstan-deprecation-rules": "^1.0",
+                    "phpstan/phpstan-strict-rules": "^1.1",
+                    "phpunit/phpunit": "^9.5.16",
+                    "predis/predis": "^1.1",
+                    "ruflin/elastica": "^7",
+                    "symfony/mailer": "^5.4 || ^6",
+                    "symfony/mime": "^5.4 || ^6"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "3.0.0"
+                },
+                "uid": 6231773
+            },
+            "3.0.0-RC1": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "3.0.0-RC1",
+                "version_normalized": "3.0.0.0-RC1",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "a71c4e02502dd04d91f1c7d72ffccf0bd11310eb"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/a71c4e02502dd04d91f1c7d72ffccf0bd11310eb",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "a71c4e02502dd04d91f1c7d72ffccf0bd11310eb"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-05-08T21:50:49+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "3.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=8.1",
+                    "psr/log": "^2.0 || ^3.0"
+                },
+                "require-dev": {
+                    "ext-json": "*",
+                    "aws/aws-sdk-php": "^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7 || ^8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "guzzlehttp/guzzle": "^7.4",
+                    "guzzlehttp/psr7": "^2.2",
+                    "mongodb/mongodb": "^1.8",
+                    "php-amqplib/php-amqplib": "~2.4 || ^3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpstan/phpstan": "^1.4",
+                    "phpstan/phpstan-deprecation-rules": "^1.0",
+                    "phpstan/phpstan-strict-rules": "^1.1",
+                    "phpunit/phpunit": "^9.5.16",
+                    "predis/predis": "^1.1",
+                    "ruflin/elastica": "^7",
+                    "symfony/mailer": "^5.4 || ^6",
+                    "symfony/mime": "^5.4 || ^6"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "3.0.0"
+                },
+                "uid": 6225984
+            },
+            "3.1.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "3.1.0",
+                "version_normalized": "3.1.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "0c375495d40df0207e5833dca333f963b171ff43"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/0c375495d40df0207e5833dca333f963b171ff43",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "0c375495d40df0207e5833dca333f963b171ff43"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-06-09T09:09:00+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "3.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=8.1",
+                    "psr/log": "^2.0 || ^3.0"
+                },
+                "require-dev": {
+                    "ext-json": "*",
+                    "aws/aws-sdk-php": "^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7 || ^8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "guzzlehttp/guzzle": "^7.4",
+                    "guzzlehttp/psr7": "^2.2",
+                    "mongodb/mongodb": "^1.8",
+                    "php-amqplib/php-amqplib": "~2.4 || ^3",
+                    "php-console/php-console": "^3.1.3",
+                    "phpstan/phpstan": "^1.4",
+                    "phpstan/phpstan-deprecation-rules": "^1.0",
+                    "phpstan/phpstan-strict-rules": "^1.1",
+                    "phpunit/phpunit": "^9.5.16",
+                    "predis/predis": "^1.1",
+                    "ruflin/elastica": "^7",
+                    "symfony/mailer": "^5.4 || ^6",
+                    "symfony/mime": "^5.4 || ^6"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "php-console/php-console": "Allow sending log messages to Google Chrome",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "3.0.0"
+                },
+                "uid": 6322757
+            },
+            "3.2.0": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "3.2.0",
+                "version_normalized": "3.2.0.0",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "305444bc6fb6c89e490f4b34fa6e979584d7fa81"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/305444bc6fb6c89e490f4b34fa6e979584d7fa81",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "305444bc6fb6c89e490f4b34fa6e979584d7fa81"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-07-24T12:00:55+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "3.x-dev"
+                    }
+                },
+                "require": {
+                    "php": ">=8.1",
+                    "psr/log": "^2.0 || ^3.0"
+                },
+                "require-dev": {
+                    "ext-json": "*",
+                    "aws/aws-sdk-php": "^3.0",
+                    "doctrine/couchdb": "~1.0@dev",
+                    "elasticsearch/elasticsearch": "^7 || ^8",
+                    "graylog2/gelf-php": "^1.4.2",
+                    "guzzlehttp/guzzle": "^7.4",
+                    "guzzlehttp/psr7": "^2.2",
+                    "mongodb/mongodb": "^1.8",
+                    "php-amqplib/php-amqplib": "~2.4 || ^3",
+                    "phpstan/phpstan": "^1.4",
+                    "phpstan/phpstan-deprecation-rules": "^1.0",
+                    "phpstan/phpstan-strict-rules": "^1.1",
+                    "phpunit/phpunit": "^9.5.16",
+                    "predis/predis": "^1.1",
+                    "ruflin/elastica": "^7",
+                    "symfony/mailer": "^5.4 || ^6",
+                    "symfony/mime": "^5.4 || ^6"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "3.0.0"
+                },
+                "uid": 6443236
+            },
+            "dev-main": {
+                "name": "monolog/monolog",
+                "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+                "keywords": [
+                    "log",
+                    "logging",
+                    "psr-3"
+                ],
+                "homepage": "https://github.com/Seldaek/monolog",
+                "version": "dev-main",
+                "version_normalized": "dev-main",
+                "license": [
+                    "MIT"
+                ],
+                "authors": [
+                    {
+                        "name": "Jordi Boggiano",
+                        "email": "j.boggiano@seld.be",
+                        "homepage": "https://seld.be"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/Seldaek/monolog.git",
+                    "type": "git",
+                    "reference": "e68c00670e310e276da9624d75965f5d2f28aa80"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/Seldaek/monolog/zipball/e68c00670e310e276da9624d75965f5d2f28aa80",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "e68c00670e310e276da9624d75965f5d2f28aa80"
+                },
+                "type": "library",
+                "funding": [
+                    {
+                        "url": "https://github.com/Seldaek",
+                        "type": "github"
+                    },
+                    {
+                        "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                        "type": "tidelift"
+                    }
+                ],
+                "time": "2022-08-20T13:21:44+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolog\\": "src/Monolog"
+                    }
+                },
+                "extra": {
+                    "branch-alias": {
+                        "dev-main": "3.x-dev"
+                    }
+                },
+                "default-branch": true,
+                "require": {
+                    "php": ">=8.1",
+                    "psr/log": "^2.0 || ^3.0"
+                },
+                "require-dev": {
+                    "doctrine/couchdb": "~1.0@dev",
+                    "mongodb/mongodb": "^1.8",
+                    "php-amqplib/php-amqplib": "~2.4 || ^3",
+                    "aws/aws-sdk-php": "^3.0",
+                    "phpunit/phpunit": "^9.5.16",
+                    "phpstan/phpstan": "^1.4",
+                    "phpstan/phpstan-deprecation-rules": "^1.0",
+                    "phpstan/phpstan-strict-rules": "^1.1",
+                    "ext-json": "*",
+                    "elasticsearch/elasticsearch": "^7 || ^8",
+                    "guzzlehttp/guzzle": "^7.4",
+                    "guzzlehttp/psr7": "^2.2",
+                    "ruflin/elastica": "^7",
+                    "symfony/mailer": "^5.4 || ^6",
+                    "symfony/mime": "^5.4 || ^6",
+                    "graylog2/gelf-php": "^1.4.2 || ^2@dev",
+                    "predis/predis": "^1.1 || ^2"
+                },
+                "suggest": {
+                    "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                    "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                    "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                    "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                    "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                    "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                    "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                    "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                    "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                    "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                    "ext-mbstring": "Allow to work properly with unicode symbols",
+                    "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                    "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                    "ext-openssl": "Required to send log messages using SSL"
+                },
+                "provide": {
+                    "psr/log-implementation": "3.0.0"
+                },
+                "uid": 4731227
             }
         },
         "notadd/wechat": {
             "dev-master": {
-                "authors": [
-                    {
-                        "email": "notadd@ibenchu.com",
-                        "name": "Notadd"
-                    }
-                ],
-                "autoload": {
-                    "psr-4": {
-                        "Notadd\\Wechat\\": "src/"
-                    }
-                },
+                "name": "notadd/wechat",
                 "description": "Notadd's Wechat Module.",
-                "dist": {
-                    "reference": "e3f684cd225f3fadf21953c0289cb8426baad0e5",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/notadd/wechat/zipball/e3f684cd225f3fadf21953c0289cb8426baad0e5"
-                },
-                "homepage": "https://notadd.com",
                 "keywords": [
                     "framework",
                     "cms",
                     "member",
                     "notadd"
                 ],
+                "homepage": "https://notadd.com",
+                "version": "dev-master",
+                "version_normalized": "9999999-dev",
                 "license": [
                     "Apache-2.0"
                 ],
-                "name": "notadd/wechat",
+                "authors": [
+                    {
+                        "name": "Notadd",
+                        "email": "notadd@ibenchu.com"
+                    }
+                ],
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/notadd/wechat.git",
+                    "reference": "e3f684cd225f3fadf21953c0289cb8426baad0e5"
+                },
+                "dist": {
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/notadd/wechat/zipball/e3f684cd225f3fadf21953c0289cb8426baad0e5",
+                    "reference": "e3f684cd225f3fadf21953c0289cb8426baad0e5",
+                    "shasum": ""
+                },
+                "type": "notadd-module",
+                "time": "2017-11-13T04:23:05+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Notadd\\Wechat\\": "src/"
+                    }
+                },
+                "require": {
+                    "php": ">=7.0",
+                    "overtrue/wechat": "~3.1"
+                },
+                "require-dev": {
+                    "notadd/installers": "0.14.*",
+                    "notadd/testing": "0.4.*",
+                    "phpunit/phpunit": "~6.0"
+                },
                 "replace": {
                     "guzzlehttp/guzzle": "*",
                     "guzzlehttp/promises": "*",
@@ -2714,59 +6748,48 @@
                     "symfony/polyfill-mbstring": "*",
                     "symfony/psr-http-message-bridge": "*"
                 },
-                "require": {
-                    "overtrue/wechat": "~3.1",
-                    "php": ">=7.0"
-                },
-                "require-dev": {
-                    "notadd/installers": "0.14.*",
-                    "notadd/testing": "0.4.*",
-                    "phpunit/phpunit": "~6.0"
-                },
-                "source": {
-                    "reference": "e3f684cd225f3fadf21953c0289cb8426baad0e5",
-                    "type": "git",
-                    "url": "https://github.com/notadd/wechat.git"
-                },
-                "time": "2017-11-13T04:23:05+00:00",
-                "type": "notadd-module",
-                "uid": 1108963,
-                "version": "dev-master",
-                "version_normalized": "9999999-dev"
+                "abandoned": true,
+                "uid": 1108963
             }
         },
         "phpointless/monolol": {
             "1.0.0": {
-                "authors": [
-                    {
-                        "email": "contact@romain-renaud.fr",
-                        "name": "Romain Renaud"
-                    }
-                ],
-                "autoload": {
-                    "psr-4": {
-                        "Monolol\\": "lib"
-                    }
-                },
+                "name": "phpointless/monolol",
                 "description": "PSR-3 compliant lol-gger",
-                "dist": {
-                    "reference": "1991e6b72b52229dc43147fd2c208f21896021bb",
-                    "shasum": "",
-                    "type": "zip",
-                    "url": "https://api.github.com/repos/PHPointless/monolol/zipball/1991e6b72b52229dc43147fd2c208f21896021bb"
-                },
-                "homepage": "",
                 "keywords": [
                     "PSR3",
                     "LoL",
                     "lol-gging"
                 ],
+                "homepage": "",
+                "version": "1.0.0",
+                "version_normalized": "1.0.0.0",
                 "license": [
                     "MIT"
                 ],
-                "name": "phpointless/monolol",
-                "provide": {
-                    "monolog/monolog": "1.12"
+                "authors": [
+                    {
+                        "name": "Romain Renaud",
+                        "email": "contact@romain-renaud.fr"
+                    }
+                ],
+                "source": {
+                    "url": "https://github.com/PHPointless/monolol.git",
+                    "type": "git",
+                    "reference": "1991e6b72b52229dc43147fd2c208f21896021bb"
+                },
+                "dist": {
+                    "url": "https://api.github.com/repos/PHPointless/monolol/zipball/1991e6b72b52229dc43147fd2c208f21896021bb",
+                    "type": "zip",
+                    "shasum": "",
+                    "reference": "1991e6b72b52229dc43147fd2c208f21896021bb"
+                },
+                "type": "library",
+                "time": "2015-03-04T13:27:14+00:00",
+                "autoload": {
+                    "psr-4": {
+                        "Monolol\\": "lib"
+                    }
                 },
                 "require": {
                     "monolog/monolog": "~1.12"
@@ -2774,16 +6797,10 @@
                 "require-dev": {
                     "phpunit/phpunit": "~4.5"
                 },
-                "source": {
-                    "reference": "1991e6b72b52229dc43147fd2c208f21896021bb",
-                    "type": "git",
-                    "url": "https://github.com/PHPointless/monolol.git"
+                "provide": {
+                    "monolog/monolog": "1.12"
                 },
-                "time": "2015-03-04T13:27:14+00:00",
-                "type": "library",
-                "uid": 347741,
-                "version": "1.0.0",
-                "version_normalized": "1.0.0.0"
+                "uid": 347741
             }
         }
     }


### PR DESCRIPTION
For a few upcoming PR's, it'll be helpful if the `monolog/monolog` packagist fixture is current to match what's _actually_ returned by https://repo.packagist.org/p/monolog/monolog.json.

Initially I updated all the other fixtures as well, but the `illuminate/*` fixtures ballooned to 43+ MB... and then when I switched them to the `v2` metadata endpoint (https://github.com/dependabot/dependabot-core/issues/3010) they shrank back down due to the new minifications... so no point in adding that much cruft to our git history when I'm going to almost immediately drop it.

But the `monolog/monolog` change is necessary because I'll be updating all the tests that point at the generic `packagist_response.json` to point at this fixture... and since it already has a newer version than is in `packagist_response.json`, might as well first ensure the fixture is fully-up-to-date.