### PR TITLE
WIP arm64 images

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -1,0 +1,43 @@
+name: ARM
+on:
+  push:
+    branches:
+      - jakecoffman/arm
+
+jobs:
+  arm:
+    name: ARM
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - { name: bundler, ecosystem: bundler }
+          - { name: cargo, ecosystem: cargo }
+          - { name: composer, ecosystem: composer }
+          - { name: docker, ecosystem: docker }
+          - { name: elm, ecosystem: elm }
+          - { name: git_submodules, ecosystem: gitsubmodule }
+          - { name: github_actions, ecosystem: github-actions }
+          - { name: go_modules, ecosystem: gomod }
+          - { name: gradle, ecosystem: gradle }
+          - { name: hex, ecosystem: mix }
+          - { name: maven, ecosystem: maven }
+          - { name: npm_and_yarn, ecosystem: npm }
+          - { name: nuget, ecosystem: nuget }
+          - { name: pub, ecosystem: pub }
+          - { name: python, ecosystem: pip }
+          - { name: terraform, ecosystem: terraform }
+    env:
+      TAG: ${{ github.sha }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Do the thing
+        run: docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
+
+      - name: Build ecosystem image
+        run: |
+          export DOCKER_BUILD_ARGS="--platform linux/arm64"
+          script/build ${{ matrix.suite.name }}

--- a/script/_common
+++ b/script/_common
@@ -34,9 +34,17 @@ function docker_build() {
   ECOSYSTEM="$1"
   set_tag
 
+  # create buildx builder if it doesn't exist
+  docker buildx inspect dependabot || docker buildx create \
+    --name dependabot \
+    --driver docker-container \
+    --bootstrap \
+    --platform linux/arm64,linux/amd64
+
   # shellcheck disable=SC2086  # as $DOCKER_BUILD_ARGS relies on word-splitting
-  docker build \
+  docker buildx build \
     $DOCKER_BUILD_ARGS \
+    --builder dependabot \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     --cache-from "$UPDATER_CORE_IMAGE" \
     -t "$UPDATER_CORE_IMAGE" \
@@ -44,8 +52,9 @@ function docker_build() {
     .
 
   # shellcheck disable=SC2086  # as $DOCKER_BUILD_ARGS relies on word-splitting
-  docker build \
+  docker buildx build \
     $DOCKER_BUILD_ARGS \
+    --builder dependabot \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     --cache-from "$UPDATER_IMAGE$TAG" \
     -t "$UPDATER_IMAGE$TAG" \


### PR DESCRIPTION
Trying to add support for arm64 images to our scripts and running into some issues.

The main one seems to be that dockerx can't pull from the local docker daemon: https://github.com/docker/buildx/issues/1453

If I add `--load` to the updater-core build, it gets transferred to the Docker daemon correctly, but then when it proceeds to build the ecosystem container it pulls from ghcr.io and there's no arm64 build there... so it ends up building an ***amd64*** base image with TARGETARCH set to arm64! This took a long time to realize what was happening. Seems like a bug.

Some folks propose starting a docker registry locally, or exporting the images to a file. Both of those options seem like they will break caching. 

Also the build in Actions is taking about an hour. Ideally we could run this after a merge, after the latest images are pushed, then publish these and run `docker manifest` commands to make a multi-image.

But this is quite a bit of work to get arm64 builds that run pretty quick for me locally at the moment. Our Actions runners already get pretty backed up sometimes as it is. 

Putting this up as Draft to document what I tried and get any other inputs or expertise. 