### PR TITLE
[python][pip-compile] Add --strip-extras by default when resolving versions

### DIFF
--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -249,7 +249,7 @@ module Dependabot
         def pip_compile_options(filename)
           options = @build_isolation ? ["--build-isolation"] : ["--no-build-isolation"]
           options += pip_compile_index_options
-          options += ["--allow-unsafe"]
+          options += ["--allow-unsafe", "--strip-extras"]
           options += ["--resolver backtracking"] if new_resolver_supported?
 
           if (requirements_file = compiled_file_for_filename(filename))


### PR DESCRIPTION
Closes #6550