### PR TITLE
We no longer need to install Bundler 1 globally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,6 @@ RUN if ! getent group "$USER_GID"; then groupadd --gid "$USER_GID" dependabot ; 
 ARG RUBY_VERSION=3.1.3
 ARG RUBY_INSTALL_VERSION=0.8.5
 
-ARG BUNDLER_V1_VERSION=1.17.3
 # When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
 # Generally simplest to match the bundler version to the one that comes by default with whatever Ruby version we install.
 # This way other projects that import this library don't have to futz around with installing new /unexpected bundler versions.
@@ -90,7 +89,6 @@ RUN mkdir -p /tmp/ruby-install \
  && cd ruby-install-$RUBY_INSTALL_VERSION/ \
  && make \
  && ./bin/ruby-install --system --cleanup ruby $RUBY_VERSION -- --disable-install-doc \
- && gem install bundler -v $BUNDLER_V1_VERSION --no-document \
  && gem install bundler -v $BUNDLER_V2_VERSION --no-document \
  && rm -rf /var/lib/gems/*/cache/* \
  && rm -rf /tmp/ruby-install


### PR DESCRIPTION
Since https://github.com/dependabot/dependabot-core/pull/5513 I think it's no longer needed.

For running updater, Bundler 1 is not used anyways, and for running native helpers, the Bundler 1 native helper installer installs Bundler 1 to an isolated location already.

Just opening a PR so that CI can prove me wrong.