### PR TITLE
Build per ecosystem dev containers

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -2,9 +2,6 @@
 
 set -e
 
-IMAGE_NAME="${IMAGE_NAME:=dependabot/dependabot-core-development}"
-CONTAINER_NAME="${CONTAINER_NAME:=dependabot-core-development}"
-DOCKERFILE="Dockerfile.development"
 HELP=false
 REBUILD=false
 
@@ -32,6 +29,10 @@ while true; do
     * ) break ;;
   esac
 done
+
+IMAGE_NAME="dependabot/dependabot-core-development-$ECOSYSTEM"
+CONTAINER_NAME="dependabot-core-development-$ECOSYSTEM"
+DOCKERFILE="Dockerfile.development"
 
 if [ "$HELP" = "true" ]; then
   echo "usage: $0 <ecosystem> [--rebuild] [ARGS]"


### PR DESCRIPTION
I built the python dev container with

```
bin/docker-dev-shell python --rebuild
```

Then I built the golang one with

```
bin/docker-dev-shell golang --rebuild
```

The I wanted to use the python one again, so I run

```
bin/docker-dev-shell python
```

No rebuild because I had already built it.

But I got "no pyenv in path" error.

I figure it was because rebuilding for golang overwrote the image.

Should we built dev separate dev containers for each ecosystem? That's what I did here. I think could've passed the `IMAGE_NAME` and `CONTAINER_NAME` variables, but we probably want this to be the default and no need to make it configurable.
