### PR TITLE
fix git config not present for certain tests

### DIFF
--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -34,6 +34,9 @@ if ENV["COVERAGE"]
   end
 end
 
+Dependabot::SharedHelpers.run_shell_command("git config --global user.email no-reply@github.com")
+Dependabot::SharedHelpers.run_shell_command("git config --global user.name dependabot-ci")
+
 RSpec.configure do |config|
   config.color = true
   config.order = :rand
@@ -117,8 +120,6 @@ def build_tmp_repo(project, path: "projects")
   FileUtils.cp_r("#{project_path}/.", tmp_repo_path)
 
   Dir.chdir(tmp_repo_path) do
-    Dependabot::SharedHelpers.run_shell_command("git config --global user.email no-reply@github.com")
-    Dependabot::SharedHelpers.run_shell_command("git config --global user.name dependabot-ci")
     Dependabot::SharedHelpers.run_shell_command("git init")
     Dependabot::SharedHelpers.run_shell_command("git add --all")
     Dependabot::SharedHelpers.run_shell_command("git commit -m init")


### PR DESCRIPTION
In #6424 I moved the git config into the tests, but didn't realize there are some tests that run `git commit` directly like this one:

https://github.com/dependabot/dependabot-core/blob/c2b0cf8cd7d58f01565128ac68c72c4818d7edf3/common/spec/dependabot/file_fetchers/base_spec.rb#L1338-L1343

This is resulting in racy failures in CI where the git config hasn't been set globally yet.

By moving this out of the function it will run as soon as it's required which should fix that problem. It's a bit of a naive solution though so I am not opposed to other ideas.