### PR TITLE
Catch up with some changes in upstream pub

### DIFF
--- a/pub/helpers/bin/dependency_services.dart
+++ b/pub/helpers/bin/dependency_services.dart
@@ -14,7 +14,7 @@ import 'package:pub/src/log.dart' as log;
 class _DependencyServicesCommandRunner extends CommandRunner<int>
     implements PubTopLevel {
   @override
-  String? get directory => argResults['directory'];
+  String get directory => argResults['directory'];
 
   @override
   bool get captureStackChains => argResults['verbose'];

--- a/pub/helpers/bin/dependency_services.dart
+++ b/pub/helpers/bin/dependency_services.dart
@@ -40,6 +40,7 @@ class _DependencyServicesCommandRunner extends CommandRunner<int>
             usageLineLength: lineLength) {
     argParser.addFlag('verbose',
         abbr: 'v', negatable: false, help: 'Shortcut for "--verbosity=all".');
+    PubTopLevel.addColorFlag(argParser);
     argParser.addOption(
       'directory',
       abbr: 'C',

--- a/pub/helpers/pubspec.lock
+++ b/pub/helpers/pubspec.lock
@@ -138,8 +138,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: c4e9ddc888c3aa89ef4462f0c4298929191e32b9
-      resolved-ref: c4e9ddc888c3aa89ef4462f0c4298929191e32b9
+      ref: "9bf4289d6fd5d6872a8929d6312bbd7098f3ea9c"
+      resolved-ref: "9bf4289d6fd5d6872a8929d6312bbd7098f3ea9c"
       url: "https://github.com/dart-lang/pub"
     source: git
     version: "0.0.0"

--- a/pub/helpers/pubspec.lock
+++ b/pub/helpers/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "40.0.0"
+    version: "52.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "5.4.0"
   args:
     dependency: "direct main"
     description:
@@ -70,7 +70,7 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.2.0"
   glob:
     dependency: transitive
     description:
@@ -138,8 +138,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "9bf4289d6fd5d6872a8929d6312bbd7098f3ea9c"
-      resolved-ref: "9bf4289d6fd5d6872a8929d6312bbd7098f3ea9c"
+      ref: "97f638d091e1afa66f422d0b83f71a0d65692b4e"
+      resolved-ref: "97f638d091e1afa66f422d0b83f71a0d65692b4e"
       url: "https://github.com/dart-lang/pub"
     source: git
     version: "0.0.0"

--- a/pub/helpers/pubspec.yaml
+++ b/pub/helpers/pubspec.yaml
@@ -12,4 +12,4 @@ dependencies:
   pub:
     git:
      url: https://github.com/dart-lang/pub
-     ref: 9bf4289d6fd5d6872a8929d6312bbd7098f3ea9c
+     ref: 97f638d091e1afa66f422d0b83f71a0d65692b4e

--- a/pub/helpers/pubspec.yaml
+++ b/pub/helpers/pubspec.yaml
@@ -12,4 +12,4 @@ dependencies:
   pub:
     git:
      url: https://github.com/dart-lang/pub
-     ref: c4e9ddc888c3aa89ef4462f0c4298929191e32b9
+     ref: 9bf4289d6fd5d6872a8929d6312bbd7098f3ea9c


### PR DESCRIPTION
It's possible that we'll need to pick up a fix in upstream pub at dart-lang/pub#3736. This PR gets ready for that by catching up with some recent changes in upstream pub.