### PR TITLE
Added Ruby 3.2.0 to RubyRequirementSetter version requirements

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb
@@ -11,7 +11,7 @@ module Dependabot
         class RubyVersionNotFound < StandardError; end
 
         RUBY_VERSIONS = %w(
-          1.8.7 1.9.3 2.0.0 2.1.10 2.2.10 2.3.8 2.4.10 2.5.9 2.6.7 2.7.3 3.0.1 3.1.1
+          1.8.7 1.9.3 2.0.0 2.1.10 2.2.10 2.3.8 2.4.10 2.5.9 2.6.7 2.7.3 3.0.1 3.1.1 3.2.0
         ).freeze
 
         attr_reader :gemspec

--- a/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/ruby_requirement_setter_spec.rb
@@ -114,6 +114,17 @@ RSpec.describe Dependabot::Bundler::FileUpdater::RubyRequirementSetter do
         it { is_expected.to include(%(gem "business", "~> 1.4.0")) }
       end
 
+      context "when requiring ruby 3.2" do
+        let(:gemspec) do
+          bundler_project_dependency_file("gemfile_require_ruby_3_2", filename: "example.gemspec")
+        end
+        let(:content) do
+          bundler_project_dependency_file("gemfile", filename: "Gemfile").content
+        end
+        it { is_expected.to include("ruby '3.2.0'\n") }
+        it { is_expected.to include(%(gem "business", "~> 1.4.0")) }
+      end
+
       context "that can't be evaluated" do
         let(:content) do
           bundler_project_dependency_file("gemfile", filename: "Gemfile").content

--- a/bundler/spec/fixtures/projects/bundler1/gemfile_require_ruby_3_2/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/gemfile_require_ruby_3_2/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler1/gemfile_require_ruby_3_2/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/gemfile_require_ruby_3_2/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/bundler/spec/fixtures/projects/bundler1/gemfile_require_ruby_3_2/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/gemfile_require_ruby_3_2/example.gemspec
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end

--- a/bundler/spec/fixtures/projects/bundler2/gemfile_require_ruby_3_2/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/gemfile_require_ruby_3_2/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "business", "~> 1.4.0"
+gem "statesman", "~> 1.2.0"

--- a/bundler/spec/fixtures/projects/bundler2/gemfile_require_ruby_3_2/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler2/gemfile_require_ruby_3_2/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+    statesman (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4.0)
+  statesman (~> 1.2.0)
+
+BUNDLED WITH
+   2.4.1

--- a/bundler/spec/fixtures/projects/bundler2/gemfile_require_ruby_3_2/example.gemspec
+++ b/bundler/spec/fixtures/projects/bundler2/gemfile_require_ruby_3_2/example.gemspec
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name         = "example"
+  spec.version      = "0.9.3"
+  spec.summary      = "Automated dependency management"
+  spec.description  = "Core logic for updating a GitHub repos dependencies"
+
+  spec.author       = "Dependabot"
+  spec.email        = "support@dependabot.com"
+  spec.homepage     = "https://github.com/hmarr/example"
+  spec.license      = "MIT"
+
+  spec.require_path = "lib"
+  spec.files        = Dir["CHANGELOG.md", "LICENSE.txt", "README.md",
+                          "lib/**/*", "helpers/**/*"]
+
+  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_rubygems_version = ">= 2.6.11"
+
+  spec.add_dependency 'business', '~> 1.0'
+end


### PR DESCRIPTION
Similar to https://github.com/dependabot/dependabot-core/pull/4912 I am getting `Dependabot::Bundler::FileUpdater::RubyRequirementSetter::RubyVersionNotFound` in a Rails engine project that uses `spec.required_ruby_version = ">= 3.1"` in the `.gemspec`.

This is the specs output from running them with the included "when requiring ruby 3.2".

<img width="943" alt="specs" src="https://user-images.githubusercontent.com/163900/213028211-40e4e374-04c6-49f2-a8c3-2419b96beb8a.png">
