### PR TITLE
Don't plumb AWS creds through dev environment

### DIFF
--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -107,7 +107,6 @@ CODE_DIR="/home/dependabot/dependabot-core"
 touch .core-bash_history
 mkdir -p dry-run tmp
 docker run --rm -ti \
-  -v "$HOME/.aws:$CODE_DIR/../.aws" \
   -v "$(pwd)/.core-bash_history:/home/dependabot/.bash_history" \
   -v "$(pwd)/.rubocop.yml:$CODE_DIR/.rubocop.yml" \
   -v "$(pwd)/bin:$CODE_DIR/bin" \


### PR DESCRIPTION
As _deivid-rodriguez pointed out in https://github.com/dependabot/dependabot-core/pull/6622#discussion_r1102041336, `bin/docker-dev-shell` is intended for dev work, including running tests. Plumbing AWS creds through from outside the dev container reduces the reproducability.

So removing this.

For entrypoints intended for prod (such as `dependabot-script`), IMO we _should_ plumb AWS creds through for a sane default, but anyone using `bin/docker-dev-shell` in prod is doing it wrong...