### PR TITLE
Delete `updater/CODEOWNERS`

### DIFF
--- a/updater/CODEOWNERS
+++ b/updater/CODEOWNERS
@@ -1,1 +1,0 @@
-* @dependabot/maintainers


### PR DESCRIPTION
This used to be a top-level file in the internal repo it came from before we open sourced it.

Now, it's no longer relevant, as:
1. this entire repo is currently requires `@dependabot/maintainer` approval for merges
2. If we did add `CODEOWNERS`, we'd probably go with a top-level file for simplicity rather than an inheritance model of one per ecosystem... (I don't recall if codeowners files support the inheritance model)
3. In the recent past we tried having per-ecosystem teams, but it was a mess... more process than we need given our current complexity level.

So for now, let's keep things simple and reduce confusion by simply removing this file.