### PR TITLE
fix updater-core caching not working

### DIFF
--- a/.github/workflows/docker-updater-core.yml
+++ b/.github/workflows/docker-updater-core.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - jakecoffman/fix-latest-build-cache
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 jobs:
@@ -26,8 +27,7 @@ jobs:
           docker build \
             -t "$UPDATER_CORE_IMAGE:latest" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from "$BASE_IMAGE" \
-            --cache-from "$UPDATER_CORE_IMAGE:latest" \
+            --cache-from "$UPDATER_CORE_IMAGE_MIRROR:latest" \
             -f Dockerfile.updater-core \
             .
       - name: Log in to GHCR

--- a/.github/workflows/docker-updater-core.yml
+++ b/.github/workflows/docker-updater-core.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - jakecoffman/fix-latest-build-cache
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 jobs:


### PR DESCRIPTION
The cache-from should come from the image in GHCR for it to work.

Also removed the `--cache-from "$BASE_IMAGE"` as it should have no effect.