### PR TITLE
Implement `widen` strategy for Python libraries with a requirements file

### DIFF
--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -97,17 +97,6 @@ module Dependabot
         raise NotImplementedError
       end
 
-      def preferred_version_resolvable_with_unlock?
-        # Our requirements file updater doesn't currently support widening
-        # ranges, so avoid updating this dependency if widening ranges has been
-        # required and the dependency is present on a requirements file.
-        # Otherwise, we will crash later on. TODO: Consider what the correct
-        # behavior is in these cases.
-        return false if requirements_update_strategy == :widen_ranges && updating_requirements_file?
-
-        super
-      end
-
       def fetch_lowest_resolvable_security_fix_version
         fix_version = lowest_security_fix_version
         return latest_resolvable_version if fix_version.nil?

--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -187,6 +187,8 @@ module Dependabot
           return req unless req.fetch(:requirement)
 
           case update_strategy
+          when :widen_ranges
+            widen_requirement(req)
           when :bump_versions
             update_requirement(req)
           when :bump_versions_if_necessary
@@ -219,6 +221,14 @@ module Dependabot
           req.merge(requirement: new_requirement)
         rescue UnfixableRequirement
           req.merge(requirement: :unfixable)
+        end
+
+        def widen_requirement(req)
+          return req if new_version_satisfies?(req)
+
+          new_requirement = widen_requirement_range(req[:requirement])
+
+          req.merge(requirement: new_requirement)
         end
 
         def new_version_satisfies?(req)

--- a/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
+++ b/python/spec/dependabot/python/update_checker/requirements_updater_spec.rb
@@ -153,9 +153,15 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
 
               its([:requirement]) { is_expected.to eq("~=1.3") }
             end
+
+            context "with the widen_ranges update strategy" do
+              let(:update_strategy) { :widen_ranges }
+
+              its([:requirement]) { is_expected.to eq("~=1.3") }
+            end
           end
 
-          context "that needs to be updated and maintain its precision" do
+          context "that does not support the new version" do
             let(:requirement_txt_req_string) { "~=1.3" }
             let(:latest_resolvable_version) { "2.1.0" }
             its([:requirement]) { is_expected.to eq("~=2.1") }
@@ -164,6 +170,12 @@ RSpec.describe Dependabot::Python::UpdateChecker::RequirementsUpdater do
               let(:update_strategy) { :bump_versions_if_necessary }
 
               its([:requirement]) { is_expected.to eq("~=2.1") }
+            end
+
+            context "with the widen_ranges update strategy" do
+              let(:update_strategy) { :widen_ranges }
+
+              its([:requirement]) { is_expected.to eq(">=1.3,<3.0") }
             end
           end
         end

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -133,9 +133,7 @@ RSpec.describe Dependabot::Python::UpdateChecker do
           )
       end
 
-      it "does not attempt an update, because updating requirements.txt file does not yet support widening ranges" do
-        expect(subject).to be_falsey
-      end
+      it { is_expected.to be_truthy }
     end
   end
 


### PR DESCRIPTION
### Before

```
$ bin/dry-run.rb pip sanderr/inmanta-module-factory
=> fetching dependency files
=> dumping fetched dependency files: ./dry-run/sanderr/inmanta-module-factory/
=> parsing dependency files
=> updating 1 dependencies: more-itertools

=== more-itertools (8.14.0)
 => checking for updates 1/1
🌍 --> GET https://pypi.org/simple/more-itertools/
🌍 <-- 200 https://pypi.org/simple/more-itertools/
 => latest available version is 9.0.0
🌍 --> GET https://pypi.org/simple/more-itertools/
🌍 <-- 200 https://pypi.org/simple/more-itertools/
 => latest allowed version is 9.0.0
🌍 --> GET https://pypi.org/pypi/lorem/json/
🌍 --> GET https://pypi.org/pypi/lorem/json
🌍 <-- 200 https://pypi.org/pypi/lorem/json
🌍 <-- 301 https://pypi.org/pypi/lorem/json/
 => requirements to unlock: update_not_possible
🌍 --> GET https://pypi.org/pypi/lorem/json/
🌍 --> GET https://pypi.org/pypi/lorem/json
🌍 <-- 200 https://pypi.org/pypi/lorem/json
🌍 <-- 301 https://pypi.org/pypi/lorem/json/
 => requirements update strategy: widen_ranges
    (no update possible 🙅‍♀️)
🌍 Total requests made: '6'
```

### After

```
$ bin/dry-run.rb pip sanderr/inmanta-module-factory
=> fetching dependency files
=> dumping fetched dependency files: ./dry-run/sanderr/inmanta-module-factory/
=> parsing dependency files
=> updating 1 dependencies: more-itertools

=== more-itertools (8.14.0)
 => checking for updates 1/1
🌍 --> GET https://pypi.org/simple/more-itertools/
🌍 <-- 200 https://pypi.org/simple/more-itertools/
 => latest available version is 9.0.0
🌍 --> GET https://pypi.org/simple/more-itertools/
🌍 <-- 200 https://pypi.org/simple/more-itertools/
 => latest allowed version is 9.0.0
🌍 --> GET https://pypi.org/pypi/lorem/json/
🌍 --> GET https://pypi.org/pypi/lorem/json
🌍 <-- 200 https://pypi.org/pypi/lorem/json
🌍 <-- 301 https://pypi.org/pypi/lorem/json/
 => requirements to unlock: own
🌍 --> GET https://pypi.org/pypi/lorem/json/
🌍 --> GET https://pypi.org/pypi/lorem/json
🌍 <-- 200 https://pypi.org/pypi/lorem/json
🌍 <-- 301 https://pypi.org/pypi/lorem/json/
 => requirements update strategy: widen_ranges
🌍 --> GET https://pypi.org/pypi/lorem/json/
🌍 --> GET https://pypi.org/pypi/lorem/json
🌍 <-- 200 https://pypi.org/pypi/lorem/json
🌍 <-- 301 https://pypi.org/pypi/lorem/json/
🌍 --> GET https://pypi.org/pypi/lorem/json/
🌍 --> GET https://pypi.org/pypi/lorem/json
🌍 <-- 200 https://pypi.org/pypi/lorem/json
🌍 <-- 301 https://pypi.org/pypi/lorem/json/
🌍 --> GET https://pypi.org/pypi/more-itertools/json
🌍 <-- 200 https://pypi.org/pypi/more-itertools/json
🌍 --> GET https://github.com/more-itertools/more-itertools.git/info/refs?service=git-upload-pack
🌍 <-- 200 https://github.com/more-itertools/more-itertools.git/info/refs?service=git-upload-pack
🌍 --> GET https://github.com/more-itertools/more-itertools.git/info/refs?service=git-upload-pack
🌍 <-- 200 https://github.com/more-itertools/more-itertools.git/info/refs?service=git-upload-pack
 => bump more-itertools from 8.14.0 to 9.0.0

    ± pyproject.toml
    ~~~
    11c11
    < 	"more-itertools>=8,<9",
    ---
    > 	"more-itertools>=8,<10",
    ~~~

    ± requirements.txt
    ~~~
    1c1
    < more-itertools==8.14.0
    ---
    > more-itertools==9.0.0
    ~~~
🌍 Total requests made: '13'
```

Fixes #6625.