### PR TITLE
Fix order-dependent Bundler spec failures

### DIFF
--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -1168,21 +1168,13 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
               to_return(status: 401)
           end
 
-          it "raises a helpful error on bundler v1", :bundler_v1_only do
+          it "raises a helpful error" do
             expect { checker.latest_resolvable_version }.
               to raise_error do |error|
                 expect(error).to be_a(Dependabot::GitDependenciesNotReachable)
                 expect(error.dependency_urls).
                   to eq(["git@github.com:no-exist-sorry/prius"])
               end
-          end
-
-          context "bundler v2", :bundler_v2_only do
-            let(:dependency_files) { bundler_project_dependency_files("private_git_source") }
-
-            it "updates the dependency" do
-              expect(checker.latest_resolvable_version).to eq(Gem::Version.new("3.4.1"))
-            end
           end
         end
 
@@ -1195,20 +1187,12 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
               to_return(status: 200)
           end
 
-          it "raises a helpful error", :bundler_v1_only do
+          it "raises a helpful error" do
             expect { checker.latest_resolvable_version }.
               to raise_error do |error|
                 expect(error).to be_a Dependabot::GitDependencyReferenceNotFound
                 expect(error.dependency).to eq("prius")
               end
-          end
-
-          context "bundler v2", :bundler_v2_only do
-            let(:dependency_files) { bundler_project_dependency_files("bad_ref") }
-
-            it "updates the dependency" do
-              expect(checker.latest_resolvable_version).to eq(Gem::Version.new("3.4.1"))
-            end
           end
         end
 

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -50,4 +50,11 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  config.after do
+    # Cleanup side effects from cloning git gems, so that they don't interfere
+    # with other specs.
+    helper_path = Dependabot::Bundler::NativeHelpers.versioned_helper_path(PackageManagerHelper.bundler_version)
+    FileUtils.rm_rf File.join(helper_path, ".bundle", "bundler")
+  end
 end


### PR DESCRIPTION
This is a weird one.

Up until now, running the spec being changed here in isolation fails:

```
$ bundle exec rspec spec/dependabot/bundler/update_checker_spec.rb:1183 --order defined --format documentation
Run options: include {:locations=>{"./spec/dependabot/bundler/update_checker_spec.rb"=>[1183]}}

Dependabot::Bundler::UpdateChecker
  #latest_resolvable_version
    given a gem with a git source
      that is not the gem we're checking
        that is private
          bundler v2
            updates the dependency (FAILED - 1)

Failures:

  1) Dependabot::Bundler::UpdateChecker#latest_resolvable_version given a gem with a git source that is not the gem we're checking that is private bundler v2 updates the dependency
     Failure/Error: raise Dependabot::GitDependenciesNotReachable, bad_uris.uniq

     Dependabot::GitDependenciesNotReachable:
       The following git URLs could not be retrieved: git@github.com:no-exist-sorry/prius
    # ...
    # ... stuff ...
    # ...

Finished in 3.35 seconds (files took 1.23 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/dependabot/bundler/update_checker_spec.rb:1183 # Dependabot::Bundler::UpdateChecker#latest_resolvable_version given a gem with a git source that is not the gem we're checking that is private bundler v2 updates the dependency
```

However, if I run the previous spec right before, it passes:

```
$ bundle exec rspec spec/dependabot/bundler/update_checker_spec.rb:1153:1183 --order defined --format documentation
Run options: include {:locations=>{"./spec/dependabot/bundler/update_checker_spec.rb"=>[1153, 1183]}}

Dependabot::Bundler::UpdateChecker
  #latest_resolvable_version
    given a gem with a git source
      that is not the gem we're checking
        is expected to eq #<Gem::Version "3.4.1">
        that is private
          bundler v2
            updates the dependency

Finished in 18.04 seconds (files took 1.48 seconds to load)
2 examples, 0 failures
```

The failing test is testing that if a git dependency is unreachable (private) but we are updating a different dependency, it works.

However, in reality, it doesn't really work.

The fact that it's passing is just luck. The previous spec is downloading a reachable gem at the exact same revision and putting it into a cache that's shared among all specs.

Then the second spec will find the gem in the cache and just work because it doesn't need to hit the network. This is not what happens in real life, so the spec should not be passing.

This PR makes sure we clean up side effects from cloning git gems after each spec, so that we don't get bit anymore by things like the above. And it changes the specs with this problem to test the actual realworld behavior of Dependabot.