### PR TITLE
Enable AWS ECR client to look for creds in default fallback locations

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -107,6 +107,7 @@ CODE_DIR="/home/dependabot/dependabot-core"
 touch .core-bash_history
 mkdir -p dry-run tmp
 docker run --rm -ti \
+  -v "$HOME/.aws:$CODE_DIR/../.aws" \
   -v "$(pwd)/.core-bash_history:/home/dependabot/.bash_history" \
   -v "$(pwd)/.rubocop.yml:$CODE_DIR/.rubocop.yml" \
   -v "$(pwd)/bin:$CODE_DIR/bin" \

--- a/docker/lib/dependabot/docker/utils/credentials_finder.rb
+++ b/docker/lib/dependabot/docker/utils/credentials_finder.rb
@@ -47,29 +47,33 @@ module Dependabot
           # If credentials have been generated from AWS we can just return them
           return registry_details if registry_details["username"] == "AWS"
 
-          # If we don't have credentials, we might get them from the proxy
-          return registry_details if registry_details["username"].nil?
-
-          # Otherwise, we need to use the provided Access Key ID and secret to
-          # generate a temporary username and password
+          # Build a client either with explicit creds or default creds
+          registry_hostname = registry_details.fetch("registry")
+          region = registry_hostname.match(AWS_ECR_URL).named_captures.fetch("region")
           aws_credentials = Aws::Credentials.new(
             registry_details["username"],
             registry_details["password"]
           )
 
-          registry_hostname = registry_details.fetch("registry")
-          region = registry_hostname.match(AWS_ECR_URL).
-                   named_captures.fetch("region")
+          ecr_client =
+            if aws_credentials.set?
+              Aws::ECR::Client.new(region: region, credentials: aws_credentials)
+            else
+              # Let the client check default locations for credentials
+              Aws::ECR::Client.new(region: region)
+            end
 
+          # If the client still lacks credentials, we might be running within GitHub's
+          # Dependabot Service, in which case we might get them from the proxy
+          return registry_details if ecr_client.config.credentials.nil?
+
+          # Otherwise, we need to use the provided Access Key ID and secret to
+          # generate a temporary username and password
           @authorization_tokens ||= {}
           @authorization_tokens[registry_hostname] ||=
-            Aws::ECR::Client.new(region: region, credentials: aws_credentials).
-            get_authorization_token.authorization_data.first.
-            authorization_token
-
+            ecr_client.get_authorization_token.authorization_data.first.authorization_token
           username, password =
             Base64.decode64(@authorization_tokens[registry_hostname]).split(":")
-
           registry_details.merge("username" => username, "password" => password)
         rescue Aws::Errors::MissingCredentialsError,
                Aws::ECR::Errors::UnrecognizedClientException,

--- a/docker/spec/dependabot/docker/utils/credentials_finder_spec.rb
+++ b/docker/spec/dependabot/docker/utils/credentials_finder_spec.rb
@@ -2,6 +2,8 @@
 
 require "spec_helper"
 require "dependabot/docker/utils/credentials_finder"
+require "aws-sdk-ecr"
+require "base64"
 
 RSpec.describe Dependabot::Docker::Utils::CredentialsFinder do
   subject(:finder) { described_class.new(credentials) }
@@ -146,6 +148,37 @@ RSpec.describe Dependabot::Docker::Utils::CredentialsFinder do
               "registry" => "695729449481.dkr.ecr.eu-west-2.amazonaws.com",
               "username" => "AWS",
               "password" => "secret_aws_password"
+            )
+          end
+        end
+      end
+
+      context "using the default credentials provider" do
+        let(:credentials) do
+          [{
+            "type" => "docker_registry",
+            "registry" => "695729449481.dkr.ecr.eu-west-2.amazonaws.com"
+          }]
+        end
+
+        context "and a valid AWS response" do
+          before do
+            ecr_stub = Aws::ECR::Client.new(stub_responses: true)
+            ecr_stub.stub_responses(
+              :get_authorization_token,
+              authorization_data:
+                [authorization_token: Base64.encode64("foo:bar")]
+            )
+            expect(Aws::ECR::Client).to \
+              receive(:new).with(region: "eu-west-2").and_return(ecr_stub)
+          end
+
+          it "returns updated, valid credentials" do
+            expect(found_credentials).to eq(
+              "type" => "docker_registry",
+              "registry" => "695729449481.dkr.ecr.eu-west-2.amazonaws.com",
+              "username" => "foo",
+              "password" => "bar"
             )
           end
         end


### PR DESCRIPTION
This enables the AWS ECR client to look for creds in default fallback locations if they are not explicitly provided.

NOTE: This will _only_ affect folks running `dependabot-core` by themselves outside of the Dependabot Service offered by GitHub.

According to the [AWS ECR SDK Client docs](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECR/Client.html#initialize-instance_method):
> When `:credentials` are not configured directly, the following locations will be searched for credentials:
> * `Aws.config[:credentials]`
> * The `:access_key_id`, `:secret_access_key`, and `:session_token` options.
> * `ENV['AWS_ACCESS_KEY_ID']`, `ENV['AWS_SECRET_ACCESS_KEY']`
> * `~/.aws/credentials`
> * `~/.aws/config`

The flow here of picking what creds to prioritize is important to get correct. We have to cover all the following scenarios:
  1. users on Dependabot Service at GitHub... our proxy will manage the creds, so `dependabot-core` never sees them
  2. users who are hardcoding creds for `dependabot-script`
  3. users who have creds in `~/.aws/`
  4. users accessing public ECR that doesn't require creds

For 1️⃣ , it'll be the same as 4️⃣ , and happens in a context where 2️⃣ / 3️⃣ won't be populated, so should be straightforward as long as there's not a big perf hit for the ECR SDK library to check the filesystem for 3️⃣.

99% of traffic through this library probably happens through the Dependabot Service on GitHub, so 99% of the time the checks will be pointless... but the naive flow is far more intuitive, so if we do need a flag for perf reasons, we should make it opt-out of credential checking rather than opt-in. And actually we'd be able to re-use this across the `dependabot-core` library anywhere we use creds.

This is an edited version of @JimNero009's original work over in https://github.com/dependabot/dependabot-core/pull/1463, and includes him as a co-author on the commit.

Fix #1009 