### PR TITLE
No need to check if env var set

### DIFF
--- a/bin/ci-test
+++ b/bin/ci-test
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-#/ usage: ci-test SUITE
+#/ usage: ci-test SUITE_NAME
 #/ simulate the process followed by ~/.github/workflows/ci.yml
 
 function print_usage() {
@@ -7,8 +7,8 @@ function print_usage() {
 }
 
 function handle_args() {
-  export SUITE=$1
-  case $SUITE in
+  export SUITE_NAME=$1
+  case $SUITE_NAME in
     bundler1 | bundler2)
       export MODULE=bundler
       ;;
@@ -17,7 +17,7 @@ function handle_args() {
       exit 1
       ;;
     *)
-      export MODULE=$SUITE
+      export MODULE=$SUITE_NAME
   esac
 
   if ! [ -d "$MODULE" ]; then
@@ -37,7 +37,9 @@ function build() {
   export CORE=dependabot/dependabot-core
   export UPDATER=dependabot/dependabot-updater
 
+  # shellcheck disable=SC2034  # shellcheck isn't smart enough to realize `docker build` uses `TARGETARCH`
   local TARGETARCH;
+  # shellcheck disable=SC2034  # shellcheck isn't smart enough to realize `docker build` uses `TARGETARCH`
   case "$(uname -m)"
   in
     amd64 | x86_64) TARGETARCH=amd64 ;;
@@ -47,19 +49,19 @@ function build() {
 
   set -x
   docker build \
-    --build-arg "TARGETARCH=${TARGETARCH}" \
+    --build-arg TARGETARCH \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     --cache-from ghcr.io/dependabot/dependabot-core \
     -t $CORE .
   docker build \
-    --build-arg "TARGETARCH=${TARGETARCH}" \
+    --build-arg TARGETARCH \
     --build-arg OMNIBUS_VERSION=latest \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     -f Dockerfile.updater \
     -t $UPDATER .
   docker run --rm \
     -e "CI=true" \
-    -e "SUITE_NAME=$SUITE" \
+    -e SUITE_NAME \
     -e "DEPENDABOT_TEST_ACCESS_TOKEN=${LOCAL_GITHUB_ACCESS_TOKEN}" \
     -e "RAISE_ON_WARNINGS=true" \
     -it $UPDATER \

--- a/script/_common
+++ b/script/_common
@@ -6,7 +6,7 @@ function docker_build() {
 
   extract_version
 
-  docker build $DOCKER_BUILD_ARGS -f Dockerfile.updater -t "$LOCAL_IMAGE" --build-arg OMNIBUS_VERSION=$OMNIBUS_VERSION .
+  docker build $DOCKER_BUILD_ARGS -f Dockerfile.updater -t "$LOCAL_IMAGE" --build-arg OMNIBUS_VERSION .
 
   # Verify max layers; an AUFS limit that was _crucial_ on Heroku (but not now)
   IMAGE_LAYERS=$(docker history -q "$LOCAL_IMAGE" | wc -l | sed -e 's/ //g')
@@ -16,7 +16,7 @@ function docker_build() {
 
 function docker_exec() {
   docker_build
-  docker run --env "DEPENDABOT_TEST_ACCESS_TOKEN=$DEPENDABOT_TEST_ACCESS_TOKEN" \
+  docker run --env DEPENDABOT_TEST_ACCESS_TOKEN \
   --rm \
   -v "$(pwd)/.:/home/dependabot/dependabot-updater:delegated" \
   -ti "$LOCAL_IMAGE" "$@"
@@ -25,13 +25,8 @@ function docker_exec() {
 function docker_bundle_exec() {
   docker_build
 
-  VCR_ARGS=""
-  if [ -n "$VCR" ]; then
-    VCR_ARGS="--env \"VCR=$VCR\""
-  fi
-
-  docker run --env "DEPENDABOT_TEST_ACCESS_TOKEN=$DEPENDABOT_TEST_ACCESS_TOKEN" \
-  $VCR_ARGS \
+  docker run --env DEPENDABOT_TEST_ACCESS_TOKEN \
+  --env VCR \
   --rm \
   -v "$(pwd)/updater/spec/fixtures/vcr_cassettes:/home/dependabot/dependabot-updater/spec/fixtures/vcr_cassettes" \
   "$LOCAL_IMAGE" bundle exec "$@"


### PR DESCRIPTION
Per the Docker [docs](https://docs.docker.com/engine/reference/commandline/run/#-set-environment-variables--e---env---env-file):
> When running the command, the Docker CLI client checks the value the variable has in your local environment and passes it to the container. If no `=` is provided and that variable is not exported in your local environment, the variable won’t be set in the container.

So there's no need to check if an env var is set in the environment before passing it to the `docker`  command.

Conveniently, this removes some of the code throwing `shellcheck` warnings over in:
* https://github.com/dependabot/dependabot-core/pull/5820