### PR TITLE
Use an actually invalid version for test

### DIFF
--- a/composer/spec/fixtures/projects/invalid_version_string/composer.json
+++ b/composer/spec/fixtures/projects/invalid_version_string/composer.json
@@ -2,6 +2,6 @@
   "name": "valid/name",
   "version": "3.1.7",
   "require": {
-    "monolog/monolog" : "^3.0|4.1.x-dev as 3.0.0"
+    "monolog/monolog" : "^3.0|feature-branch as 3.0.0"
   }
 }


### PR DESCRIPTION
The previous string `"^3.0|4.1.x-dev as 3.0.0"` isn't actually an invalid version... because `4.1.x-dev` can technically be an exact version number.

However, this passed unit tests just fine due to an upstream bug in `composer` which was fixed in https://github.com/composer/composer/issues/11086 / https://github.com/composer/composer/commit/8618f004f791144dc33a196a5e5346ab56f77f7b. So when we upgrade to a newer version of `composer` that includes this fix, the test will start failing.

On composer `2.4.1`, the version string `"^3.0|4.1.x-dev as 3.0.0"` throws:
```
{"error":"Invalid version string \"^3.0|4.1.x-dev\" in \"^3.0|4.1.x-dev as 3.0.0\", the alias source must be an exact version, if it is a branch name you should prefix it with dev-"}
```
Compare with `2.5.1`, where it parses that as a valid version string, and then fails because we're currently running `php` `7.4`:
```
{"error":"Your requirements could not be resolved to an installable set of packages.\n  Problem 1\n    - monolog\/monolog dev-main requires php >=8.1 -> your php version (7.4.33) does not satisfy that requirement.\n    - monolog\/monolog 3.x-dev is an alias of monolog\/monolog dev-main and thus requires it to be installed too.\n    - Root composer.json requires monolog\/monolog ^3.0|4.1.x-dev as 3.0.0 -> satisfiable by monolog\/monolog[3.0.0-RC1, ..., 3.x-dev (alias of dev-main)].\n"}
```

I double-checked with the upstream `composer` team in https://github.com/composer/composer/issues/11282 and they [confirmed our test fixture is incorrect](https://github.com/composer/composer/issues/11282#issuecomment-1406268566).