### PR TITLE
fix latest ecosystem push broken due to errant tag

### DIFF
--- a/.github/workflows/eco-latest-releases.yml
+++ b/.github/workflows/eco-latest-releases.yml
@@ -64,7 +64,7 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: |
           docker build \
-            -t "ghcr.io/dependabot/dependabot-updater-core:$TAG" \
+            -t "ghcr.io/dependabot/dependabot-updater-core" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --cache-from ghcr.io/dependabot/dependabot-updater-core \
             -f Dockerfile.updater-core \


### PR DESCRIPTION
We didn't notice this was broken because updater-core was in GHCR and was being downloaded each time. In https://github.com/dependabot/dependabot-core/pull/6495 curl was removed and moved into updater-core, so it broke the deploy when it pulled the version that didn't have curl. 

By removing the tag, it builds "latest" which gets picked up by the ecosystem image build in the next step.