### PR TITLE
Improve error when native helper gives empty output

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -127,7 +127,7 @@ module Dependabot
       )
     rescue JSON::ParserError
       raise HelperSubprocessFailed.new(
-        message: stdout || "No output from command",
+        message: stdout.empty? ? "No output from command. Error from command: #{stderr}" : stdout,
         error_class: "JSON::ParserError",
         error_context: error_context
       )


### PR DESCRIPTION
If native helper output is empty, an empty string is unparseable JSON and we end up getting an error about that, but no information about the underlying culprit.

In this case, show the native error output, which is likely to contain something useful.

#### Before

```
Dependabot::Bundler::UpdateChecker::VersionResolver#latest_resolvable_version_details with a gemspec and a Gemfile with an upper bound that is lower than the current req 
Failure/Error: raise Dependabot::DependencyFileNotEvaluatable, msg

Dependabot::DependencyFileNotEvaluatable:
  Error evaluating your dependency files:
# ./lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb:82:in `handle_bundler_errors'
# ./lib/dependabot/bundler/update_checker/version_resolver.rb:119:in `rescue in fetch_latest_resolvable_version_details'
# ./lib/dependabot/bundler/update_checker/version_resolver.rb:75:in `fetch_latest_resolvable_version_details'
# ./lib/dependabot/bundler/update_checker/version_resolver.rb:44:in `latest_resolvable_version_details'
# ./spec/dependabot/bundler/update_checker/version_resolver_spec.rb:52:in `block (3 levels) in <top (required)>'
# ./spec/dependabot/bundler/update_checker/version_resolver_spec.rb:414:in `block (5 levels) in <top (required)>'
# ./spec/spec_helper.rb:50:in `block (2 levels) in <top (required)>'
# /home/dependabot/common/spec/spec_helper.rb:63:in `block (2 levels) in <top (required)>'
# ./.bundle/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
# ------------------
# --- Caused by: ---
# JSON::ParserError:
#   unexpected token at ''
#   ./.bundle/ruby/3.1.0/gems/json-2.6.3/lib/json/common.rb:216:in `parse'
```

#### After

```
Dependabot::Bundler::UpdateChecker::VersionResolver#latest_resolvable_version_details with a gemspec and a Gemfile with an upper bound that is lower than the current req 
Failure/Error: raise Dependabot::DependencyFileNotEvaluatable, msg

Dependabot::DependencyFileNotEvaluatable:
  Error evaluating your dependency files: No output from command. Error from command: /usr/local/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/definition.rb:432:in `validate_ruby!': Your Ruby version is 3.1.3, but your Gemfile specified 2.4.10 (Bundler::RubyVersionMismatch)
  	from /usr/local/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/definition.rb:407:in `validate_runtime!'
  	from /usr/local/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler.rb:155:in `setup'
  	from /usr/local/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/setup.rb:20:in `block in <top (required)>'
  	from /usr/local/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/ui/shell.rb:136:in `with_level'
  	from /usr/local/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/ui/shell.rb:88:in `silence'
  	from /usr/local/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/setup.rb:20:in `<top (required)>'
  	from <internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
  	from <internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
  	from /opt/bundler/v2/run.rb:4:in `<main>'
# ./lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb:82:in `handle_bundler_errors'
# ./lib/dependabot/bundler/update_checker/version_resolver.rb:119:in `rescue in fetch_latest_resolvable_version_details'
# ./lib/dependabot/bundler/update_checker/version_resolver.rb:75:in `fetch_latest_resolvable_version_details'
# ./lib/dependabot/bundler/update_checker/version_resolver.rb:44:in `latest_resolvable_version_details'
# ./spec/dependabot/bundler/update_checker/version_resolver_spec.rb:52:in `block (3 levels) in <top (required)>'
# ./spec/dependabot/bundler/update_checker/version_resolver_spec.rb:414:in `block (5 levels) in <top (required)>'
# ./spec/spec_helper.rb:50:in `block (2 levels) in <top (required)>'
# /home/dependabot/common/spec/spec_helper.rb:63:in `block (2 levels) in <top (required)>'
# ./.bundle/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
# ------------------
# --- Caused by: ---
# JSON::ParserError:
#   unexpected token at ''
#   ./.bundle/ruby/3.1.0/gems/json-2.6.3/lib/json/common.rb:216:in `parse'
```

Fix https://github.com/dependabot/dependabot-core/issues/4948