### PR TITLE
Bump `rust` to `1.66.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -249,7 +249,7 @@ ENV RUSTUP_HOME=/opt/rust \
   PATH="${PATH}:/opt/rust/bin"
 RUN mkdir -p "$RUSTUP_HOME" && chown dependabot:dependabot "$RUSTUP_HOME"
 USER dependabot
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.64.0 --profile minimal
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.66.0 --profile minimal
 
 
 ### Terraform


### PR DESCRIPTION
https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1660-2022-12-15

The new `cargo remove` command may be something we could leverage at some point, but for now let's just bump the version.