### PR TITLE
Cleanup Dockerfile's `apt-get install` lines

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -4,7 +4,12 @@ FROM $FROM_IMAGE
 # Temporarily switch to root user in order to install packages
 USER root
 RUN apt-get update \
-  && apt-get install -y vim strace ltrace gdb shellcheck \
+  && apt-get install -y --no-install-recommends \
+    vim \
+    strace \
+    ltrace \
+    gdb \
+    shellcheck \
   && rm -rf /var/lib/apt/lists/*
 USER dependabot
 


### PR DESCRIPTION
1. list packages on separate lines for easier `git blame` spelunking
2. Default to not installing recommended packages

I audited all the Dockerfiles, and this was the only one that was missing these things.