### PR TITLE
Re-bump Ruby to `3.1.3` to fix regression

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -37,11 +37,13 @@ RUN apt-get update \
 ### RUBY
 
 # When bumping Ruby minor, need to also add the previous version to `bundler/helpers/v{1,2}/monkey_patches/definition_ruby_version_patch.rb`
-ARG RUBY_VERSION=3.1.2
+ARG RUBY_VERSION=3.1.3
 ARG RUBY_INSTALL_VERSION=0.8.5
 
 # When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
-ARG BUNDLER_V2_VERSION=2.3.25
+# Generally simplest to match the bundler version to the one that comes by default with whatever Ruby version we install.
+# This way other projects that import this library don't have to futz around with installing new /unexpected bundler versions.
+ARG BUNDLER_V2_VERSION=2.3.26
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
 # Allow gem installs as the dependabot user
 ENV BUNDLE_PATH=".bundle"


### PR DESCRIPTION
During the recent Dockerfile refactoring to split into per-ecosystem, the ruby version regressed from `3.1.3` to `3.1.2`... probably because some of the changes from https://github.com/dependabot/dependabot-core/pull/6257 weren't pulled in.

So this re-applies them. I checked the other files change in that PR and they all still looked correct, this was the only file from that PR that regressed.