### PR TITLE
Pin codespace ruby version to match the rest of the repo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
     "github-cli": "latest",
     "node": "lts",
     "golang": "latest",
-    "ruby": "latest",
+    "ruby": "3.1.3",
     "rust": "latest",
     "dotnet": "latest",
     "ghcr.io/devcontainers/features/sshd:1": {


### PR DESCRIPTION
This was coming up as `3.2.0`, which was inconvenient when I was trying to regenerate the `Gemfile.lock` etc... life is simpler if we pin this to match the ruby version we use in the rest of `dependabot-core` and then update it in lockstep.