### PR TITLE
The updater shuffles dependencies once

### DIFF
--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -66,8 +66,6 @@ module Dependabot
       @created_pull_requests = []
     end
 
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/PerceivedComplexity
     def run
       return unless job
 
@@ -76,11 +74,7 @@ module Dependabot
         check_and_update_existing_pr_with_error_handling(dependencies)
       else
         logger_info("Starting update job for #{job.source.repo}")
-        if ENV["UPDATER_DETERMINISTIC"]
-          dependencies.each { |dep| check_and_create_pr_with_error_handling(dep) }
-        else
-          dependencies.shuffle.each { |dep| check_and_create_pr_with_error_handling(dep) }
-        end
+        dependencies.each { |dep| check_and_create_pr_with_error_handling(dep) }
       end
     rescue *RUN_HALTING_ERRORS.keys => e
       if e.is_a?(Dependabot::AllVersionsIgnored) && !job.security_updates_only?
@@ -96,8 +90,6 @@ module Dependabot
       error = { "error-type": RUN_HALTING_ERRORS.fetch(e.class) }
       record_error(error)
     end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/PerceivedComplexity
 
     private
 


### PR DESCRIPTION
This PR removes one use of `shuffle` on the dependencies list.

EDIT: Thanks to some detective work from @deivid-rodriguez and @mctofu, we've verified the original duplication was unintentional, so we can clean this up with confidence.

----

In addition to the top-level call when we actually execute the check-and-create, we also shuffle within the `Updater#dependencies` method itself here:
https://github.com/dependabot/dependabot-core/blob/afbc9fb35e40961ffd7cf17f2891608f49310b9c/updater/lib/dependabot/updater.rb#L626-L630

Immediately after this, we then attempt to pull vulnerable dependencies to the top of the list:
https://github.com/dependabot/dependabot-core/blob/afbc9fb35e40961ffd7cf17f2891608f49310b9c/updater/lib/dependabot/updater.rb#L637-L640

The second shuffle will undo this but it isn't apparent when looking at the method since it happens at the top level, so I think we should either:
1. Do all the shuffling within this method so the intended state that is actually used in `Updater#run` is created in one place
2. Remove the second shuffle on the assumption while we want to randomise the overall order, we still want to have a preference for the first 10 vulnerable packages in the randomised set[^1]

I've ended up going for (2) as I think that's most consistent with the original intent to pull Vulnerable updates to the top of the queue, but in the event there are more than 10, we will still pull them forward randomly on each attempt.

What gives me pause about this change is I don't fully understand this comment:
https://github.com/dependabot/dependabot-core/blob/afbc9fb35e40961ffd7cf17f2891608f49310b9c/updater/lib/dependabot/updater.rb#L627-L629

Specifically:
> with top-level dependencies considered first

The logic to make sure top-level dependencies first isn't in this method, my assumption is we expect of it our contract with the `dependency_file_parser`? The comment is slightly misleading so we might want to indicate that if this is the case, otherwise this comment may be stale and something has been removed?

[^1]: The reality of this logic is that currently, Vulnerability Updates do not include advisory data and Security Updates focus a single dependency, so this logic is likely only pulling 1 Dependency forward in most cases, but that's something I'd prefer to address separately.