### PR TITLE
Delete `updater/Brewfile`

### DIFF
--- a/updater/Brewfile
+++ b/updater/Brewfile
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-brew "awscli"
-brew "awssume"
-cask "docker" unless File.executable? "/usr/local/bin/docker"


### PR DESCRIPTION
This is only useful for running the `updater` locally on `mac` (although I suppose could also be used with Linuxbrew).

But these days, I don't think anyone uses this as we run everything within docker containers, including the updater, so this will just get outdated over time.

Instead, let's delete it.