### PR TITLE
Use source for GitHub client to support fetching metadata from GHES instances

### DIFF
--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -375,7 +375,7 @@ module Dependabot
 
         def github_client
           @github_client ||= Dependabot::Clients::GithubWithRetries.
-                             for_github_dot_com(credentials: credentials)
+                             for_source(source: source, credentials: credentials)
         end
 
         def azure_client

--- a/common/lib/dependabot/metadata_finders/base/commits_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/commits_finder.rb
@@ -321,7 +321,7 @@ module Dependabot
 
         def github_client
           @github_client ||= Dependabot::Clients::GithubWithRetries.
-                             for_github_dot_com(credentials: credentials)
+                             for_source(source: source, credentials: credentials)
         end
 
         def azure_client

--- a/common/lib/dependabot/metadata_finders/base/release_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/release_finder.rb
@@ -300,7 +300,7 @@ module Dependabot
 
         def github_client
           @github_client ||= Dependabot::Clients::GithubWithRetries.
-                             for_github_dot_com(credentials: credentials)
+                             for_source(source: source, credentials: credentials)
         end
       end
     end


### PR DESCRIPTION
We weren't providing the source here so we'd inadvertently load the metadata from github.com instead. The source provides the hostname & api endpoint to use when making requests.

codeql is flagging an issue in the changelog finder but since it's not related to this change I think we should address it in a separate PR.