### PR TITLE
Run RuboCop as a monorepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
           - { path: npm_and_yarn, name: npm_and_yarn, ci_node_total: 3, ci_node_index: 1 }
           - { path: npm_and_yarn, name: npm_and_yarn, ci_node_total: 3, ci_node_index: 2 }
           - { path: nuget, name: nuget }
-          - { path: omnibus, name: omnibus }
           - { path: python, name: python, ci_node_total: 5, ci_node_index: 0 }
           - { path: python, name: python, ci_node_total: 5, ci_node_index: 1 }
           - { path: python, name: python, ci_node_total: 5, ci_node_index: 2 }
@@ -63,91 +62,103 @@ jobs:
             bundler:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'bundler/**'
             cargo:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'cargo/**'
             common:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
             composer:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'composer/**'
             docker:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'docker/**'
             elm:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'elm/**'
             git_submodules:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'git_submodules/**'
             github_actions:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'github_actions/**'
             go_modules:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'go_modules/**'
             gradle:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'maven/**'
               - 'gradle/**'
             hex:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'hex/**'
             maven:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'maven/**'
             npm_and_yarn:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'npm_and_yarn/**'
             nuget:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'nuget/**'
-            omnibus:
-              - Dockerfile
-              - 'common/**'
-              - '.github/workflows/ci.yml'
-              - 'omnibus/**'
             pub:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'pub/**'
             python:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'python/**'
             terraform:
               - Dockerfile
               - 'common/**'
+              - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'terraform/**'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,10 +204,6 @@ jobs:
             .
       - name: Build
         run: script/build
-      - name: Lint
-        run: script/lint
-        env:
-          SKIP_BUILD: true
       - name: Run updater tests
         run: ./script/ci-test-updater
         env:
@@ -219,4 +215,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
       - run: ./bin/lint

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -84,4 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
       - run: ./bin/lint

--- a/bin/lint
+++ b/bin/lint
@@ -11,3 +11,5 @@ shellcheck \
   ./*/helpers/build \
   ./*/script/* \
   "$@"
+
+bundle exec rubocop

--- a/bundler/script/ci-test
+++ b/bundler/script/ci-test
@@ -3,7 +3,6 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec
 
 # NOTE: Don't use `if` branches without `else` part, since the code in some of

--- a/cargo/script/ci-test
+++ b/cargo/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec rspec spec

--- a/common/script/ci-test
+++ b/common/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec rspec spec

--- a/composer/script/ci-test
+++ b/composer/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec

--- a/docker/script/ci-test
+++ b/docker/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec rspec spec

--- a/elm/script/ci-test
+++ b/elm/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec rspec spec

--- a/git_submodules/script/ci-test
+++ b/git_submodules/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec rspec spec

--- a/github_actions/script/ci-test
+++ b/github_actions/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec rspec spec

--- a/go_modules/script/ci-test
+++ b/go_modules/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec

--- a/gradle/script/ci-test
+++ b/gradle/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec rspec spec

--- a/hex/script/ci-test
+++ b/hex/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec

--- a/maven/script/ci-test
+++ b/maven/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec rspec spec

--- a/npm_and_yarn/script/ci-test
+++ b/npm_and_yarn/script/ci-test
@@ -3,7 +3,6 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 export YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
 bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec
 

--- a/nuget/script/ci-test
+++ b/nuget/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec rspec spec

--- a/omnibus/.rubocop.yml
+++ b/omnibus/.rubocop.yml
@@ -277,6 +277,9 @@ Style/NegatedIfElseCondition:
   Enabled: true
 Style/NilLambda:
   Enabled: true
+Style/NumericPredicate:
+  Exclude:
+    - "../*/spec/**/*"
 Style/OptionalBooleanParameter:
   Enabled: false
 Style/PercentLiteralDelimiters:

--- a/omnibus/.rubocop.yml
+++ b/omnibus/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "../*/bin/**/*"
     - "../**/tmp/**/*"
     - "../*/spec/fixtures/**/*"
+    - "../vendor/**/*"
     - "../dry-run/**/*"
   NewCops: enable
   SuggestExtensions: false

--- a/omnibus/script/ci-test
+++ b/omnibus/script/ci-test
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e
-
-echo "No tests here"

--- a/omnibus/script/ci-test
+++ b/omnibus/script/ci-test
@@ -2,5 +2,4 @@
 
 set -e
 
-bundle install
-bundle exec rubocop .
+echo "No tests here"

--- a/pub/script/ci-test
+++ b/pub/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec rspec spec

--- a/python/script/ci-test
+++ b/python/script/ci-test
@@ -4,5 +4,4 @@ set -e
 
 bundle install
 pyenv exec flake8 helpers/. --count --exclude=./.*,./python/spec/fixtures --show-source --statistics
-bundle exec rubocop .
 bundle exec parallel_test spec/ -n "$CI_NODE_TOTAL" --only-group "$CI_NODE_INDEX" --group-by filesize --type rspec

--- a/script/lint
+++ b/script/lint
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -e
-cd "$(dirname "$0")/.."
-source script/_common
-
-export OMNIBUS_VERSION="latest"
-docker_bundle_exec rubocop

--- a/terraform/script/ci-test
+++ b/terraform/script/ci-test
@@ -3,5 +3,4 @@
 set -e
 
 bundle install
-bundle exec rubocop .
 bundle exec rspec spec


### PR DESCRIPTION
Currently, if you introduce a style issue in one ecosystem, you'll get the same failure for all jobs of that ecosystem. I think it's better to get the failure in the lint job instead.

This PR also removes omnibus jobs, since `omnibus` has no tests and changes very rarely, so I think (even with Docker caching), they're just overhead. Instead, those few times when it does changes, run everything.