### PR TITLE
publish updater-core image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@ env:
   BASE_IMAGE: "ubuntu:20.04"
   CORE_IMAGE: "dependabot/dependabot-core"
   CORE_IMAGE_MIRROR: "ghcr.io/dependabot/dependabot-core"
+  UPDATER_CORE_IMAGE: "dependabot/dependabot-updater-core"
+  UPDATER_CORE_IMAGE_MIRROR: "ghcr.io/dependabot/dependabot-updater-core"
   UPDATER_IMAGE: "dependabot/dependabot-updater"
   UPDATER_IMAGE_MIRROR: "ghcr.io/dependabot/dependabot-updater"
 on:
@@ -51,6 +53,46 @@ jobs:
           docker push "$CORE_IMAGE:$VERSION"
           docker tag "$CORE_IMAGE:latest" "$CORE_IMAGE_MIRROR:$VERSION"
           docker push "$CORE_IMAGE_MIRROR:$VERSION"
+  push-updater-core-image:
+    name: Push dependabot-updater-core image to docker hub
+    runs-on: ubuntu-latest
+    if: github.repository == 'dependabot/dependabot-core'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Build dependabot-updater-core image
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker build \
+            -t "$UPDATER_CORE_IMAGE:latest" \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --cache-from "$BASE_IMAGE" \
+            --cache-from "$UPDATER_CORE_IMAGE:latest" \
+            -f Dockerfile.updater-core \
+            .
+      - name: Log in to the Docker registry
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Push latest image
+        run: |
+          docker push "$UPDATER_CORE_IMAGE:latest"
+          docker tag "$UPDATER_CORE_IMAGE:latest" "$UPDATER_CORE_IMAGE_MIRROR:latest"
+          docker push "$UPDATER_CORE_IMAGE_MIRROR:latest"
+      - name: Push tagged image
+        if: contains(github.ref, 'refs/tags')
+        run: |
+          VERSION="$(grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" common/lib/dependabot/version.rb)"
+          docker tag "$UPDATER_CORE_IMAGE:latest" "$UPDATER_CORE_IMAGE:$VERSION"
+          docker push "$UPDATER_CORE_IMAGE:$VERSION"
+          docker tag "$UPDATER_CORE_IMAGE:latest" "$UPDATER_CORE_IMAGE_MIRROR:$VERSION"
+          docker push "$UPDATER_CORE_IMAGE_MIRROR:$VERSION"
   push-updater-image:
     name: Push tagged dependabot-updater image
     runs-on: ubuntu-latest


### PR DESCRIPTION
This publishes the latest tag for our new base image for all the ecosystem-specific images. Publishing this helps with caching. 