### PR TITLE
Map `updater` ecosystem to `bundler`

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -21,7 +21,14 @@ fi
 if [[ -z "$1" ]]; then
   HELP=true
 fi
-ECOSYSTEM="$1"
+
+# Technically every ecosystem results in building a per-ecosystem updater image.
+# But currently running the `updater` unit tests requires the `bundler` ecosystem image.
+if [ "$1" == "updater" ]; then
+  ECOSYSTEM="bundler"
+else
+  ECOSYSTEM="$1"
+fi
 
 while true; do
   case "$2" in

--- a/updater/README.md
+++ b/updater/README.md
@@ -11,11 +11,10 @@ GitHub network, and so is not generally accessible.
 
 ## Setup
 
-To work on the Updater, you will need to start a Docker dev shell. The bundler
-shell will suffice
+To work on the Updater, you will need to start a Docker dev shell:
 
 ```zsh
-➜ bin/docker-dev-shell bundler
+➜ bin/docker-dev-shell updater  # the docker-dev-shell internally maps 'updater' to the 'bundler' ecosystem image
 [dependabot-core-dev] ~/dependabot-core $ cd updater/
 [dependabot-core-dev] ~/dependabot-core/updater $ bundle
 ```


### PR DESCRIPTION
Technically every ecosystem results in building a per-ecosystem updater image. But currently running the `updater` unit tests requires the `bundler` ecosystem image.

So this is a convenience to make it so we don't have to rememeber that
and can just run `bin/docker-dev-shell updater`.