### PR TITLE
Update README and helper scripts for the updater

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,11 +181,11 @@ jobs:
         uses: actions/checkout@v3
       # using bundler as the test updater
       - name: Build ecosystem image
-        run: script/build bundler
+        run: updater/script/build
       - name: Run updater tests
         env:
           DEPENDABOT_TEST_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: script/ci-test-updater
+        run: updater/script/test
 
   lint:
     name: Lint

--- a/updater/README.md
+++ b/updater/README.md
@@ -11,30 +11,33 @@ GitHub network, and so is not generally accessible.
 
 ## Setup
 
-You will need to provide the build a Personal Access Token to access the GitHub Package Registry to retrieve
-dependency containers.
+To work with the updater, you will need to build the bundler image using the
+build script in this directory:
 
-[Create a token](https://github.com/settings/tokens/new) with the `packages:read` scope and set it in your environment
-as `GPR_TOKEN`
-
-Run the setup script:
-
-```
-script/setup
+```bash
+script/build
 ```
 
 ## Tests
 
 We run [rspec](https://rspec.info/) tests inside a Docker container for this project:
 
-```
+```bash
 script/test
 ```
 
 You can run an individual test file like so:
 
-```
+```bash
 script/test spec/dependabot/integration_spec.rb
+```
+
+A small number of tests hit the GitHub API, so you will need to set the envvar
+`DEPENDABOT_TEST_ACCESS_TOKEN` with a Personal Access Token with the full `repo`
+scope.
+
+```bash
+export DEPENDABOT_TEST_ACCESS_TOKEN=ghp_xxx
 ```
 
 ### VCR
@@ -51,17 +54,13 @@ If you are adding a new test that makes network calls, please ensure you record 
 If you've added a new test which has the `vcr: true` metadata, you can record a fixture for just those changes like so:
 
 ```
-VCR=new_episodes DEPENDABOT_TEST_ACCESS_TOKEN=<redacted> script/test
+VCR=new_episodes script/test
 ```
-
-`DEPENDABOT_TEST_ACCESS_TOKEN` will need to be a Personal Access Token with the full `repo` scope.
 
 #### Updating existing fixtures
 
 If you need to upadate existing fixtures, you can use the `all` flag like so:
 
 ```
-VCR=all DEPENDABOT_TEST_ACCESS_TOKEN=<redacted> bundle exec rspec spec
+VCR=all script/test
 ```
-
-As above, you will need a PAT with the full `repo` scope

--- a/updater/script/build
+++ b/updater/script/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+cd "$(dirname "$0")/../.."
+# For simplicity, we just use the bundler base image for the updater environment
+script/build bundler

--- a/updater/script/test
+++ b/updater/script/test
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 set -e
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/../.."
 source script/_common
 
 # Previously the updater image contained all ecosystems. Now the ecosystems are broken apart,
 # but we still have some tests that need to run against other ecosystems. So by mounting the
 # other ecosystems with -v into the updater image we can still run those tests.
-script/build bundler
+updater/script/build
 docker run --env DEPENDABOT_TEST_ACCESS_TOKEN \
   --pull never \
   --env VCR \
@@ -16,4 +16,4 @@ docker run --env DEPENDABOT_TEST_ACCESS_TOKEN \
   -v "$(pwd)/npm_and_yarn:/home/dependabot/npm_and_yarn" \
   -v "$(pwd)/go_modules:/home/dependabot/go_modules" \
   -v "$(pwd)/composer:/home/dependabot/composer" \
-  "ghcr.io/dependabot/dependabot-updater-bundler:latest" bundle exec rspec
+  "ghcr.io/dependabot/dependabot-updater-bundler:latest" bundle exec rspec "${@}"


### PR DESCRIPTION
The Updater maintains its own README which needs some tweaks now we have leaned out our Docker images 🎉 

As part of this, I've created a `script/updater/build` helper which abstracts away the need to know that the Updater builds against the Bundler base image.

I've also moved `script/ci-test-updater` into `updater/script/test` as the test requirements for CI and developers are functionally identical.