### PR TITLE
Adjust parent pom fetching logic

### DIFF
--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -92,9 +92,18 @@ module Dependabot
       def recursively_fetch_relative_path_parents(pom, fetched_filenames:)
         path = parent_path_for_pom(pom)
 
-        return [] if fetched_filenames.include?(path) || path.start_with?("..")
+        return [] if fetched_filenames.include?(path)
+
+        full_path_parts =
+          [directory.gsub(%r{^/}, ""), path].reject(&:empty?).compact
+
+        full_path = Pathname.new(File.join(*full_path_parts)).
+                    cleanpath.to_path
+
+        return [] if full_path.start_with?("..")
 
         parent_pom = fetch_file_from_host(path)
+        parent_pom.support_file = true
 
         [
           parent_pom,

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -92,18 +92,18 @@ module Dependabot
       def recursively_fetch_relative_path_parents(pom, fetched_filenames:)
         path = parent_path_for_pom(pom)
 
-        return [] if fetched_filenames.include?(path)
+        return [] if path.nil? || fetched_filenames.include?(path)
 
         full_path_parts =
           [directory.gsub(%r{^/}, ""), path].reject(&:empty?).compact
 
-        full_path = Pathname.new(File.join(*full_path_parts)).
-                    cleanpath.to_path
+        full_path = Pathname.new(File.join(*full_path_parts)).cleanpath.to_path
 
         return [] if full_path.start_with?("..")
 
         parent_pom = fetch_file_from_host(path)
-        parent_pom.support_file = true
+
+        return [] unless fetched_pom_is_parent(pom, parent_pom)
 
         [
           parent_pom,
@@ -120,6 +120,8 @@ module Dependabot
         doc = Nokogiri::XML(pom.content)
         doc.remove_namespaces!
 
+        return unless doc.at_xpath("/project/parent")
+
         relative_parent_path =
           doc.at_xpath("/project/parent/relativePath")&.content&.strip || ".."
 
@@ -130,6 +132,28 @@ module Dependabot
         ].compact.reject(&:empty?)
 
         Pathname.new(File.join(*name_parts)).cleanpath.to_path
+      end
+
+      def fetched_pom_is_parent(pom, parent_pom)
+        pom_doc = Nokogiri::XML(pom.content).remove_namespaces!
+        pom_artifact_id, pom_group_id, pom_version = fetch_pom_unique_ids(pom_doc, true)
+
+        parent_doc = Nokogiri::XML(parent_pom.content).remove_namespaces!
+        parent_artifact_id, parent_group_id, parent_version = fetch_pom_unique_ids(parent_doc, false)
+
+        if parent_group_id.nil?
+          [parent_artifact_id, parent_version] == [pom_artifact_id, pom_version]
+        else
+          [parent_group_id, parent_artifact_id, parent_version] == [pom_group_id, pom_artifact_id, pom_version]
+        end
+      end
+
+      def fetch_pom_unique_ids(doc, check_parent_node)
+        parent = check_parent_node ? "/parent" : ""
+        group_id = doc.at_xpath("/project#{parent}/groupId")&.content&.strip
+        artifact_id = doc.at_xpath("/project#{parent}/artifactId")&.content&.strip
+        version = doc.at_xpath("/project#{parent}/version")&.content&.strip
+        [artifact_id, group_id, version]
       end
     end
   end

--- a/maven/spec/dependabot/maven/file_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/file_fetcher_spec.rb
@@ -325,7 +325,9 @@ RSpec.describe Dependabot::Maven::FileFetcher do
         let(:directory) { "/util/util" }
 
         it "fetches the relevant poms" do
-          expect(file_fetcher_instance.files.map(&:name)).to eq(%w(pom.xml))
+          expect(file_fetcher_instance.files.count).to eq(3)
+          expect(file_fetcher_instance.files.map(&:name)).
+            to match_array(%w(pom.xml ../pom.xml ../../pom.xml))
         end
       end
 

--- a/maven/spec/dependabot/maven/file_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/file_fetcher_spec.rb
@@ -324,10 +324,8 @@ RSpec.describe Dependabot::Maven::FileFetcher do
         end
         let(:directory) { "/util/util" }
 
-        it "fetches the relevant poms" do
-          expect(file_fetcher_instance.files.count).to eq(3)
-          expect(file_fetcher_instance.files.map(&:name)).
-            to match_array(%w(pom.xml ../pom.xml ../../pom.xml))
+        it "fetches the relevant pom" do
+          expect(file_fetcher_instance.files.map(&:name)).to eq(%w(pom.xml))
         end
       end
 
@@ -424,7 +422,7 @@ RSpec.describe Dependabot::Maven::FileFetcher do
         with(headers: { "Authorization" => "token token" }).
         to_return(
           status: 200,
-          body: fixture("github", "contents_java_basic_pom.json"),
+          body: fixture("github", "contents_java_parent_pom_custom_name_parent.json"),
           headers: { "content-type" => "application/json" }
         )
 
@@ -441,6 +439,163 @@ RSpec.describe Dependabot::Maven::FileFetcher do
         to match_array(
           %w(pom.xml parentpom.xml)
         )
+    end
+  end
+
+  context "with a project with multiple related and unrelated maven modules inside" do
+    before do
+      stub_request(:get, File.join(url, "parent_modules_project/pom.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "parent_modules_root_pom.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get,
+                   File.join(url, "parent_modules_project/pom_with_parent_groupid/pom_with_parent/pom.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "parent_modules_pom_with_parent.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, "parent_modules_project/pom_with_parent_groupid/pom_parent.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "parent_modules_parent_of_pom_with_parent.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, "parent_modules_project/pom_with_no_parent/pom.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "parent_modules_no_parent_pom.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, "parent_modules_project/pom_with_implicit_parent_path/pom.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "parent_modules_implicit_parent_pom.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, "parent_modules_project/different_version/pom.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "parent_modules_different_version_pom.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, "parent_modules_project/different_group_id/pom.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "parent_modules_different_group_pom.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, "parent_modules_project/different_artifact_id/pom.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "parent_modules_different_artifact_pom.json"),
+          headers: { "content-type" => "application/json" }
+        )
+
+      stub_request(:get, File.join(url, "parent_modules_project/pom_with_parent_groupid/pom_with_parent/.mvn?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 404
+        )
+
+      stub_request(:get, File.join(url, "parent_modules_project/pom_with_no_parent/.mvn?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 404
+        )
+
+      stub_request(:get, File.join(url, "parent_modules_project/pom_with_implicit_parent_path/.mvn?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 404
+        )
+
+      stub_request(:get, File.join(url, "parent_modules_project/different_version/.mvn?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 404
+        )
+
+      stub_request(:get, File.join(url, "parent_modules_project/different_group_id/.mvn?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 404
+        )
+
+      stub_request(:get, File.join(url, "parent_modules_project/different_artifact_id/.mvn?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 404
+        )
+
+      stub_request(:get, File.join(url, ".mvn/extensions.xml?ref=sha")).
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 404
+        )
+    end
+
+    context "when asked to fetch a pom with a parent which has inherited group id" do
+      let(:directory) { "/parent_modules_project/pom_with_parent_groupid/pom_with_parent" }
+      it "fetches the relevant poms" do
+        expect(file_fetcher_instance.files.count).to eq(3)
+        expect(file_fetcher_instance.files.map(&:name)).
+          to match_array(%w(pom.xml ../pom_parent.xml ../../pom.xml))
+      end
+    end
+
+    context "when asked to fetch a pom with no parent defined" do
+      let(:directory) { "/parent_modules_project/pom_with_no_parent" }
+      it "fetches only this pom" do
+        expect(file_fetcher_instance.files.map(&:name)).to eq(%w(pom.xml))
+      end
+    end
+
+    context "when asked to fetch a pom with an implicit path to parent defined" do
+      let(:directory) { "/parent_modules_project/pom_with_implicit_parent_path" }
+      it "fetches only both this pom and its implicit parent" do
+        expect(file_fetcher_instance.files.count).to eq(2)
+        expect(file_fetcher_instance.files.map(&:name)).
+          to match_array(%w(pom.xml ../pom.xml))
+      end
+    end
+
+    context "when asked to fetch a pom which local parent has different version" do
+      let(:directory) { "/parent_modules_project/different_version" }
+      it "fetches only this pom" do
+        expect(file_fetcher_instance.files.map(&:name)).to eq(%w(pom.xml))
+      end
+    end
+
+    context "when asked to fetch a pom which local parent has different groupId" do
+      let(:directory) { "/parent_modules_project/different_group_id" }
+      it "fetches only this pom" do
+        expect(file_fetcher_instance.files.map(&:name)).to eq(%w(pom.xml))
+      end
+    end
+
+    context "when asked to fetch a pom which local parent has different artifactId" do
+      let(:directory) { "/parent_modules_project/different_artifact_id" }
+      it "fetches only this pom" do
+        expect(file_fetcher_instance.files.map(&:name)).to eq(%w(pom.xml))
+      end
     end
   end
 end

--- a/maven/spec/fixtures/github/contents_java_parent_pom_custom_name_parent.json
+++ b/maven/spec/fixtures/github/contents_java_parent_pom_custom_name_parent.json
@@ -1,0 +1,18 @@
+{
+  "name": "parentpom.xml",
+  "path": "submodule-one/parentpom.xml",
+  "sha": "29baf7e28e635b2a35e1b2750751999c0762d486",
+  "size": 929,
+  "url": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/submodule-one/parentpom.xml?ref=main",
+  "html_url": "https://github.com/soulus13/dependabot-maven-test/blob/main/submodule-one/parentpom.xml",
+  "git_url": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/29baf7e28e635b2a35e1b2750751999c0762d486",
+  "download_url": "https://raw.githubusercontent.com/soulus13/dependabot-maven-test/main/submodule-one/parentpom.xml",
+  "type": "file",
+  "content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHByb2pl\nY3QgeG1sbnM9Imh0dHA6Ly9tYXZlbi5hcGFjaGUub3JnL1BPTS80LjAuMCIK\nICAgICAgICAgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hN\nTFNjaGVtYS1pbnN0YW5jZSIKICAgICAgICAgeHNpOnNjaGVtYUxvY2F0aW9u\nPSJodHRwOi8vbWF2ZW4uYXBhY2hlLm9yZy9QT00vNC4wLjAgaHR0cDovL21h\ndmVuLmFwYWNoZS5vcmcveHNkL21hdmVuLTQuMC4wLnhzZCI+CiAgICA8bW9k\nZWxWZXJzaW9uPjQuMC4wPC9tb2RlbFZlcnNpb24+CgogICAgPHBhY2thZ2lu\nZz5wb208L3BhY2thZ2luZz4KCiAgICA8Z3JvdXBJZD5vcmcuZXhhbXBsZTwv\nZ3JvdXBJZD4KICAgIDxhcnRpZmFjdElkPm1hdmVuLXRlc3Qtc3VibW9kdWxl\nLW9uZS1wYXJlbnQ8L2FydGlmYWN0SWQ+CiAgICA8dmVyc2lvbj4xLjAtU05B\nUFNIT1Q8L3ZlcnNpb24+CgogICAgPHByb3BlcnRpZXM+CiAgICAgICAgPG1h\ndmVuLmNvbXBpbGVyLnNvdXJjZT44PC9tYXZlbi5jb21waWxlci5zb3VyY2U+\nCiAgICAgICAgPG1hdmVuLmNvbXBpbGVyLnRhcmdldD44PC9tYXZlbi5jb21w\naWxlci50YXJnZXQ+CiAgICAgICAgPHByb2plY3QuYnVpbGQuc291cmNlRW5j\nb2Rpbmc+VVRGLTg8L3Byb2plY3QuYnVpbGQuc291cmNlRW5jb2Rpbmc+CiAg\nICA8L3Byb3BlcnRpZXM+CgogICAgPGRlcGVuZGVuY2llcz4KICAgICAgICA8\nZGVwZW5kZW5jeT4KICAgICAgICAgICAgPGdyb3VwSWQ+b3JnLnNwcmluZ2Zy\nYW1ld29yazwvZ3JvdXBJZD4KICAgICAgICAgICAgPGFydGlmYWN0SWQ+c3By\naW5nLWFvcDwvYXJ0aWZhY3RJZD4KICAgICAgICAgICAgPHZlcnNpb24+NC4w\nLjUuUkVMRUFTRTwvdmVyc2lvbj4KICAgICAgICA8L2RlcGVuZGVuY3k+CiAg\nICA8L2RlcGVuZGVuY2llcz4KCjwvcHJvamVjdD4=\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/submodule-one/parentpom.xml?ref=main",
+    "git": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/29baf7e28e635b2a35e1b2750751999c0762d486",
+    "html": "https://github.com/soulus13/dependabot-maven-test/blob/main/submodule-one/parentpom.xml"
+  }
+}

--- a/maven/spec/fixtures/github/parent_modules_different_artifact_pom.json
+++ b/maven/spec/fixtures/github/parent_modules_different_artifact_pom.json
@@ -1,0 +1,18 @@
+{
+  "name": "pom.xml",
+  "path": "parent_modules_project/different_artifact_id/pom.xml",
+  "sha": "dbb97f2ddeb67065a95444dc871445486e86c2ff",
+  "size": 910,
+  "url": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/different_artifact_id/pom.xml?ref=main",
+  "html_url": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/different_artifact_id/pom.xml",
+  "git_url": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/dbb97f2ddeb67065a95444dc871445486e86c2ff",
+  "download_url": "https://raw.githubusercontent.com/soulus13/dependabot-maven-test/main/parent_modules_project/different_artifact_id/pom.xml",
+  "type": "file",
+  "content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHByb2pl\nY3QgeG1sbnM9Imh0dHA6Ly9tYXZlbi5hcGFjaGUub3JnL1BPTS80LjAuMCIK\nICAgICAgICAgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hN\nTFNjaGVtYS1pbnN0YW5jZSIKICAgICAgICAgeHNpOnNjaGVtYUxvY2F0aW9u\nPSJodHRwOi8vbWF2ZW4uYXBhY2hlLm9yZy9QT00vNC4wLjAgaHR0cDovL21h\ndmVuLmFwYWNoZS5vcmcveHNkL21hdmVuLTQuMC4wLnhzZCI+CiAgICA8bW9k\nZWxWZXJzaW9uPjQuMC4wPC9tb2RlbFZlcnNpb24+CgogICAgPHBhY2thZ2lu\nZz5wb208L3BhY2thZ2luZz4KCiAgICA8cGFyZW50PgogICAgICAgIDxncm91\ncElkPm9yZy5wYXJlbnQubW9kdWxlczwvZ3JvdXBJZD4KICAgICAgICA8YXJ0\naWZhY3RJZD5wYXJlbnQtbW9kdWxlcy1hcnRpZmFjdC1uZXc8L2FydGlmYWN0\nSWQ+CiAgICAgICAgPHZlcnNpb24+MS4wLjA8L3ZlcnNpb24+CiAgICAgICAg\nPHJlbGF0aXZlUGF0aD4uLi9wb20ueG1sPC9yZWxhdGl2ZVBhdGg+CiAgICA8\nL3BhcmVudD4KCiAgICA8Z3JvdXBJZD5vcmcucGFyZW50Lm1vZHVsZXM8L2dy\nb3VwSWQ+CiAgICA8YXJ0aWZhY3RJZD5wYXJlbnQtbW9kdWxlcy1hcnRpZmFj\ndDwvYXJ0aWZhY3RJZD4KICAgIDx2ZXJzaW9uPjEuNi4wPC92ZXJzaW9uPgoK\nICAgIDxwcm9wZXJ0aWVzPgogICAgICAgIDxtYXZlbi5jb21waWxlci5zb3Vy\nY2U+ODwvbWF2ZW4uY29tcGlsZXIuc291cmNlPgogICAgICAgIDxtYXZlbi5j\nb21waWxlci50YXJnZXQ+ODwvbWF2ZW4uY29tcGlsZXIudGFyZ2V0PgogICAg\nICAgIDxwcm9qZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPlVURi04PC9wcm9q\nZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPgogICAgPC9wcm9wZXJ0aWVzPgoK\nPC9wcm9qZWN0Pg==\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/different_artifact_id/pom.xml?ref=main",
+    "git": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/dbb97f2ddeb67065a95444dc871445486e86c2ff",
+    "html": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/different_artifact_id/pom.xml"
+  }
+}

--- a/maven/spec/fixtures/github/parent_modules_different_group_pom.json
+++ b/maven/spec/fixtures/github/parent_modules_different_group_pom.json
@@ -1,0 +1,18 @@
+{
+  "name": "pom.xml",
+  "path": "parent_modules_project/different_group_id/pom.xml",
+  "sha": "269ae65e7f70ef547b4578cbe574e5cd951de0aa",
+  "size": 910,
+  "url": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/different_group_id/pom.xml?ref=main",
+  "html_url": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/different_group_id/pom.xml",
+  "git_url": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/269ae65e7f70ef547b4578cbe574e5cd951de0aa",
+  "download_url": "https://raw.githubusercontent.com/soulus13/dependabot-maven-test/main/parent_modules_project/different_group_id/pom.xml",
+  "type": "file",
+  "content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHByb2pl\nY3QgeG1sbnM9Imh0dHA6Ly9tYXZlbi5hcGFjaGUub3JnL1BPTS80LjAuMCIK\nICAgICAgICAgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hN\nTFNjaGVtYS1pbnN0YW5jZSIKICAgICAgICAgeHNpOnNjaGVtYUxvY2F0aW9u\nPSJodHRwOi8vbWF2ZW4uYXBhY2hlLm9yZy9QT00vNC4wLjAgaHR0cDovL21h\ndmVuLmFwYWNoZS5vcmcveHNkL21hdmVuLTQuMC4wLnhzZCI+CiAgICA8bW9k\nZWxWZXJzaW9uPjQuMC4wPC9tb2RlbFZlcnNpb24+CgogICAgPHBhY2thZ2lu\nZz5wb208L3BhY2thZ2luZz4KCiAgICA8cGFyZW50PgogICAgICAgIDxncm91\ncElkPm9yZy5wYXJlbnQubW9kdWxlcy5uZXc8L2dyb3VwSWQ+CiAgICAgICAg\nPGFydGlmYWN0SWQ+cGFyZW50LW1vZHVsZXMtYXJ0aWZhY3Q8L2FydGlmYWN0\nSWQ+CiAgICAgICAgPHZlcnNpb24+MS4wLjA8L3ZlcnNpb24+CiAgICAgICAg\nPHJlbGF0aXZlUGF0aD4uLi9wb20ueG1sPC9yZWxhdGl2ZVBhdGg+CiAgICA8\nL3BhcmVudD4KCiAgICA8Z3JvdXBJZD5vcmcucGFyZW50Lm1vZHVsZXM8L2dy\nb3VwSWQ+CiAgICA8YXJ0aWZhY3RJZD5wYXJlbnQtbW9kdWxlcy1hcnRpZmFj\ndDwvYXJ0aWZhY3RJZD4KICAgIDx2ZXJzaW9uPjEuNS4wPC92ZXJzaW9uPgoK\nICAgIDxwcm9wZXJ0aWVzPgogICAgICAgIDxtYXZlbi5jb21waWxlci5zb3Vy\nY2U+ODwvbWF2ZW4uY29tcGlsZXIuc291cmNlPgogICAgICAgIDxtYXZlbi5j\nb21waWxlci50YXJnZXQ+ODwvbWF2ZW4uY29tcGlsZXIudGFyZ2V0PgogICAg\nICAgIDxwcm9qZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPlVURi04PC9wcm9q\nZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPgogICAgPC9wcm9wZXJ0aWVzPgoK\nPC9wcm9qZWN0Pg==\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/different_group_id/pom.xml?ref=main",
+    "git": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/269ae65e7f70ef547b4578cbe574e5cd951de0aa",
+    "html": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/different_group_id/pom.xml"
+  }
+}

--- a/maven/spec/fixtures/github/parent_modules_different_version_pom.json
+++ b/maven/spec/fixtures/github/parent_modules_different_version_pom.json
@@ -1,0 +1,18 @@
+{
+  "name": "pom.xml",
+  "path": "parent_modules_project/different_version/pom.xml",
+  "sha": "881e7801619ba88dbf7bd02dd304763e5a635485",
+  "size": 905,
+  "url": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/different_version/pom.xml?ref=main",
+  "html_url": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/different_version/pom.xml",
+  "git_url": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/881e7801619ba88dbf7bd02dd304763e5a635485",
+  "download_url": "https://raw.githubusercontent.com/soulus13/dependabot-maven-test/main/parent_modules_project/different_version/pom.xml",
+  "type": "file",
+  "content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHByb2pl\nY3QgeG1sbnM9Imh0dHA6Ly9tYXZlbi5hcGFjaGUub3JnL1BPTS80LjAuMCIK\nICAgICAgICAgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hN\nTFNjaGVtYS1pbnN0YW5jZSIKICAgICAgICAgeHNpOnNjaGVtYUxvY2F0aW9u\nPSJodHRwOi8vbWF2ZW4uYXBhY2hlLm9yZy9QT00vNC4wLjAgaHR0cDovL21h\ndmVuLmFwYWNoZS5vcmcveHNkL21hdmVuLTQuMC4wLnhzZCI+CiAgICA8bW9k\nZWxWZXJzaW9uPjQuMC4wPC9tb2RlbFZlcnNpb24+CgogICAgPHBhY2thZ2lu\nZz5wb208L3BhY2thZ2luZz4KICAgIDxwYXJlbnQ+CiAgICAgICAgPGdyb3Vw\nSWQ+b3JnLnBhcmVudC5tb2R1bGVzPC9ncm91cElkPgogICAgICAgIDxhcnRp\nZmFjdElkPnBhcmVudC1tb2R1bGVzLWFydGlmYWN0PC9hcnRpZmFjdElkPgog\nICAgICAgIDx2ZXJzaW9uPjEuNC4wPC92ZXJzaW9uPgogICAgICAgIDxyZWxh\ndGl2ZVBhdGg+Li4vcG9tLnhtbDwvcmVsYXRpdmVQYXRoPgogICAgPC9wYXJl\nbnQ+CgogICAgPGdyb3VwSWQ+b3JnLnBhcmVudC5tb2R1bGVzPC9ncm91cElk\nPgogICAgPGFydGlmYWN0SWQ+cGFyZW50LW1vZHVsZXMtYXJ0aWZhY3Q8L2Fy\ndGlmYWN0SWQ+CiAgICA8dmVyc2lvbj4xLjQuMDwvdmVyc2lvbj4KCiAgICA8\ncHJvcGVydGllcz4KICAgICAgICA8bWF2ZW4uY29tcGlsZXIuc291cmNlPjg8\nL21hdmVuLmNvbXBpbGVyLnNvdXJjZT4KICAgICAgICA8bWF2ZW4uY29tcGls\nZXIudGFyZ2V0Pjg8L21hdmVuLmNvbXBpbGVyLnRhcmdldD4KICAgICAgICA8\ncHJvamVjdC5idWlsZC5zb3VyY2VFbmNvZGluZz5VVEYtODwvcHJvamVjdC5i\ndWlsZC5zb3VyY2VFbmNvZGluZz4KICAgIDwvcHJvcGVydGllcz4KCjwvcHJv\namVjdD4=\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/different_version/pom.xml?ref=main",
+    "git": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/881e7801619ba88dbf7bd02dd304763e5a635485",
+    "html": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/different_version/pom.xml"
+  }
+}

--- a/maven/spec/fixtures/github/parent_modules_implicit_parent_pom.json
+++ b/maven/spec/fixtures/github/parent_modules_implicit_parent_pom.json
@@ -1,0 +1,18 @@
+{
+  "name": "pom.xml",
+  "path": "parent_modules_project/pom_with_implicit_parent_path/pom.xml",
+  "sha": "45a6f0ac4eeeb80673659cf03712fd5c1cd940d5",
+  "size": 820,
+  "url": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/pom_with_implicit_parent_path/pom.xml?ref=main",
+  "html_url": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/pom_with_implicit_parent_path/pom.xml",
+  "git_url": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/45a6f0ac4eeeb80673659cf03712fd5c1cd940d5",
+  "download_url": "https://raw.githubusercontent.com/soulus13/dependabot-maven-test/main/parent_modules_project/pom_with_implicit_parent_path/pom.xml",
+  "type": "file",
+  "content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHByb2pl\nY3QgeG1sbnM9Imh0dHA6Ly9tYXZlbi5hcGFjaGUub3JnL1BPTS80LjAuMCIK\nICAgICAgICAgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hN\nTFNjaGVtYS1pbnN0YW5jZSIKICAgICAgICAgeHNpOnNjaGVtYUxvY2F0aW9u\nPSJodHRwOi8vbWF2ZW4uYXBhY2hlLm9yZy9QT00vNC4wLjAgaHR0cDovL21h\ndmVuLmFwYWNoZS5vcmcveHNkL21hdmVuLTQuMC4wLnhzZCI+CiAgICA8bW9k\nZWxWZXJzaW9uPjQuMC4wPC9tb2RlbFZlcnNpb24+CgogICAgPHBhY2thZ2lu\nZz5wb208L3BhY2thZ2luZz4KCiAgICA8cGFyZW50PgogICAgICAgIDxncm91\ncElkPm9yZy5wYXJlbnQubW9kdWxlczwvZ3JvdXBJZD4KICAgICAgICA8YXJ0\naWZhY3RJZD5wYXJlbnQtbW9kdWxlcy1hcnRpZmFjdDwvYXJ0aWZhY3RJZD4K\nICAgICAgICA8dmVyc2lvbj4xLjAuMDwvdmVyc2lvbj4KICAgIDwvcGFyZW50\nPgoKICAgIDxhcnRpZmFjdElkPnBhcmVudC1tb2R1bGVzLWFydGlmYWN0LW9u\nZTwvYXJ0aWZhY3RJZD4KICAgIDx2ZXJzaW9uPjEuMi4wPC92ZXJzaW9uPgoK\nICAgIDxwcm9wZXJ0aWVzPgogICAgICAgIDxtYXZlbi5jb21waWxlci5zb3Vy\nY2U+ODwvbWF2ZW4uY29tcGlsZXIuc291cmNlPgogICAgICAgIDxtYXZlbi5j\nb21waWxlci50YXJnZXQ+ODwvbWF2ZW4uY29tcGlsZXIudGFyZ2V0PgogICAg\nICAgIDxwcm9qZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPlVURi04PC9wcm9q\nZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPgogICAgPC9wcm9wZXJ0aWVzPgoK\nPC9wcm9qZWN0Pg==\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/pom_with_implicit_parent_path/pom.xml?ref=main",
+    "git": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/45a6f0ac4eeeb80673659cf03712fd5c1cd940d5",
+    "html": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/pom_with_implicit_parent_path/pom.xml"
+  }
+}

--- a/maven/spec/fixtures/github/parent_modules_no_parent_pom.json
+++ b/maven/spec/fixtures/github/parent_modules_no_parent_pom.json
@@ -1,0 +1,18 @@
+{
+  "name": "pom.xml",
+  "path": "parent_modules_project/pom_with_no_parent/pom.xml",
+  "sha": "bbe683acd366f29e1a6141916706cf1a5b79a63e",
+  "size": 694,
+  "url": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/pom_with_no_parent/pom.xml?ref=main",
+  "html_url": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/pom_with_no_parent/pom.xml",
+  "git_url": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/bbe683acd366f29e1a6141916706cf1a5b79a63e",
+  "download_url": "https://raw.githubusercontent.com/soulus13/dependabot-maven-test/main/parent_modules_project/pom_with_no_parent/pom.xml",
+  "type": "file",
+  "content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHByb2pl\nY3QgeG1sbnM9Imh0dHA6Ly9tYXZlbi5hcGFjaGUub3JnL1BPTS80LjAuMCIK\nICAgICAgICAgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hN\nTFNjaGVtYS1pbnN0YW5jZSIKICAgICAgICAgeHNpOnNjaGVtYUxvY2F0aW9u\nPSJodHRwOi8vbWF2ZW4uYXBhY2hlLm9yZy9QT00vNC4wLjAgaHR0cDovL21h\ndmVuLmFwYWNoZS5vcmcveHNkL21hdmVuLTQuMC4wLnhzZCI+CiAgICA8bW9k\nZWxWZXJzaW9uPjQuMC4wPC9tb2RlbFZlcnNpb24+CgogICAgPHBhY2thZ2lu\nZz5wb208L3BhY2thZ2luZz4KCiAgICA8Z3JvdXBJZD5vcmcucGFyZW50Lm1v\nZHVsZXM8L2dyb3VwSWQ+CiAgICA8YXJ0aWZhY3RJZD5wYXJlbnQtbW9kdWxl\ncy1hcnRpZmFjdDwvYXJ0aWZhY3RJZD4KICAgIDx2ZXJzaW9uPjEuMy4wPC92\nZXJzaW9uPgoKICAgIDxwcm9wZXJ0aWVzPgogICAgICAgIDxtYXZlbi5jb21w\naWxlci5zb3VyY2U+ODwvbWF2ZW4uY29tcGlsZXIuc291cmNlPgogICAgICAg\nIDxtYXZlbi5jb21waWxlci50YXJnZXQ+ODwvbWF2ZW4uY29tcGlsZXIudGFy\nZ2V0PgogICAgICAgIDxwcm9qZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPlVU\nRi04PC9wcm9qZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPgogICAgPC9wcm9w\nZXJ0aWVzPgoKPC9wcm9qZWN0Pg==\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/pom_with_no_parent/pom.xml?ref=main",
+    "git": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/bbe683acd366f29e1a6141916706cf1a5b79a63e",
+    "html": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/pom_with_no_parent/pom.xml"
+  }
+}

--- a/maven/spec/fixtures/github/parent_modules_parent_of_pom_with_parent.json
+++ b/maven/spec/fixtures/github/parent_modules_parent_of_pom_with_parent.json
@@ -1,0 +1,18 @@
+{
+  "name": "pom_parent.xml",
+  "path": "parent_modules_project/pom_with_parent_groupid/pom_parent.xml",
+  "sha": "ead2fcd6283c9bca5b7442323209d8e91b42be59",
+  "size": 868,
+  "url": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/pom_with_parent_groupid/pom_parent.xml?ref=main",
+  "html_url": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/pom_with_parent_groupid/pom_parent.xml",
+  "git_url": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/ead2fcd6283c9bca5b7442323209d8e91b42be59",
+  "download_url": "https://raw.githubusercontent.com/soulus13/dependabot-maven-test/main/parent_modules_project/pom_with_parent_groupid/pom_parent.xml",
+  "type": "file",
+  "content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHByb2pl\nY3QgeG1sbnM9Imh0dHA6Ly9tYXZlbi5hcGFjaGUub3JnL1BPTS80LjAuMCIK\nICAgICAgICAgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hN\nTFNjaGVtYS1pbnN0YW5jZSIKICAgICAgICAgeHNpOnNjaGVtYUxvY2F0aW9u\nPSJodHRwOi8vbWF2ZW4uYXBhY2hlLm9yZy9QT00vNC4wLjAgaHR0cDovL21h\ndmVuLmFwYWNoZS5vcmcveHNkL21hdmVuLTQuMC4wLnhzZCI+CiAgICA8bW9k\nZWxWZXJzaW9uPjQuMC4wPC9tb2RlbFZlcnNpb24+CgogICAgPHBhY2thZ2lu\nZz5wb208L3BhY2thZ2luZz4KCiAgICA8cGFyZW50PgogICAgICAgIDxncm91\ncElkPm9yZy5wYXJlbnQubW9kdWxlczwvZ3JvdXBJZD4KICAgICAgICA8YXJ0\naWZhY3RJZD5wYXJlbnQtbW9kdWxlcy1hcnRpZmFjdDwvYXJ0aWZhY3RJZD4K\nICAgICAgICA8dmVyc2lvbj4xLjAuMDwvdmVyc2lvbj4KICAgICAgICA8cmVs\nYXRpdmVQYXRoPi4uL3BvbS54bWw8L3JlbGF0aXZlUGF0aD4KICAgIDwvcGFy\nZW50PgoKICAgIDxhcnRpZmFjdElkPnBhcmVudC1tb2R1bGVzLWFydGlmYWN0\nLW9uZTwvYXJ0aWZhY3RJZD4KICAgIDx2ZXJzaW9uPjEuMS4wPC92ZXJzaW9u\nPgoKICAgIDxwcm9wZXJ0aWVzPgogICAgICAgIDxtYXZlbi5jb21waWxlci5z\nb3VyY2U+ODwvbWF2ZW4uY29tcGlsZXIuc291cmNlPgogICAgICAgIDxtYXZl\nbi5jb21waWxlci50YXJnZXQ+ODwvbWF2ZW4uY29tcGlsZXIudGFyZ2V0Pgog\nICAgICAgIDxwcm9qZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPlVURi04PC9w\ncm9qZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPgogICAgPC9wcm9wZXJ0aWVz\nPgoKPC9wcm9qZWN0Pg==\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/pom_with_parent_groupid/pom_parent.xml?ref=main",
+    "git": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/ead2fcd6283c9bca5b7442323209d8e91b42be59",
+    "html": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/pom_with_parent_groupid/pom_parent.xml"
+  }
+}

--- a/maven/spec/fixtures/github/parent_modules_pom_with_parent.json
+++ b/maven/spec/fixtures/github/parent_modules_pom_with_parent.json
@@ -1,0 +1,18 @@
+{
+  "name": "pom.xml",
+  "path": "parent_modules_project/pom_with_parent_groupid/pom_with_parent/pom.xml",
+  "sha": "05bfce1fa90b1d034796dd1e92f5088c2f4f9f67",
+  "size": 921,
+  "url": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/pom_with_parent_groupid/pom_with_parent/pom.xml?ref=main",
+  "html_url": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/pom_with_parent_groupid/pom_with_parent/pom.xml",
+  "git_url": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/05bfce1fa90b1d034796dd1e92f5088c2f4f9f67",
+  "download_url": "https://raw.githubusercontent.com/soulus13/dependabot-maven-test/main/parent_modules_project/pom_with_parent_groupid/pom_with_parent/pom.xml",
+  "type": "file",
+  "content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHByb2pl\nY3QgeG1sbnM9Imh0dHA6Ly9tYXZlbi5hcGFjaGUub3JnL1BPTS80LjAuMCIK\nICAgICAgICAgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hN\nTFNjaGVtYS1pbnN0YW5jZSIKICAgICAgICAgeHNpOnNjaGVtYUxvY2F0aW9u\nPSJodHRwOi8vbWF2ZW4uYXBhY2hlLm9yZy9QT00vNC4wLjAgaHR0cDovL21h\ndmVuLmFwYWNoZS5vcmcveHNkL21hdmVuLTQuMC4wLnhzZCI+CiAgICA8bW9k\nZWxWZXJzaW9uPjQuMC4wPC9tb2RlbFZlcnNpb24+CgogICAgPHBhY2thZ2lu\nZz5wb208L3BhY2thZ2luZz4KCiAgICA8cGFyZW50PgogICAgICAgIDxncm91\ncElkPm9yZy5wYXJlbnQubW9kdWxlczwvZ3JvdXBJZD4KICAgICAgICA8YXJ0\naWZhY3RJZD5wYXJlbnQtbW9kdWxlcy1hcnRpZmFjdC1vbmU8L2FydGlmYWN0\nSWQ+CiAgICAgICAgPHZlcnNpb24+MS4xLjA8L3ZlcnNpb24+CiAgICAgICAg\nPHJlbGF0aXZlUGF0aD4uLi9wb21fcGFyZW50LnhtbDwvcmVsYXRpdmVQYXRo\nPgogICAgPC9wYXJlbnQ+CgogICAgPGdyb3VwSWQ+b3JnLnBhcmVudC5tb2R1\nbGVzLm93bjwvZ3JvdXBJZD4KICAgIDxhcnRpZmFjdElkPnBhcmVudC1tb2R1\nbGVzLWFydGlmYWN0PC9hcnRpZmFjdElkPgogICAgPHZlcnNpb24+MS4xLjE8\nL3ZlcnNpb24+CgogICAgPHByb3BlcnRpZXM+CiAgICAgICAgPG1hdmVuLmNv\nbXBpbGVyLnNvdXJjZT44PC9tYXZlbi5jb21waWxlci5zb3VyY2U+CiAgICAg\nICAgPG1hdmVuLmNvbXBpbGVyLnRhcmdldD44PC9tYXZlbi5jb21waWxlci50\nYXJnZXQ+CiAgICAgICAgPHByb2plY3QuYnVpbGQuc291cmNlRW5jb2Rpbmc+\nVVRGLTg8L3Byb2plY3QuYnVpbGQuc291cmNlRW5jb2Rpbmc+CiAgICA8L3By\nb3BlcnRpZXM+Cgo8L3Byb2plY3Q+\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/pom_with_parent_groupid/pom_with_parent/pom.xml?ref=main",
+    "git": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/05bfce1fa90b1d034796dd1e92f5088c2f4f9f67",
+    "html": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/pom_with_parent_groupid/pom_with_parent/pom.xml"
+  }
+}

--- a/maven/spec/fixtures/github/parent_modules_root_pom.json
+++ b/maven/spec/fixtures/github/parent_modules_root_pom.json
@@ -1,0 +1,18 @@
+{
+  "name": "pom.xml",
+  "path": "parent_modules_project/pom.xml",
+  "sha": "4ef030119e255874b5f9820e9e22432e40236b22",
+  "size": 694,
+  "url": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/pom.xml?ref=main",
+  "html_url": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/pom.xml",
+  "git_url": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/4ef030119e255874b5f9820e9e22432e40236b22",
+  "download_url": "https://raw.githubusercontent.com/soulus13/dependabot-maven-test/main/parent_modules_project/pom.xml",
+  "type": "file",
+  "content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHByb2pl\nY3QgeG1sbnM9Imh0dHA6Ly9tYXZlbi5hcGFjaGUub3JnL1BPTS80LjAuMCIK\nICAgICAgICAgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hN\nTFNjaGVtYS1pbnN0YW5jZSIKICAgICAgICAgeHNpOnNjaGVtYUxvY2F0aW9u\nPSJodHRwOi8vbWF2ZW4uYXBhY2hlLm9yZy9QT00vNC4wLjAgaHR0cDovL21h\ndmVuLmFwYWNoZS5vcmcveHNkL21hdmVuLTQuMC4wLnhzZCI+CiAgICA8bW9k\nZWxWZXJzaW9uPjQuMC4wPC9tb2RlbFZlcnNpb24+CgogICAgPHBhY2thZ2lu\nZz5wb208L3BhY2thZ2luZz4KCiAgICA8Z3JvdXBJZD5vcmcucGFyZW50Lm1v\nZHVsZXM8L2dyb3VwSWQ+CiAgICA8YXJ0aWZhY3RJZD5wYXJlbnQtbW9kdWxl\ncy1hcnRpZmFjdDwvYXJ0aWZhY3RJZD4KICAgIDx2ZXJzaW9uPjEuMC4wPC92\nZXJzaW9uPgoKICAgIDxwcm9wZXJ0aWVzPgogICAgICAgIDxtYXZlbi5jb21w\naWxlci5zb3VyY2U+ODwvbWF2ZW4uY29tcGlsZXIuc291cmNlPgogICAgICAg\nIDxtYXZlbi5jb21waWxlci50YXJnZXQ+ODwvbWF2ZW4uY29tcGlsZXIudGFy\nZ2V0PgogICAgICAgIDxwcm9qZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPlVU\nRi04PC9wcm9qZWN0LmJ1aWxkLnNvdXJjZUVuY29kaW5nPgogICAgPC9wcm9w\nZXJ0aWVzPgoKPC9wcm9qZWN0Pg==\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/soulus13/dependabot-maven-test/contents/parent_modules_project/pom.xml?ref=main",
+    "git": "https://api.github.com/repos/soulus13/dependabot-maven-test/git/blobs/4ef030119e255874b5f9820e9e22432e40236b22",
+    "html": "https://github.com/soulus13/dependabot-maven-test/blob/main/parent_modules_project/pom.xml"
+  }
+}


### PR DESCRIPTION
Reverted the fix in #6557 
Updated the parent fetching logic:
 - added a check that we only try to fetch parent `pom.xml` when the `parent` node is defined in the file
 - added additional checks when we fetch parent file to validate its `groupId`, `artifactId` and `versionId` against the ones provided in its "child" `pom.xml`
 - additionally added the cases for the empty `groupId` in case the `groupId` of the parent `pom.xml` is inherited from its own parent
 - covered the logic with tests and amended the old tests which have demonstrated incorrect behavior but worked fine before the logic adjustment