### PR TITLE
Fix flaky spec failure in updater

### DIFF
--- a/updater/spec/bin_run_spec.rb
+++ b/updater/spec/bin_run_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "bin/run" do
         ENV["DEPENDABOT_JOB_ID"] = nil
         ENV["DEPENDABOT_JOB_TOKEN"] = nil
         ENV["DEPENDABOT_JOB_PATH"] = nil
+        ENV["DEPENDABOT_OUTPUT_PATH"] = nil
         ENV["DEPENDABOT_API_URL"] = nil
       end
     end


### PR DESCRIPTION
Authenticate updater spec to by-pass rate limiting, otherwise it may fail randomly. For example: https://github.com/dependabot/dependabot-core/actions/runs/3949825265/jobs/6761544223.

```
Failures:

  1) bin/run fetch_files completes the job successfully and persists the files
     Failure/Error: expect(result).to include("Finished job processing")

       expected "I, [2023-01-18T14:31:25.371276 #292]  INFO -- sentry: ** [Raven] Raven 3.1.2 configured not to captu...s:\nDependabot encountered '2' error(s) during execution, please check the logs for more details.\n" to include "Finished job processing"
       Diff:
       @@ -1,26 +1,51 @@
       -Finished job processing
       +I, [2023-01-18T14:31:25.371276 #292]  INFO -- sentry: ** [Raven] Raven 3.1.2 configured not to capture errors: DSN not set
       +INFO <job_1> Starting job processing
       +ERROR <job_1> Repository is rate limited, attempting to retry in 734.285586435s
       +ERROR <job_1> <?xml version="1.0" encoding="iso-8859-1"?>
       +<job_1> <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
       +<job_1>          "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
       +<job_1> <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
       +<job_1> 	<head>
       +<job_1> 		<title>404 - Not Found</title>
       +<job_1> 	</head>
       +<job_1> 	<body>
       +<job_1> 		<h1>404 - Not Found</h1>
       +<job_1> 		<script type="text/javascript" src="//wpc.75674.betacdn.net/0075674/www/ec_tpm_bcon.js"></script>
       +<job_1> 	</body>
       +<job_1> </html>
       +
       +ERROR <job_1> /home/dependabot/dependabot-updater/lib/dependabot/api_client.rb:98:in `record_update_job_error'
       +ERROR <job_1> /home/dependabot/dependabot-updater/lib/dependabot/service.rb:38:in `record_update_job_error'
       +ERROR <job_1> /home/dependabot/dependabot-updater/lib/dependabot/file_fetcher_job.rb:179:in `record_error'
       +ERROR <job_1> /home/dependabot/dependabot-updater/lib/dependabot/file_fetcher_job.rb:163:in `handle_file_fetcher_error'
       +ERROR <job_1> /home/dependabot/dependabot-updater/lib/dependabot/file_fetcher_job.rb:29:in `rescue in perform_job'
       +ERROR <job_1> /home/dependabot/dependabot-updater/lib/dependabot/file_fetcher_job.rb:13:in `perform_job'
       +ERROR <job_1> /home/dependabot/dependabot-updater/lib/dependabot/base_job.rb:50:in `run'
       +ERROR <job_1> bin/fetch_files.rb:23:in `<main>'
       +INFO Results:
       +Dependabot encountered '2' error(s) during execution, please check the logs for more details.
     # ./spec/bin_run_spec.rb:27:in `block (3 levels) in <top (required)>'
     # ./vendor/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```