### PR TITLE
Add Bundler native helper Gemfiles to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@ updates:
       interval: "weekly"
 
   # Watch the per-ecosystem native helpers
+  - package-ecosystem: "bundler"
+    directory: "/bundler/helpers/v1"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "bundler"
+    directory: "/bundler/helpers/v2"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "composer"
     directory: "/composer/helpers/v1"
     schedule:


### PR DESCRIPTION
Watch:
* https://github.com/dependabot/dependabot-core/blob/700751a4f53098b94f690564d574e65fd6a15f70/bundler/helpers/v1/Gemfile
* https://github.com/dependabot/dependabot-core/blob/700751a4f53098b94f690564d574e65fd6a15f70/bundler/helpers/v2/Gemfile 