### PR TITLE
use the build scripts in the workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
           - { path: composer, name: composer, ci_node_total: 2, ci_node_index: 1, ecosystem: composer }
           - { path: docker, name: docker, ecosystem: docker }
           - { path: elm, name: elm, ecosystem: elm }
-          - { path: git_submodules, name: git_submodules, ecosystem: submodule }
+          - { path: git_submodules, name: git_submodules, ecosystem: gitsubmodule }
           - { path: github_actions, name: github_actions, ecosystem: github-actions }
           - { path: go_modules, name: go_module, ci_node_total: 2, ci_node_index: 0, ecosystem: gomod }
           - { path: go_modules, name: go_module, ci_node_total: 2, ci_node_index: 1, ecosystem: gomod }
           - { path: gradle, name: gradle, ecosystem: gradle }
-          - { path: hex, name: hex, ci_node_total: 2, ci_node_index: 0, ecosystem: hex }
-          - { path: hex, name: hex, ci_node_total: 2, ci_node_index: 1, ecosystem: hex }
+          - { path: hex, name: hex, ci_node_total: 2, ci_node_index: 0, ecosystem: mix }
+          - { path: hex, name: hex, ci_node_total: 2, ci_node_index: 1, ecosystem: mix }
           - { path: maven, name: maven, ecosystem: maven }
           - { path: npm_and_yarn, name: npm_and_yarn, ci_node_total: 3, ci_node_index: 0, ecosystem: npm }
           - { path: npm_and_yarn, name: npm_and_yarn, ci_node_total: 3, ci_node_index: 1, ecosystem: npm }
@@ -153,34 +153,15 @@ jobs:
               - 'terraform/**'
               - '.github/workflows/ecosystem-ci.yml'
 
-      - name: Build updater core image
-        if: steps.changes.outputs[matrix.suite.path] == 'true'
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -t "ghcr.io/dependabot/dependabot-updater-core:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from ghcr.io/dependabot/dependabot-updater-core \
-            -f Dockerfile.updater-core \
-            .
-
       - name: Build ecosystem image
         if: steps.changes.outputs[matrix.suite.path] == 'true'
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -t "dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }} \
-            -f ${{ matrix.suite.path }}/Dockerfile \
-            .
+        run: script/build ${{ matrix.suite.path }}
 
       - name: Run ${{ matrix.suite.name }} tests
         if: steps.changes.outputs[matrix.suite.path] == 'true'
         run: |
           docker run \
+            --pull never \
             --env "CI=true" \
             --env "RAISE_ON_WARNINGS=true" \
             --env "DEPENDABOT_TEST_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }}" \
@@ -198,23 +179,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Build updater core image
-        run: |
-          docker build \
-            -t "ghcr.io/dependabot/dependabot-updater-core:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from ghcr.io/dependabot/dependabot-updater-core \
-            -f Dockerfile.updater-core \
-            .
       # using bundler as the test updater
       - name: Build ecosystem image
-        run: |
-          docker build \
-            -t "dependabot/dependabot-updater-bundler:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from ghcr.io/dependabot/dependabot-updater-bundler \
-            -f bundler/Dockerfile \
-            .
+        run: script/build bundler
       - name: Run updater tests
         env:
           DEPENDABOT_TEST_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -223,6 +190,7 @@ jobs:
         # other ecosystems with -v into the updater image we can still run those tests.
         run: |
           docker run --env DEPENDABOT_TEST_ACCESS_TOKEN \
+            --pull never \
             --env VCR \
             --rm \
             -v "$(pwd)/updater/spec/fixtures/vcr_cassettes:/home/dependabot/dependabot-updater/spec/fixtures/vcr_cassettes" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,102 +56,102 @@ jobs:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
               - 'bundler/**'
             cargo:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
               - 'cargo/**'
             common:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
             composer:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
               - 'composer/**'
             docker:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
               - 'docker/**'
             elm:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
               - 'elm/**'
             git_submodules:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
               - 'git_submodules/**'
             github_actions:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
               - 'github_actions/**'
             go_modules:
               - Dockerfile.updater-core
               - 'common/**'
               - 'go_modules/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
             gradle:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
               - 'maven/**'
               - 'gradle/**'
             hex:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
               - 'hex/**'
             maven:
               - Dockerfile.updater-core
               - 'common/**'
               - 'maven/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
             npm_and_yarn:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
               - 'npm_and_yarn/**'
             nuget:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
               - 'nuget/**'
             pub:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
               - 'pub/**'
             python:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
               - 'python/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
             terraform:
               - Dockerfile.updater-core
               - 'common/**'
               - 'omnibus/**'
               - 'terraform/**'
-              - '.github/workflows/ecosystem-ci.yml'
+              - '.github/workflows/ci.yml'
 
       - name: Build ecosystem image
         if: steps.changes.outputs[matrix.suite.path] == 'true'
@@ -197,7 +197,7 @@ jobs:
             -v "$(pwd)/npm_and_yarn:/home/dependabot/npm_and_yarn" \
             -v "$(pwd)/go_modules:/home/dependabot/go_modules" \
             -v "$(pwd)/composer:/home/dependabot/composer" \
-            "dependabot/dependabot-updater-bundler:latest" bundle exec rspec
+            "ghcr.io/dependabot/dependabot-updater-bundler:latest" bundle exec rspec
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,19 +185,7 @@ jobs:
       - name: Run updater tests
         env:
           DEPENDABOT_TEST_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Previously the updater image contained all ecosystems. Now the ecosystems are broken apart,
-        # but we still have some tests that need to run against other ecosystems. So by mounting the
-        # other ecosystems with -v into the updater image we can still run those tests.
-        run: |
-          docker run --env DEPENDABOT_TEST_ACCESS_TOKEN \
-            --pull never \
-            --env VCR \
-            --rm \
-            -v "$(pwd)/updater/spec/fixtures/vcr_cassettes:/home/dependabot/dependabot-updater/spec/fixtures/vcr_cassettes" \
-            -v "$(pwd)/npm_and_yarn:/home/dependabot/npm_and_yarn" \
-            -v "$(pwd)/go_modules:/home/dependabot/go_modules" \
-            -v "$(pwd)/composer:/home/dependabot/composer" \
-            "ghcr.io/dependabot/dependabot-updater-bundler:latest" bundle exec rspec
+        run: script/ci-test-updater
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
             --env "SUITE_NAME=${{ matrix.suite.name }}" \
             --env "CI_NODE_TOTAL=${{ matrix.suite.ci_node_total }}" \
             --env "CI_NODE_INDEX=${{ matrix.suite.ci_node_index }}" \
-            --rm dependabot/dependabot-updater-${{ matrix.suite.ecosystem }} bash -c \
+            --rm ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }} bash -c \
             "cd /home/dependabot/${{ matrix.suite.path }} && ./script/ci-test"
 
   updater:

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -1,4 +1,4 @@
-name: Eco branch images
+name: Branch images
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 on:
@@ -61,30 +61,9 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Build updater core image
-        if: env.DECISION == 'APPROVED:OPEN'
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -t "ghcr.io/dependabot/dependabot-updater-core:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from ghcr.io/dependabot/dependabot-updater-core \
-            -f Dockerfile.updater-core \
-            .
-
       - name: Build ecosystem image
         if: env.DECISION == 'APPROVED:OPEN'
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -t "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}:$TAG" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from ghcr.io/dependabot/dependabot-updater-core \
-            --cache-from ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }} \
-            -f ${{ matrix.suite.name }}/Dockerfile \
-            .
+        run: script/build ${{ matrix.suite.name }}
 
       - name: Push branch image
         if: env.DECISION == 'APPROVED:OPEN'

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Push branch image
         if: env.DECISION == 'APPROVED:OPEN'
         run: |
+          docker tag "dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}" "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}:$TAG"
           docker push "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}:$TAG"
 
       - name: Set summary

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Push branch image
         if: env.DECISION == 'APPROVED:OPEN'
         run: |
-          docker tag "dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}" "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}:$TAG"
+          docker tag "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}" "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}:$TAG"
           docker push "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}:$TAG"
 
       - name: Set summary

--- a/.github/workflows/images-fork.yml
+++ b/.github/workflows/images-fork.yml
@@ -1,4 +1,4 @@
-name: Push fork images
+name: Fork images
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 on:
@@ -64,28 +64,8 @@ jobs:
           git cherry-pick $PICK
           echo "TAG=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
-      - name: Build updater core image
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -t "ghcr.io/dependabot/dependabot-updater-core:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from ghcr.io/dependabot/dependabot-updater-core \
-            -f Dockerfile.updater-core \
-            .
-
       - name: Build ecosystem image
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -t "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}:$TAG" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from ghcr.io/dependabot/dependabot-updater-core \
-            --cache-from ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }} \
-            -f ${{ matrix.suite.name }}/Dockerfile \
-            .
+        run: script/build ${{ matrix.suite.name }}
 
       - name: Log in to GHCR
         run: |

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -1,4 +1,4 @@
-name: Push latest ecosystem images
+name: Latest images
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   UPDATER_IMAGE: "dependabot/updater-"
@@ -59,27 +59,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Build dependabot-updater-core image
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -t "ghcr.io/dependabot/dependabot-updater-core" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from ghcr.io/dependabot/dependabot-updater-core \
-            -f Dockerfile.updater-core \
-            .
-
       - name: Build dependabot-updater image
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -t "${UPDATER_IMAGE}${ECOSYSTEM}:$TAG" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from "${UPDATER_IMAGE_MIRROR}${ECOSYSTEM}" \
-            -f ${NAME}/Dockerfile \
-            .
+        run: script/build ${NAME}
 
       - name: Log in to GHCR
         run: |

--- a/.github/workflows/images-updater-core.yml
+++ b/.github/workflows/images-updater-core.yml
@@ -1,4 +1,4 @@
-name: Push updater-core image
+name: Updater-Core image
 env:
   UPDATER_CORE_IMAGE: "dependabot/dependabot-updater-core"
   UPDATER_CORE_IMAGE_MIRROR: "ghcr.io/dependabot/dependabot-updater-core"
@@ -20,15 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Build dependabot-updater-core image
-        env:
-          DOCKER_BUILDKIT: 1
-        run: |
-          docker build \
-            -t "$UPDATER_CORE_IMAGE:latest" \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from "$UPDATER_CORE_IMAGE_MIRROR:latest" \
-            -f Dockerfile.updater-core \
-            .
+        run: script/build common
       - name: Log in to GHCR
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,5 +1,5 @@
 # Runs all ecosystems cached and concurrently.
-name: Eco Smoke
+name: Smoke
 
 on:
   workflow_dispatch:
@@ -27,7 +27,7 @@ jobs:
           - { path: github_actions, name: actions, ecosystem: github-actions }
           - { path: go_modules, name: go, ecosystem: gomod }
           - { path: gradle, name: gradle, ecosystem: gradle }
-          - { path: hex, name: hex, ecosystem: hex }
+          - { path: hex, name: hex, ecosystem: mix }
           - { path: maven, name: maven, ecosystem: maven }
           - { path: npm_and_yarn, name: npm, ecosystem: npm}
           - { path: npm_and_yarn, name: npm-remove-transitive, ecosystem: npm}
@@ -47,106 +47,127 @@ jobs:
       with:
         filters: |
           bundler:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'bundler/**'
           cargo:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'cargo/**'
           composer:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'composer/**'
           docker:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'docker/**'
           elm:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'elm/**'
           git_submodules:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'git_submodules/**'
           github_actions:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'github_actions/**'
           go:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'go_modules/**'
           gradle:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'gradle/**'
           hex:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'hex/**'
           maven:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'maven/**'
           npm:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'npm_and_yarn/**'
           'npm-remove-transitive':
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'npm_and_yarn/**'
           nuget:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'nuget/**'
           pip:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'python/**'
           'pip-compile':
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'python/**'
           pipenv:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'python/**'
           poetry:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'python/**'
           pub:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'pub/**'
           terraform:
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'terraform/**'
           'yarn-berry':
+            - .github/workflows/eco-smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
@@ -169,30 +190,9 @@ jobs:
         cd cache
         gh run download --repo dependabot/smoke-tests --name cache-${{ matrix.suite.name }}
 
-    - name: Build updater core image
-      if: steps.changes.outputs[matrix.suite.name] == 'true'
-      env:
-        DOCKER_BUILDKIT: 1
-      run: |
-        docker build \
-          -t "ghcr.io/dependabot/dependabot-updater-core:latest" \
-          --build-arg BUILDKIT_INLINE_CACHE=1 \
-          --cache-from ghcr.io/dependabot/dependabot-updater-core \
-          -f Dockerfile.updater-core \
-          .
-
     - name: Build ecosystem image
       if: steps.changes.outputs[matrix.suite.name] == 'true'
-      env:
-        DOCKER_BUILDKIT: 1
-        OMNIBUS_VERSION: latest
-      run: |
-        docker build \
-          -t "dependabot/updater:latest" \
-          --build-arg BUILDKIT_INLINE_CACHE=1 \
-          --cache-from ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }} \
-          -f ${{ matrix.suite.path }}/Dockerfile \
-          .
+      run: script/build ${{ matrix.suite.path }}
 
     - name: ${{ matrix.suite.name }}
       if: steps.changes.outputs[matrix.suite.name] == 'true'
@@ -200,7 +200,13 @@ jobs:
         LOCAL_GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -o pipefail
-        ./dependabot test -f=smoke.yaml -o=result.yaml --cache=cache --timeout=20m --updater-image=dependabot/updater:latest 2>&1 | tee -a log.txt
+        ./dependabot test \
+          -f=smoke.yaml \
+          -o=result.yaml \
+          --cache=cache \
+          --timeout=20m \
+          --updater-image=ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}:latest \
+          2>&1 | tee -a log.txt
 
     - name: Diff
       if: always()

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -47,127 +47,127 @@ jobs:
       with:
         filters: |
           bundler:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'bundler/**'
           cargo:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'cargo/**'
           composer:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'composer/**'
           docker:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'docker/**'
           elm:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'elm/**'
           git_submodules:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'git_submodules/**'
           github_actions:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'github_actions/**'
           go:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'go_modules/**'
           gradle:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'gradle/**'
           hex:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'hex/**'
           maven:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'maven/**'
           npm:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'npm_and_yarn/**'
           'npm-remove-transitive':
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'npm_and_yarn/**'
           nuget:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'nuget/**'
           pip:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'python/**'
           'pip-compile':
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'python/**'
           pipenv:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'python/**'
           poetry:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'python/**'
           pub:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'pub/**'
           terraform:
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'
             - 'terraform/**'
           'yarn-berry':
-            - .github/workflows/eco-smoke.yml
+            - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'
             - 'updater/**'

--- a/script/_common
+++ b/script/_common
@@ -1,16 +1,45 @@
 # shellcheck shell=bash
-export LOCAL_IMAGE="ghcr.io/dependabot/dependabot-updater-"
+export UPDATER_CORE_IMAGE="ghcr.io/dependabot/dependabot-updater-core"
+export UPDATER_IMAGE="ghcr.io/dependabot/dependabot-updater-"
+export DOCKER_BUILDKIT=1
+
+function set_tag() {
+    case $ECOSYSTEM in
+      go_modules)
+        TAG=gomod
+        ;;
+      hex)
+        TAG=mix
+        ;;
+      npm_and_yarn)
+        TAG=npm
+        ;;
+      python)
+        TAG=pip
+        ;;
+      git_submodules)
+        TAG=gitsubmodule
+        ;;
+      github_actions)
+        TAG=github-actions
+        ;;
+      *)
+        TAG=$ECOSYSTEM
+        ;;
+    esac
+}
 
 function docker_build() {
   [[ -n "$SKIP_BUILD" ]] && return
   ECOSYSTEM="$1"
+  set_tag
 
   # shellcheck disable=SC2086  # as $DOCKER_BUILD_ARGS relies on word-splitting
   docker build \
     $DOCKER_BUILD_ARGS \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
-    --cache-from "ghcr.io/dependabot/dependabot-updater-core" \
-    -t "ghcr.io/dependabot/dependabot-updater-core" \
+    --cache-from "$UPDATER_CORE_IMAGE" \
+    -t "$UPDATER_CORE_IMAGE" \
     -f Dockerfile.updater-core \
     .
 
@@ -18,14 +47,14 @@ function docker_build() {
   docker build \
     $DOCKER_BUILD_ARGS \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
-    --cache-from "ghcr.io/dependabot/dependabot-updater-$ECOSYSTEM" \
-    -t "$LOCAL_IMAGE$ECOSYSTEM" \
+    --cache-from "$UPDATER_IMAGE$TAG" \
+    -t "$UPDATER_IMAGE$TAG" \
     -f $ECOSYSTEM/Dockerfile \
     .
 
   # Verify max layers; an AUFS limit that was _crucial_ on Heroku (but not now)
-  IMAGE_LAYERS=$(docker history -q "$LOCAL_IMAGE$ECOSYSTEM" | wc -l | sed -e 's/ //g')
-  echo "$LOCAL_IMAGE$ECOSYSTEM contains $IMAGE_LAYERS layers"
+  IMAGE_LAYERS=$(docker history -q "$UPDATER_IMAGE$TAG" | wc -l | sed -e 's/ //g')
+  echo "$UPDATER_IMAGE$TAG contains $IMAGE_LAYERS layers"
   [[ $IMAGE_LAYERS -lt 126 ]]
 }
 
@@ -34,7 +63,7 @@ function docker_exec() {
   docker run --env DEPENDABOT_TEST_ACCESS_TOKEN \
   --rm \
   -v "$(pwd)/.:/home/dependabot/dependabot-updater:delegated" \
-  -ti "$LOCAL_IMAGE$ECOSYSTEM" "${@:2}"
+  -ti "$UPDATER_IMAGE$TAG" "${@:2}"
 }
 
 function docker_bundle_exec() {
@@ -44,5 +73,5 @@ function docker_bundle_exec() {
   --env VCR \
   --rm \
   -v "$(pwd)/updater/spec/fixtures/vcr_cassettes:/home/dependabot/dependabot-updater/spec/fixtures/vcr_cassettes" \
-  "$LOCAL_IMAGE$ECOSYSTEM" bundle exec "${@:2}"
+  "$UPDATER_IMAGE$TAG" bundle exec "${@:2}"
 }

--- a/script/ci-test-updater
+++ b/script/ci-test-updater
@@ -4,5 +4,16 @@ set -e
 cd "$(dirname "$0")/.."
 source script/_common
 
-export OMNIBUS_VERSION="latest"
-docker_bundle_exec bundler rspec "$@"
+# Previously the updater image contained all ecosystems. Now the ecosystems are broken apart,
+# but we still have some tests that need to run against other ecosystems. So by mounting the
+# other ecosystems with -v into the updater image we can still run those tests.
+script/build bundler
+docker run --env DEPENDABOT_TEST_ACCESS_TOKEN \
+  --pull never \
+  --env VCR \
+  --rm \
+  -v "$(pwd)/updater/spec/fixtures/vcr_cassettes:/home/dependabot/dependabot-updater/spec/fixtures/vcr_cassettes" \
+  -v "$(pwd)/npm_and_yarn:/home/dependabot/npm_and_yarn" \
+  -v "$(pwd)/go_modules:/home/dependabot/go_modules" \
+  -v "$(pwd)/composer:/home/dependabot/composer" \
+  "ghcr.io/dependabot/dependabot-updater-bundler:latest" bundle exec rspec

--- a/script/test
+++ b/script/test
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-cd "$(dirname "$0")/.."
-source script/_common
-
-docker_bundle_exec bundler rspec "$@"


### PR DESCRIPTION
Also other enhancements:
- renamed workflows to be more consistent
- added `pull=never` to run commands to ensure the tests are testing what was built
- fixed some incorrect ecosystems in workflows
