### PR TITLE
Refactor python version detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           - { path: pub, name: pub, ci_node_total: 2, ci_node_index: 0, ecosystem: pub }
           - { path: pub, name: pub, ci_node_total: 2, ci_node_index: 1, ecosystem: pub }
           - { path: python, name: python, ci_node_total: 2, ci_node_index: 0, ecosystem: pip }
-          - { path: python, name: python, ci_node_total: 2, ci_node_index: 1, ecosystem: pip}
+          - { path: python, name: python, ci_node_total: 2, ci_node_index: 1, ecosystem: pip }
           - { path: python, name: python_slow, ci_node_total: 2, ci_node_index: 0, ecosystem: pip }
           - { path: python, name: python_slow, ci_node_total: 2, ci_node_index: 1, ecosystem: pip }
           - { path: terraform, name: terraform, ecosystem: terraform }

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -547,14 +547,16 @@ module Dependabot
 
         def python_requirement_parser
           @python_requirement_parser ||=
-            FileParser::PythonRequirementParser.
-            new(dependency_files: dependency_files)
+            FileParser::PythonRequirementParser.new(
+              dependency_files: dependency_files
+            )
         end
 
         def language_version_manager
           @language_version_manager ||=
-            LanguageVersionManager.
-            new(python_requirement_parser: python_requirement_parser)
+            LanguageVersionManager.new(
+              python_requirement_parser: python_requirement_parser
+            )
         end
 
         def setup_files

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -18,7 +18,7 @@ module Dependabot
     class FileUpdater
       # rubocop:disable Metrics/ClassLength
       class PipCompileFileUpdater
-      include Helpers
+        include Helpers
         require_relative "requirement_replacer"
         require_relative "requirement_file_updater"
         require_relative "setup_file_sanitizer"

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -176,7 +176,7 @@ module Dependabot
 
         def run_pip_compile_command(command, allow_unsafe_shell_command: false, fingerprint:)
           run_command(
-            "pyenv local #{Helpers.python_major_minor(python_version)}",
+            "pyenv local #{Helpers.python_major_minor(dependency_files)}",
             fingerprint: "pyenv local <python_major_minor>"
           )
 
@@ -210,7 +210,7 @@ module Dependabot
           end
 
           # Overwrite the .python-version with updated content
-          File.write(".python-version", Helpers.python_major_minor(python_version))
+          File.write(".python-version", Helpers.python_major_minor(dependency_files))
 
           setup_files.each do |file|
             path = file.name
@@ -585,10 +585,6 @@ module Dependabot
             FileParser::PythonRequirementParser.new(
               dependency_files: dependency_files
             )
-        end
-
-        def pre_installed_python?(version)
-          PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.include?(version)
         end
 
         def setup_files

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -15,7 +15,7 @@ module Dependabot
   module Python
     class FileUpdater
       class PipfileFileUpdater
-      include Helpers
+        include Helpers
         require_relative "pipfile_preparer"
         require_relative "pipfile_manifest_updater"
         require_relative "setup_file_sanitizer"

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -286,14 +286,16 @@ module Dependabot
 
         def python_requirement_parser
           @python_requirement_parser ||=
-            FileParser::PythonRequirementParser.
-            new(dependency_files: dependency_files)
+            FileParser::PythonRequirementParser.new(
+              dependency_files: dependency_files
+            )
         end
 
         def language_version_manager
           @language_version_manager ||=
-            LanguageVersionManager.
-            new(python_requirement_parser: python_requirement_parser)
+            LanguageVersionManager.new(
+              python_requirement_parser: python_requirement_parser
+            )
         end
 
         def pyproject

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -17,7 +17,7 @@ module Dependabot
   module Python
     class FileUpdater
       class PoetryFileUpdater
-      include Helpers
+        include Helpers
         require_relative "pyproject_preparer"
 
         attr_reader :dependencies, :dependency_files, :credentials

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -17,6 +17,7 @@ module Dependabot
   module Python
     class FileUpdater
       class PoetryFileUpdater
+      include Helpers
         require_relative "pyproject_preparer"
 
         attr_reader :dependencies, :dependency_files, :credentials
@@ -135,7 +136,7 @@ module Dependabot
         def update_python_requirement(pyproject_content)
           PyprojectPreparer.
             new(pyproject_content: pyproject_content).
-            update_python_requirement(Helpers.python_major_minor(dependency_files))
+            update_python_requirement(python_major_minor)
         end
 
         def lock_declaration_to_new_version!(poetry_object, dep)
@@ -178,10 +179,10 @@ module Dependabot
               write_temporary_dependency_files(pyproject_content)
               add_auth_env_vars
 
-              Helpers.install_required_python(dependency_files)
+              install_required_python
 
               # use system git instead of the pure Python dulwich
-              unless Helpers.python_version(dependency_files)&.start_with?("3.6")
+              unless python_version&.start_with?("3.6")
                 run_poetry_command("pyenv exec poetry config experimental.system-git-client true")
               end
 
@@ -232,7 +233,7 @@ module Dependabot
           end
 
           # Overwrite the .python-version with updated content
-          File.write(".python-version", Helpers.python_major_minor(dependency_files)) if Helpers.python_version(dependency_files)
+          File.write(".python-version", python_major_minor) if python_version
 
           # Overwrite the pyproject with updated content
           File.write("pyproject.toml", pyproject_content)

--- a/python/lib/dependabot/python/helpers.rb
+++ b/python/lib/dependabot/python/helpers.rb
@@ -6,31 +6,51 @@ require "dependabot/python/version"
 module Dependabot
   module Python
     module Helpers
-      def self.install_required_python(python_version)
+      def self.install_required_python(dependency_files)
         # The leading space is important in the version check
-        return if SharedHelpers.run_shell_command("pyenv versions").include?(" #{python_major_minor(python_version)}.")
+        return if SharedHelpers.run_shell_command("pyenv versions").include?(" #{python_major_minor(dependency_files)}.")
 
-        if File.exist?("/usr/local/.pyenv/#{python_major_minor(python_version)}.tar.gz")
+        if File.exist?("/usr/local/.pyenv/#{python_major_minor(dependency_files)}.tar.gz")
           SharedHelpers.run_shell_command(
-            "tar xzf /usr/local/.pyenv/#{python_major_minor(python_version)}.tar.gz -C /usr/local/.pyenv/"
+            "tar xzf /usr/local/.pyenv/#{python_major_minor(dependency_files)}.tar.gz -C /usr/local/.pyenv/"
           )
           return if SharedHelpers.run_shell_command("pyenv versions").
-                    include?(" #{python_major_minor(python_version)}.")
+                    include?(" #{python_major_minor(dependency_files)}.")
         end
 
-        Dependabot.logger.info("Installing required Python #{python_version}.")
+        Dependabot.logger.info("Installing required Python #{python_version(dependency_files)}.")
         start = Time.now
-        SharedHelpers.run_shell_command("pyenv install -s #{python_version}")
+        SharedHelpers.run_shell_command("pyenv install -s #{python_version(dependency_files)}")
         SharedHelpers.run_shell_command("pyenv exec pip install --upgrade pip")
         SharedHelpers.run_shell_command("pyenv exec pip install -r" \
                                         "#{NativeHelpers.python_requirements_path}")
         time_taken = Time.now - start
-        Dependabot.logger.info("Installing Python #{python_version} took #{time_taken}s.")
+        Dependabot.logger.info("Installing Python #{python_version(dependency_files)} took #{time_taken}s.")
       end
 
-      def self.python_major_minor(python_version)
-        python = Python::Version.new(python_version)
+      def self.python_major_minor(dependency_files)
+        @python ||= Python::Version.new(python_version(dependency_files))
         "#{python.segments[0]}.#{python.segments[1]}"
+      end
+
+      def self.python_version(dependency_files)
+        requirements = python_requirement_parser(dependency_files).user_specified_requirements
+        requirements = requirements.
+                       map { |r| Python::Requirement.requirements_array(r) }
+
+        @python_version ||= PythonVersions::SUPPORTED_VERSIONS_TO_ITERATE.find do |version|
+          requirements.all? do |reqs|
+            reqs.any? { |r| r.satisfied_by?(Python::Version.new(version)) }
+          end
+        end
+
+      end
+
+      def self.python_requirement_parser(dependency_files)
+        @python_requirement_parser ||=
+          FileParser::PythonRequirementParser.new(
+            dependency_files: dependency_files
+          )
       end
     end
   end

--- a/python/lib/dependabot/python/helpers.rb
+++ b/python/lib/dependabot/python/helpers.rb
@@ -30,7 +30,7 @@ module Dependabot
 
       def self.python_major_minor(dependency_files)
         @python ||= Python::Version.new(python_version(dependency_files))
-        "#{python.segments[0]}.#{python.segments[1]}"
+        "#{@python.segments[0]}.#{@python.segments[1]}"
       end
 
       def self.python_version(dependency_files)

--- a/python/lib/dependabot/python/helpers.rb
+++ b/python/lib/dependabot/python/helpers.rb
@@ -6,35 +6,35 @@ require "dependabot/python/version"
 module Dependabot
   module Python
     module Helpers
-      def self.install_required_python(dependency_files)
+      def install_required_python
         # The leading space is important in the version check
-        return if SharedHelpers.run_shell_command("pyenv versions").include?(" #{python_major_minor(dependency_files)}.")
+        return if SharedHelpers.run_shell_command("pyenv versions").include?(" #{python_major_minor}.")
 
-        if File.exist?("/usr/local/.pyenv/#{python_major_minor(dependency_files)}.tar.gz")
+        if File.exist?("/usr/local/.pyenv/#{python_major_minor}.tar.gz")
           SharedHelpers.run_shell_command(
-            "tar xzf /usr/local/.pyenv/#{python_major_minor(dependency_files)}.tar.gz -C /usr/local/.pyenv/"
+            "tar xzf /usr/local/.pyenv/#{python_major_minor}.tar.gz -C /usr/local/.pyenv/"
           )
           return if SharedHelpers.run_shell_command("pyenv versions").
-                    include?(" #{python_major_minor(dependency_files)}.")
+                    include?(" #{python_major_minor}.")
         end
 
-        Dependabot.logger.info("Installing required Python #{python_version(dependency_files)}.")
+        Dependabot.logger.info("Installing required Python #{python_version}.")
         start = Time.now
-        SharedHelpers.run_shell_command("pyenv install -s #{python_version(dependency_files)}")
+        SharedHelpers.run_shell_command("pyenv install -s #{python_version}")
         SharedHelpers.run_shell_command("pyenv exec pip install --upgrade pip")
         SharedHelpers.run_shell_command("pyenv exec pip install -r" \
                                         "#{NativeHelpers.python_requirements_path}")
         time_taken = Time.now - start
-        Dependabot.logger.info("Installing Python #{python_version(dependency_files)} took #{time_taken}s.")
+        Dependabot.logger.info("Installing Python #{python_version} took #{time_taken}s.")
       end
 
-      def self.python_major_minor(dependency_files)
-        @python ||= Python::Version.new(python_version(dependency_files))
+      def python_major_minor
+        @python ||= Python::Version.new(python_version)
         "#{@python.segments[0]}.#{@python.segments[1]}"
       end
 
-      def self.python_version(dependency_files)
-        requirements = python_requirement_parser(dependency_files).user_specified_requirements
+      def python_version
+        requirements = python_requirement_parser.user_specified_requirements
         requirements = requirements.
                        map { |r| Python::Requirement.requirements_array(r) }
 
@@ -46,11 +46,52 @@ module Dependabot
 
       end
 
-      def self.python_requirement_parser(dependency_files)
+      def python_requirement_parser
         @python_requirement_parser ||=
           FileParser::PythonRequirementParser.new(
             dependency_files: dependency_files
           )
+      end
+
+      def python_version
+        @python_version ||=
+          user_specified_python_version ||
+          python_version_matching_imputed_requirements ||
+          PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.first
+      end
+
+      def user_specified_python_version
+        return unless python_requirement_parser.user_specified_requirements.any?
+
+        user_specified_requirements =
+          python_requirement_parser.user_specified_requirements.
+          map { |r| Python::Requirement.requirements_array(r) }
+        python_version_matching(user_specified_requirements)
+      end
+
+      def python_version_matching_imputed_requirements
+        compiled_file_python_requirement_markers =
+          python_requirement_parser.imputed_requirements.map do |r|
+            Dependabot::Python::Requirement.new(r)
+          end
+        python_version_matching(compiled_file_python_requirement_markers)
+      end
+
+      def python_version_matching(requirements)
+        PythonVersions::SUPPORTED_VERSIONS_TO_ITERATE.find do |version_string|
+          version = Python::Version.new(version_string)
+          requirements.all? do |req|
+            next req.any? { |r| r.satisfied_by?(version) } if req.is_a?(Array)
+
+            req.satisfied_by?(version)
+          end
+        end
+      end
+
+      def python_requirement_parser
+        @python_requirement_parser ||=
+          FileParser::PythonRequirementParser.
+          new(dependency_files: dependency_files)
       end
     end
   end

--- a/python/lib/dependabot/python/language_version_manager.rb
+++ b/python/lib/dependabot/python/language_version_manager.rb
@@ -110,10 +110,6 @@ module Dependabot
           end
         end
       end
-
-      def pre_installed_python?(version)
-        PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.include?(version)
-      end
     end
   end
 end

--- a/python/lib/dependabot/python/language_version_manager.rb
+++ b/python/lib/dependabot/python/language_version_manager.rb
@@ -111,12 +111,6 @@ module Dependabot
         end
       end
 
-      def python_requirement_parser
-        @python_requirement_parser ||=
-          FileParser::PythonRequirementParser.
-          new(dependency_files: dependency_files)
-      end
-
       def pre_installed_python?(version)
         PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.include?(version)
       end

--- a/python/lib/dependabot/python/language_version_manager.rb
+++ b/python/lib/dependabot/python/language_version_manager.rb
@@ -5,7 +5,11 @@ require "dependabot/python/version"
 
 module Dependabot
   module Python
-    module Helpers
+    class LanguageVersionManager
+      def initialize(python_requirement_parser:)
+        @python_requirement_parser = python_requirement_parser
+      end
+
       def install_required_python
         # The leading space is important in the version check
         return if SharedHelpers.run_shell_command("pyenv versions").include?(" #{python_major_minor}.")
@@ -85,12 +89,12 @@ module Dependabot
       end
 
       def user_specified_python_version
-        python_requirement_parser.user_specified_requirements.first
+        @python_requirement_parser.user_specified_requirements.first
       end
 
       def python_version_matching_imputed_requirements
         compiled_file_python_requirement_markers =
-          python_requirement_parser.imputed_requirements.map do |r|
+          @python_requirement_parser.imputed_requirements.map do |r|
             Dependabot::Python::Requirement.new(r)
           end
         python_version_matching(compiled_file_python_requirement_markers)

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -322,7 +322,7 @@ module Dependabot
           end
 
           # Overwrite the .python-version with updated content
-          File.write(".python-version", Helpers.python_major_minor(python_version))
+          File.write(".python-version", Helpers.python_major_minor(dependency_files))
 
           setup_files.each do |file|
             path = file.name

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -481,14 +481,16 @@ module Dependabot
 
         def python_requirement_parser
           @python_requirement_parser ||=
-            FileParser::PythonRequirementParser.
-            new(dependency_files: dependency_files)
+            FileParser::PythonRequirementParser.new(
+              dependency_files: dependency_files
+            )
         end
 
         def language_version_manager
           @language_version_manager ||=
-            LanguageVersionManager.
-            new(python_requirement_parser: python_requirement_parser)
+            LanguageVersionManager.new(
+              python_requirement_parser: python_requirement_parser
+            )
         end
 
         def setup_files

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -23,9 +23,8 @@ module Dependabot
       # This class does version resolution for pip-compile. Its approach is:
       # - Unlock the dependency we're checking in the requirements.in file
       # - Run `pip-compile` and see what the result is
-      # rubocop:disable Metrics/ClassLength
       class PipCompileVersionResolver
-      include Helpers
+        include Helpers
         GIT_DEPENDENCY_UNREACHABLE_REGEX = /git clone --filter=blob:none --quiet (?<url>[^\s]+).* /
         GIT_REFERENCE_NOT_FOUND_REGEX = /Did not find branch or tag '(?<tag>[^\n"]+)'/m
         NATIVE_COMPILATION_ERROR =
@@ -496,7 +495,6 @@ module Dependabot
           dependency_files.select { |f| f.name.end_with?("setup.cfg") }
         end
       end
-      # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -25,6 +25,7 @@ module Dependabot
       # - Run `pip-compile` and see what the result is
       # rubocop:disable Metrics/ClassLength
       class PipCompileVersionResolver
+      include Helpers
         GIT_DEPENDENCY_UNREACHABLE_REGEX = /git clone --filter=blob:none --quiet (?<url>[^\s]+).* /
         GIT_REFERENCE_NOT_FOUND_REGEX = /Did not find branch or tag '(?<tag>[^\n"]+)'/m
         NATIVE_COMPILATION_ERROR =
@@ -71,7 +72,7 @@ module Dependabot
             SharedHelpers.in_a_temporary_directory do
               SharedHelpers.with_git_configured(credentials: credentials) do
                 write_temporary_dependency_files(updated_req: requirement)
-                Helpers.install_required_python(python_version)
+                install_required_python
 
                 filenames_to_compile.each do |filename|
                   # Shell out to pip-compile.
@@ -275,7 +276,7 @@ module Dependabot
 
         def run_pip_compile_command(command, fingerprint:)
           run_command(
-            "pyenv local #{Helpers.python_major_minor(python_version)}",
+            "pyenv local #{python_major_minor}",
             fingerprint: "pyenv local <python_major_minor>"
           )
 
@@ -322,7 +323,7 @@ module Dependabot
           end
 
           # Overwrite the .python-version with updated content
-          File.write(".python-version", Helpers.python_major_minor(dependency_files))
+          File.write(".python-version", python_major_minor)
 
           setup_files.each do |file|
             path = file.name

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -480,52 +480,6 @@ module Dependabot
           ).parse.find { |d| d.name == dependency.name }&.version
         end
 
-        def python_version
-          @python_version ||=
-            user_specified_python_version ||
-            python_version_matching_imputed_requirements ||
-            PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.first
-        end
-
-        def user_specified_python_version
-          return unless python_requirement_parser.user_specified_requirements.any?
-
-          user_specified_requirements =
-            python_requirement_parser.user_specified_requirements.
-            map { |r| Python::Requirement.requirements_array(r) }
-          python_version_matching(user_specified_requirements)
-        end
-
-        def python_version_matching_imputed_requirements
-          compiled_file_python_requirement_markers =
-            python_requirement_parser.imputed_requirements.map do |r|
-              Dependabot::Python::Requirement.new(r)
-            end
-          python_version_matching(compiled_file_python_requirement_markers)
-        end
-
-        def python_version_matching(requirements)
-          PythonVersions::SUPPORTED_VERSIONS_TO_ITERATE.find do |version_string|
-            version = Python::Version.new(version_string)
-            requirements.all? do |req|
-              next req.any? { |r| r.satisfied_by?(version) } if req.is_a?(Array)
-
-              req.satisfied_by?(version)
-            end
-          end
-        end
-
-        def python_requirement_parser
-          @python_requirement_parser ||=
-            FileParser::PythonRequirementParser.new(
-              dependency_files: dependency_files
-            )
-        end
-
-        def pre_installed_python?(version)
-          PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.include?(version)
-        end
-
         def setup_files
           dependency_files.select { |f| f.name.end_with?("setup.py") }
         end

--- a/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "dependabot/python/helpers"
+require "dependabot/python/language_version_manager"
 require "dependabot/python/update_checker"
 require "dependabot/python/update_checker/latest_version_finder"
 require "dependabot/python/file_parser/python_requirement_parser"
@@ -9,8 +9,6 @@ module Dependabot
   module Python
     class UpdateChecker
       class PipVersionResolver
-        include Helpers
-
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, raise_on_ignored: false,
                        security_advisories:)
@@ -23,17 +21,17 @@ module Dependabot
         end
 
         def latest_resolvable_version
-          latest_version_finder.latest_version(python_version: python_version)
+          latest_version_finder.latest_version(python_version: language_version_manager.python_version)
         end
 
         def latest_resolvable_version_with_no_unlock
           latest_version_finder.
-            latest_version_with_no_unlock(python_version: python_version)
+            latest_version_with_no_unlock(python_version: language_version_manager.python_version)
         end
 
         def lowest_resolvable_security_fix_version
           latest_version_finder.
-            lowest_security_fix_version(python_version: python_version)
+            lowest_security_fix_version(python_version: language_version_manager.python_version)
         end
 
         private
@@ -50,6 +48,18 @@ module Dependabot
             raise_on_ignored: @raise_on_ignored,
             security_advisories: security_advisories
           )
+        end
+
+        def python_requirement_parser
+          @python_requirement_parser ||=
+            FileParser::PythonRequirementParser.
+            new(dependency_files: dependency_files)
+        end
+
+        def language_version_manager
+          @language_version_manager ||=
+            LanguageVersionManager.
+            new(python_requirement_parser: python_requirement_parser)
         end
       end
     end

--- a/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
@@ -52,14 +52,16 @@ module Dependabot
 
         def python_requirement_parser
           @python_requirement_parser ||=
-            FileParser::PythonRequirementParser.
-            new(dependency_files: dependency_files)
+            FileParser::PythonRequirementParser.new(
+              dependency_files: dependency_files
+            )
         end
 
         def language_version_manager
           @language_version_manager ||=
-            LanguageVersionManager.
-            new(python_requirement_parser: python_requirement_parser)
+            LanguageVersionManager.new(
+              python_requirement_parser: python_requirement_parser
+            )
         end
       end
     end

--- a/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
@@ -9,7 +9,8 @@ module Dependabot
   module Python
     class UpdateChecker
       class PipVersionResolver
-      include Helpers
+        include Helpers
+
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, raise_on_ignored: false,
                        security_advisories:)

--- a/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dependabot/python/helpers"
 require "dependabot/python/update_checker"
 require "dependabot/python/update_checker/latest_version_finder"
 require "dependabot/python/file_parser/python_requirement_parser"
@@ -8,6 +9,7 @@ module Dependabot
   module Python
     class UpdateChecker
       class PipVersionResolver
+      include Helpers
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, raise_on_ignored: false,
                        security_advisories:)
@@ -47,47 +49,6 @@ module Dependabot
             raise_on_ignored: @raise_on_ignored,
             security_advisories: security_advisories
           )
-        end
-
-        def python_version
-          @python_version ||=
-            user_specified_python_version ||
-            python_version_matching_imputed_requirements ||
-            PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.first
-        end
-
-        def user_specified_python_version
-          return unless python_requirement_parser.user_specified_requirements.any?
-
-          user_specified_requirements =
-            python_requirement_parser.user_specified_requirements.
-            map { |r| Python::Requirement.requirements_array(r) }
-          python_version_matching(user_specified_requirements)
-        end
-
-        def python_version_matching_imputed_requirements
-          compiled_file_python_requirement_markers =
-            python_requirement_parser.imputed_requirements.map do |r|
-              Dependabot::Python::Requirement.new(r)
-            end
-          python_version_matching(compiled_file_python_requirement_markers)
-        end
-
-        def python_version_matching(requirements)
-          PythonVersions::SUPPORTED_VERSIONS_TO_ITERATE.find do |version_string|
-            version = Python::Version.new(version_string)
-            requirements.all? do |req|
-              next req.any? { |r| r.satisfied_by?(version) } if req.is_a?(Array)
-
-              req.satisfied_by?(version)
-            end
-          end
-        end
-
-        def python_requirement_parser
-          @python_requirement_parser ||=
-            FileParser::PythonRequirementParser.
-            new(dependency_files: dependency_files)
         end
       end
     end

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -29,7 +29,7 @@ module Dependabot
       # just raise if the latest version can't be resolved. Knowing that is
       # still better than nothing, though.
       class PipenvVersionResolver
-      include Helpers
+        include Helpers
         # rubocop:disable Layout/LineLength
         GIT_DEPENDENCY_UNREACHABLE_REGEX = /git clone -q (?<url>[^\s]+).* /
         GIT_REFERENCE_NOT_FOUND_REGEX = %r{git checkout -q (?<tag>[^\n"]+)\n?[^\n]*/(?<name>.*?)(\\n'\]|$)}m

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -29,6 +29,7 @@ module Dependabot
       # just raise if the latest version can't be resolved. Knowing that is
       # still better than nothing, though.
       class PipenvVersionResolver
+      include Helpers
         # rubocop:disable Layout/LineLength
         GIT_DEPENDENCY_UNREACHABLE_REGEX = /git clone -q (?<url>[^\s]+).* /
         GIT_REFERENCE_NOT_FOUND_REGEX = %r{git checkout -q (?<tag>[^\n"]+)\n?[^\n]*/(?<name>.*?)(\\n'\]|$)}m
@@ -78,6 +79,12 @@ module Dependabot
             SharedHelpers.in_a_temporary_directory do
               SharedHelpers.with_git_configured(credentials: credentials) do
                 write_temporary_dependency_files(updated_req: requirement)
+                # Initialize a git repo to appease pip-tools
+                begin
+                  run_command("git init") if setup_files.any?
+                rescue Dependabot::SharedHelpers::HelperSubprocessFailed
+                  nil
+                end
                 install_required_python
 
                 # Shell out to Pipenv, which handles everything for us.
@@ -290,7 +297,7 @@ module Dependabot
           end
 
           # Overwrite the .python-version with updated content
-          File.write(".python-version", Helpers.python_major_minor(python_version))
+          File.write(".python-version", python_major_minor)
 
           setup_files.each do |file|
             path = file.name
@@ -310,17 +317,6 @@ module Dependabot
             "Pipfile",
             pipfile_content(updated_requirement: updated_req)
           )
-        end
-
-        def install_required_python
-          # Initialize a git repo to appease pip-tools
-          begin
-            run_command("git init") if setup_files.any?
-          rescue Dependabot::SharedHelpers::HelperSubprocessFailed
-            nil
-          end
-
-          Helpers.install_required_python(python_version)
         end
 
         def sanitized_setup_file_content(file)
@@ -354,7 +350,7 @@ module Dependabot
         def update_python_requirement(pipfile_content)
           Python::FileUpdater::PipfilePreparer.
             new(pipfile_content: pipfile_content).
-            update_python_requirement(Helpers.python_major_minor(python_version))
+            update_python_requirement(python_major_minor)
         end
 
         # rubocop:disable Metrics/PerceivedComplexity
@@ -398,57 +394,6 @@ module Dependabot
             replace_sources(credentials)
         end
 
-        def python_version
-          @python_version ||= python_version_from_supported_versions
-        end
-
-        def python_version_from_supported_versions
-          requirement_string =
-            if @using_python_two then "2.7.*"
-            elsif user_specified_python_requirement
-              parts = user_specified_python_requirement.split(".")
-              parts.fill("*", (parts.length)..2).join(".")
-            else
-              PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.first
-            end
-
-          # Ideally, the requirement is satisfied by a Python version we support
-          requirement =
-            Python::Requirement.requirements_array(requirement_string).first
-          version =
-            PythonVersions::SUPPORTED_VERSIONS_TO_ITERATE.
-            find { |v| requirement.satisfied_by?(Python::Version.new(v)) }
-          return version if version
-
-          # If not, and changing the patch version would fix things, we do that
-          # as the patch version is unlikely to affect resolution
-          requirement =
-            Python::Requirement.new(requirement_string.gsub(/\.\d+$/, ".*"))
-          version =
-            PythonVersions::SUPPORTED_VERSIONS_TO_ITERATE.
-            find { |v| requirement.satisfied_by?(Python::Version.new(v)) }
-          return version if version
-
-          # Otherwise we have to raise, giving details of the Python versions
-          # that Dependabot supports
-          msg = "Dependabot detected the following Python requirement " \
-                "for your project: '#{requirement_string}'.\n\nCurrently, the " \
-                "following Python versions are supported in Dependabot: " \
-                "#{PythonVersions::SUPPORTED_VERSIONS.join(', ')}."
-          raise DependencyFileNotResolvable, msg
-        end
-
-        def user_specified_python_requirement
-          python_requirement_parser.user_specified_requirements.first
-        end
-
-        def python_requirement_parser
-          @python_requirement_parser ||=
-            FileParser::PythonRequirementParser.new(
-              dependency_files: dependency_files
-            )
-        end
-
         def run_command(command, env: {})
           start = Time.now
           command = SharedHelpers.escape_command(command)
@@ -468,7 +413,7 @@ module Dependabot
         end
 
         def run_pipenv_command(command, env: pipenv_env_variables)
-          run_command("pyenv local #{Helpers.python_major_minor(python_version)}")
+          run_command("pyenv local #{python_major_minor}")
           run_command(command, env: env)
         end
 

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -182,7 +182,7 @@ module Dependabot
           end
 
           if error.message.include?("UnsupportedPythonVersion") &&
-             user_specified_python_requirement
+             user_specified_python_version
             check_original_requirements_resolvable
 
             # The latest version of the dependency we're updating to needs a
@@ -238,7 +238,7 @@ module Dependabot
           end
 
           if error.message.include?("UnsupportedPythonVersion") &&
-             user_specified_python_requirement
+             user_specified_python_version
             msg = clean_error_message(error.message).
                   lines.take_while { |l| !l.start_with?("File") }.join.strip
             raise if msg.empty?

--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -78,13 +78,7 @@ module Dependabot
             SharedHelpers.in_a_temporary_directory do
               SharedHelpers.with_git_configured(credentials: credentials) do
                 write_temporary_dependency_files(updated_req: requirement)
-                # Initialize a git repo to appease pip-tools
-                begin
-                  run_command("git init") if setup_files.any?
-                rescue Dependabot::SharedHelpers::HelperSubprocessFailed
-                  nil
-                end
-                language_version_manager.install_required_python
+                install_required_python
 
                 # Shell out to Pipenv, which handles everything for us.
                 # Whilst calling `lock` avoids doing an install as part of the
@@ -318,6 +312,17 @@ module Dependabot
           )
         end
 
+        def install_required_python
+          # Initialize a git repo to appease pip-tools
+          begin
+            run_command("git init") if setup_files.any?
+          rescue Dependabot::SharedHelpers::HelperSubprocessFailed
+            nil
+          end
+
+          language_version_manager.install_required_python
+        end
+
         def sanitized_setup_file_content(file)
           @sanitized_setup_file_content ||= {}
           @sanitized_setup_file_content[file.name] ||=
@@ -432,14 +437,16 @@ module Dependabot
 
         def python_requirement_parser
           @python_requirement_parser ||=
-            FileParser::PythonRequirementParser.
-            new(dependency_files: dependency_files)
+            FileParser::PythonRequirementParser.new(
+              dependency_files: dependency_files
+            )
         end
 
         def language_version_manager
           @language_version_manager ||=
-            LanguageVersionManager.
-            new(python_requirement_parser: python_requirement_parser)
+            LanguageVersionManager.new(
+              python_requirement_parser: python_requirement_parser
+            )
         end
 
         def pipfile

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -225,36 +225,6 @@ module Dependabot
             add_auth_env_vars(credentials)
         end
 
-        def python_version
-          requirements = python_requirement_parser.user_specified_requirements
-          requirements = requirements.
-                         map { |r| Python::Requirement.requirements_array(r) }
-
-          version = PythonVersions::SUPPORTED_VERSIONS_TO_ITERATE.find do |v|
-            requirements.all? do |reqs|
-              reqs.any? { |r| r.satisfied_by?(Python::Version.new(v)) }
-            end
-          end
-          return version if version
-
-          msg = "Dependabot detected the following Python requirements " \
-                "for your project: '#{requirements}'.\n\nCurrently, the " \
-                "following Python versions are supported in Dependabot: " \
-                "#{PythonVersions::SUPPORTED_VERSIONS.join(', ')}."
-          raise DependencyFileNotResolvable, msg
-        end
-
-        def python_requirement_parser
-          @python_requirement_parser ||=
-            FileParser::PythonRequirementParser.new(
-              dependency_files: dependency_files
-            )
-        end
-
-        def pre_installed_python?(version)
-          PythonVersions::PRE_INSTALLED_PYTHON_VERSIONS.include?(version)
-        end
-
         def updated_pyproject_content(updated_requirement:)
           content = pyproject.content
           content = sanitize_pyproject_content(content)

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -23,6 +23,7 @@ module Dependabot
     class UpdateChecker
       # This class does version resolution for pyproject.toml files.
       class PoetryVersionResolver
+      include Helpers
         GIT_REFERENCE_NOT_FOUND_REGEX = /
           (?:'git'.*pypoetry-git-(?<name>.+?).{8}',
           'checkout',
@@ -92,7 +93,7 @@ module Dependabot
                 write_temporary_dependency_files(updated_req: requirement)
                 add_auth_env_vars
 
-                Helpers.install_required_python(python_version)
+                install_required_python
 
                 # use system git instead of the pure Python dulwich
                 unless python_version&.start_with?("3.6")
@@ -205,7 +206,7 @@ module Dependabot
           end
 
           # Overwrite the .python-version with updated content
-          File.write(".python-version", Helpers.python_major_minor(python_version)) if python_version
+          File.write(".python-version", python_major_minor) if python_version
 
           # Overwrite the pyproject with updated content
           if update_pyproject

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -290,14 +290,16 @@ module Dependabot
 
         def python_requirement_parser
           @python_requirement_parser ||=
-            FileParser::PythonRequirementParser.
-            new(dependency_files: dependency_files)
+            FileParser::PythonRequirementParser.new(
+              dependency_files: dependency_files
+            )
         end
 
         def language_version_manager
           @language_version_manager ||=
-            LanguageVersionManager.
-            new(python_requirement_parser: python_requirement_parser)
+            LanguageVersionManager.new(
+              python_requirement_parser: python_requirement_parser
+            )
         end
 
         def pyproject

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -23,7 +23,7 @@ module Dependabot
     class UpdateChecker
       # This class does version resolution for pyproject.toml files.
       class PoetryVersionResolver
-      include Helpers
+        include Helpers
         GIT_REFERENCE_NOT_FOUND_REGEX = /
           (?:'git'.*pypoetry-git-(?<name>.+?).{8}',
           'checkout',

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -23,7 +23,6 @@ module Dependabot
     class UpdateChecker
       # This class does version resolution for pyproject.toml files.
       class PoetryVersionResolver
-        include Helpers
         GIT_REFERENCE_NOT_FOUND_REGEX = /
           (?:'git'.*pypoetry-git-(?<name>.+?).{8}',
           'checkout',
@@ -93,10 +92,10 @@ module Dependabot
                 write_temporary_dependency_files(updated_req: requirement)
                 add_auth_env_vars
 
-                install_required_python
+                language_version_manager.install_required_python
 
                 # use system git instead of the pure Python dulwich
-                unless python_version&.start_with?("3.6")
+                unless language_version_manager.python_version&.start_with?("3.6")
                   run_poetry_command("pyenv exec poetry config experimental.system-git-client true")
                 end
 
@@ -206,7 +205,7 @@ module Dependabot
           end
 
           # Overwrite the .python-version with updated content
-          File.write(".python-version", python_major_minor) if python_version
+          File.write(".python-version", language_version_manager.python_major_minor)
 
           # Overwrite the pyproject with updated content
           if update_pyproject
@@ -287,6 +286,18 @@ module Dependabot
             fetch("category")
 
           category == "dev" ? "dev-dependencies" : "dependencies"
+        end
+
+        def python_requirement_parser
+          @python_requirement_parser ||=
+            FileParser::PythonRequirementParser.
+            new(dependency_files: dependency_files)
+        end
+
+        def language_version_manager
+          @language_version_manager ||=
+            LanguageVersionManager.
+            new(python_requirement_parser: python_requirement_parser)
         end
 
         def pyproject


### PR DESCRIPTION
## Context
The 4 python package managers had very nearly copy/pasted code to detect the project python version and install the correct python version. This copy/pasted code had drifted over time in some package managers (pipenv and poetry had gained some additional error handling around unsupported python versions among others). This aims to clean up the copy/pasted code and provide a new mixin module that can hold cross package manager methods to increase code reuse going forward

## Approach
I implemented a new mixin module in `python/helpers.rb` and attempted to unify the behavior of detecting a project python version, verifying support for said python version in Dependabot, and getting that python version installed. Going forward this will hopefully simplify the task of changing our python installation strategy to possibly utilize a process similar to Actions "setup/python" method.