### PR TITLE
Install `cmake` by default in codespace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,8 @@ ARG VARIANT="jammy"
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+      cmake  # required for `bundle install` within the updater
 
 


### PR DESCRIPTION
For some of the Dependabot PR's that bump gems within the Updater, we have to run `bundle install` within the `updater` subfolder in order to regenerate the updater's `Gemfile.lock`.

Unfortunately, doing that within the codespace was failing due to a missing `cmake`. So let's install it by default for convenience.