### PR TITLE
Fix updating requirement files with multiline hashes

### DIFF
--- a/python/lib/dependabot/python/requirement_parser.rb
+++ b/python/lib/dependabot/python/requirement_parser.rb
@@ -9,7 +9,7 @@ module Dependabot
       VERSION = /([1-9][0-9]*!)?[0-9]+[a-zA-Z0-9\-_.*]*(\+[0-9a-zA-Z]+(\.[0-9a-zA-Z]+)*)?/
 
       REQUIREMENT = /(?<comparison>#{COMPARISON})\s*\\?\s*(?<version>#{VERSION})/
-      HASH = /--hash=(?<algorithm>.*?):(?<hash>.*?)(?=\s|$)/
+      HASH = /--hash=(?<algorithm>.*?):(?<hash>.*?)(?=\s|\\|$)/
       REQUIREMENTS = /#{REQUIREMENT}(\s*,\s*\\?\s*#{REQUIREMENT})*/
       HASHES = /#{HASH}(\s*\\?\s*#{HASH})*/
       MARKER_OP = /\s*(#{COMPARISON}|(\s*in)|(\s*not\s*in))/

--- a/python/spec/dependabot/python/file_updater/requirement_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/requirement_file_updater_spec.rb
@@ -201,6 +201,20 @@ RSpec.describe Dependabot::Python::FileUpdater::RequirementFileUpdater do
           end
         end
 
+        context "with linebreaks and no space after each hash" do
+          let(:requirements_fixture_name) { "hashes_multiline_no_space.txt" }
+
+          its(:content) do
+            is_expected.to eq(
+              "pytest==3.3.1 \\\n" \
+              "    --hash=sha256:ae4a2d0bae1098bbe938ecd6c20a526d5d47a94dc4" \
+              "2ad7331c9ad06d0efe4962\\\n" \
+              "    --hash=sha256:cf8436dc59d8695346fcd3ab296de46425ecab00d6" \
+              "4096cebe79fb51ecb2eb93\n"
+            )
+          end
+        end
+
         context "with markers and linebreaks" do
           let(:requirements_fixture_name) { "markers_and_hashes_multiline.txt" }
 

--- a/python/spec/fixtures/requirements/hashes_multiline_no_space.txt
+++ b/python/spec/fixtures/requirements/hashes_multiline_no_space.txt
@@ -1,0 +1,3 @@
+pytest==3.2.3 \
+    --hash=sha256:81a25f36a97da3313e1125fce9e7bbbba565bc7fec3c5beb14c262ddab238ac1\
+    --hash=sha256:27fa6617efc2869d3e969a3e75ec060375bfb28831ade8b5cdd68da3a741dc3c


### PR DESCRIPTION
If the hashes used line continuation right after the hash (without a space in the middle), Dependabot would generate an invalid requirements file.

Fixes #2689.