### PR TITLE
Breakout the remaining "helper" based ecosystems

### DIFF
--- a/.github/workflows/eco-branch-images.yml
+++ b/.github/workflows/eco-branch-images.yml
@@ -21,15 +21,20 @@ jobs:
         suite:
           - { name: bundler, ecosystem: bundler }
           - { name: cargo, ecosystem: cargo }
+          - { name: composer, ecosystem: composer }
           - { name: docker, ecosystem: docker }
+          - { name: elm, ecosystem: elm }
           - { name: git_submodules, ecosystem: gitsubmodule }
           - { name: github_actions, ecosystem: github-actions }
           - { name: go_modules, ecosystem: gomod }
           - { name: gradle, ecosystem: gradle }
+          - { name: hex, ecosystem: hex }
           - { name: maven, ecosystem: maven }
           - { name: npm_and_yarn, ecosystem: npm }
           - { name: nuget, ecosystem: nuget }
+          - { name: pub, ecosystem: pub }
           - { name: python, ecosystem: pip }
+          - { name: terraform, ecosystem: terraform }
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/eco-latest-releases.yml
+++ b/.github/workflows/eco-latest-releases.yml
@@ -37,15 +37,20 @@ jobs:
         suite:
           - { name: bundler, ecosystem: bundler }
           - { name: cargo, ecosystem: cargo }
+          - { name: composer, ecosystem: composer }
           - { name: docker, ecosystem: docker }
+          - { name: elm, ecosystem: elm }
           - { name: git_submodules, ecosystem: gitsubmodule }
           - { name: github_actions, ecosystem: github-actions }
           - { name: go_modules, ecosystem: gomod }
           - { name: gradle, ecosystem: gradle }
+          - { name: hex, ecosystem: hex }
           - { name: maven, ecosystem: maven }
           - { name: npm_and_yarn, ecosystem: npm }
           - { name: nuget, ecosystem: nuget }
+          - { name: pub, ecosystem: pub }
           - { name: python, ecosystem: pip }
+          - { name: terraform, ecosystem: terraform }
     env:
       TAG: ${{ github.sha }}
       NAME: ${{ matrix.suite.name }}

--- a/.github/workflows/eco-latest-releases.yml
+++ b/.github/workflows/eco-latest-releases.yml
@@ -64,7 +64,7 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: |
           docker build \
-            -t "dependabot/dependabot-updater-core:$TAG" \
+            -t "ghcr.io/dependabot/dependabot-updater-core:$TAG" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --cache-from ghcr.io/dependabot/dependabot-updater-core \
             -f Dockerfile.updater-core \

--- a/.github/workflows/eco-smoke.yml
+++ b/.github/workflows/eco-smoke.yml
@@ -20,20 +20,25 @@ jobs:
         suite:
           - { path: bundler, name: bundler, ecosystem: bundler }
           - { path: cargo, name: cargo, ecosystem: cargo }
+          - { path: composer, name: composer, ecosystem: composer }
           - { path: docker, name: docker, ecosystem: docker }
+          - { path: elm, name: elm, ecosystem: elm }
           - { path: git_submodules, name: submodules, ecosystem: gitsubmodule }
           - { path: github_actions, name: actions, ecosystem: github-actions }
           - { path: go_modules, name: go, ecosystem: gomod }
           - { path: gradle, name: gradle, ecosystem: gradle }
+          - { path: hex, name: hex, ecosystem: hex }
           - { path: maven, name: maven, ecosystem: maven }
           - { path: npm_and_yarn, name: npm, ecosystem: npm}
           - { path: npm_and_yarn, name: npm-remove-transitive, ecosystem: npm}
           - { path: npm_and_yarn, name: yarn-berry, ecosystem: npm}
           - { path: nuget, name: nuget, ecosystem: nuget }
+          - { path: pub, name: pub, ecosystem: pub }
           - { path: python, name: pip, ecosystem: pip }
           - { path: python, name: pipenv, ecosystem: pip}
           - { path: python, name: pip-compile, ecosystem: pip }
           - { path: python, name: poetry, ecosystem: pip }
+          - { path: terraform, name: terraform, ecosystem: terraform }
     steps:
     - uses: actions/checkout@v3
     - uses: dorny/paths-filter@v2
@@ -51,11 +56,21 @@ jobs:
             - 'common/**'
             - 'updater/**'
             - 'cargo/**'
+          composer:
+            - Dockerfile.updater-core
+            - 'common/**'
+            - 'updater/**'
+            - 'composer/**'
           docker:
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'docker/**'
+          elm:
+            - Dockerfile.updater-core
+            - 'common/**'
+            - 'updater/**'
+            - 'elm/**'
           git_submodules:
             - Dockerfile.updater-core
             - 'common/**'
@@ -76,6 +91,11 @@ jobs:
             - 'common/**'
             - 'updater/**'
             - 'gradle/**'
+          hex:
+            - Dockerfile.updater-core
+            - 'common/**'
+            - 'updater/**'
+            - 'hex/**'
           maven:
             - Dockerfile.updater-core
             - 'common/**'
@@ -116,6 +136,16 @@ jobs:
             - 'common/**'
             - 'updater/**'
             - 'python/**'
+          pub:
+            - Dockerfile.updater-core
+            - 'common/**'
+            - 'updater/**'
+            - 'pub/**'
+          terraform:
+            - Dockerfile.updater-core
+            - 'common/**'
+            - 'updater/**'
+            - 'terraform/**'
           'yarn-berry':
             - Dockerfile.updater-core
             - 'common/**'

--- a/.github/workflows/eco-smoke.yml
+++ b/.github/workflows/eco-smoke.yml
@@ -175,7 +175,7 @@ jobs:
         DOCKER_BUILDKIT: 1
       run: |
         docker build \
-          -t "dependabot/dependabot-updater-core:latest" \
+          -t "ghcr.io/dependabot/dependabot-updater-core:latest" \
           --build-arg BUILDKIT_INLINE_CACHE=1 \
           --cache-from ghcr.io/dependabot/dependabot-updater-core \
           -f Dockerfile.updater-core \

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -19,21 +19,29 @@ jobs:
           - { path: bundler, name: bundler2, ci_node_total: 2, ci_node_index: 0, ecosystem: bundler }
           - { path: bundler, name: bundler2, ci_node_total: 2, ci_node_index: 1, ecosystem: bundler }
           - { path: cargo, name: cargo, ecosystem: cargo }
+          - { path: composer, name: composer, ci_node_total: 2, ci_node_index: 0, ecosystem: composer }
+          - { path: composer, name: composer, ci_node_total: 2, ci_node_index: 1, ecosystem: composer }
           - { path: docker, name: docker, ecosystem: docker }
+          - { path: elm, name: elm, ecosystem: elm }
           - { path: git_submodules, name: git_submodules, ecosystem: submodule }
           - { path: github_actions, name: github_actions, ecosystem: github-actions }
           - { path: go_modules, name: go_module, ci_node_total: 2, ci_node_index: 0, ecosystem: gomod }
           - { path: go_modules, name: go_module, ci_node_total: 2, ci_node_index: 1, ecosystem: gomod }
           - { path: gradle, name: gradle, ecosystem: gradle }
+          - { path: hex, name: hex, ci_node_total: 2, ci_node_index: 0, ecosystem: hex }
+          - { path: hex, name: hex, ci_node_total: 2, ci_node_index: 1, ecosystem: hex }
           - { path: maven, name: maven, ecosystem: maven }
           - { path: npm_and_yarn, name: npm_and_yarn, ci_node_total: 3, ci_node_index: 0, ecosystem: npm }
           - { path: npm_and_yarn, name: npm_and_yarn, ci_node_total: 3, ci_node_index: 1, ecosystem: npm }
           - { path: npm_and_yarn, name: npm_and_yarn, ci_node_total: 3, ci_node_index: 2, ecosystem: npm }
           - { path: nuget, name: nuget, ecosystem: nuget }
+          - { path: pub, name: pub, ci_node_total: 2, ci_node_index: 0, ecosystem: pub }
+          - { path: pub, name: pub, ci_node_total: 2, ci_node_index: 1, ecosystem: pub }
           - { path: python, name: python, ci_node_total: 2, ci_node_index: 0, ecosystem: pip }
           - { path: python, name: python, ci_node_total: 2, ci_node_index: 1, ecosystem: pip}
           - { path: python, name: python_slow, ci_node_total: 2, ci_node_index: 0, ecosystem: pip }
           - { path: python, name: python_slow, ci_node_total: 2, ci_node_index: 1, ecosystem: pip }
+          - { path: terraform, name: terraform, ecosystem: terraform }
 
     steps:
       - name: Checkout code
@@ -55,12 +63,24 @@ jobs:
               - 'omnibus/**'
               - '.github/workflows/ecosystem-ci.yml'
               - 'cargo/**'
+            composer:
+              - Dockerfile.updater-core
+              - 'common/**'
+              - 'omnibus/**'
+              - '.github/workflows/ecosystem-ci.yml'
+              - 'composer/**'
             docker:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
               - '.github/workflows/ecosystem-ci.yml'
               - 'docker/**'
+            elm:
+              - Dockerfile.updater-core
+              - 'common/**'
+              - 'omnibus/**'
+              - '.github/workflows/ecosystem-ci.yml'
+              - 'elm/**'
             git_submodules:
               - Dockerfile.updater-core
               - 'common/**'
@@ -73,6 +93,11 @@ jobs:
               - 'omnibus/**'
               - '.github/workflows/ecosystem-ci.yml'
               - 'github_actions/**'
+            go_modules:
+              - Dockerfile.updater-core
+              - 'common/**'
+              - 'go_modules/**'
+              - '.github/workflows/ecosystem-ci.yml'
             gradle:
               - Dockerfile.updater-core
               - 'common/**'
@@ -80,17 +105,12 @@ jobs:
               - '.github/workflows/ecosystem-ci.yml'
               - 'maven/**'
               - 'gradle/**'
-            nuget:
+            hex:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
               - '.github/workflows/ecosystem-ci.yml'
-              - 'nuget/**'
-            python:
-              - Dockerfile.updater-core
-              - 'common/**'
-              - 'python/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - 'hex/**'
             maven:
               - Dockerfile.updater-core
               - 'common/**'
@@ -102,10 +122,29 @@ jobs:
               - 'omnibus/**'
               - '.github/workflows/ecosystem-ci.yml'
               - 'npm_and_yarn/**'
-            go_modules:
+            nuget:
               - Dockerfile.updater-core
               - 'common/**'
-              - 'go_modules/**'
+              - 'omnibus/**'
+              - '.github/workflows/ecosystem-ci.yml'
+              - 'nuget/**'
+            pub:
+              - Dockerfile.updater-core
+              - 'common/**'
+              - 'omnibus/**'
+              - '.github/workflows/ecosystem-ci.yml'
+              - 'pub/**'
+            python:
+              - Dockerfile.updater-core
+              - 'common/**'
+              - 'omnibus/**'
+              - 'python/**'
+              - '.github/workflows/ecosystem-ci.yml'
+            terraform:
+              - Dockerfile.updater-core
+              - 'common/**'
+              - 'omnibus/**'
+              - 'terraform/**'
               - '.github/workflows/ecosystem-ci.yml'
 
       - name: Build updater core image

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -153,7 +153,7 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: |
           docker build \
-            -t "dependabot/dependabot-updater-core:latest" \
+            -t "ghcr.io/dependabot/dependabot-updater-core:latest" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --cache-from ghcr.io/dependabot/dependabot-updater-core \
             -f Dockerfile.updater-core \

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -116,8 +116,10 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     # dev dependencies for CI
     build-essential \
+    curl \
     zlib1g-dev \
     libgmp-dev \
+    unzip \
     # VCS section
     git \
     git-lfs \

--- a/bundler/Dockerfile
+++ b/bundler/Dockerfile
@@ -1,10 +1,5 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends \
-    curl
-
 USER dependabot
 
 COPY --chown=dependabot:dependabot bundler/helpers /opt/bundler/helpers

--- a/cargo/Dockerfile
+++ b/cargo/Dockerfile
@@ -1,9 +1,6 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER root
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends curl
 
 # Install Rust
 ENV RUSTUP_HOME=/opt/rust \

--- a/composer/Dockerfile
+++ b/composer/Dockerfile
@@ -1,0 +1,54 @@
+FROM ghcr.io/dependabot/dependabot-updater-core
+ARG COMPOSER_V1_VERSION=1.10.26
+ARG COMPOSER_V2_VERSION=2.3.9
+ENV COMPOSER_ALLOW_SUPERUSER=1
+RUN add-apt-repository ppa:ondrej/php \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    php7.4 \
+    php7.4-apcu \
+    php7.4-bcmath \
+    php7.4-cli \
+    php7.4-common \
+    php7.4-curl \
+    php7.4-gd \
+    php7.4-geoip \
+    php7.4-gettext \
+    php7.4-gmp \
+    php7.4-imagick \
+    php7.4-imap \
+    php7.4-intl \
+    php7.4-json \
+    php7.4-ldap \
+    php7.4-mbstring \
+    php7.4-memcached \
+    php7.4-mongodb \
+    php7.4-mysql \
+    php7.4-redis \
+    php7.4-soap \
+    php7.4-sqlite3 \
+    php7.4-tidy \
+    php7.4-xml \
+    php7.4-zip \
+    php7.4-zmq \
+    php7.4-mcrypt \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer1 --version=${COMPOSER_V1_VERSION}
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_V2_VERSION}
+
+USER dependabot
+# Perform a fake `composer update` to warm ~/dependabot/.cache/composer/repo
+# with historic data (we don't care about package files here)
+RUN mkdir /tmp/composer-cache \
+  && cd /tmp/composer-cache \
+  && echo '{"require":{"psr/log": "^1.1.3"}}' > composer.json \
+  && composer update --no-scripts --dry-run \
+  && cd /tmp \
+  && rm -rf /home/dependabot/.cache/composer/files \
+  && rm -rf /tmp/composer-cache
+
+COPY --chown=dependabot:dependabot composer/helpers /opt/composer/helpers
+RUN bash /opt/composer/helpers/v1/build \
+  && bash /opt/composer/helpers/v2/build
+COPY --chown=dependabot:dependabot composer /home/dependabot/composer

--- a/composer/Dockerfile
+++ b/composer/Dockerfile
@@ -2,6 +2,10 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG COMPOSER_V1_VERSION=1.10.26
 ARG COMPOSER_V2_VERSION=2.3.9
 ENV COMPOSER_ALLOW_SUPERUSER=1
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends \
+    software-properties-common
 RUN add-apt-repository ppa:ondrej/php \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/elm/Dockerfile
+++ b/elm/Dockerfile
@@ -1,0 +1,16 @@
+FROM ghcr.io/dependabot/dependabot-updater-core
+ARG TARGETARCH=amd64
+# Install Elm
+# This is currently amd64 only, see:
+# - https://github.com/elm/compiler/issues/2007
+# - https://github.com/elm/compiler/issues/2232
+ENV PATH="$PATH:/node_modules/.bin"
+RUN [ "$TARGETARCH" != "amd64" ] \
+  || (curl -sSLfO "https://github.com/elm/compiler/releases/download/0.19.0/binaries-for-linux.tar.gz" \
+  && tar xzf binaries-for-linux.tar.gz \
+  && mv elm /usr/local/bin/elm19 \
+  && rm -f binaries-for-linux.tar.gz)
+
+USER dependabot
+
+COPY --chown=dependabot:dependabot elm /home/dependabot/elm

--- a/go_modules/Dockerfile
+++ b/go_modules/Dockerfile
@@ -2,9 +2,6 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH=amd64
 
 USER root
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends curl
 
 # Install Go
 ARG GOLANG_VERSION=1.19

--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -1,5 +1,8 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
-
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends \
+    gnupg2
 # Install Erlang and Elixir
 ENV PATH="$PATH:/usr/local/elixir/bin"
 # https://github.com/elixir-lang/elixir/releases

--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -1,0 +1,28 @@
+FROM ghcr.io/dependabot/dependabot-updater-core
+
+# Install Erlang and Elixir
+ENV PATH="$PATH:/usr/local/elixir/bin"
+# https://github.com/elixir-lang/elixir/releases
+ARG ELIXIR_VERSION=v1.14.2
+ARG ELIXIR_CHECKSUM=2e4addb85de85218d32c16b3710e8087f5b18b3b1560742137ad4c41bbbea63a
+ARG ERLANG_MAJOR_VERSION=24
+ARG ERLANG_VERSION=1:${ERLANG_MAJOR_VERSION}.2.1-1
+RUN curl -sSLfO https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb \
+  && dpkg -i erlang-solutions_2.0_all.deb \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends esl-erlang=${ERLANG_VERSION} \
+  && curl -sSLfO https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
+  && echo "$ELIXIR_CHECKSUM  elixir-otp-${ERLANG_MAJOR_VERSION}.zip" | sha256sum -c - \
+  && unzip -d /usr/local/elixir -x elixir-otp-${ERLANG_MAJOR_VERSION}.zip \
+  && rm -f elixir-otp-${ERLANG_MAJOR_VERSION}.zip erlang-solutions_2.0_all.deb \
+  && rm -rf /var/lib/apt/lists/*
+
+USER dependabot
+
+COPY --chown=dependabot:dependabot hex/helpers /opt/hex/helpers
+ENV MIX_HOME="/opt/hex/mix"
+# https://github.com/hexpm/hex/releases
+ENV HEX_VERSION="1.0.1"
+RUN bash /opt/hex/helpers/build
+
+COPY --chown=dependabot:dependabot hex /home/dependabot/hex

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -3,11 +3,7 @@ ENV DEPENDABOT_HOME /home/dependabot
 ### JAVASCRIPT
 
 # Install Node and npm
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends \
-  curl \
-  && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
   nodejs \

--- a/pub/Dockerfile
+++ b/pub/Dockerfile
@@ -1,0 +1,29 @@
+FROM ghcr.io/dependabot/dependabot-updater-core
+ARG TARGETARCH=amd64
+# Install Dart
+ENV PUB_CACHE=/opt/dart/pub-cache \
+  PUB_ENVIRONMENT="dependabot" \
+  PATH="${PATH}:/opt/dart/dart-sdk/bin"
+
+# https://dart.dev/get-dart/archive
+ARG DART_VERSION=2.18.6
+
+RUN DART_ARCH=${TARGETARCH} \
+  && if [ "$TARGETARCH" = "amd64" ]; then DART_ARCH=x64; fi \
+  && DART_EXE="dartsdk-linux-${DART_ARCH}-release.zip" \
+  && DOWNLOAD_URL="https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/${DART_EXE}" \
+  && curl --connect-timeout 15 --retry 5 "${DOWNLOAD_URL}" > "/tmp/${DART_EXE}" \
+  && curl --connect-timeout 15 --retry 5 "${DOWNLOAD_URL}.sha256sum" > "/tmp/${DART_EXE}.sha256sum" \
+  && cd /tmp/ \
+  && echo "$(cat /tmp/${DART_EXE}.sha256sum)" | sha256sum -c \
+  && mkdir -p "$PUB_CACHE" \
+  && chown dependabot:dependabot "$PUB_CACHE" \
+  && unzip "/tmp/${DART_EXE}" -d "/opt/dart" > /dev/null \
+  && chmod -R o+rx "/opt/dart/dart-sdk" \
+  && rm "/tmp/${DART_EXE}" \
+  && dart --version
+
+USER dependabot
+COPY --chown=dependabot:dependabot pub/helpers /opt/pub/helpers
+RUN bash /opt/pub/helpers/build
+COPY --chown=dependabot:dependabot pub /home/dependabot/pub

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -3,6 +3,7 @@ ARG PY_3_10=3.10.9
 ARG PY_3_9=3.9.16
 ARG PY_3_8=3.8.16
 ARG PY_3_7=3.7.16
+ARG PYENV_VERSION=v2.3.9
 
 FROM ghcr.io/dependabot/dependabot-updater-core as python-core
 ARG PY_3_11
@@ -10,6 +11,7 @@ ARG PY_3_10
 ARG PY_3_9
 ARG PY_3_8
 ARG PY_3_7
+ARG PYENV_VERSION
 USER root
 
 RUN apt-get update \
@@ -23,7 +25,6 @@ RUN apt-get update \
     tzdata \
     zip \
     openssh-client \
-    software-properties-common \
     build-essential \
     make \
     libpq-dev \
@@ -51,7 +52,7 @@ ENV PYENV_ROOT=/usr/local/.pyenv \
 RUN mkdir -p "$PYENV_ROOT" && chown dependabot:dependabot "$PYENV_ROOT"
 USER dependabot
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
-RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch v2.3.9 --single-branch --depth=1 /usr/local/.pyenv
+RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch $PYENV_VERSION --single-branch --depth=1 /usr/local/.pyenv
 
 FROM python-core as python-3.10
 RUN pyenv install $PY_3_10 \
@@ -80,6 +81,7 @@ RUN pyenv install $PY_3_7 \
 
 FROM ghcr.io/dependabot/dependabot-updater-core
 ARG PY_3_11
+ARG PYENV_VERSION
 USER root
 RUN apt-get update \
   && apt-get upgrade -y \
@@ -92,7 +94,6 @@ RUN apt-get update \
     tzdata \
     zip \
     openssh-client \
-    software-properties-common \
     build-essential \
     make \
     libpq-dev \
@@ -121,7 +122,7 @@ ENV PYENV_ROOT=/usr/local/.pyenv \
 RUN mkdir -p "$PYENV_ROOT" && chown dependabot:dependabot "$PYENV_ROOT"
 USER dependabot
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
-RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch v2.3.9 --single-branch --depth=1 /usr/local/.pyenv
+RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch $PYENV_VERSION --single-branch --depth=1 /usr/local/.pyenv
 RUN pyenv install $PY_3_11 \
   && pyenv global $PY_3_11 \
   && bash /opt/python/helpers/build_for_version $PY_3_11

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
     dirmngr \
-    gnupg2 \
     zlib1g-dev \
     liblzma-dev \
     libgdbm-dev \
@@ -86,7 +85,6 @@ RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
     dirmngr \
-    gnupg2 \
     zlib1g-dev \
     liblzma-dev \
     libgdbm-dev \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -23,10 +23,8 @@ RUN apt-get update \
     bison \
     tzdata \
     zip \
-    unzip \
     openssh-client \
     software-properties-common \
-    curl \
     build-essential \
     make \
     libpq-dev \
@@ -95,10 +93,8 @@ RUN apt-get update \
     bison \
     tzdata \
     zip \
-    unzip \
     openssh-client \
     software-properties-common \
-    curl \
     build-essential \
     make \
     libpq-dev \

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,0 +1,16 @@
+FROM ghcr.io/dependabot/dependabot-updater-core
+ARG TARGETARCH=amd64
+ARG TERRAFORM_VERSION=1.3.7
+ARG TERRAFORM_AMD64_CHECKSUM=b8cf184dee15dfa89713fe56085313ab23db22e17284a9a27c0999c67ce3021e
+ARG TERRAFORM_ARM64_CHECKSUM=5b491c555ea8a62dda551675fd9f27d369f5cdbe87608d2a7367d3da2d38ea38
+RUN cd /tmp \
+  && curl -o terraform-${TARGETARCH}.tar.gz https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip \
+  && printf "$TERRAFORM_AMD64_CHECKSUM terraform-amd64.tar.gz\n$TERRAFORM_ARM64_CHECKSUM terraform-arm64.tar.gz\n" | sha256sum -c --ignore-missing - \
+  && unzip -d /usr/local/bin terraform-${TARGETARCH}.tar.gz \
+  && rm terraform-${TARGETARCH}.tar.gz
+
+USER dependabot
+COPY --chown=dependabot:dependabot terraform/helpers /opt/terraform/helpers
+RUN bash /opt/terraform/helpers/build
+
+COPY --chown=dependabot:dependabot terraform /home/dependabot/terraform


### PR DESCRIPTION
This breaks out:

- composer
- elm
- hex
- pub
- terraform

It also pulls a couple commonly used dependencies into updater-core.