### PR TITLE
Fix lockfile incorrectly updated with unrelated path gem version

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -89,7 +89,7 @@ module Dependabot
             path = gemspec.name
             FileUtils.mkdir_p(Pathname.new(path).dirname)
             updated_content = updated_gemspec_content(gemspec)
-            File.write(path, sanitized_gemspec_content(updated_content))
+            File.write(path, sanitized_gemspec_content(path, updated_content))
           end
 
           write_ruby_version_file
@@ -115,7 +115,7 @@ module Dependabot
           path_gemspecs.each do |file|
             path = file.name
             FileUtils.mkdir_p(Pathname.new(path).dirname)
-            File.write(path, sanitized_gemspec_content(file.content))
+            File.write(path, sanitized_gemspec_content(path, file.content))
           end
 
           specification_files.each do |file|
@@ -195,32 +195,27 @@ module Dependabot
           )
         end
 
-        def sanitized_gemspec_content(gemspec_content)
-          new_version = replacement_version_for_gemspec(gemspec_content)
+        def sanitized_gemspec_content(path, gemspec_content)
+          new_version = replacement_version_for_gemspec(path, gemspec_content)
 
           GemspecSanitizer.
             new(replacement_version: new_version).
             rewrite(gemspec_content)
         end
 
-        # rubocop:disable Metrics/PerceivedComplexity
-        def replacement_version_for_gemspec(gemspec_content)
+        def replacement_version_for_gemspec(path, gemspec_content)
           return "0.0.1" unless lockfile
-
-          gemspec_specs =
-            ::Bundler::LockfileParser.new(sanitized_lockfile_body).specs.
-            select { |s| gemspec_sources.include?(s.source.class) }
 
           gem_name =
             GemspecDependencyNameFinder.new(gemspec_content: gemspec_content).
-            dependency_name
+            dependency_name || File.basename(path, ".gemspec")
 
-          return gemspec_specs.first&.version || "0.0.1" unless gem_name
+          gemspec_specs =
+            ::Bundler::LockfileParser.new(sanitized_lockfile_body).specs.
+            select { |s| s.name == gem_name && gemspec_sources.include?(s.source.class) }
 
-          spec = gemspec_specs.find { |s| s.name == gem_name }
-          spec&.version || gemspec_specs.first&.version || "0.0.1"
+          gemspec_specs.first&.version || "0.0.1"
         end
-        # rubocop:enable Metrics/PerceivedComplexity
 
         def prepared_gemfile_content(file)
           content = updated_gemfile_content(file)

--- a/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_contexts"
+require "dependabot/dependency"
+require "dependabot/bundler/file_updater/lockfile_updater"
+
+RSpec.describe Dependabot::Bundler::FileUpdater::LockfileUpdater do
+  include_context "stub rubygems compact index"
+
+  let(:updater) do
+    described_class.new(
+      dependencies: [dependency],
+      dependency_files: [gemspec, other_gemspec, gemfile, lockfile],
+      options: {},
+      credentials: []
+    )
+  end
+  let(:gemspec) do
+    bundler_project_dependency_file("multiple_path_gems", filename: "vendor/net-imap/net-imap.gemspec")
+  end
+  let(:other_gemspec) do
+    bundler_project_dependency_file("multiple_path_gems", filename: "vendor/couchrb/couchrb.gemspec")
+  end
+  let(:gemfile) do
+    bundler_project_dependency_file("multiple_path_gems", filename: "Gemfile")
+  end
+  let(:lockfile) do
+    bundler_project_dependency_file("multiple_path_gems", filename: "Gemfile.lock")
+  end
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "ice_nine",
+      version: "0.11.2",
+      previous_version: "0.11.1",
+      requirements: [],
+      previous_requirements: [],
+      package_manager: "bundler"
+    )
+  end
+
+  describe "#updated_lockfile_content" do
+    let(:updated_lockfile_content) { updater.updated_lockfile_content }
+
+    it "upgrades dependency" do
+      expect(updated_lockfile_content).to  include("ice_nine (0.11.2)")
+    end
+
+    it "keeps correct versions of path dependencies" do
+      expect(updated_lockfile_content).to  include("couchrb (0.9.0)")
+      expect(updated_lockfile_content).to  include("net-imap (0.3.3)")
+    end
+  end
+end

--- a/bundler/spec/fixtures/projects/bundler1/multiple_path_gems/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/multiple_path_gems/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "couchrb", path: "vendor/couchrb"
+gem "net-imap", path: "vendor/net-imap"

--- a/bundler/spec/fixtures/projects/bundler1/multiple_path_gems/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/multiple_path_gems/Gemfile.lock
@@ -1,0 +1,25 @@
+PATH
+  remote: vendor/couchrb
+  specs:
+    couchrb (0.9.0)
+      ice_nine
+
+PATH
+  remote: vendor/net-imap
+  specs:
+    net-imap (0.3.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ice_nine (0.11.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  couchrb!
+  net-imap!
+
+BUNDLED WITH
+   1.17.3

--- a/bundler/spec/fixtures/projects/bundler1/multiple_path_gems/vendor/couchrb/couchrb.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/multiple_path_gems/vendor/couchrb/couchrb.gemspec
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name          = "couchrb"
+  spec.version       = "0.9.0"
+  spec.authors       = ["nicholas a. evans"]
+  spec.email         = ["<nevans@410labs.com>"]
+
+  spec.summary       = %q{CouchDB client library.}
+  spec.description   = %q{CouchRb provides a ruby-flavored interface to CouchDB.  The basic resources try to follow the CouchDB API as closely as possible, but many additional features are available.}
+  spec.homepage      = "https://github.com/410labs/couchrb"
+
+  spec.add_dependency "ice_nine"
+end

--- a/bundler/spec/fixtures/projects/bundler1/multiple_path_gems/vendor/net-imap/net-imap.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/multiple_path_gems/vendor/net-imap/net-imap.gemspec
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = "0.3.3"
+
+Gem::Specification.new do |spec|
+  spec.name          = name
+  spec.version       = version
+  spec.authors       = ["Shugo Maeda", "nicholas a. evans"]
+  spec.email         = ["shugo@ruby-lang.org", "nick@ekenosen.net"]
+
+  spec.summary       = %q{Ruby client api for Internet Message Access Protocol}
+  spec.description   = %q{Ruby client api for Internet Message Access Protocol}
+  spec.homepage      = "https://github.com/ruby/net-imap"
+end

--- a/bundler/spec/fixtures/projects/bundler2/multiple_path_gems/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/multiple_path_gems/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "couchrb", path: "vendor/couchrb"
+gem "net-imap", path: "vendor/net-imap"

--- a/bundler/spec/fixtures/projects/bundler2/multiple_path_gems/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler2/multiple_path_gems/Gemfile.lock
@@ -1,0 +1,25 @@
+PATH
+  remote: vendor/couchrb
+  specs:
+    couchrb (0.9.0)
+      ice_nine
+
+PATH
+  remote: vendor/net-imap
+  specs:
+    net-imap (0.3.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ice_nine (0.11.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  couchrb!
+  net-imap!
+
+BUNDLED WITH
+   2.3.26

--- a/bundler/spec/fixtures/projects/bundler2/multiple_path_gems/vendor/couchrb/couchrb.gemspec
+++ b/bundler/spec/fixtures/projects/bundler2/multiple_path_gems/vendor/couchrb/couchrb.gemspec
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name          = "couchrb"
+  spec.version       = "0.9.0"
+  spec.authors       = ["nicholas a. evans"]
+  spec.email         = ["<nevans@410labs.com>"]
+
+  spec.summary       = %q{CouchDB client library.}
+  spec.description   = %q{CouchRb provides a ruby-flavored interface to CouchDB.  The basic resources try to follow the CouchDB API as closely as possible, but many additional features are available.}
+  spec.homepage      = "https://github.com/410labs/couchrb"
+
+  spec.add_dependency "ice_nine"
+end

--- a/bundler/spec/fixtures/projects/bundler2/multiple_path_gems/vendor/net-imap/net-imap.gemspec
+++ b/bundler/spec/fixtures/projects/bundler2/multiple_path_gems/vendor/net-imap/net-imap.gemspec
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name = File.basename(__FILE__, ".gemspec")
+version = "0.3.3"
+
+Gem::Specification.new do |spec|
+  spec.name          = name
+  spec.version       = version
+  spec.authors       = ["Shugo Maeda", "nicholas a. evans"]
+  spec.email         = ["shugo@ruby-lang.org", "nick@ekenosen.net"]
+
+  spec.summary       = %q{Ruby client api for Internet Message Access Protocol}
+  spec.description   = %q{Ruby client api for Internet Message Access Protocol}
+  spec.homepage      = "https://github.com/ruby/net-imap"
+end


### PR DESCRIPTION
If Bundler was unable to infer the name of a gemspec, it would use the version of the first parsed path gemspec, which... is not correct.

This change makes Bundler try harder to find the gem name by also considering the name of the gemspec file, which in most cases matches the gem name.

Fixes #6627.