### PR TITLE
[gomod] Support updating indirect dependencies

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -155,12 +155,10 @@ module Dependabot
       end
 
       def skip_dependency?(dep)
-        begin
-          path_uri = URI.parse("https://#{dep['Path']}")
-          !path_uri.host.include?(".")
-        rescue URI::InvalidURIError
-          false
-        end
+        path_uri = URI.parse("https://#{dep['Path']}")
+        !path_uri.host.include?(".")
+      rescue URI::InvalidURIError
+        false
       end
 
       def dependency_is_replaced(details)

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -53,7 +53,7 @@ module Dependabot
         Dependency.new(
           name: details["Path"],
           version: version,
-          requirements: details["Indirect"] || dependency_is_replaced(details) ? [] : reqs,
+          requirements: details["Indirect"] ? [] : reqs,
           package_manager: "go_modules"
         )
       end
@@ -155,6 +155,9 @@ module Dependabot
       end
 
       def skip_dependency?(dep)
+        # Updating replaced dependencies is not supported
+        return true if dependency_is_replaced(dep)
+
         path_uri = URI.parse("https://#{dep['Path']}")
         !path_uri.host.include?(".")
       rescue URI::InvalidURIError

--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -155,8 +155,6 @@ module Dependabot
       end
 
       def skip_dependency?(dep)
-        return true if dep["Indirect"]
-
         begin
           path_uri = URI.parse("https://#{dep['Path']}")
           !path_uri.host.include?(".")

--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -28,7 +28,7 @@ module Dependabot
       def updated_dependency_files
         updated_files = []
 
-        if go_mod && file_changed?(go_mod)
+        if go_mod && dependency_changed?(go_mod)
           updated_files <<
             updated_file(
               file: go_mod,
@@ -55,6 +55,11 @@ module Dependabot
       end
 
       private
+
+      def dependency_changed?(go_mod)
+        # file_changed? only checks for changed requirements. Need to check for indirect dep version changes too.
+        file_changed?(go_mod) || dependencies.any? { |dep| dep.previous_version != dep.version }
+      end
 
       def check_required_files
         return if go_mod

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -26,12 +26,6 @@ module Dependabot
       def lowest_resolvable_security_fix_version
         raise "Dependency not vulnerable!" unless vulnerable?
 
-        unless dependency.top_level?
-          return unless dependency.version
-
-          return current_version
-        end
-
         lowest_security_fix_version
       end
 

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -13,17 +13,6 @@ module Dependabot
       require_relative "update_checker/latest_version_finder"
 
       def latest_resolvable_version
-        # We don't yet support updating indirect dependencies for go_modules
-        #
-        # To update indirect dependencies we'll need to promote the indirect
-        # dependency to the go.mod file forcing the resolver to pick this
-        # version (possibly as `// indirect`)
-        unless dependency.top_level?
-          return unless dependency.version
-
-          return current_version
-        end
-
         latest_version_finder.latest_version
       end
 

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -75,6 +75,10 @@ module Dependabot
         end
 
         def available_versions
+          @available_versions ||= fetch_available_versions
+        end
+
+        def fetch_available_versions
           SharedHelpers.in_a_temporary_directory do
             SharedHelpers.with_git_configured(credentials: credentials) do
               manifest = parse_manifest

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Dependabot::GoModules::FileParser do
   describe "parse" do
     subject(:dependencies) { parser.parse }
 
-    its(:length) { is_expected.to eq(3) }
+    its(:length) { is_expected.to eq(5) }
 
     describe "top level dependencies" do
       subject(:dependencies) do
@@ -126,6 +126,27 @@ RSpec.describe Dependabot::GoModules::FileParser do
               }]
             )
           end
+        end
+      end
+    end
+
+    describe "indirect dependencies" do
+      subject(:dependencies) do
+        parser.parse.reject(&:top_level?)
+      end
+
+      its(:length) { is_expected.to eq(3) }
+
+      describe "a dependency that uses go modules" do
+        subject(:dependency) do
+          dependencies.find { |d| d.name == "github.com/mattn/go-isatty" }
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("github.com/mattn/go-isatty")
+          expect(dependency.version).to eq("0.0.4")
+          expect(dependency.requirements).to be_empty
         end
       end
     end

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Dependabot::GoModules::FileParser do
   describe "parse" do
     subject(:dependencies) { parser.parse }
 
-    its(:length) { is_expected.to eq(5) }
+    its(:length) { is_expected.to eq(4) }
 
     describe "top level dependencies" do
       subject(:dependencies) do
@@ -135,7 +135,7 @@ RSpec.describe Dependabot::GoModules::FileParser do
         parser.parse.reject(&:top_level?)
       end
 
-      its(:length) { is_expected.to eq(3) }
+      its(:length) { is_expected.to eq(2) }
 
       describe "a dependency that uses go modules" do
         subject(:dependency) do
@@ -156,11 +156,8 @@ RSpec.describe Dependabot::GoModules::FileParser do
         dependencies.find { |d| d.name == "rsc.io/qr" }
       end
 
-      it "has the right details" do
-        expect(dependency).to be_a(Dependabot::Dependency)
-        expect(dependency.name).to eq("rsc.io/qr")
-        expect(dependency.version).to eq("0.1.0")
-        expect(dependency.requirements).to eq([])
+      it "is skipped as unsupported" do
+        expect(dependency).to be_nil
       end
     end
 
@@ -295,9 +292,8 @@ RSpec.describe Dependabot::GoModules::FileParser do
         dependencies.find { |d| d.name == "rsc.io/qr" }
       end
 
-      it "has the right details" do
-        expect(dependency).to be_a(Dependabot::Dependency)
-        expect(dependency.name).to eq("rsc.io/qr")
+      it "is skipped as unsupported" do
+        expect(dependency).to be_nil
       end
     end
 
@@ -346,7 +342,6 @@ RSpec.describe Dependabot::GoModules::FileParser do
       it "parses root file" do
         expect(dependencies.map(&:name)).
           to eq(%w(
-            github.com/dependabot/vgotest/common
             rsc.io/qr
           ))
       end
@@ -358,7 +353,6 @@ RSpec.describe Dependabot::GoModules::FileParser do
         it "parses nested file" do
           expect(dependencies.map(&:name)).
             to eq(%w(
-              github.com/dependabot/vgotest/common
               rsc.io/qr
             ))
         end

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -84,6 +84,19 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
       expect(updated_files.find { |f| f.name == "go.sum" }).to_not be_nil
     end
 
+    context "with an indirect dependency update" do
+      let(:requirements) { [] }
+      let(:previous_requirements) { [] }
+
+      it "includes an updated go.mod" do
+        expect(updated_files.find { |f| f.name == "go.mod" }).to_not be_nil
+      end
+
+      it "includes an updated go.sum" do
+        expect(updated_files.find { |f| f.name == "go.sum" }).to_not be_nil
+      end
+    end
+
     context "with an invalid module path" do
       let(:stderr) do
         <<~STDERR

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -63,12 +63,11 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
       end
     end
 
-    context "doesn't update indirect dependencies (not supported)" do
+    context "updates indirect dependencies" do
       let(:requirements) { [] }
-      it do
-        is_expected.to eq(
-          Dependabot::GoModules::Version.new(dependency.version)
-        )
+
+      it "updates to the newer version" do
+        is_expected.to eq(Dependabot::GoModules::Version.new("1.1.0"))
       end
     end
 
@@ -123,12 +122,11 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
       end
     end
 
-    context "doesn't update indirect dependencies (not supported)" do
+    context "updates indirect dependencies" do
       let(:requirements) { [] }
-      it do
-        is_expected.to eq(
-          Dependabot::GoModules::Version.new(dependency.version)
-        )
+
+      it "updates to the least new supported version" do
+        is_expected.to eq(Dependabot::GoModules::Version.new("1.0.5"))
       end
     end
 


### PR DESCRIPTION
This is an improved take on an [earlier spike](https://github.com/dependabot/dependabot-core/pull/5555) I did to support updating indirect dependencies in a security update. This allows updating indirect dependencies that are listed in the `go.mod` file in either version or security updates. Dependencies that are only included in the `go.sum` and not the `go.mod` still can't be updated but using the go 1.17+ `go.mod` file any used indirect dependencies should be contained in the `go.mod`.

For version updates, the default allow filter is to only update direct dependencies so indirect dependencies will only be updated if a user configures their `dependabot.yml` to do so.

A benefit over my previous attempt is that this approach maintains the indirect dependency distinction so using the https://github.com/dependabot/fetch-metadata to inspect the commit metadata for the PR will correctly indicate an indirect dependency is being updated.

Another edge case I ran into with https://github.com/dependabot/dependabot-core/pull/6361/commits/bdb3ae3854f3fbee61b28955b0e5c0d8d428df6a is that we previously parsed "replaced" dependencies but removed their requirements. That caused us to treat them as indirect dependencies and not attempt to update them. I've preserved the behavior of not updating replaced dependencies (until we can implement a way to properly update them) by skipping them during the file parsing step.

The go smoke test is currently failing but that's expected. It needs to be updated to:
- Use the default allow condition so indirect deps aren't updated
- Update the expectation for the submitted dependency list which will now include indirect deps but exclude replaced deps.
