### PR TITLE
Fix dry-run and tmp permissions

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -101,6 +101,7 @@ fi
 echo "$(tput setaf 2)=> running docker development shell$(tput sgr0)"
 CODE_DIR="/home/dependabot/dependabot-core"
 touch .core-bash_history
+mkdir -p dry-run tmp
 docker run --rm -ti \
   -v "$(pwd)/.core-bash_history:/home/dependabot/.bash_history" \
   -v "$(pwd)/.rubocop.yml:$CODE_DIR/.rubocop.yml" \


### PR DESCRIPTION
If these folders are not yet created when running `bin/docker-dev-shell`, and Docker is not configured in rootless mode, then they will be created by the container with root ownership.

Make sure they are created before running the container so that permissions from the host system are inherited.

Closes #6452.