### PR TITLE
Fix update to lockfile on yarn berry projects with workspaces

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -32,6 +32,7 @@ jobs:
           - { path: npm_and_yarn, name: npm, ecosystem: npm}
           - { path: npm_and_yarn, name: npm-remove-transitive, ecosystem: npm}
           - { path: npm_and_yarn, name: yarn-berry, ecosystem: npm}
+          - { path: npm_and_yarn, name: yarn-berry-workspaces, ecosystem: npm}
           - { path: nuget, name: nuget, ecosystem: nuget }
           - { path: pub, name: pub, ecosystem: pub }
           - { path: python, name: pip, ecosystem: pip }
@@ -167,6 +168,12 @@ jobs:
             - 'updater/**'
             - 'terraform/**'
           'yarn-berry':
+            - .github/workflows/smoke.yml
+            - Dockerfile.updater-core
+            - 'common/**'
+            - 'updater/**'
+            - 'npm_and_yarn/**'
+          'yarn-berry-workspaces':
             - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -48,13 +48,17 @@ module Dependabot
       def self.yarn_berry_args
         if yarn_major_version == 2
           ""
-        elsif yarn_major_version >= 3 && (yarn_zero_install? || yarn_offline_cache?)
+        elsif yarn_berry_skip_build?
           "--mode=skip-build"
         else
           # We only want this mode if the cache is not being updated/managed
           # as this improperly leaves old versions in the cache
           "--mode=update-lockfile"
         end
+      end
+
+      def self.yarn_berry_skip_build?
+        yarn_major_version >= 3 && (yarn_zero_install? || yarn_offline_cache?)
       end
 
       def self.setup_yarn_berry

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -64,6 +64,8 @@ module Dependabot
       def self.setup_yarn_berry
         # Always disable immutable installs so yarn's CI detection doesn't prevent updates.
         SharedHelpers.run_shell_command("yarn config set enableImmutableInstalls false")
+        # Do not generate a cache if offline cache disabled. Otherwise side effects may confuse further checks
+        SharedHelpers.run_shell_command("yarn config set enableGlobalCache true") unless yarn_berry_skip_build?
         # We never want to execute postinstall scripts, either set this config or mode=skip-build must be set
         if yarn_major_version == 2 || !yarn_zero_install?
           SharedHelpers.run_shell_command("yarn config set enableScripts false")


### PR DESCRIPTION
If a dependency has a bad checksum, we fail to `yarn install --mode=skip-build` even when yarn cache is not necessary because of not being on any situation needing the cache.

We can fix this by explicitly configuring a global cache the first time we detect we won't need it because otherwise yarn runs may generate a cache and result in further commands running in `--mode=skip-build`.

Closes #6432.
~Closes #6565.~ Already closed by #6587.
Closes #6003.