### PR TITLE
ecosystem-images: speed up base build

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -30,13 +30,17 @@ jobs:
         with:
           filters: |
             python:
+              - Dockerfile.updater-core
               - Dockerfile.python
               - 'common/**'
               - 'python/**'
+              - '.github/workflows/ecosystem-ci.yml'
             go_modules:
+              - Dockerfile.updater-core
               - Dockerfile.go_modules
               - 'common/**'
               - 'go_modules/**'
+              - '.github/workflows/ecosystem-ci.yml'
 
       - name: Build updater core image
         if: steps.changes.outputs[matrix.suite.path] == 'true'

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -14,17 +14,9 @@ RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
     build-essential \
-    dirmngr \
-    git \
-    git-lfs \
-    bzr \
-    mercurial \
-    gnupg2 \
     ca-certificates \
     curl \
-    file \
     zlib1g-dev \
-    liblzma-dev \
     libyaml-dev \
     libgdbm-dev \
     bison \
@@ -32,31 +24,15 @@ RUN apt-get update \
     zip \
     unzip \
     locales \
-    openssh-client \
-    software-properties-common \
-    # Everything from here onwards is only installed to ensure
-    # Python support works with all packages (which may require
-    # specific libraries at install time).
     make \
-    libpq-dev \
     libssl-dev \
     libbz2-dev \
     libffi-dev \
     libreadline-dev \
-    libsqlite3-dev \
-    libcurl4-openssl-dev \
-    llvm \
     libncurses5-dev \
-    libncursesw5-dev \
-    libmysqlclient-dev \
     xz-utils \
     tk-dev \
-    libxml2-dev \
-    libxmlsec1-dev \
-    libgeos-dev \
-    python3-enchant \
-  && locale-gen en_US.UTF-8 \
-  && rm -rf /var/lib/apt/lists/*
+  && locale-gen en_US.UTF-8
 
 ### RUBY
 
@@ -77,7 +53,7 @@ RUN mkdir -p /tmp/ruby-install \
  && tar -xzvf ruby-install-$RUBY_INSTALL_VERSION.tar.gz \
  && cd ruby-install-$RUBY_INSTALL_VERSION/ \
  && make \
- && ./bin/ruby-install --system --cleanup ruby $RUBY_VERSION -- --disable-install-doc \
+ && ./bin/ruby-install -j4 --system --cleanup ruby $RUBY_VERSION -- --disable-install-doc \
  && gem install bundler -v $BUNDLER_V2_VERSION --no-document \
  && rm -rf /var/lib/gems/*/cache/* \
  && rm -rf /tmp/ruby-install
@@ -89,20 +65,12 @@ WORKDIR ${HOME}
 ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-amd64.tar.gz"
 RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
 
-# Disable automatic pulling of files stored with Git LFS
-# This avoids downloading large files not necessary for the dependabot scripts
-ENV GIT_LFS_SKIP_SMUDGE=1
-
 ENV DEPENDABOT_HOME /home/dependabot
-
-RUN mkdir $DEPENDABOT_HOME/dependabot-updater
-
-COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock $DEPENDABOT_HOME/dependabot-updater/
-
-COPY --chown=dependabot:dependabot .ruby-version ${DEPENDABOT_HOME}/.ruby-version
-COPY --chown=dependabot:dependabot .rubocop.yml ${DEPENDABOT_HOME}/.rubocop.yml
-
 WORKDIR ${DEPENDABOT_HOME}
+
+COPY updater/Gemfile updater/Gemfile.lock dependabot-updater/
+COPY .ruby-version .ruby-version
+COPY .rubocop.yml .rubocop.yml
 COPY omnibus omnibus
 COPY git_submodules/Gemfile git_submodules/dependabot-git_submodules.gemspec git_submodules/
 COPY terraform/Gemfile terraform/dependabot-terraform.gemspec terraform/
@@ -171,6 +139,10 @@ RUN if ! getent group "$USER_GID"; then groupadd --gid "$USER_GID" dependabot ; 
   && useradd --uid "${USER_UID}" --gid "${USER_GID}" -m dependabot \
   && mkdir -p /opt && chown dependabot:dependabot /opt && chgrp dependabot /etc/ssl/certs && chmod g+w /etc/ssl/certs
 
+# Disable automatic pulling of files stored with Git LFS
+# This avoids downloading large files not necessary for the dependabot scripts
+ENV GIT_LFS_SKIP_SMUDGE=1
+
 COPY --from=builder /opt /opt
 COPY --from=builder --chown=dependabot:dependabot /usr/local /usr/local
 COPY --from=builder --chown=dependabot:dependabot /home/dependabot /home/dependabot
@@ -181,10 +153,9 @@ ENV DEPENDABOT_HOME /home/dependabot
 COPY --chown=dependabot:dependabot LICENSE $DEPENDABOT_HOME
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 
-ENV PATH="$HOME/bin:/opt/go/bin:/opt/go_modules/bin:$PATH"
+ENV PATH="$HOME/bin:$PATH"
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 
-USER dependabot
 WORKDIR $DEPENDABOT_HOME/dependabot-updater
 
 CMD ["bundle", "exec", "ruby", "bin/dependabot_update.rb"]


### PR DESCRIPTION
- Remove apt dependencies that are not needed for the ruby-install build
- Pass the `-j` flag to ruby-install which will build with multiple cores (I set to 4 but we might need to use 2 to match the number of cores in the Actions runner)

Also a couple of minor clean-ups. 