### PR TITLE
Add compatibility with composer v2.4+

### DIFF
--- a/composer/helpers/v2/src/UpdateChecker.php
+++ b/composer/helpers/v2/src/UpdateChecker.php
@@ -6,6 +6,7 @@ namespace Dependabot\Composer;
 
 use Composer\DependencyResolver\Request;
 use Composer\Factory;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Installer;
 use Composer\Package\PackageInterface;
 
@@ -59,6 +60,8 @@ final class UpdateChecker
             $composer->getAutoloadGenerator()
         );
 
+        $composer->getEventDispatcher()->setRunScripts(false);
+
         // For all potential options, see UpdateCommand in composer
         $install
             ->setUpdate(true)
@@ -66,8 +69,11 @@ final class UpdateChecker
             ->setDevMode(true)
             ->setUpdateAllowTransitiveDependencies(Request::UPDATE_LISTED_WITH_TRANSITIVE_DEPS)
             ->setDumpAutoloader(false)
-            ->setRunScripts(false)
-            ->setIgnorePlatformRequirements(false);
+            ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList(false));
+
+        if (method_exists($install, 'setAudit')) {
+            $install->setAudit(false);
+        }
 
         // if no lock is present, we do not do a partial update as
         // this is not supported by the Installer

--- a/composer/helpers/v2/src/Updater.php
+++ b/composer/helpers/v2/src/Updater.php
@@ -6,6 +6,7 @@ namespace Dependabot\Composer;
 
 use Composer\DependencyResolver\Request;
 use Composer\Factory;
+use Composer\Filter\PlatformRequirementFilter\PlatformRequirementFilterFactory;
 use Composer\Installer;
 
 final class Updater
@@ -74,6 +75,8 @@ final class Updater
             $composer->getAutoloadGenerator()
         );
 
+        $composer->getEventDispatcher()->setRunScripts(false);
+
         // For all potential options, see UpdateCommand in composer
         $install
             ->setWriteLock(true)
@@ -84,8 +87,11 @@ final class Updater
             ->setUpdateAllowTransitiveDependencies(Request::UPDATE_LISTED_WITH_TRANSITIVE_DEPS)
             ->setExecuteOperations(true)
             ->setDumpAutoloader(false)
-            ->setRunScripts(false)
-            ->setIgnorePlatformRequirements(false);
+            ->setPlatformRequirementFilter(PlatformRequirementFilterFactory::fromBoolOrList(false));
+
+        if (method_exists($install, 'setAudit')) {
+            $install->setAudit(false);
+        }
 
         $install->run();
 


### PR DESCRIPTION
When running the dependabot-script with `DEBUG_HELPERS=true` I saw this error:
```
PHP Deprecated:  Installer::setIgnorePlatformRequirements is deprecated since Composer 2.2, use setPlatformRequirementFilter instead. in /opt/composer/v2/vendor/composer/composer/src/Composer/Installer.php on line 1289
```

In this PR I work around the deprecations (there was one more, which was not verbose) and also added a forward compatible change to [disable the audit](https://github.com/dependabot/dependabot-core/pull/6385#issuecomment-1372922640).

Applied changes:
- Use `eventDispatcher::setRunScripts` instead of [deprecated `Installer::setRunScripts`](https://github.com/composer/composer/blob/2.5.1/src/Composer/Installer.php#L1241)
- Use `Installer::setPlatformRequirementFilter` instead of [deprecated `Installer::setIgnorePlatformRequirements`](https://github.com/composer/composer/blob/2.5.1/src/Composer/Installer.php#L1297)
- Use `setAudit(false)` if Installer has that method