### PR TITLE
Use branch releases API for fetching source URL

### DIFF
--- a/composer/lib/dependabot/composer/metadata_finder.rb
+++ b/composer/lib/dependabot/composer/metadata_finder.rb
@@ -47,7 +47,11 @@ module Dependabot
       def packagist_listing
         return @packagist_listing unless @packagist_listing.nil?
 
-        response = Dependabot::RegistryClient.get(url: "https://repo.packagist.org/p2/#{dependency.name.downcase}.json")
+        # The `~dev` suffix denotes branch releases rather than tagged releases. The branch releases list is typically
+        # _much_ shorter than the tagged releases, so querying it saves bytes. This wouldn't work for querying available
+        # versions, but it's fine here since only used for finding the metadata source URL.
+        branch_releases_url = "https://repo.packagist.org/p2/#{dependency.name.downcase}~dev.json"
+        response = Dependabot::RegistryClient.get(url: branch_releases_url)
 
         return nil unless response.status == 200
 


### PR DESCRIPTION
As noted in
https://github.com/dependabot/dependabot-core/pull/6315#discussion_r1054093070, we can optimize this call to query the branch releases API for fetching the source URL as it will typically be far smaller than the tagged releases listing... and this will become only more true over time.