### PR TITLE
Fix terraform runtime error if `version` preceeds `source` in `required_providers` block

### DIFF
--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -310,18 +310,24 @@ module Dependabot
       def provider_declaration_regex
         name = Regexp.escape(dependency.name)
         %r{
-          ((source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)?#{name}["']|\s*#{name}\s*=\s*\{.*)
-          (?:(?!^\}).)+)
+          ((\s*version\s=\s*["'].*["'])
+              |(\s*source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)
+                ?#{name}["']
+                |\s*#{name}\s*=\s*\{.*
+          )){2}
         }mx
       end
 
       def registry_declaration_regex
         %r{
-          ((\s*version\s=\s*["'].*["'])
-              |(\s*source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)
-                ?#{Regexp.escape(dependency.name)}["']
-                |\s*#{Regexp.escape(dependency.name)}\s*=\s*\{.*
-          )){2}
+          (?<=\{)
+          (?:(?!^\}).)*
+          source\s*=\s*["']
+            (#{Regexp.escape(registry_host_for(dependency))}/)?
+            #{Regexp.escape(dependency.name)}
+            (//modules/\S+)?
+            ["']
+          (?:(?!^\}).)*
         }mx
       end
 

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -112,7 +112,11 @@ module Dependabot
       end
 
       def update_registry_declaration(new_req, old_req, updated_content)
-        regex = new_req[:source][:type] == "provider" ? provider_declaration_regex(updated_content) : registry_declaration_regex
+        if (new_req[:source][:type] == "provider")
+          regex = provider_declaration_regex(updated_content)
+        else
+          regex = registry_declaration_regex
+        end
         updated_content.gsub!(regex) do |regex_match|
           regex_match.sub(/^\s*version\s*=.*/) do |req_line_match|
             req_line_match.sub(old_req[:requirement], new_req[:requirement])
@@ -311,15 +315,12 @@ module Dependabot
         name = Regexp.escape(dependency.name)
         registry_host = Regexp.escape(registry_host_for(dependency))
         regex_version_preceeds = %r{
-            (((?<!required_)version\s=\s*[^\}]*["'].*["'])
-            |(\s*source\s*=\s*["'](#{registry_host})?#{name}["']|\s*#{name}\s*=\s*\{.*))
+          (((?<!required_)version\s=\s*["'].*["'])
+          (\s*source\s*=\s*["'](#{registry_host}/)?#{name}["']|\s*#{name}\s*=\s*\{.*))
         }mx
         regex_source_preceeds = %r{
-          ((\s*version\s=\s*["'].*["'])
-              |(\s*source\s*=\s*["'](#{registry_host}/)
-                ?#{name}["']
-                |\s*#{name}\s*=\s*\{.*
-          )){2}
+          ((source\s*=\s*["'](#{registry_host}/)?#{name}["']|\s*#{name}\s*=\s*\{.*)
+          (?:(?!^\}).)+)
         }mx
 
         if updated_content.match(regex_version_preceeds)

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -317,7 +317,11 @@ module Dependabot
 
       def registry_declaration_regex
         %r{
-          ((\s*version\s=\s*["'].*["'])|(\s*source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)?#{Regexp.escape(dependency.name)}["']|\s*#{Regexp.escape(dependency.name)}\s*=\s*\{.*)){2}
+          ((\s*version\s=\s*["'].*["'])
+              |(\s*source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)?#{Regexp.escape(dependency.name)}["']
+                |\s*#{Regexp.escape(dependency.name)}\s*=\s*\{.*
+                )
+          ){2}
         }mx
       end
 

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -317,7 +317,7 @@ module Dependabot
 
       def registry_declaration_regex
         %r{
-          ((\s*version\s=\s*["'].*["'])|(\s*source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)?#{name}["']|\s*#{name}\s*=\s*\{.*)){2}
+          ((\s*version\s=\s*["'].*["'])|(\s*source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)?#{Regexp.escape(dependency.name)}["']|\s*#{Regexp.escape(dependency.name)}\s*=\s*\{.*)){2}
         }mx
       end
 

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -112,11 +112,11 @@ module Dependabot
       end
 
       def update_registry_declaration(new_req, old_req, updated_content)
-        if (new_req[:source][:type] == "provider")
-          regex = provider_declaration_regex(updated_content)
-        else
-          regex = registry_declaration_regex
-        end
+        regex = if new_req[:source][:type] == "provider"
+                  provider_declaration_regex(updated_content)
+                else
+                  registry_declaration_regex
+                end
         updated_content.gsub!(regex) do |regex_match|
           regex_match.sub(/^\s*version\s*=.*/) do |req_line_match|
             req_line_match.sub(old_req[:requirement], new_req[:requirement])

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -321,8 +321,7 @@ module Dependabot
               |(\s*source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)
                 ?#{Regexp.escape(dependency.name)}["']
                 |\s*#{Regexp.escape(dependency.name)}\s*=\s*\{.*
-                )
-          ){2}
+          )){2}
         }mx
       end
 

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -318,7 +318,8 @@ module Dependabot
       def registry_declaration_regex
         %r{
           ((\s*version\s=\s*["'].*["'])
-              |(\s*source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)?#{Regexp.escape(dependency.name)}["']
+              |(\s*source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)
+                ?#{Regexp.escape(dependency.name)}["']
                 |\s*#{Regexp.escape(dependency.name)}\s*=\s*\{.*
                 )
           ){2}

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -317,14 +317,7 @@ module Dependabot
 
       def registry_declaration_regex
         %r{
-          (?<=\{)
-          (?:(?!^\}).)*
-          source\s*=\s*["']
-            (#{Regexp.escape(registry_host_for(dependency))}/)?
-            #{Regexp.escape(dependency.name)}
-            (//modules/\S+)?
-            ["']
-          (?:(?!^\}).)*
+          ((\s*version\s=\s*["'].*["'])|(\s*source\s*=\s*["'](#{Regexp.escape(registry_host_for(dependency))}/)?#{name}["']|\s*#{name}\s*=\s*\{.*)){2}
         }mx
       end
 

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -1585,6 +1585,55 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
       end
     end
 
+    describe "when provider version preceeds its source" do
+      let(:project_name) { "provider_version_preceed" }
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "hashicorp/azurerm",
+            version: "3.40.0",
+            previous_version: "3.30.0",
+            requirements: [{
+               requirement: "3.40.0",
+               groups: [],
+               file: "providers.tf",
+               source: {
+                 type: "provider",
+                 registry_hostname: "registry.terraform.io",
+                 module_identifier: "hashicorp/azurerm"
+               }
+             }],
+            previous_requirements: [{
+              requirement: "3.31.0",
+              groups: [],
+              file: "providers.tf",
+              source: {
+                type: "provider",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "hashicorp/azurerm"
+              }
+            }],
+            package_manager: "terraform"
+          )
+        ]
+      end
+
+      it "parses correctly and updates the module version" do
+        updated_file = subject.find { |file| file.name == "providers.tf" }
+
+        expect(updated_file.content).to include(
+        <<~DEP
+                                            terraform {
+                                              required_providers {
+                                                azurerm = {
+                                                  version = "3.40.0"
+                                                  source  = "hashicorp/azurerm"
+                                                }
+        DEP
+        )
+      end
+    end
+
     context "with duplicate children modules" do
       let(:project_name) { "duplicate_child_modules" }
       let(:dependencies) do

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -1594,15 +1594,15 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
             version: "3.40.0",
             previous_version: "3.30.0",
             requirements: [{
-               requirement: "3.40.0",
-               groups: [],
-               file: "providers.tf",
-               source: {
-                 type: "provider",
-                 registry_hostname: "registry.terraform.io",
-                 module_identifier: "hashicorp/azurerm"
-               }
-             }],
+              requirement: "3.40.0",
+              groups: [],
+              file: "providers.tf",
+              source: {
+                type: "provider",
+                registry_hostname: "registry.terraform.io",
+                module_identifier: "hashicorp/azurerm"
+              }
+            }],
             previous_requirements: [{
               requirement: "3.31.0",
               groups: [],
@@ -1622,14 +1622,14 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
         updated_file = subject.find { |file| file.name == "providers.tf" }
 
         expect(updated_file.content).to include(
-        <<~DEP
-                                            terraform {
-                                              required_providers {
-                                                azurerm = {
-                                                  version = "3.40.0"
-                                                  source  = "hashicorp/azurerm"
-                                                }
-        DEP
+          <<~DEP
+            terraform {
+              required_providers {
+                azurerm = {
+                  version = "3.40.0"
+                  source  = "hashicorp/azurerm"
+              }
+          DEP
         )
       end
     end

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -1620,17 +1620,7 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
 
       it "parses correctly and updates the module version" do
         updated_file = subject.find { |file| file.name == "providers.tf" }
-
-        expect(updated_file.content).to include(
-          <<~DEP
-            terraform {
-              required_providers {
-                azurerm = {
-                  version = "3.40.0"
-                  source  = "hashicorp/azurerm"
-              }
-          DEP
-        )
+        expect(updated_file.content).to include("version = \"3.40.0\"")
       end
     end
 

--- a/terraform/spec/fixtures/projects/provider_version_preceed/providers.tf
+++ b/terraform/spec/fixtures/projects/provider_version_preceed/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    azurerm = {
+      version = "3.31.0"
+      source  = "hashicorp/azurerm"
+    }
+  }
+}


### PR DESCRIPTION
The current terraform provider regex doesn't work correctly if `version` is preceeding the `source` which leads to the Runtime error mentioned in https://github.com/dependabot/dependabot-core/issues/5361.

Current regex: `((source\s*=\s*["'](registry\.terraform\.io\/)?hashicorp\/azurerm["']|\s*hashicorp\/azurerm\s*=\s*\{.*)
(?:(?!^\}).)+)`
![image](https://user-images.githubusercontent.com/46575727/215326707-d099b4c1-bebb-4d37-ba21-b3a03ad0ed60.png)

Updated regex: `((\s*version\s=\s*["'].*["'])|(\s*source\s*=\s*["'](registry\.terraform\.io\/)?hashicorp\/azurerm["']|\s*hashicorp\/azurerm\s*=\s*\{.*)){2}`
![image](https://user-images.githubusercontent.com/46575727/215326778-85825e4d-7d79-4cc4-accc-cce3400eac06.png)

~~At the moment this is just a first approach. I didn't take a closer look at test cases yet. I think there should be added one that covers this case at least.~~

Fix #5361 