### PR TITLE
Fallback to github.com for actions source

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -53,20 +53,16 @@ module Dependabot
       end
 
       def build_github_dependency(file, string)
-        details = string.match(GITHUB_REPO_REFERENCE).named_captures
-        name = "#{details.fetch('owner')}/#{details.fetch('repo')}"
         unless source.hostname == "github.com"
-          potential_url = "https://#{source.hostname}/#{name}"
-          dep = github_dependency(file, string, potential_url)
+          dep = github_dependency(file, string, source.hostname)
           git_checker = Dependabot::GitCommitChecker.new(dependency: dep, credentials: credentials)
           return dep if git_checker.git_repo_reachable?
         end
 
-        url = "https://github.com/#{name}"
-        github_dependency(file, string, url)
+        github_dependency(file, string, "github.com")
       end
 
-      def github_dependency(file, string, url)
+      def github_dependency(file, string, hostname)
         details = string.match(GITHUB_REPO_REFERENCE).named_captures
         name = "#{details.fetch('owner')}/#{details.fetch('repo')}"
         ref = details.fetch("ref")
@@ -79,7 +75,7 @@ module Dependabot
             groups: [],
             source: {
               type: "git",
-              url: url,
+              url: "https://#{hostname}/#{name}",
               ref: ref,
               branch: nil
             },

--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -61,44 +61,32 @@ module Dependabot
         unless source.hostname == "github.com"
           potential_url = "https://#{source.hostname}/#{name}"
 
-          dep = Dependency.new(
-            name: name,
+          dep = github_dependency(name, version, potential_url, ref, file.name)
+          git_checker = Dependabot::GitCommitChecker.new(dependency: dep, credentials: credentials)
+          return dep if git_checker.git_repo_reachable?
+        end
+
+        url = "https://github.com/#{name}"
+        github_dependency(name, version, url, ref, file.name)
+      end
+
+      def github_dependency(name, version, url, ref, file_name)
+        Dependency.new(
+          name: name,
             version: version,
             requirements: [{
               requirement: nil,
               groups: [],
               source: {
                 type: "git",
-                url: potential_url,
+                url: url,
                 ref: ref,
                 branch: nil
               },
-              file: file.name,
+              file: file_name,
               metadata: { declaration_string: string }
             }],
             package_manager: "github_actions"
-          )
-          git_checker = Dependabot::GitCommitChecker.new(dependency: dep, credentials: credentials)
-          return dep if git_checker.git_repo_reachable?
-        end
-
-        url = "https://github.com/#{name}"
-        Dependency.new(
-          name: name,
-          version: version,
-          requirements: [{
-            requirement: nil,
-            groups: [],
-            source: {
-              type: "git",
-              url: url,
-              ref: ref,
-              branch: nil
-            },
-            file: file.name,
-            metadata: { declaration_string: string }
-          }],
-          package_manager: "github_actions"
         )
       end
 

--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -61,16 +61,16 @@ module Dependabot
         unless source.hostname == "github.com"
           potential_url = "https://#{source.hostname}/#{name}"
 
-          dep = github_dependency(name, version, potential_url, ref, file.name)
+          dep = github_dependency(name, version, potential_url, ref, file.name, string)
           git_checker = Dependabot::GitCommitChecker.new(dependency: dep, credentials: credentials)
           return dep if git_checker.git_repo_reachable?
         end
 
         url = "https://github.com/#{name}"
-        github_dependency(name, version, url, ref, file.name)
+        github_dependency(name, version, url, ref, file.name, string)
       end
 
-      def github_dependency(name, version, url, ref, file_name)
+      def github_dependency(name, version, url, ref, file_name, string)
         Dependency.new(
           name: name,
             version: version,

--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -53,9 +53,10 @@ module Dependabot
       end
 
       def build_github_dependency(file, string)
+        details = string.match(GITHUB_REPO_REFERENCE).named_captures
+        name = "#{details.fetch('owner')}/#{details.fetch('repo')}"
         unless source.hostname == "github.com"
           potential_url = "https://#{source.hostname}/#{name}"
-
           dep = github_dependency(file, string, potential_url)
           git_checker = Dependabot::GitCommitChecker.new(dependency: dep, credentials: credentials)
           return dep if git_checker.git_repo_reachable?


### PR DESCRIPTION
## Context
There have been a few reported issues where Dependabot is attempting to source actions incorrectly from non-github.com sources. 

## Approach
Following @mctofu's advice, this implements a check and fallback so non-github sources will work, but will default to github.com if the non-github source is incorrect/inaccessible.