### PR TITLE
remove bundler cache after installing

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -96,7 +96,8 @@ WORKDIR $HOME/dependabot-updater
 RUN bundle config set --local path 'vendor' && \
 bundle config set --local frozen 'true' && \
 bundle config set --local without 'development' && \
-bundle install
+bundle install && \
+rm -rf ~/.bundle
 
 FROM ubuntu:20.04
 


### PR DESCRIPTION
The Bundler ecosystem is evading the smoke test cache after a while, causing failures. This is probably due to how Bundler caches dependency data. When we run `bundle install` during a build, it stores a cache of the versions it fetched under `~/.bundle`. After a day or so this is out of date and Bundler attempts to get new data, probably sending new headers to do so, avoiding the cache.

So by removing the Bundler cache during image build, our tests should always make the same call to get fresh data instead of starting with a snapshot at the time of build.

An outstanding question is whether this is a good idea outside of testing. With this change, updates become more deterministic, so I think it's worth the extra download cost it incurs. Also we don't need to make a special case in tests to handle this one-off discrepancy. Other opinions on this are welcome.
