### PR TITLE
fixes docker-dev-shell not using the cache due to wrong tag

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 set -e
+cd "$(dirname "$0")/.."
+source script/_common
 
 HELP=false
 REBUILD=false
@@ -43,26 +45,12 @@ build_image() {
   export BUILT_IMAGE=true
   echo "$(tput setaf 2)=> building image from Dockerfile$(tput sgr0)"
 
-  docker build \
-    --build-arg BUILDKIT_INLINE_CACHE=1 \
-    --build-arg "USER_UID=$(id -u)" \
-    --build-arg "USER_GID=$(id -g)" \
-    --cache-from "ghcr.io/dependabot/dependabot-updater-core" \
-    -t "ghcr.io/dependabot/dependabot-updater-core" \
-    -f Dockerfile.updater-core \
-    .
-
-  docker build \
-    --build-arg BUILDKIT_INLINE_CACHE=1 \
-    --cache-from "ghcr.io/dependabot/dependabot-updater-$ECOSYSTEM" \
-    -t "dependabot/dependabot-updater-$ECOSYSTEM" \
-    -f "$ECOSYSTEM"/Dockerfile \
-    .
+  docker_build "$ECOSYSTEM"
 
   echo "$(tput setaf 2)=> building image from $DOCKERFILE$(tput sgr0)"
   docker build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
-    --build-arg "FROM_IMAGE=dependabot/dependabot-updater-$ECOSYSTEM" \
+    --build-arg "FROM_IMAGE=$UPDATER_IMAGE_NAME" \
     -t "$IMAGE_NAME" \
     -f "$DOCKERFILE" \
     .

--- a/script/_common
+++ b/script/_common
@@ -43,18 +43,20 @@ function docker_build() {
     -f Dockerfile.updater-core \
     .
 
+  export UPDATER_IMAGE_NAME="$UPDATER_IMAGE$TAG"
+
   # shellcheck disable=SC2086  # as $DOCKER_BUILD_ARGS relies on word-splitting
   docker build \
     $DOCKER_BUILD_ARGS \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
-    --cache-from "$UPDATER_IMAGE$TAG" \
-    -t "$UPDATER_IMAGE$TAG" \
+    --cache-from "$UPDATER_IMAGE_NAME" \
+    -t "$UPDATER_IMAGE_NAME" \
     -f $ECOSYSTEM/Dockerfile \
     .
 
   # Verify max layers; an AUFS limit that was _crucial_ on Heroku (but not now)
-  IMAGE_LAYERS=$(docker history -q "$UPDATER_IMAGE$TAG" | wc -l | sed -e 's/ //g')
-  echo "$UPDATER_IMAGE$TAG contains $IMAGE_LAYERS layers"
+  IMAGE_LAYERS=$(docker history -q "$UPDATER_IMAGE_NAME" | wc -l | sed -e 's/ //g')
+  echo "$UPDATER_IMAGE_NAME contains $IMAGE_LAYERS layers"
   [[ $IMAGE_LAYERS -lt 126 ]]
 }
 


### PR DESCRIPTION
The `script/_common` scripts have a small section where it translates certain ecosystem names (like `npm_and_yarn`) to their official image name (`npm` in this example). So if we hook it up here in the `docker-dev-shell` script it will then use the cache since the tag matches. 

Thanks to @pavera for pointing this out.