### PR TITLE
Remove duplicate `git init` call

### DIFF
--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -199,10 +199,6 @@ module Dependabot
                 write_temporary_dependency_files(prepared_pipfile_content)
                 install_required_python
 
-                # Initialize a git repo to appease pip-tools
-                command = SharedHelpers.escape_command("git init")
-                IO.popen(command, err: %i(child out)) if setup_files.any?
-
                 run_pipenv_command(
                   "pyenv exec pipenv lock"
                 )


### PR DESCRIPTION
This already happens as part of `install_required_python`: https://github.com/dependabot/dependabot-core/blob/26e670a2bdc6833efe9421979aa121b6a3f139d1/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb#L306-L311

Which is called right above the deleted code:
https://github.com/dependabot/dependabot-core/blob/26e670a2bdc6833efe9421979aa121b6a3f139d1/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb#L200

This probably was a simple oversight of the refactoring in https://github.com/dependabot/dependabot-core/pull/6609.