### PR TITLE
Clarify `composer` `v1` `PEAR` unit test

### DIFF
--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -434,6 +434,16 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
         }]
       end
 
+      # This unit test is testing that a dependency located on https://pear.horde.org is still correctly
+      # handled by composer. So ignore the fact that this package actually exists on packagist, and
+      # pretend it just 404's.
+      let(:packagist_response) { '{"error":{"code":404,"message":"Not Found"}}' }
+      before do
+        v1_metadata_url = "https://repo.packagist.org/p/#{dependency_name.downcase}.json"
+        # v1 url doesn't always return 404 for missing packages
+        stub_request(:get, v1_metadata_url).to_return(status: 200, body: packagist_response)
+      end
+
       it "is between 2.0.0 and 3.0.0" do
         expect(latest_resolvable_version).to be < Gem::Version.new("3.0.0")
         expect(latest_resolvable_version).to be > Gem::Version.new("2.0.0")

--- a/composer/spec/fixtures/packagist_responses/pear-pear.horde.org--horde_date.json
+++ b/composer/spec/fixtures/packagist_responses/pear-pear.horde.org--horde_date.json
@@ -1,1 +1,0 @@
-{"error":{"code":404,"message":"Not Found"}}


### PR DESCRIPTION
It took me a while to understand this unit test, because this package _is_ actually present on packagist: https://repo.packagist.org/p/pear-pear.horde.org/horde_date.json

However, from the associated `composer.json` fixture plus the existing fixture, it's clear that this test is checking what happens when a PEAR dependency is _not_ present on packagist.

So remove the fixture from the `packagist_responses` directory which is supposed to match what Packagist actually returns and instead hardcode the response for this single unit test to avoid confusion of future devs thinking they need to update it to match the actual packagist response.

This will make the https://github.com/dependabot/dependabot-core/pull/6315 a bit more straightforward because composer v1 doesn't know about the v2 metadata API so I will need to hardcode both v1 and v2 metadata responses (which return different HTTP status codes).

PEAR is mostly dead it seems, but it doesn't hurt to leave it around in case any old composer v1 projects still have PEAR deps listed... and this will all be gone soon enough once we remove support for `composer` `v1`:
* https://github.com/dependabot/dependabot-core/issues/6298