### PR TITLE
Don't fetch poms outside of configured dir

### DIFF
--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -92,18 +92,9 @@ module Dependabot
       def recursively_fetch_relative_path_parents(pom, fetched_filenames:)
         path = parent_path_for_pom(pom)
 
-        return [] if fetched_filenames.include?(path)
-
-        full_path_parts =
-          [directory.gsub(%r{^/}, ""), path].reject(&:empty?).compact
-
-        full_path = Pathname.new(File.join(*full_path_parts)).
-                    cleanpath.to_path
-
-        return [] if full_path.start_with?("..")
+        return [] if fetched_filenames.include?(path) || path.start_with?("..")
 
         parent_pom = fetch_file_from_host(path)
-        parent_pom.support_file = true
 
         [
           parent_pom,

--- a/maven/spec/dependabot/maven/file_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/file_fetcher_spec.rb
@@ -325,9 +325,7 @@ RSpec.describe Dependabot::Maven::FileFetcher do
         let(:directory) { "/util/util" }
 
         it "fetches the relevant poms" do
-          expect(file_fetcher_instance.files.count).to eq(3)
-          expect(file_fetcher_instance.files.map(&:name)).
-            to match_array(%w(pom.xml ../pom.xml ../../pom.xml))
+          expect(file_fetcher_instance.files.map(&:name)).to eq(%w(pom.xml))
         end
       end
 


### PR DESCRIPTION
When Dependabot needs some files to perform an update, but those files should not be updated, we normally use the `#support_file` dependency attribute. However, in this case, I think users normally configure directories for completely disjoint maven apps, so we can avoid fetching files outside of directory altogether.