### PR TITLE
Don't raise all versions ignored error if digest can be updated

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -404,7 +404,10 @@ module Dependabot
             version = comparable_version_from(tag)
             ignore_requirements.any? { |r| r.satisfied_by?(version) }
           end
-        if @raise_on_ignored && filter_lower_versions(filtered).empty? && filter_lower_versions(candidate_tags).any?
+        if @raise_on_ignored &&
+           filter_lower_versions(filtered).empty? &&
+           filter_lower_versions(candidate_tags).any? &&
+           digest_up_to_date?
           raise AllVersionsIgnored
         end
 

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -238,6 +238,26 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       end
     end
 
+    context "when all later versions are being ignored, but more tags available" do
+      let(:ignored_versions) { [">= 17.10"] }
+      let(:source) { { digest: "old_digest", tag: "17.04" } }
+
+      context "raise_on_ignored" do
+        let(:raise_on_ignored) { true }
+
+        before do
+          new_headers =
+            fixture("docker", "registry_manifest_headers", "generic.json")
+          stub_request(:head, repo_url + "manifests/17.04").
+            and_return(status: 200, body: "", headers: JSON.parse(new_headers))
+        end
+
+        it "doesn't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
+
     context "when ignoring multiple versions" do
       let(:ignored_versions) { [">= 17.10, < 17.2"] }
       it { is_expected.to eq("17.10") }


### PR DESCRIPTION
User may have all three ignores `["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]` configured, but will still want digest updates if pinned to specific digests.

This PR fixes that.

Closes #1971.