### PR TITLE
Fix running tests in devcontainer

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -39,18 +39,16 @@ COPY --chown=dependabot:dependabot terraform/Gemfile terraform/dependabot-terraf
 COPY --chown=dependabot:dependabot omnibus/Gemfile omnibus/dependabot-omnibus.gemspec ${CODE_DIR}/omnibus/
 WORKDIR ${CODE_DIR}
 
+RUN for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 -name 'Gemfile' | xargs dirname`; do \
+  cd $d && bundle config path ${CODE_DIR}/omnibus/.bundle; \
+done
+
 RUN cd omnibus \
   && bundle install \
   && BUNDLE_BIN=.bundle/bin bundle binstubs --all \
   && rm .bundle/bin/bundle # let RubyGems manage Bundler
 
 ENV PATH="${CODE_DIR}/omnibus/.bundle/bin:$PATH"
-
-RUN for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
-    -not -path "${CODE_DIR}/omnibus/Gemfile" \
-    -name 'Gemfile' | xargs dirname`; do \
-    cd $d && bundle config path ${CODE_DIR}/omnibus/.bundle; \
-  done
 
 # Create directory for volume containing VS Code extensions, to avoid reinstalling on image rebuilds
 RUN mkdir -p ~/.vscode-server ~/.vscode-server-insiders

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -46,14 +46,9 @@ RUN cd omnibus \
 
 ENV PATH="${CODE_DIR}/omnibus/.bundle/bin:$PATH"
 
-RUN GREEN='\033[0;32m'; NC='\033[0m'; \
-  for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
+RUN for d in `find ${CODE_DIR} -type f -mindepth 2 -maxdepth 2 \
     -not -path "${CODE_DIR}/omnibus/Gemfile" \
     -name 'Gemfile' | xargs dirname`; do \
-    echo && \
-    echo "---------------------------------------------------------------------------" && \
-    echo "Installing gems for ${GREEN}$(realpath --relative-to=${CODE_DIR} $d)${NC}..." && \
-    echo "---------------------------------------------------------------------------" && \
     cd $d && bundle config path ${CODE_DIR}/omnibus/.bundle; \
   done
 

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -42,9 +42,8 @@ ARG RUBY_INSTALL_VERSION=0.8.5
 
 # When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
 # Generally simplest to match the bundler version to the one that comes by default with whatever Ruby version we install.
-# This way other projects that import this library don't have to futz around with installing new /unexpected bundler versions.
+# This way other projects that import this library don't have to futz around with installing new / unexpected bundler versions.
 ARG BUNDLER_V2_VERSION=2.3.26
-ENV BUNDLE_SILENCE_ROOT_WARNING=1
 
 # Install Ruby, update RubyGems, and install Bundler
 RUN mkdir -p /tmp/ruby-install \
@@ -64,9 +63,6 @@ WORKDIR ${HOME}
 # Place a git shim ahead of git on the path to rewrite git arguments to use HTTPS.
 ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-amd64.tar.gz"
 RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
-
-ENV DEPENDABOT_HOME /home/dependabot
-WORKDIR ${DEPENDABOT_HOME}
 
 COPY updater/Gemfile updater/Gemfile.lock dependabot-updater/
 COPY .ruby-version .ruby-version
@@ -96,7 +92,7 @@ RUN for ecosystem in git_submodules terraform github_actions hex elm docker nuge
       touch $ecosystem/lib/dependabot/$ecosystem.rb; \
     done
 
-WORKDIR $DEPENDABOT_HOME/dependabot-updater
+WORKDIR $HOME/dependabot-updater
 
 RUN bundle config set --local path 'vendor' && \
 bundle config set --local frozen 'true' && \

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -45,8 +45,6 @@ ARG RUBY_INSTALL_VERSION=0.8.5
 # This way other projects that import this library don't have to futz around with installing new /unexpected bundler versions.
 ARG BUNDLER_V2_VERSION=2.3.26
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
-# Allow gem installs as the dependabot user
-ENV BUNDLE_PATH=".bundle"
 
 # Install Ruby, update RubyGems, and install Bundler
 RUN mkdir -p /tmp/ruby-install \


### PR DESCRIPTION
I run into similar issues to #6534.

I investigated and found the culprit to be that `BUNDLE_PATH` is no longer set in the devcontainer so gems get installed globally, not at the path they got previously installed. So `bundle exec rspec` no longer works.

The reason is that the base Dockerfile is now multistage, and the `ENV BUNDLE_PATH` line was left behind in the builder stage, but it's no longer present in the final image.

This PR fixes the issue plus other little things I found while investigating. More details in commit messages.

Fixes #6534.