### PR TITLE
Revert "remove Dockerfile.ci as it is redundant"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,8 +150,8 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: |
           docker build \
-            -f Dockerfile.updater \
-            -t "dependabot-updater:latest" \
+            -f Dockerfile.ci \
+            -t "dependabot-core-ci:latest" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             .
 
@@ -165,8 +165,8 @@ jobs:
             --env "SUITE_NAME=${{ matrix.suite.name }}" \
             --env "CI_NODE_TOTAL=${{ matrix.suite.ci_node_total }}" \
             --env "CI_NODE_INDEX=${{ matrix.suite.ci_node_index }}" \
-            --rm dependabot-updater bash -c \
-            "cd /home/dependabot/dependabot/${{ matrix.suite.path }} && ./script/ci-test"
+            --rm dependabot-core-ci bash -c \
+            "cd /home/dependabot/dependabot-core/${{ matrix.suite.path }} && ./script/ci-test"
 
   updater:
     name: Updater

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,28 @@
+FROM dependabot/dependabot-core
+
+RUN git config --global user.name dependabot-ci \
+  && git config --global user.email no-reply@github.com
+
+ARG CODE_DIR=/home/dependabot/dependabot-core
+WORKDIR ${CODE_DIR}
+
+COPY --chown=dependabot:dependabot .ruby-version ${CODE_DIR}/.ruby-version
+COPY --chown=dependabot:dependabot .rubocop.yml ${CODE_DIR}/.rubocop.yml
+COPY --chown=dependabot:dependabot omnibus ${CODE_DIR}/omnibus
+COPY --chown=dependabot:dependabot git_submodules ${CODE_DIR}/git_submodules
+COPY --chown=dependabot:dependabot terraform ${CODE_DIR}/terraform
+COPY --chown=dependabot:dependabot github_actions ${CODE_DIR}/github_actions
+COPY --chown=dependabot:dependabot hex ${CODE_DIR}/hex
+COPY --chown=dependabot:dependabot elm ${CODE_DIR}/elm
+COPY --chown=dependabot:dependabot docker ${CODE_DIR}/docker
+COPY --chown=dependabot:dependabot nuget ${CODE_DIR}/nuget
+COPY --chown=dependabot:dependabot maven ${CODE_DIR}/maven
+COPY --chown=dependabot:dependabot gradle ${CODE_DIR}/gradle
+COPY --chown=dependabot:dependabot cargo ${CODE_DIR}/cargo
+COPY --chown=dependabot:dependabot composer ${CODE_DIR}/composer
+COPY --chown=dependabot:dependabot go_modules ${CODE_DIR}/go_modules
+COPY --chown=dependabot:dependabot python ${CODE_DIR}/python
+COPY --chown=dependabot:dependabot pub ${CODE_DIR}/pub
+COPY --chown=dependabot:dependabot npm_and_yarn ${CODE_DIR}/npm_and_yarn
+COPY --chown=dependabot:dependabot bundler ${CODE_DIR}/bundler
+COPY --chown=dependabot:dependabot common ${CODE_DIR}/common


### PR DESCRIPTION
Reverts dependabot/dependabot-core#6418

The CI only passed because it skipped everything and now I've got it running them there are some linter failures that might be due to rubocop config being in the wrong place perhaps.

Either way this will get our CI working again. 