### PR TITLE
Skip invalid docker image references in helm charts

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -168,7 +168,9 @@ module Dependabot
 
           images.each do |string|
             # TODO: Support Docker references and path references
-            details = string.match(IMAGE_SPEC).named_captures
+            match = string.match(IMAGE_SPEC)
+            next unless match
+            details = match.named_captures
             details["registry"] = nil if details["registry"] == "docker.io"
 
             version = version_from(details)


### PR DESCRIPTION
It is possible to include variables/references in a helm chart, ex:
```yaml
image:
  repository: foo/bar
  tag: "${bar.foo}"
```
Currently, the docker parser will extract this and construct the docker reference as the string `foo/bar:${bar.foo}`.

Because this reference contains invalid characters (`{`, `}`, `$`) for a docker tag, the regex match against `IMAGE_SPEC` will (correctly) result in nil:
```
lib/dependabot/docker/file_parser.rb:172:in `block (2 levels) in workfile_file_dependencies': undefined method `named_captures' for nil:NilClass (NoMethodError)
``` 
By adding a `next unless` check we can skip over references like this without crashing allowing the rest of the file/directory to be upgraded.