### PR TITLE
Don't require whitespace before image tag in helm charts

### DIFF
--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -183,7 +183,7 @@ module Dependabot
         modified_content = file.content
 
         old_images.each do |old_image|
-          old_image_regex = /^\s+(?:-\s)?image:\s+#{old_image}(?=\s|$)/
+          old_image_regex = /^\s*(?:-\s)?image:\s+#{old_image}(?=\s|$)/
           modified_content = modified_content.gsub(old_image_regex) do |old_img|
             old_img.gsub(old_image.to_s, new_yaml_image(file).to_s)
           end


### PR DESCRIPTION
A helm `values.yaml` can be a complex file with nested structures, ex:
```yaml
---
service_a:
  image: foo/bar:v1.2.3
````
However, a very simple values files could also contain `image` as a top level tag, ex:
```yaml
---
image: foo/bar:v1.2.3
```
Dependabot assumes there will be whitespace `\s+` before the `image:` tag, but this is not always true.