### PR TITLE
rename hex image to match YAML value

### DIFF
--- a/.github/workflows/eco-branch-images.yml
+++ b/.github/workflows/eco-branch-images.yml
@@ -28,7 +28,7 @@ jobs:
           - { name: github_actions, ecosystem: github-actions }
           - { name: go_modules, ecosystem: gomod }
           - { name: gradle, ecosystem: gradle }
-          - { name: hex, ecosystem: hex }
+          - { name: hex, ecosystem: mix }
           - { name: maven, ecosystem: maven }
           - { name: npm_and_yarn, ecosystem: npm }
           - { name: nuget, ecosystem: nuget }

--- a/.github/workflows/eco-latest-releases.yml
+++ b/.github/workflows/eco-latest-releases.yml
@@ -44,7 +44,7 @@ jobs:
           - { name: github_actions, ecosystem: github-actions }
           - { name: go_modules, ecosystem: gomod }
           - { name: gradle, ecosystem: gradle }
-          - { name: hex, ecosystem: hex }
+          - { name: hex, ecosystem: mix }
           - { name: maven, ecosystem: maven }
           - { name: npm_and_yarn, ecosystem: npm }
           - { name: nuget, ecosystem: nuget }


### PR DESCRIPTION
We're using the documented YAML values as the GHCR image names since they are the official names in dependabot.yml. This one was mistakingly named "hex" so renaming to "mix."