### PR TITLE
Allow updating GitHub reusable workflows

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_fetcher.rb
+++ b/github_actions/lib/dependabot/github_actions/file_fetcher.rb
@@ -21,7 +21,6 @@ module Dependabot
       def fetch_files
         fetched_files = []
         fetched_files += correctly_encoded_workflow_files
-        fetched_files += referenced_local_workflow_files
 
         return fetched_files if fetched_files.any?
 
@@ -64,11 +63,6 @@ module Dependabot
           repo_contents(dir: workflows_dir, raise_errors: false).
           select { |f| f.type == "file" && f.name.match?(/\.ya?ml$/) }.
           map { |f| fetch_file_from_host("#{workflows_dir}/#{f.name}") }
-      end
-
-      def referenced_local_workflow_files
-        # TODO: Fetch referenced local workflow files
-        []
       end
 
       def correctly_encoded_workflow_files

--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -40,7 +40,7 @@ module Dependabot
         dependency_set = DependencySet.new
 
         json = YAML.safe_load(file.content, aliases: true)
-        uses_strings = deep_fetch_uses(json).uniq
+        uses_strings = deep_fetch_uses(json.fetch("jobs", nil)).uniq
 
         uses_strings.each do |string|
           # TODO: Support Docker references and path references
@@ -86,10 +86,10 @@ module Dependabot
         )
       end
 
-      def deep_fetch_uses(json_obj)
+      def deep_fetch_uses(json_obj, found_uses = [])
         case json_obj
-        when Hash then deep_fetch_uses_from_hash(json_obj)
-        when Array then json_obj.flat_map { |o| deep_fetch_uses(o) }
+        when Hash then deep_fetch_uses_from_hash(json_obj, found_uses)
+        when Array then json_obj.flat_map { |o| deep_fetch_uses(o, found_uses) }
         else []
         end
       end
@@ -111,20 +111,17 @@ module Dependabot
         resolved.compact.each { |dep| dependency_set << dep }
       end
 
-      def deep_fetch_uses_from_hash(json_object)
-        steps = json_object.fetch("steps", [])
+      def deep_fetch_uses_from_hash(json_object, found_uses)
+        if json_object.key?("uses")
+          found_uses << json_object["uses"]
+        elsif json_object.key?("steps")
+          # Bypass other fields as uses are under steps if they exist
+          deep_fetch_uses(json_object["steps"], found_uses)
+        else
+          json_object.values.flat_map { |obj| deep_fetch_uses(obj, found_uses) }
+        end
 
-        uses_strings =
-          if steps.is_a?(Array) && steps.all?(Hash)
-            steps.
-              map { |step| step.fetch("uses", nil) }.
-              select { |use| use.is_a?(String) }
-          else
-            []
-          end
-
-        uses_strings +
-          json_object.values.flat_map { |obj| deep_fetch_uses(obj) }
+        found_uses
       end
 
       def workflow_files

--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -40,6 +40,8 @@ module Dependabot
         dependency_set = DependencySet.new
 
         json = YAML.safe_load(file.content, aliases: true)
+        return dependency_set if json.nil?
+
         uses_strings = deep_fetch_uses(json.fetch("jobs", nil)).uniq
 
         uses_strings.each do |string|

--- a/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
@@ -167,6 +167,16 @@ RSpec.describe Dependabot::GithubActions::FileParser do
       end
     end
 
+    describe "with empty" do
+      subject(:dependency) { dependencies.first }
+      let(:workflow_file_fixture_name) { "empty.yml" }
+
+      it "has no dependencies" do
+        expect(dependencies.count).to be(0)
+        expect(dependency).to be_nil
+      end
+    end
+
     context "with a bad Ruby object" do
       let(:workflow_file_fixture_name) { "bad_ruby_object.yml" }
 

--- a/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
@@ -140,6 +140,33 @@ RSpec.describe Dependabot::GithubActions::FileParser do
       end
     end
 
+    describe "with reusable workflow" do
+      subject(:dependency) { dependencies.first }
+      let(:workflow_file_fixture_name) { "workflow_reusable.yml" }
+
+      let(:expected_requirements) do
+        [{
+          requirement: nil,
+          groups: [],
+          file: ".github/workflows/workflow.yml",
+          source: {
+            type: "git",
+            url: "https://github.com/actions/checkout",
+            ref: "v2.1.0",
+            branch: nil
+          },
+          metadata: { declaration_string: "actions/checkout/.github/workflows/test.yml@v2.1.0" }
+        }]
+      end
+
+      it "has the right details" do
+        expect(dependency).to be_a(Dependabot::Dependency)
+        expect(dependency.name).to eq("actions/checkout")
+        expect(dependency.version).to eq("2.1.0")
+        expect(dependency.requirements).to eq(expected_requirements)
+      end
+    end
+
     context "with a bad Ruby object" do
       let(:workflow_file_fixture_name) { "bad_ruby_object.yml" }
 
@@ -165,6 +192,54 @@ RSpec.describe Dependabot::GithubActions::FileParser do
       it "ignores the Docker url reference" do
         expect(dependencies.count).to be(0)
         expect(dependency).to be_nil
+      end
+    end
+
+    context "with a semver tag pinned to a reusable workflow commit" do
+      let(:workflow_file_fixture_name) { "workflow_semver_reusable.yml" }
+      let(:service_pack_url) do
+        "https://github.com/actions/checkout.git/info/refs" \
+          "?service=git-upload-pack"
+      end
+      before do
+        stub_request(:get, service_pack_url).
+          to_return(
+            status: 200,
+            body: fixture("git", "upload_packs", "checkout"),
+            headers: {
+              "content-type" => "application/x-git-upload-pack-advertisement"
+            }
+          )
+      end
+
+      its(:length) { is_expected.to eq(1) }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: ".github/workflows/workflow.yml",
+            source: {
+              type: "git",
+              url: "https://github.com/actions/checkout",
+              ref: "01aecccf739ca6ff86c0539fbc67a7a5007bbc81",
+              branch: nil
+            },
+            metadata: {
+              declaration_string:
+              "actions/checkout/.github/workflows/test.yml@01aecccf739ca6ff86c0539fbc67a7a5007bbc81"
+            }
+          }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("actions/checkout")
+          expect(dependency.version).to eq("2.1.0")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
       end
     end
 

--- a/github_actions/spec/fixtures/workflow_files/workflow_reusable.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_reusable.yml
@@ -1,0 +1,6 @@
+on:
+  pull_request:
+
+jobs:
+  test:
+    uses: actions/checkout/.github/workflows/test.yml@v2.1.0

--- a/github_actions/spec/fixtures/workflow_files/workflow_semver_reusable.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_semver_reusable.yml
@@ -1,0 +1,6 @@
+on:
+  pull_request:
+
+jobs:
+  test:
+    uses: actions/checkout/.github/workflows/test.yml@01aecccf739ca6ff86c0539fbc67a7a5007bbc81


### PR DESCRIPTION
This PR fixes #4327

It changes how the "uses" key is searched for and found.  Reusable workflows do not have the "steps" key, this fix no longer make the assumption that a "steps" key exists, however it still processes the "steps" key if it does exist.  

The fix also allows for a mix of reusable or standard workflows to exist in the same directory.

New logic to find and update "uses":
Check for "jobs" key and provide that section to the search.
Recursively search for "uses" key.
If it is a hash and has "uses" key, then add the "uses" value to the `found_uses` array.
If it is a hash and has "steps" key, then send the "steps" value recursive search function.
If neither "steps" or "uses" are found, then send each item in the current hash/array into the recursive search function.

Once the entire jobs section has been searched return the `found_uses` and build a dependency set out of them.

Adds the following tests:
empty File
semver Reusable Workflow
standard Reusable Workflow