### PR TITLE
Bump go.mod to 1.20

### DIFF
--- a/go_modules/helpers/go.mod
+++ b/go_modules/helpers/go.mod
@@ -1,5 +1,5 @@
 module github.com/dependabot/dependabot-core/go_modules/helpers
 
-go 1.19
+go 1.20
 
 require github.com/Masterminds/vcs v1.13.3


### PR DESCRIPTION
This should have been included as part of:
* https://github.com/dependabot/dependabot-core/pull/6576

Not a big deal since no functional changes, but makes it easier for us to grep/replace if it stays in sync on versions.