### PR TITLE
Mention `"metadata"` in `--pull-request` description

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -241,7 +241,7 @@ option_parse = OptionParser.new do |opts|
   end
 
   opts.on("--pull-request",
-          "Output pull request information: title, description") do
+          "Output pull request information metadata: title, description") do
     $options[:pull_request] = true
   end
 end


### PR DESCRIPTION
I was helping a friend repro a bug, and he was using the dry-run script... when we initially grep'd for "metadata", we didn't find this `--pull-request` option, so adding it here for easier grep'ability.