### PR TITLE
Azure DevOps now supports HTML in PR descriptions

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -145,7 +145,6 @@ module Dependabot
         end
 
         def build_details_tag(summary:, body:)
-          # Azure DevOps does not support <details> tag (https://developercommunity.visualstudio.com/content/problem/608769/add-support-for-in-markdown.html)
           # Bitbucket does not support <details> tag (https://jira.atlassian.com/browse/BCLOUD-20231)
           # CodeCommit does not support the <details> tag (no url available)
           if source_provider_supports_html?
@@ -241,7 +240,7 @@ module Dependabot
         end
 
         def source_provider_supports_html?
-          !%w(azure bitbucket codecommit).include?(source.provider)
+          !%w(bitbucket codecommit).include?(source.provider)
         end
 
         def sanitize_links_and_mentions(text, unsafe: false)


### PR DESCRIPTION
While researching https://github.com/dependabot/dependabot-core/pull/6287#discussion_r1072768837, I noticed that https://developercommunity.visualstudio.com/content/problem/608769/add-support-for-in-markdown.html eventually leads to https://developercommunity.visualstudio.com/t/add-support-for-the-html-tag-in-markdown/609415#T-N1190213 which says that Azure ADO now supports the `<details>` tag in Markdown.

Furthermore, I suspect that ADO now fully supports HTML in PR descriptions but it's not documented either way in https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/create?view=azure-devops-rest-7.0&tabs=HTTP#request-body.

So opening this PR as the simple solution. If ADO doesn't support HTML but does support the `<details>` tag, then we'll unfortunately need a more complex solution of refactoring things... but I hope not.

Fix #2537.