### PR TITLE
fix CLI installation in devcontainer

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
-tar xzvf "*.tar.gz" >/dev/null 2>&1
+tar xzvf ./*.tar.gz >/dev/null 2>&1
 sudo mv dependabot /usr/local/bin
-rm "*.tar.gz"
+rm ./*.tar.gz
 
 echo "export LOCAL_GITHUB_ACCESS_TOKEN=$GITHUB_TOKEN" >> ~/.bashrc


### PR DESCRIPTION
I must have messed this up! Putting quotes around the asterisks prevents the globbing I was going for. Removing them fixes dependabot CLI not being installed properly in the dev container. 