### PR TITLE
fix: make sure to escape requests

### DIFF
--- a/common/lib/dependabot/clients/bitbucket.rb
+++ b/common/lib/dependabot/clients/bitbucket.rb
@@ -207,7 +207,7 @@ module Dependabot
 
       def get(url)
         response = Excon.get(
-          URI::Parser.new.escape(url),
+          URI::DEFAULT_PARSER.escape(url),
           user: credentials&.fetch("username", nil),
           password: credentials&.fetch("password", nil),
           # Setting to false to prevent Excon retries, use BitbucketWithRetries for retries.

--- a/common/lib/dependabot/clients/bitbucket.rb
+++ b/common/lib/dependabot/clients/bitbucket.rb
@@ -207,7 +207,7 @@ module Dependabot
 
       def get(url)
         response = Excon.get(
-          URI.escape(url),
+          URI::Parser.new.escape(url),
           user: credentials&.fetch("username", nil),
           password: credentials&.fetch("password", nil),
           # Setting to false to prevent Excon retries, use BitbucketWithRetries for retries.

--- a/common/lib/dependabot/clients/bitbucket.rb
+++ b/common/lib/dependabot/clients/bitbucket.rb
@@ -207,7 +207,7 @@ module Dependabot
 
       def get(url)
         response = Excon.get(
-          url,
+          URI.escape(url),
           user: credentials&.fetch("username", nil),
           password: credentials&.fetch("password", nil),
           # Setting to false to prevent Excon retries, use BitbucketWithRetries for retries.


### PR DESCRIPTION
This should fix requests failing for URLs composed of parts where spaces might be possible

fix: #6381