### PR TITLE
Support "increase-if-necessary" strategy on PEP621 projects

### DIFF
--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -184,6 +184,8 @@ module Dependabot
             update_requirement(req)
           when :bump_versions_if_necessary
             update_requirement_if_needed(req)
+          else
+            raise "Unexpected update strategy: #{update_strategy}"
           end
         end
 

--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -88,10 +88,17 @@ module Dependabot
           case update_strategy
           when :widen_ranges then widen_pyproject_requirement(req)
           when :bump_versions then update_pyproject_version(req)
+          when :bump_versions_if_necessary then update_pyproject_version_if_needed(req)
           else raise "Unexpected update strategy: #{update_strategy}"
           end
         rescue UnfixableRequirement
           req.merge(requirement: :unfixable)
+        end
+
+        def update_pyproject_version_if_needed(req)
+          return req if new_version_satisfies?(req)
+
+          update_pyproject_version(req)
         end
 
         def update_pyproject_version(req)

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -375,117 +375,119 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
       subject { updated_requirements.find { |r| r[:file] == "pyproject.toml" } }
       let(:pyproject_req_string) { "*" }
 
-      context "when asked to bump versions" do
-        let(:update_strategy) { :bump_versions }
+      %i(bump_versions bump_versions_if_necessary).each do |update_strategy|
+        context "when asked to #{update_strategy}" do
+          let(:update_strategy) { update_strategy }
 
-        context "when there is no resolvable version" do
-          let(:latest_resolvable_version) { nil }
-          it { is_expected.to eq(pyproject_req) }
-        end
-
-        context "when there is a resolvable version" do
-          let(:latest_resolvable_version) { "1.5.0" }
-
-          context "and a full version was previously pinned" do
-            let(:pyproject_req_string) { "1.4.0" }
-            its([:requirement]) { is_expected.to eq("1.5.0") }
-
-            context "that has fewer digits than the new version" do
-              let(:pyproject_req_string) { "1.4" }
-              let(:latest_resolvable_version) { "1.5.0" }
-              its([:requirement]) { is_expected.to eq("1.5.0") }
-            end
-
-            context "that had a local version" do
-              let(:pyproject_req_string) { "1.4.0+gc.1" }
-              its([:requirement]) { is_expected.to eq("1.5.0") }
-            end
-
-            context "and used an equality matcher" do
-              let(:pyproject_req_string) { "==1.4.0" }
-              its([:requirement]) { is_expected.to eq("==1.5.0") }
-
-              context "with a single equals" do
-                let(:pyproject_req_string) { "=1.4.0" }
-                its([:requirement]) { is_expected.to eq("=1.5.0") }
-              end
-            end
-          end
-
-          context "and an asterisk was specified" do
-            let(:pyproject_req_string) { "*" }
+          context "when there is no resolvable version" do
+            let(:latest_resolvable_version) { nil }
             it { is_expected.to eq(pyproject_req) }
           end
 
-          context "and a range requirement was specified" do
-            let(:pyproject_req_string) { ">=1.3.0" }
-            it { is_expected.to eq(pyproject_req) }
+          context "when there is a resolvable version" do
+            let(:latest_resolvable_version) { "1.5.0" }
 
-            context "that is too high" do
-              let(:pyproject_req_string) { ">=2.0.0" }
-              its([:requirement]) { is_expected.to eq(:unfixable) }
-            end
+            context "and a full version was previously pinned" do
+              let(:pyproject_req_string) { "1.4.0" }
+              its([:requirement]) { is_expected.to eq("1.5.0") }
 
-            context "that had a local version" do
-              let(:pyproject_req_string) { ">=1.3.0+gc.1" }
-              it { is_expected.to eq(pyproject_req) }
-            end
-
-            context "with an upper bound" do
-              let(:pyproject_req_string) { ">=1.3.0, <=1.5.0" }
-              it { is_expected.to eq(pyproject_req) }
-
-              context "that needs updating" do
-                let(:pyproject_req_string) { ">=1.3.0, <1.5" }
-                its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
+              context "that has fewer digits than the new version" do
+                let(:pyproject_req_string) { "1.4" }
+                let(:latest_resolvable_version) { "1.5.0" }
+                its([:requirement]) { is_expected.to eq("1.5.0") }
               end
-            end
-          end
 
-          context "and a ~= requirement was specified" do
-            let(:pyproject_req_string) { "~=1.3.0" }
-            its([:requirement]) { is_expected.to eq("~=1.5.0") }
-          end
+              context "that had a local version" do
+                let(:pyproject_req_string) { "1.4.0+gc.1" }
+                its([:requirement]) { is_expected.to eq("1.5.0") }
+              end
 
-          context "and a ~ requirement was specified" do
-            let(:pyproject_req_string) { "~1.3.0" }
-            its([:requirement]) { is_expected.to eq("~1.5.0") }
-          end
+              context "and used an equality matcher" do
+                let(:pyproject_req_string) { "==1.4.0" }
+                its([:requirement]) { is_expected.to eq("==1.5.0") }
 
-          context "and a ^ requirement was specified" do
-            let(:pyproject_req_string) { "^1.3.0" }
-            its([:requirement]) { is_expected.to eq("^1.5.0") }
-
-            context "without a lockfile" do
-              let(:has_lockfile) { false }
-              its([:requirement]) { is_expected.to eq("^1.3.0") }
-
-              context "that needs updating" do
-                let(:latest_resolvable_version) { "2.5.0" }
-                its([:requirement]) { is_expected.to eq("^2.5.0") }
+                context "with a single equals" do
+                  let(:pyproject_req_string) { "=1.4.0" }
+                  its([:requirement]) { is_expected.to eq("=1.5.0") }
+                end
               end
             end
 
-            context "with an || specifier" do
-              let(:pyproject_req_string) { "^0.8.0 || ^1.3.0" }
-              its([:requirement]) { is_expected.to eq("^0.8.0 || ^1.3.0") }
-            end
-          end
-
-          context "and a wildcard match was specified" do
-            context "that is satisfied" do
-              let(:pyproject_req_string) { "==1.*.*" }
+            context "and an asterisk was specified" do
+              let(:pyproject_req_string) { "*" }
               it { is_expected.to eq(pyproject_req) }
             end
 
-            context "that needs updating" do
-              let(:pyproject_req_string) { "==1.4.*" }
-              its([:requirement]) { is_expected.to eq("==1.5.*") }
+            context "and a range requirement was specified" do
+              let(:pyproject_req_string) { ">=1.3.0" }
+              it { is_expected.to eq(pyproject_req) }
+
+              context "that is too high" do
+                let(:pyproject_req_string) { ">=2.0.0" }
+                its([:requirement]) { is_expected.to eq(:unfixable) }
+              end
+
+              context "that had a local version" do
+                let(:pyproject_req_string) { ">=1.3.0+gc.1" }
+                it { is_expected.to eq(pyproject_req) }
+              end
+
+              context "with an upper bound" do
+                let(:pyproject_req_string) { ">=1.3.0, <=1.5.0" }
+                it { is_expected.to eq(pyproject_req) }
+
+                context "that needs updating" do
+                  let(:pyproject_req_string) { ">=1.3.0, <1.5" }
+                  its([:requirement]) { is_expected.to eq(">=1.3.0,<1.6") }
+                end
+              end
             end
 
-            context "along with an exact match" do
-              let(:pyproject_req_string) { "==1.4.*, ==1.4.1" }
-              its([:requirement]) { is_expected.to eq("==1.5.0") }
+            context "and a ~= requirement was specified" do
+              let(:pyproject_req_string) { "~=1.3.0" }
+              its([:requirement]) { is_expected.to eq("~=1.5.0") }
+            end
+
+            context "and a ~ requirement was specified" do
+              let(:pyproject_req_string) { "~1.3.0" }
+              its([:requirement]) { is_expected.to eq("~1.5.0") }
+            end
+
+            context "and a ^ requirement was specified" do
+              let(:pyproject_req_string) { "^1.3.0" }
+              its([:requirement]) { is_expected.to eq(update_strategy == :bump_versions ? "^1.5.0" : "^1.3.0") }
+
+              context "without a lockfile" do
+                let(:has_lockfile) { false }
+                its([:requirement]) { is_expected.to eq("^1.3.0") }
+
+                context "that needs updating" do
+                  let(:latest_resolvable_version) { "2.5.0" }
+                  its([:requirement]) { is_expected.to eq("^2.5.0") }
+                end
+              end
+
+              context "with an || specifier" do
+                let(:pyproject_req_string) { "^0.8.0 || ^1.3.0" }
+                its([:requirement]) { is_expected.to eq("^0.8.0 || ^1.3.0") }
+              end
+            end
+
+            context "and a wildcard match was specified" do
+              context "that is satisfied" do
+                let(:pyproject_req_string) { "==1.*.*" }
+                it { is_expected.to eq(pyproject_req) }
+              end
+
+              context "that needs updating" do
+                let(:pyproject_req_string) { "==1.4.*" }
+                its([:requirement]) { is_expected.to eq("==1.5.*") }
+              end
+
+              context "along with an exact match" do
+                let(:pyproject_req_string) { "==1.4.*, ==1.4.1" }
+                its([:requirement]) { is_expected.to eq("==1.5.0") }
+              end
             end
           end
         end


### PR DESCRIPTION
This PR adds support for the "increase-if-necessary" update strategy for Python projects following PEP621.

Fixes #6371. 