### PR TITLE
Let `pip-compile` unlock sub-dependencies when necessary

### DIFF
--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -36,6 +36,8 @@ module Dependabot
         @latest_resolvable_version ||=
           if resolver_type == :requirements
             resolver.latest_resolvable_version
+          elsif resolver_type == :pip_compile && resolver.resolvable?(version: latest_version)
+            latest_version
           else
             resolver.latest_resolvable_version(
               requirement: unlocked_requirement_string

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
       context "including pep621 dependencies" do
         let(:pyproject_fixture_name) { "pep621_exact_requirement.toml" }
 
-        it "delegates to PoetryVersionResolver" do
+        it "delegates to PipVersionResolver" do
           dummy_resolver =
             instance_double(described_class::PipVersionResolver)
           allow(described_class::PipVersionResolver).to receive(:new).


### PR DESCRIPTION
This is what's normally done when updating a direct dependency through pip-compile:

* Say we have `mkdocs-material==9.0.3` in the requirements.in file.
* We'll first unlock the requirement to allow the latest version, like this: `mkdocs-material>=9.0.3,<=9.0.4`.
* Then we'll run something like `pip-compile -v --build-isolation --allow-unsafe --resolver backtracking --output-file=requirements.txt -P mkdocs-material requirements.in`.
* Then we'll look at the version of `mkdocs-material` in the new requirements.txt and we'll consider that version as the latest resolvable version.

However, if updating to 9.0.4 requires an indirect dependency to also be updated, the above `pip-compile` command won't update anything in the lockfile, since it finds an existing `requirement.txt` and is happy with that.

BUT I observed that forcing the requirement to be `9.0.4` instead through `mkdocs-material==9.0.4`, then `pip-compile` will run into a conflict and automatically resolve it by unlock what needs to be unlocked, showing the following output:

```
  ERROR: Cannot install -r mkdocs-requirements.in (line 2) because these package versions have conflicting dependencies.
Discarding pymdown-extensions==9.9 (from -r mkdocs-requirements.txt (line 17)) to proceed the resolution
...
```

And happily updates the `requirements.txt` to use the latest version of `mkdocs-material` and also a compatible version of the subdependency.

This is exactly what security updates do to "force" the fixed version, but I think we can leverage that for version updates too.

With this change, an update running into this situation succeeds:

```
$ bin/dry-run.rb pip GW2ToolBelt/api-generator --dep mkdocs-material --cache=files --dir /.github/workflows/

=> reading dependency files from cache manifest: ./dry-run/GW2ToolBelt/api-generator/.github/workflows/cache-manifest-pip.json
=> parsing dependency files
=> updating 1 dependencies: mkdocs-material

=== mkdocs-material (9.0.3)
 => checking for updates 1/1
🌍 https://pypi.org/simple/mkdocs-material/
 => latest available version is 9.0.4
 => latest allowed version is 9.0.4
 => requirements to unlock: own
 => requirements update strategy: bump_versions
 => updating mkdocs-material from 9.0.3 to 9.0.4

    ± mkdocs-requirements.in
    ~~~
    2c2
    < mkdocs-material==9.0.3
    ---
    > mkdocs-material==9.0.4
    ~~~

    ± mkdocs-requirements.txt
    ~~~
    13c13
    < mkdocs-material==9.0.3
    ---
    > mkdocs-material==9.0.4
    17c17
    < pymdown-extensions==9.9
    ---
    > pymdown-extensions==9.9.1
    ~~~
🌍 Total requests made: '1'
```

~Still needs tests but should fix #6428.~

Tests added.

Fixes #6428.