### PR TITLE
Include ecosystem name in job summary

### DIFF
--- a/.github/workflows/eco-latest-releases.yml
+++ b/.github/workflows/eco-latest-releases.yml
@@ -100,5 +100,5 @@ jobs:
         run: |
           echo "updater uploaded with tag \`$TAG\`" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "$UPDATER_IMAGE_MIRROR:$TAG" >> $GITHUB_STEP_SUMMARY
+          echo "${UPDATER_IMAGE_MIRROR}${ECOSYSTEM}:$TAG" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
I noticed in https://github.com/dependabot/dependabot-core/actions/runs/4034930902/attempts/1 that the docker image names are missing the ecosystem name. Having this correct makes it easier to update smoke tests, for example I had to copy the full image name when doing https://github.com/dependabot/smoke-tests/pull/27.

So I added it, by copying the format from the step above where we're building the `dependabot-updater image`:
https://github.com/dependabot/dependabot-core/blob/5eff30823a1eb0aba02f2267d14427a8bb547414/.github/workflows/eco-latest-releases.yml#L90-L91

I double-checked, and the summaries for `eco-branch-images.yml` and the similar action for forks already include this in their job summary: https://github.com/dependabot/dependabot-core/blob/5eff30823a1eb0aba02f2267d14427a8bb547414/.github/workflows/eco-branch-images.yml#L99