### PR TITLE
Allow helm/k8s image tag to be double/single quoted

### DIFF
--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -183,7 +183,7 @@ module Dependabot
         modified_content = file.content
 
         old_images.each do |old_image|
-          old_image_regex = /^\s+(?:-\s)?image:\s+#{old_image}(?=\s|$)/
+          old_image_regex = /^\s+(?:-\s)?image:\s+["']?#{old_image}["']?(?=\s|$)/
           modified_content = modified_content.gsub(old_image_regex) do |old_img|
             old_img.gsub(old_image.to_s, new_yaml_image(file).to_s)
           end


### PR DESCRIPTION
Similar to #6344, allow the `image: "..."` YAML tag to be quoted.