### PR TITLE
Detect path dependencies falling outside of repository and error out

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -275,6 +275,9 @@ module Dependabot
         current_dir = file.name.rpartition("/").first
         current_dir = nil if current_dir == ""
 
+        current_depth = File.join(directory, file.name).split("/").count { |path| !path.empty? }
+        path_to_directory = "../" * current_depth
+
         dep_types = NpmAndYarn::FileParser::DEPENDENCY_TYPES
         parsed_manifest = JSON.parse(file.content)
         dependency_objects = parsed_manifest.values_at(*dep_types).compact
@@ -294,7 +297,7 @@ module Dependabot
           select { |_, v| v.is_a?(String) && v.start_with?(*path_starts) }.
           map do |name, path|
             path = path.gsub(PATH_DEPENDENCY_CLEAN_REGEX, "")
-            raise PathDependenciesNotReachable, "#{name} at #{path}" if path.start_with?("/")
+            raise PathDependenciesNotReachable, "#{name} at #{path}" if path.start_with?("/", "#{path_to_directory}..")
 
             path = File.join(current_dir, path) unless current_dir.nil?
             [name, Pathname.new(path).cleanpath.to_path]

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -241,6 +241,23 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
           to raise_error(Dependabot::PathDependenciesNotReachable)
       end
     end
+
+    context "with a path dependency that is a relative path pointing outside of the repo" do
+      before do
+        stub_request(:get, File.join(url, "package.json?ref=sha")).
+          with(headers: { "Authorization" => "token token" }).
+          to_return(
+            status: 200,
+            body: fixture("github", "package_json_with_path_content_file_relative_outside_repo.json"),
+            headers: json_header
+          )
+      end
+
+      it "raises PathDependenciesNotReachable" do
+        expect { file_fetcher_instance.files }.
+          to raise_error(Dependabot::PathDependenciesNotReachable)
+      end
+    end
   end
 
   context "with a yarn.lock but no package-lock.json file" do

--- a/npm_and_yarn/spec/fixtures/github/package_json_with_path_content_file_relative_outside_repo.json
+++ b/npm_and_yarn/spec/fixtures/github/package_json_with_path_content_file_relative_outside_repo.json
@@ -1,0 +1,18 @@
+{
+  "name": "package.json",
+  "path": "package.json",
+  "sha": "c8857484c3de00d7e9eff435b2f9513d849163a9",
+  "size": 517,
+  "url": "https://api.github.com/repos/rodcisal/meteor-react-native-simple-boilerplate/contents/package.json?ref=master",
+  "html_url": "https://github.com/rodcisal/meteor-react-native-simple-boilerplate/blob/master/package.json",
+  "git_url": "https://api.github.com/repos/rodcisal/meteor-react-native-simple-boilerplate/git/blobs/c8857484c3de00d7e9eff435b2f9513d849163a9",
+  "download_url": "https://raw.githubusercontent.com/rodcisal/meteor-react-native-simple-boilerplate/master/package.json",
+  "type": "file",
+  "content": "ewogICJuYW1lIjogIlJOQXBwIiwKICAidmVyc2lvbiI6ICIwLjAuMSIsCiAg\nInByaXZhdGUiOiB0cnVlLAogICJzY3JpcHRzIjogewogICAgInN0YXJ0Ijog\nIm5vZGUgbm9kZV9tb2R1bGVzL3JlYWN0LW5hdGl2ZS9sb2NhbC1jbGkvY2xp\nLmpzIHN0YXJ0IiwKICAgICJpb3MiOiAib3BlbiBpb3MvUk5BcHAueGNvZGVw\ncm9qIgogIH0sCiAgImRlcGVuZGVuY2llcyI6IHsKICAgICJyZWFjdCI6ICJe\nMTUuMy4xIiwKICAgICJyZWFjdC1uYXRpdmUiOiAiXjAuMzguMCIsCiAgICAi\ncmVhY3QtbmF0aXZlLW1ldGVvciI6ICJmaWxlOi4uLy4uIiwKICAgICJyZWFj\ndC1uYXRpdmUtcm91dGVyLWZsdXgiOiAiXjMuMjYuMyIsCiAgICAicmVhY3Qt\nbmF0aXZlLXRhYnMiOiAiXjEuMC41IgogIH0sCiAgImRldkRlcGVuZGVuY2ll\ncyI6IHsKICAgICJiYWJlbC1wbHVnaW4tdHJhbnNmb3JtLWRlY29yYXRvcnMt\nbGVnYWN5IjogIl4xLjMuNCIsCiAgICAiYmFiZWwtcHJlc2V0LXJlYWN0LW5h\ndGl2ZSI6ICJeMS41LjMiCiAgfQp9Cg==\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/rodcisal/meteor-react-native-simple-boilerplate/contents/package.json?ref=master",
+    "git": "https://api.github.com/repos/rodcisal/meteor-react-native-simple-boilerplate/git/blobs/c8857484c3de00d7e9eff435b2f9513d849163a9",
+    "html": "https://github.com/rodcisal/meteor-react-native-simple-boilerplate/blob/master/package.json"
+  }
+}


### PR DESCRIPTION
Otherwise we hang infinitely.

Fixes https://github.com/dependabot/dependabot-core/issues/5945.

Needs tests and I haven't even run npm CI locally either, so just opening a WIP for now.