### PR TITLE
Fix flaky spec failure in updater (take 2)

### DIFF
--- a/updater/spec/bin_run_spec.rb
+++ b/updater/spec/bin_run_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "bin/run" do
         job_path = File.join(tempdir, "job.json")
 
         job_info = JSON.parse(File.read("spec/fixtures/jobs/job_with_credentials.json"))
-        job_info["job"]["credentials"][0]["password"] = test_access_token
+        job_info["credentials"][0]["password"] = test_access_token
 
         File.write(job_path, JSON.dump(job_info))
 

--- a/updater/spec/fixtures/get_job.json
+++ b/updater/spec/fixtures/get_job.json
@@ -11,19 +11,6 @@
           "update-type": "security"
         }
       ],
-      "credentials": [
-        {
-          "type": "git_source",
-          "host": "github.com",
-          "username": "x-access-token",
-          "password": "v1.exampletokenfromgithubinityesitisforsure"
-        },
-        {
-          "type": "rubygems_index",
-          "host": "my.rubygems-host.org",
-          "token": "secret"
-        }
-      ],
       "credentials-metadata": [
         {
           "type": "git_source",

--- a/updater/spec/fixtures/jobs/job_with_credentials.json
+++ b/updater/spec/fixtures/jobs/job_with_credentials.json
@@ -10,19 +10,6 @@
         "update-type": "security"
       }
     ],
-    "credentials": [
-      {
-        "type": "git_source",
-        "host": "github.com",
-        "username": "x-access-token",
-        "password": "v1.exampletokenfromgithubinityesitisforsure"
-      },
-      {
-        "type": "rubygems_index",
-        "host": "my.rubygems-host.org",
-        "token": "secret"
-      }
-    ],
     "credentials-metadata": [
       {
         "type": "git_source",
@@ -54,5 +41,18 @@
     "updating-a-pull-request": false,
     "vendor-dependencies": false,
     "security-updates-only": false
-  }
+  },
+  "credentials": [
+    {
+      "type": "git_source",
+      "host": "github.com",
+      "username": "x-access-token",
+      "password": "v1.exampletokenfromgithubinityesitisforsure"
+    },
+    {
+      "type": "rubygems_index",
+      "host": "my.rubygems-host.org",
+      "token": "secret"
+    }
+  ]
 }

--- a/updater/spec/fixtures/jobs/job_with_vendor_dependencies.json
+++ b/updater/spec/fixtures/jobs/job_with_vendor_dependencies.json
@@ -10,19 +10,6 @@
         "update-type": "security"
       }
     ],
-    "credentials": [
-      {
-        "type": "git_source",
-        "host": "github.com",
-        "username": "x-access-token",
-        "password": "v1.exampletokenfromgithubinityesitisforsure"
-      },
-      {
-        "type": "rubygems_index",
-        "host": "my.rubygems-host.org",
-        "token": "secret"
-      }
-    ],
     "credentials-metadata": [
       {
         "type": "git_source",
@@ -54,5 +41,18 @@
     "updating-a-pull-request": false,
     "vendor-dependencies": true,
     "security-updates-only": false
-  }
+  },
+  "credentials": [
+    {
+      "type": "git_source",
+      "host": "github.com",
+      "username": "x-access-token",
+      "password": "v1.exampletokenfromgithubinityesitisforsure"
+    },
+    {
+      "type": "rubygems_index",
+      "host": "my.rubygems-host.org",
+      "token": "secret"
+    }
+  ]
 }


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/6461, I attempted to inject environment credentials in the fixture file that `bin_run_spec.rb` uses so that the spec's requests don't get rate limited.

However, turns out credentials were not being properly picked up by the fetcher.

I think the reason is that "credentials" were located at the wrong position in the fixture file, so were getting ignored. I also corrected other fixtures with the same problem.