### PR TITLE
Fix broken `composer` unit tests

### DIFF
--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -198,8 +198,8 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
     end
 
     context "when the user is ignoring the latest version" do
-      let(:ignored_versions) { [">= 1.22.0.a, < 3.0"] }
-      it { is_expected.to eq(Gem::Version.new("2.8.0")) }
+      let(:ignored_versions) { [">= 1.22.0.a, < 4.0"] }
+      it { is_expected.to eq(Gem::Version.new("1.21.0")) }
     end
 
     context "without a lockfile" do
@@ -746,8 +746,8 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
   describe "#preferred_resolvable_version" do
     subject { checker.preferred_resolvable_version }
 
-    let(:ignored_versions) { [">= 1.22.0.a, < 3.0"] }
-    it { is_expected.to eq(Gem::Version.new("2.8.0")) }
+    let(:ignored_versions) { [">= 1.22.0.a, < 4.0"] }
+    it { is_expected.to eq(Gem::Version.new("1.21.0")) }
 
     context "with an insecure version" do
       let(:dependency_version) { "1.0.1" }


### PR DESCRIPTION
`monolog/monolog` released a new `2.9.x` version which broke these unit
tests: https://github.com/Seldaek/monolog/releases/tag/2.9.1

A couple of things going on here:
- the native helper calls out to Packagist, and since it's not Ruby,
  it can't be easily stubbed, so that's why it suddenly started picking
  up the 2.9.1 release.
- However, this illustrated that I actually introduced a bug in the
  tests back in https://github.com/dependabot/dependabot-core/pull/6334 / 34216d42d099c60d9d999664e4dcb956721e1c89
  because anything above `1.22.0.a` should have been ignored.
- The tests were still broken because there's been a 3.0 release that
  isn't resolvable because it requires PHP 8, but we're still running
  PHP 7, so it exposed the bug described in: 
  https://github.com/dependabot/dependabot-core/blob/3846a60c18074d6b52f6d05c33a554e6a1b6ff31/composer/lib/dependabot/composer/update_checker/version_resolver.rb#L219-L226
- So to workaround the bug, I bumped the top of the unit test ignored
  version up to `4.0`, which is unreleased. This will also prevent this
  test failing again when we bump to PHP 8.

So this fixes the unit test back to a range that includes the latest
release, and also back to the expected value.