### PR TITLE
Allow updating pom's named `pom_parent.xml`

### DIFF
--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -130,7 +130,7 @@ module Dependabot
         name_parts = [
           File.dirname(pom.name),
           relative_parent_path,
-          relative_parent_path.end_with?("pom.xml") ? nil : "pom.xml"
+          relative_parent_path.end_with?("pom.xml", "pom_parent.xml") ? nil : "pom.xml"
         ].compact.reject(&:empty?)
 
         Pathname.new(File.join(*name_parts)).cleanpath.to_path

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -58,7 +58,7 @@ module Dependabot
       end
 
       def recursively_fetch_child_poms(pom, fetched_filenames:)
-        base_path = pom.name.gsub(/pom\.xml$/, "")
+        base_path = File.dirname(pom.name)
         doc = Nokogiri::XML(pom.content)
 
         doc.css(MODULE_SELECTOR).flat_map do |module_node|
@@ -128,7 +128,7 @@ module Dependabot
           doc.at_xpath("/project/parent/relativePath")&.content&.strip || ".."
 
         name_parts = [
-          pom.name.gsub(/pom\.xml$/, "").gsub(/pom_parent\.xml$/, ""),
+          File.dirname(pom.name),
           relative_parent_path,
           relative_parent_path.end_with?("pom.xml") ? nil : "pom.xml"
         ].compact.reject(&:empty?)

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -92,10 +92,7 @@ module Dependabot
       def recursively_fetch_relative_path_parents(pom, fetched_filenames:)
         path = parent_path_for_pom(pom)
 
-        if fetched_filenames.include?(path) ||
-           fetched_filenames.include?(path.gsub("pom.xml", "pom_parent.xml"))
-          return []
-        end
+        return [] if fetched_filenames.include?(path)
 
         full_path_parts =
           [directory.gsub(%r{^/}, ""), path].reject(&:empty?).compact
@@ -107,7 +104,6 @@ module Dependabot
 
         parent_pom = fetch_file_from_host(path)
         parent_pom.support_file = true
-        parent_pom.name = parent_pom.name.gsub("pom.xml", "pom_parent.xml")
 
         [
           parent_pom,

--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -271,9 +271,8 @@ module Dependabot
       end
 
       def pomfiles
-        # NOTE: this (correctly) excludes any parent POMs that were downloaded
         @pomfiles ||=
-          dependency_files.select { |f| f.name.end_with?("pom.xml") }
+          dependency_files.select { |f| f.name.end_with?("pom.xml", "pom_parent.xml") }
       end
 
       def extensionfiles

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -31,11 +31,10 @@ module Dependabot
           )
         end
 
-        updated_files.select! { |f| f.name.end_with?("pom.xml", "extensions.xml") }
+        updated_files.select! { |f| f.name.end_with?("pom.xml", "pom_parent.xml", "extensions.xml") }
         updated_files.reject! { |f| dependency_files.include?(f) }
 
         raise "No files changed!" if updated_files.none?
-        raise "Updated a supporting POM!" if updated_files.any? { |f| f.name.end_with?("pom_parent.xml") }
 
         updated_files
       end

--- a/maven/lib/dependabot/maven/update_checker.rb
+++ b/maven/lib/dependabot/maven/update_checker.rb
@@ -68,8 +68,7 @@ module Dependabot
             property_details(property_name: prop_name, callsite_pom: pom)&.
             fetch(:file)
 
-          declaration_pom_name == "remote_pom.xml" ||
-            declaration_pom_name&.end_with?("pom_parent.xml")
+          declaration_pom_name == "remote_pom.xml"
         end
       end
 

--- a/maven/spec/dependabot/maven/file_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/file_fetcher_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe Dependabot::Maven::FileFetcher do
         it "fetches the relevant poms" do
           expect(file_fetcher_instance.files.count).to eq(3)
           expect(file_fetcher_instance.files.map(&:name)).
-            to match_array(%w(pom.xml ../pom_parent.xml ../../pom_parent.xml))
+            to match_array(%w(pom.xml ../pom.xml ../../pom.xml))
         end
       end
 

--- a/maven/spec/dependabot/maven/file_parser_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser_spec.rb
@@ -497,7 +497,7 @@ RSpec.describe Dependabot::Maven::FileParser do
           to include("junit:junit")
       end
 
-      context "when the parent was downloaded only as a supporting POM" do
+      context "when parent is named pom_parent" do
         let(:files) { [pom, parent_pom] }
         let(:pom_body) { fixture("poms", "sigtran-map.pom") }
         let(:parent_pom) do
@@ -507,11 +507,11 @@ RSpec.describe Dependabot::Maven::FileParser do
           )
         end
 
-        it "excludes parent dependencies" do
+        it "includes parent dependencies" do
           expect(dependencies.map(&:name)).
             to include("uk.me.lwood.sigtran:sigtran-tcap")
           expect(dependencies.map(&:name)).
-            to_not include("junit:junit")
+            to include("junit:junit")
         end
       end
     end

--- a/maven/spec/dependabot/maven/update_checker_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker_spec.rb
@@ -847,7 +847,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
       end
       it { is_expected.to eq(true) }
 
-      context "that inherits from a parent POM downloaded for support" do
+      context "that inherits from a parent POM" do
         let(:dependency_files) { [pom, parent_pom] }
         let(:pom_body) { fixture("poms", "sigtran-map.pom") }
         let(:parent_pom) do
@@ -872,7 +872,7 @@ RSpec.describe Dependabot::Maven::UpdateChecker do
           }]
         end
 
-        it { is_expected.to eq(false) }
+        it { is_expected.to eq(true) }
       end
 
       context "that inherits from a remote POM" do


### PR DESCRIPTION
During review of #6248, we noticed that Dependabot special cases the `pom_parent.xml` name as some trick to fetch parent poms. #6248 tries to preserve that, resulting in that with that PR, Dependabot can now update any pom names, except for `pom_parent.xml`.

We concluded that this "magic name" is not necessary. So this PR removes the magic and instead adds the `pom_parent.xml` to the list of "allowed names", so repositories like https://github.com/filip26/titanium-json-ld can now get updates.

I'm hesitant to add any specs over manual testing because those specs would be exercising a special case that should completely go way after we merge #6248, since that will allow any names.