### PR TITLE
Mark test `pending` for `composer` `Dependabot::PrivateSourceTimedOut`

### DIFF
--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -274,21 +274,23 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       end
     end
 
-    # This test is extremely slow, as it needs to wait for Composer to time out.
-    # As a result we currently keep it commented out.
-    # context "with an unreachable private registry" do
-    #   let(:project_name) { "unreachable_private_registry" }
-    #   let(:dependency_name) { "dependabot/dummy-pkg-a" }
-    #   let(:dependency_version) { nil }
-    #   let(:string_req) { "*" }
-    #   let(:latest_allowable_version) { Gem::Version.new("6.0.0") }
+    context "with an unreachable private registry" do
+      let(:project_name) { "unreachable_private_registry" }
+      let(:dependency_name) { "dependabot/dummy-pkg-a" }
+      let(:dependency_version) { nil }
+      let(:string_req) { "*" }
+      let(:latest_allowable_version) { Gem::Version.new("6.0.0") }
 
-    #   it "raises a Dependabot::PrivateSourceTimedOut error" do
-    #     expect { resolver.latest_resolvable_version }.
-    #       to raise_error(Dependabot::PrivateSourceTimedOut) do |error|
-    #         expect(error.source).to eq("https://composer.dependabot.com")
-    #       end
-    #   end
-    # end
+      before { ENV["COMPOSER_PROCESS_TIMEOUT"] = "1" }
+      after { ENV.delete("COMPOSER_PROCESS_TIMEOUT") }
+
+      it "raises a Dependabot::PrivateSourceTimedOut error" do
+        pending("TODO: this URL has no DNS record post GitHub acquisition, so switch to a routable URL that hangs")
+        expect { resolver.latest_resolvable_version }.
+          to raise_error(Dependabot::PrivateSourceTimedOut) do |error|
+            expect(error.source).to eq("https://composer.dependabot.com")
+          end
+      end
+    end
   end
 end


### PR DESCRIPTION
This was commented out because it had to wait til `composer` timed out, which defaults to 300 seconds (5 mins).

However, `composer` supports setting a custom timeout using the env var `COMPOSER_PROCESS_TIMEOUT`.

So set a much lower timeout and re-enable the test. When I first re-enabled the test, I discovered a code bug. Furthermore, once that was fixed by https://github.com/dependabot/dependabot-core/pull/6435, I discovered a bug in the test itself, so we should keep this enabled if we have any hope of deriving value from it.