### PR TITLE
Remove spec for composer patches due to change upstream behavior

### DIFF
--- a/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
+++ b/composer/spec/dependabot/composer/file_updater/lockfile_updater_spec.rb
@@ -711,17 +711,6 @@ RSpec.describe Dependabot::Composer::FileUpdater::LockfileUpdater do
           package_manager: "composer"
         )
       end
-
-      # This is a known issue in the composer-patches plugin and composer v2:
-      # https://github.com/cweagans/composer-patches/issues/338
-      pending "doesn't strip the patches" do
-        updated_dep = JSON.parse(updated_lockfile_content).
-                      fetch("packages").
-                      find { |p| p["name"] == "ehime/hello-world" }
-
-        expect(updated_dep.dig("extra", "patches_applied")).
-          to include("[PATCH] markdown modified")
-      end
     end
 
     context "regression spec for media-organizer" do


### PR DESCRIPTION
The upstream issue was just closed:
* https://github.com/cweagans/composer-patches/issues/338#issuecomment-1421336293

Effectively it's a "wontfix" because patch data isn't going to be re-applied to `composer.lock`:
* https://github.com/composer/composer/discussions/11295#discussioncomment-4869345

Instead, `composer-patches` will add a new lockfile called `patches.lock`. Supporting that might make sense as a feature request down the road, but for now let's remove the `pending` test since that behavior is never coming back.