### PR TITLE
Fix yarn parsing of locked dependencies with multiple requirements

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -98,22 +98,24 @@ module Dependabot
           dependency_set = Dependabot::NpmAndYarn::FileParser::DependencySet.new
 
           yarn_locks.each do |yarn_lock|
-            parse_yarn_lock(yarn_lock).each do |req, details|
-              next unless semver_version_for(details["version"])
-              next if alias_package?(req)
-              next if workspace_package?(req)
-              next if req == "__metadata"
+            parse_yarn_lock(yarn_lock).each do |reqs, details|
+              reqs.split(", ").each do |req|
+                next unless semver_version_for(details["version"])
+                next if alias_package?(req)
+                next if workspace_package?(req)
+                next if req == "__metadata"
 
-              # NOTE: The DependencySet will de-dupe our dependencies, so they
-              # end up unique by name. That's not a perfect representation of
-              # the nested nature of JS resolution, but it makes everything work
-              # comparably to other flat-resolution strategies
-              dependency_set << Dependency.new(
-                name: req.split(/(?<=\w)\@/).first,
-                version: semver_version_for(details["version"]),
-                package_manager: "npm_and_yarn",
-                requirements: []
-              )
+                # NOTE: The DependencySet will de-dupe our dependencies, so they
+                # end up unique by name. That's not a perfect representation of
+                # the nested nature of JS resolution, but it makes everything work
+                # comparably to other flat-resolution strategies
+                dependency_set << Dependency.new(
+                  name: req.split(/(?<=\w)\@/).first,
+                  version: semver_version_for(details["version"]),
+                  package_manager: "npm_and_yarn",
+                  requirements: []
+                )
+              end
             end
           end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         end
       end
 
+      context "that contains dependencies with multiple requirements" do
+        let(:dependency_files) { project_dependency_files("yarn_berry/multiple_requirements") }
+
+        its(:length) { is_expected.to eq(172) }
+
+        it "includes those dependencies" do
+          expect(dependencies.map(&:name)).to include("@nodelib/fs.stat")
+        end
+      end
+
       context "that contain bad lockfile" do
         let(:dependency_files) { project_dependency_files("yarn/broken_lockfile") }
 


### PR DESCRIPTION
This was extracted from #6516 because this fix alone is enough to fix #6565.

I also added a spec so this one should be ready!

Closes #6565.