### PR TITLE
[Prototype] Generating grouped update PRs

### DIFF
--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -40,9 +40,15 @@ module Dependabot
     end
 
     def create_pull_request(job_id, dependencies, updated_dependency_files,
-                            base_commit_sha, pr_message)
+                            base_commit_sha, pr_message, grouped_update = false)
       api_url = "#{base_url}/update_jobs/#{job_id}/create_pull_request"
-      data = create_pull_request_data(dependencies, updated_dependency_files, base_commit_sha, pr_message)
+      data = create_pull_request_data(
+        dependencies,
+        updated_dependency_files,
+        base_commit_sha,
+        pr_message,
+        grouped_update
+      )
       response = http_client.post(api_url, json: { data: data })
       raise ApiError, response.body if response.code >= 400
     rescue HTTP::ConnectionError, OpenSSL::SSL::SSLError
@@ -179,7 +185,7 @@ module Dependabot
       sleep(rand(3.0..10.0)) && retry
     end
 
-    def create_pull_request_data(dependencies, updated_dependency_files, base_commit_sha, pr_message)
+    def create_pull_request_data(dependencies, updated_dependency_files, base_commit_sha, pr_message, grouped_update)
       data = {
         dependencies: dependencies.map do |dep|
           {
@@ -193,7 +199,8 @@ module Dependabot
           }.compact)
         end,
         "updated-dependency-files": updated_dependency_files,
-        "base-commit-sha": base_commit_sha
+        "base-commit-sha": base_commit_sha,
+        "grouped-update": grouped_update
       }
       return data unless pr_message
 

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -39,6 +39,7 @@ module Dependabot
       Job.new(job_data.merge(token: token))
     end
 
+    # rubocop:disable Metrics:ParameterLists
     def create_pull_request(job_id, dependencies, updated_dependency_files,
                             base_commit_sha, pr_message, grouped_update = false)
       api_url = "#{base_url}/update_jobs/#{job_id}/create_pull_request"
@@ -58,6 +59,7 @@ module Dependabot
 
       sleep(rand(3.0..10.0)) && retry
     end
+    # rubocop:enable Metrics:ParameterLists
 
     def update_pull_request(job_id, dependencies, updated_dependency_files,
                             base_commit_sha)
@@ -199,9 +201,10 @@ module Dependabot
           }.compact)
         end,
         "updated-dependency-files": updated_dependency_files,
-        "base-commit-sha": base_commit_sha,
-        "grouped-update": grouped_update
-      }
+        "base-commit-sha": base_commit_sha
+      }.merge({
+        "grouped-update": grouped_update ? true : nil
+      }.compact)
       return data unless pr_message
 
       data["commit-message"] = pr_message.commit_message

--- a/updater/lib/dependabot/experimental_grouped_updater.rb
+++ b/updater/lib/dependabot/experimental_grouped_updater.rb
@@ -234,7 +234,7 @@ module Dependabot
       #
       #        It is also worth noting that it mutates the `dependency_files`
       #        ivar which I *think* is acceptable in interests of memory management
-      group_updated_files = update_batch.inject(dependency_files) do |files, (lead_dep, updated_deps)|
+      group_updated_files = update_batch.inject(dependency_files) do |files, (lead_dep_name, updated_deps)|
         # FIXME: Move the creation of the all_updated_deps list into this loop
         #
         # If we fail to generate a diff, the PR body and Service will still get the `updated_deps` that
@@ -244,6 +244,10 @@ module Dependabot
         # which might include supressing 'downgrades' if a previous step moved a given dep to a higher
         # value already.
         if updated_deps&.any?
+          lead_dep_name = lead_dep_name.downcase
+          lead_dep = updated_deps.find do |dep|
+            dep.name.downcase == lead_dep_name
+          end
           generate_dependency_files_for(lead_dep, updated_deps, files) if updated_deps&.any?
         else
           files # pass on the existing if there are no updated dependencies for this lead dependency

--- a/updater/lib/dependabot/experimental_grouped_updater.rb
+++ b/updater/lib/dependabot/experimental_grouped_updater.rb
@@ -85,14 +85,17 @@ module Dependabot
       # END: Security-only updates checks
       return log_up_to_date(dependency) if checker.up_to_date? # retained from above block
 
-      if pr_exists_for_latest_version?(checker)
-        # FIXME: Security-only updates are not supported for grouped updates yet
-        # record_pull_request_exists_for_latest_version(checker) if job.security_updates_only?
-        return logger_info(
-          "Pull request already exists for #{checker.dependency.name} " \
-          "with latest version #{checker.latest_version}"
-        )
-      end
+      # FIXME: Prototype grouped updates do not need to check for existing PRs
+      #        at this stage as we haven't defined their mutual exclusivity
+      #        requirements yet.
+      # if pr_exists_for_latest_version?(checker)
+      #   # FIXME: Security-only updates are not supported for grouped updates yet
+      #   # record_pull_request_exists_for_latest_version(checker) if job.security_updates_only?
+      #   return logger_info(
+      #     "Pull request already exists for #{checker.dependency.name} " \
+      #     "with latest version #{checker.latest_version}"
+      #   )
+      # end
 
       requirements_to_unlock = requirements_to_unlock(checker)
       log_requirements_for_update(requirements_to_unlock, checker)

--- a/updater/lib/dependabot/experimental_grouped_updater.rb
+++ b/updater/lib/dependabot/experimental_grouped_updater.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# This class is a variation on the Strangler Pattern which the Updater#run
+# method delegates to when the `prototype_grouped_updates` experiment is
+# enabled.
+#
+# The goal of this is to allow us to use the existing Updater code that is
+# shared but re-implement the methods that need to change _without_ jeopardising
+# the Updater implementation for current users.
+#
+# This class is not expected to be long-lived once we have a better idea of how
+# to pull apart the existing Updater into Single- and Grouped-strategy classes.
+module Dependabot
+  # Let's use SimpleDelegator so this class behaves like Dependabot::Updater
+  # unless we override it.
+  class ExperimentalGroupedUpdater < SimpleDelegator
+    def run_grouped
+      # Nothing new implemented yet, let's just shake loose the Dependabot::Updater tests
+      # which relate to top-level error handling and update/rebase jobs
+      run_fresh
+    end
+    alias run run_grouped
+
+    private
+
+    # We should allow the rescue in Dependabot::Updater#run to handle errors and avoid trapping them ourselves in case
+    # it results in deviating from shared behaviour. This is a safety-catch to stop that happening by accident and fail
+    # tests if we override something without thinking carefully about how it should raise.
+    def handle_dependabot_error(_error:, _dependency:)
+      raise NoMethodError, "#{__method__} is not implemented by the delegator, call __getobj__.#{__method__} instead."
+    end
+  end
+end

--- a/updater/lib/dependabot/experimental_grouped_updater.rb
+++ b/updater/lib/dependabot/experimental_grouped_updater.rb
@@ -15,13 +15,144 @@ module Dependabot
   # unless we override it.
   class ExperimentalGroupedUpdater < SimpleDelegator
     def run_grouped
-      raise Dependabot::NotImplemented, "Grouped updates do not currently support rebasing." if job.updating_a_pull_request?
+      if job.updating_a_pull_request?
+        raise Dependabot::NotImplemented,
+              "Grouped updates do not currently support rebasing."
+      end
 
-      # Nothing new implemented yet, let's just shake loose the Dependabot::Updater tests
-      # which relate to top-level error handling and update/rebase jobs
-      run_fresh
+      logger_info("[Experimental] Starting grouped update job for #{job.source.repo}")
+      # Establish collection
+      # Do the check and diff
+      dependencies.each { |dep| check_and_create_pr_with_error_handling(dep) }
+      # PR everything
     end
     alias run run_grouped
+
+    def check_and_create_pr_with_error_handling(dependency)
+      check_and_create_pull_request(dependency)
+    rescue Dependabot::InconsistentRegistryResponse => e
+      log_error(
+        dependency: dependency,
+        error: e,
+        error_type: "inconsistent_registry_response",
+        error_detail: e.message
+      )
+    rescue StandardError => e
+      raise if Dependabot::Updater::RUN_HALTING_ERRORS.keys.any? { |err| e.is_a?(err) }
+
+      __getobj__.handle_dependabot_error(error: e, dependency: dependency)
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/MethodLength
+    def check_and_create_pull_request(dependency)
+      checker = update_checker_for(dependency, raise_on_ignored: raise_on_ignored?(dependency))
+
+      log_checking_for_update(dependency)
+
+      return if all_versions_ignored?(dependency, checker)
+
+      # If the dependency isn't vulnerable or we can't know for sure we won't be
+      # able to know if the updated dependency fixes any advisories
+      if job.security_updates_only?
+        unless checker.vulnerable?
+          # The current dependency isn't vulnerable if the version is correct and
+          # can be matched against the advisories affected versions
+          if checker.version_class.correct?(checker.dependency.version)
+            return record_security_update_not_needed_error(checker)
+          end
+
+          return record_dependency_file_not_supported_error(checker)
+        end
+        return record_security_update_ignored(checker) unless job.allowed_update?(dependency)
+      end
+
+      if checker.up_to_date?
+        # The current version is still vulnerable and  Dependabot can't find a
+        # published or compatible non-vulnerable version, this can happen if the
+        # fixed version hasn't been published yet or the published version isn't
+        # compatible with the current enviroment (e.g. python version) or
+        # version (uses a different version suffix for gradle/maven)
+        return record_security_update_not_found(checker) if job.security_updates_only?
+
+        return log_up_to_date(dependency)
+      end
+
+      if pr_exists_for_latest_version?(checker)
+        record_pull_request_exists_for_latest_version(checker) if job.security_updates_only?
+        return logger_info(
+          "Pull request already exists for #{checker.dependency.name} " \
+          "with latest version #{checker.latest_version}"
+        )
+      end
+
+      requirements_to_unlock = requirements_to_unlock(checker)
+      log_requirements_for_update(requirements_to_unlock, checker)
+
+      if requirements_to_unlock == :update_not_possible
+        return record_security_update_not_possible_error(checker) if job.security_updates_only? && job.dependencies
+
+        return logger_info(
+          "No update possible for #{dependency.name} #{dependency.version}"
+        )
+      end
+
+      updated_deps = checker.updated_dependencies(
+        requirements_to_unlock: requirements_to_unlock
+      )
+
+      # Prevent updates that don't end up fixing any security advisories,
+      # blocking any updates where dependabot-core updates to a vulnerable
+      # version. This happens for npm/yarn subdendencies where Dependabot has no
+      # control over the target version. Related issue:
+      # https://github.com/github/dependabot-api/issues/905
+      if job.security_updates_only? &&
+         updated_deps.none? { |d| job.security_fix?(d) }
+        return record_security_update_not_possible_error(checker)
+      end
+
+      if (existing_pr = existing_pull_request(updated_deps))
+        # Create a update job error to prevent dependabot-api from creating a
+        # update_not_possible error, this is likely caused by a update job retry
+        # so should be invisible to users (as the first job completed with a pull
+        # request)
+        record_pull_request_exists_for_security_update(existing_pr) if job.security_updates_only?
+
+        deps = existing_pr.map do |dep|
+          if dep.fetch("dependency-removed", false)
+            "#{dep.fetch('dependency-name')}@removed"
+          else
+            "#{dep.fetch('dependency-name')}@#{dep.fetch('dependency-version')}"
+          end
+        end
+
+        return logger_info(
+          "Pull request already exists for #{deps.join(', ')}"
+        )
+      end
+
+      if peer_dependency_should_update_instead?(checker.dependency.name, updated_deps)
+        return logger_info(
+          "No update possible for #{dependency.name} #{dependency.version} " \
+          "(peer dependency can be updated)"
+        )
+      end
+
+      updated_files = generate_dependency_files_for(updated_deps)
+      updated_deps = updated_deps.reject do |d|
+        next false if d.name == checker.dependency.name
+        next true if d.top_level? && d.requirements == d.previous_requirements
+
+        d.version == d.previous_version
+      end
+      create_pull_request(updated_deps, updated_files, pr_message(updated_deps, updated_files))
+    end
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
 
     private
 

--- a/updater/lib/dependabot/experimental_grouped_updater.rb
+++ b/updater/lib/dependabot/experimental_grouped_updater.rb
@@ -52,7 +52,8 @@ module Dependabot
 
       log_checking_for_update(dependency)
 
-      return if all_versions_ignored?(dependency, checker)
+      # FIXME: Prototype grouped updates do not interact with the ignore list
+      # return if all_versions_ignored?(dependency, checker)
 
       # If the dependency isn't vulnerable or we can't know for sure we won't be
       # able to know if the updated dependency fixes any advisories
@@ -161,6 +162,24 @@ module Dependabot
     # tests if we override something without thinking carefully about how it should raise.
     def handle_dependabot_error(_error:, _dependency:)
       raise NoMethodError, "#{__method__} is not implemented by the delegator, call __getobj__.#{__method__} instead."
+    end
+
+    # Override the checker initialisation to skip configuration we don't use right now
+    #
+    # FIXME: Prototype grouped updates do not interact with the ignore list
+    # FIXME: Prototype grouped updates to not interact with advisory data
+    def update_checker_for(dependency, raise_on_ignored:)
+      Dependabot::UpdateCheckers.for_package_manager(job.package_manager).new(
+        dependency: dependency,
+        dependency_files: dependency_files,
+        repo_contents_path: repo_contents_path,
+        credentials: credentials,
+        ignored_versions: [],
+        security_advisories: [],
+        raise_on_ignored: raise_on_ignored,
+        requirements_update_strategy: job.requirements_update_strategy,
+        options: job.experiments
+      )
     end
   end
 end

--- a/updater/lib/dependabot/experimental_grouped_updater.rb
+++ b/updater/lib/dependabot/experimental_grouped_updater.rb
@@ -331,5 +331,28 @@ module Dependabot
         options: job.experiments
       )
     end
+
+    # Override the PR creation to add the grouped_update flag
+    def create_pull_request(dependencies, updated_dependency_files, pr_message)
+      logger_info("Submitting #{dependencies.map(&:name).join(', ')} " \
+                  "pull request for creation")
+
+      service.create_pull_request(
+        job_id,
+        dependencies,
+        updated_dependency_files.map(&:to_h),
+        base_commit_sha,
+        pr_message,
+        true # grouped_update is true
+      )
+
+      created_pull_requests << dependencies.map do |dep|
+        {
+          "dependency-name" => dep.name,
+          "dependency-version" => dep.version,
+          "dependency-removed" => dep.removed? ? true : nil
+        }.compact
+      end
+    end
   end
 end

--- a/updater/lib/dependabot/experimental_grouped_updater.rb
+++ b/updater/lib/dependabot/experimental_grouped_updater.rb
@@ -15,6 +15,8 @@ module Dependabot
   # unless we override it.
   class ExperimentalGroupedUpdater < SimpleDelegator
     def run_grouped
+      raise Dependabot::NotImplemented, "Grouped updates do not currently support rebasing." if job.updating_a_pull_request?
+
       # Nothing new implemented yet, let's just shake loose the Dependabot::Updater tests
       # which relate to top-level error handling and update/rebase jobs
       run_fresh

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -19,10 +19,20 @@ module Dependabot
 
     def_delegators :client, :get_job, :mark_job_as_processed, :update_dependency_list, :record_package_manager_version
 
-    def create_pull_request(job_id, dependencies, updated_dependency_files, base_commit_sha, pr_message)
-      client.create_pull_request(job_id, dependencies, updated_dependency_files, base_commit_sha, pr_message)
+    # rubocop:disable Metrics:ParameterLists
+    def create_pull_request(job_id, dependencies, updated_dependency_files, base_commit_sha, pr_message,
+                            grouped_update = false)
+      client.create_pull_request(
+        job_id,
+        dependencies,
+        updated_dependency_files,
+        base_commit_sha,
+        pr_message,
+        grouped_update
+      )
       @pull_requests << [humanize(dependencies), :created]
     end
+    # rubocop:enable Metrics:ParameterLists
 
     def update_pull_request(job_id, dependencies, updated_dependency_files, base_commit_sha)
       client.update_pull_request(job_id, dependencies, updated_dependency_files, base_commit_sha)

--- a/updater/spec/dependabot/experimental_grouped_updater_spec.rb
+++ b/updater/spec/dependabot/experimental_grouped_updater_spec.rb
@@ -1093,8 +1093,8 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
           expect(updater_delegate).
             to receive(:run_update_existing).
             and_call_original
-          expect(updater_delegate).
-            to_not receive(:check_and_create_pr_with_error_handling)
+          expect(updater).
+            to_not receive(:compile_updates_for)
           expect(service).to receive(:create_pull_request).once
 
           updater.run
@@ -1180,8 +1180,8 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
             expect(updater_delegate).
               to receive(:run_update_existing).
               and_call_original
-            expect(updater_delegate).
-              to_not receive(:check_and_create_pr_with_error_handling)
+            expect(updater).
+              to_not receive(:compile_updates_for)
             expect(service).to receive(:create_pull_request).once
             expect(service).not_to receive(:close_pull_request)
 
@@ -1240,7 +1240,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
 
         it "only attempts to update dependencies on the specified list" do
           expect(updater).
-            to receive(:check_and_create_pr_with_error_handling).
+            to receive(:compile_updates_for).
             and_call_original
           expect(updater_delegate).
             to_not receive(:run_update_existing)
@@ -1263,7 +1263,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
 
           it "only attempts to update dependencies on the specified list" do
             expect(updater).
-              to receive(:check_and_create_pr_with_error_handling).
+              to receive(:compile_updates_for).
               and_call_original
             expect(updater_delegate).
               to_not receive(:run_update_existing)
@@ -1293,7 +1293,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
 
           it "still attempts to update the dependency" do
             expect(updater).
-              to receive(:check_and_create_pr_with_error_handling).
+              to receive(:compile_updates_for).
               and_call_original
             expect(updater_delegate).
               to_not receive(:run_update_existing)

--- a/updater/spec/dependabot/experimental_grouped_updater_spec.rb
+++ b/updater/spec/dependabot/experimental_grouped_updater_spec.rb
@@ -488,7 +488,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
               skip: "Security-only updates are out of scope" do
         it "doesn't update the dependency" do
           expect(checker).to receive(:up_to_date?).and_return(true)
-          expect(updater_delegate).to_not receive(:generate_dependency_files_for)
+          expect(updater).to_not receive(:generate_dependency_files_for)
           expect(service).to_not receive(:create_pull_request)
           expect(service).to receive(:record_update_job_error).
             with(
@@ -819,7 +819,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         before { allow(peer_checker).to receive(:can_update?).and_return(true) }
 
         it "doesn't update the dependency" do
-          expect(updater_delegate).to_not receive(:generate_dependency_files_for)
+          expect(updater).to_not receive(:generate_dependency_files_for)
           expect(service).to_not receive(:create_pull_request)
           updater.run
         end
@@ -883,7 +883,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
 
         it "doesn't call can_update? (so short-circuits resolution)" do
           expect(checker).to_not receive(:can_update?)
-          expect(updater_delegate).to_not receive(:generate_dependency_files_for)
+          expect(updater).to_not receive(:generate_dependency_files_for)
           expect(service).to_not receive(:create_pull_request)
           expect(service).to_not receive(:record_update_job_error)
           expect(logger).
@@ -904,7 +904,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         it "doesn't update the dependency" do
           expect(checker).to receive(:up_to_date?).and_return(false, false)
           expect(checker).to receive(:can_update?).and_return(true, false)
-          expect(updater_delegate).to_not receive(:generate_dependency_files_for)
+          expect(updater).to_not receive(:generate_dependency_files_for)
           expect(service).to_not receive(:create_pull_request)
           expect(service).to_not receive(:record_update_job_error)
           expect(logger).
@@ -931,7 +931,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         it "creates an update job error and short-circuits" do
           expect(checker).to receive(:up_to_date?).and_return(false)
           expect(checker).to receive(:can_update?).and_return(true)
-          expect(updater_delegate).to_not receive(:generate_dependency_files_for)
+          expect(updater).to_not receive(:generate_dependency_files_for)
           expect(service).to_not receive(:create_pull_request)
           expect(service).to receive(:record_update_job_error).
             with(
@@ -967,7 +967,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
 
         it "doesn't call can_update? (so short-circuits resolution)" do
           expect(checker).to_not receive(:can_update?)
-          expect(updater_delegate).to_not receive(:generate_dependency_files_for)
+          expect(updater).to_not receive(:generate_dependency_files_for)
           expect(service).to_not receive(:create_pull_request)
           expect(service).to receive(:record_update_job_error).
             with(
@@ -1058,7 +1058,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
       it "creates an update job error and short-circuits" do
         expect(checker).to receive(:up_to_date?).and_return(false)
         expect(checker).to receive(:can_update?).and_return(true)
-        expect(updater_delegate).to_not receive(:generate_dependency_files_for)
+        expect(updater).to_not receive(:generate_dependency_files_for)
         expect(service).to_not receive(:create_pull_request)
         expect(service).to receive(:record_update_job_error).
           with(

--- a/updater/spec/dependabot/experimental_grouped_updater_spec.rb
+++ b/updater/spec/dependabot/experimental_grouped_updater_spec.rb
@@ -1003,7 +1003,8 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
       end
     end
 
-    context "when a PR already exists for a removed dependency", skip: "Managing existing PRs is out of scope for the prototype" do
+    context "when a PR already exists for a removed dependency",
+            skip: "Managing existing PRs is out of scope for the prototype" do
       let(:existing_pull_requests) do
         [
           [
@@ -1697,7 +1698,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         updater.run
       end
 
-      it "still processes the other jobs" do
+      it "still processes the other jobs", skip: "Grouped updates are one-and-done for now, nothing else runs after" do
         expect(service).to receive(:create_pull_request).once
         updater.run
       end

--- a/updater/spec/dependabot/experimental_grouped_updater_spec.rb
+++ b/updater/spec/dependabot/experimental_grouped_updater_spec.rb
@@ -335,7 +335,8 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         updater.run
       end
 
-      context "when the dep has no version so we can't check vulnerability" do
+      context "when the dep has no version so we can't check vulnerability",
+              skip: "Security-only updates are out of scope" do
         let(:original_dependency) do
           Dependabot::Dependency.new(
             name: "dummy-pkg-b",
@@ -395,7 +396,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         end
       end
 
-      context "when the update is still vulnerable" do
+      context "when the update is still vulnerable", skip: "Security-only updates are out of scope" do
         let(:security_advisories) do
           [{ "dependency-name" => "dummy-pkg-b",
              "affected-versions" => ["1.1.0", "1.2.0"] }]
@@ -483,7 +484,8 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         end
       end
 
-      context "when the dependency is deemed up-to-date but still vulnerable" do
+      context "when the dependency is deemed up-to-date but still vulnerable",
+              skip: "Security-only updates are out of scope" do
         it "doesn't update the dependency" do
           expect(checker).to receive(:up_to_date?).and_return(true)
           expect(updater_delegate).to_not receive(:generate_dependency_files_for)
@@ -652,7 +654,8 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         end
       end
 
-      describe "when ignores define update-types with feature enabled", skip: "Ignore rules are out of scope for the prototype" do
+      describe "when ignores define update-types with feature enabled",
+               skip: "Ignore rules are out of scope for the prototype" do
         let(:requested_dependencies) { ["dummy-pkg-b"] }
         let(:ignore_conditions) do
           [
@@ -948,7 +951,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         end
       end
 
-      context "when security only updates for the latest version" do
+      context "when security only updates for the latest version", skip: "Security-only updates are out of scope" do
         let(:security_updates_only) { true }
         let(:security_advisories) do
           [{ "dependency-name" => "dummy-pkg-b",
@@ -1300,7 +1303,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
           end
         end
 
-        context "for security only updates" do
+        context "for security only updates", skip: "Security-only updates are out of scope" do
           let(:security_updates_only) { true }
 
           before do

--- a/updater/spec/dependabot/experimental_grouped_updater_spec.rb
+++ b/updater/spec/dependabot/experimental_grouped_updater_spec.rb
@@ -763,7 +763,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
       pr_message = nil
       expect(service).
         to receive(:create_pull_request).
-        with(job_id, dependencies, updated_dependency_files, base_commit_sha, pr_message)
+        with(job_id, dependencies, updated_dependency_files, base_commit_sha, pr_message, true)
 
       updater.run
     end
@@ -1797,7 +1797,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
           pr_message = nil
           expect(service).
             to receive(:create_pull_request).
-            with(job_id, dependencies, updated_dependency_files, base_commit_sha, pr_message)
+            with(job_id, dependencies, updated_dependency_files, base_commit_sha, pr_message, true)
 
           updater.run
         end
@@ -1926,7 +1926,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         pr_message = nil
         expect(service).
           to receive(:create_pull_request).
-          with(job_id, dependencies, updated_dependency_files, base_commit_sha, pr_message)
+          with(job_id, dependencies, updated_dependency_files, base_commit_sha, pr_message, true)
 
         expect(Dependabot::FileParsers).to receive(:for_package_manager).once
 

--- a/updater/spec/dependabot/experimental_grouped_updater_spec.rb
+++ b/updater/spec/dependabot/experimental_grouped_updater_spec.rb
@@ -1930,4 +1930,33 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
       end
     end
   end
+
+  describe "#run_grouped" do
+    let(:dependency_files) do
+      [
+        Dependabot::DependencyFile.new(
+          name: "Gemfile",
+          content: fixture("bundler/original/Gemfile"),
+          directory: "/"
+        ),
+        Dependabot::DependencyFile.new(
+          name: "Gemfile.lock",
+          content: fixture("bundler/original/Gemfile.lock"),
+          directory: "/"
+        )
+      ]
+    end
+
+    context "the job wants to update an existing PR" do
+      before do
+        allow(service).to receive(:record_update_job_error).and_return(nil)
+        allow(job).to receive(:updating_a_pull_request?).and_return(true)
+      end
+
+      it "raises a not implemented error" do
+        expect{ updater.run }.
+          to raise_error(Dependabot::NotImplemented, "Grouped updates do not currently support rebasing.")
+      end
+    end
+  end
 end

--- a/updater/spec/dependabot/experimental_grouped_updater_spec.rb
+++ b/updater/spec/dependabot/experimental_grouped_updater_spec.rb
@@ -1236,7 +1236,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         let(:updating_a_pull_request) { false }
 
         it "only attempts to update dependencies on the specified list" do
-          expect(updater_delegate).
+          expect(updater).
             to receive(:check_and_create_pr_with_error_handling).
             and_call_original
           expect(updater_delegate).
@@ -1259,7 +1259,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
           let(:requested_dependencies) { ["Dummy-pkg-b"] }
 
           it "only attempts to update dependencies on the specified list" do
-            expect(updater_delegate).
+            expect(updater).
               to receive(:check_and_create_pr_with_error_handling).
               and_call_original
             expect(updater_delegate).
@@ -1289,7 +1289,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
           end
 
           it "still attempts to update the dependency" do
-            expect(updater_delegate).
+            expect(updater).
               to receive(:check_and_create_pr_with_error_handling).
               and_call_original
             expect(updater_delegate).
@@ -1954,7 +1954,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
       end
 
       it "raises a not implemented error" do
-        expect{ updater.run }.
+        expect { updater.run }.
           to raise_error(Dependabot::NotImplemented, "Grouped updates do not currently support rebasing.")
       end
     end

--- a/updater/spec/dependabot/experimental_grouped_updater_spec.rb
+++ b/updater/spec/dependabot/experimental_grouped_updater_spec.rb
@@ -862,7 +862,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
       end
     end
 
-    context "when a PR already exists" do
+    context "when a PR already exists", skip: "Managing existing PRs is out of scope for the prototype" do
       let(:existing_pull_requests) do
         [
           [
@@ -1003,7 +1003,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
       end
     end
 
-    context "when a PR already exists for a removed dependency" do
+    context "when a PR already exists for a removed dependency", skip: "Managing existing PRs is out of scope for the prototype" do
       let(:existing_pull_requests) do
         [
           [

--- a/updater/spec/dependabot/experimental_grouped_updater_spec.rb
+++ b/updater/spec/dependabot/experimental_grouped_updater_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
       end
     end
 
-    it "logs the current and latest versions" do
+    it "logs the current and latest versions", skip: "this secretly tests ignore functionality we've skipped" do
       expect(logger).
         to receive(:info).
         with("<job_1> Checking if dummy-pkg-b 1.1.0 needs updating")
@@ -509,7 +509,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
       end
     end
 
-    context "when ignore conditions are set" do
+    context "when ignore conditions are set", skip: "Ignore rules are out of scope for the prototype" do
       def expect_update_checker_with_ignored_versions(versions)
         expect(Dependabot::Bundler::UpdateChecker).to have_received(:new).with(
           dependency: anything,
@@ -534,7 +534,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         end
       end
 
-      describe "when all versions are ignored" do
+      describe "when all versions are ignored", skip: "Ignore rules are out of scope for the prototype" do
         let(:ignore_conditions) do
           [
             { "dependency-name" => "dummy-pkg-a", "version-requirement" => "~> 2.0.0" },
@@ -590,7 +590,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         end
       end
 
-      describe "with an ignored version" do
+      describe "with an ignored version", skip: "Ignore rules are out of scope for the prototype" do
         let(:requested_dependencies) { ["dummy-pkg-b"] }
         let(:ignore_conditions) { [{ "dependency-name" => "dummy-pkg-b", "version-requirement" => "~> 1.0.0" }] }
 
@@ -610,7 +610,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         end
       end
 
-      describe "with an ignored update-type" do
+      describe "with an ignored update-type", skip: "Ignore rules are out of scope for the prototype" do
         let(:requested_dependencies) { ["dummy-pkg-b"] }
         let(:ignore_conditions) do
           [{ "dependency-name" => "dummy-pkg-b", "update-types" => ["version-update:semver-patch"] }]
@@ -632,7 +632,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         end
       end
 
-      describe "when ignores don't match the name" do
+      describe "when ignores don't match the name", skip: "Ignore rules are out of scope for the prototype" do
         let(:requested_dependencies) { ["dummy-pkg-a"] }
         let(:ignore_conditions) { [{ "dependency-name" => "dummy-pkg-b", "version-requirement" => ">= 0" }] }
 
@@ -642,7 +642,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         end
       end
 
-      describe "when ignores match a wildcard name" do
+      describe "when ignores match a wildcard name", skip: "Ignore rules are out of scope for the prototype" do
         let(:requested_dependencies) { ["dummy-pkg-a"] }
         let(:ignore_conditions) { [{ "dependency-name" => "dummy-pkg-*", "version-requirement" => ">= 0" }] }
 
@@ -652,7 +652,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         end
       end
 
-      describe "when ignores define update-types with feature enabled" do
+      describe "when ignores define update-types with feature enabled", skip: "Ignore rules are out of scope for the prototype" do
         let(:requested_dependencies) { ["dummy-pkg-b"] }
         let(:ignore_conditions) do
           [
@@ -1395,7 +1395,7 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
         allow(checker).to receive(:can_update?) { values.shift.call }
       end
 
-      context "during parsing" do
+      context "during parsing", skip: "Handled for us in Dependabot::Updater#run, Inadvertantly tests ignoring" do
         before { allow(updater).to receive(:dependency_files).and_raise(error) }
 
         context "and it's an unknown error" do
@@ -1956,6 +1956,26 @@ RSpec.describe Dependabot::ExperimentalGroupedUpdater do
       it "raises a not implemented error" do
         expect { updater.run }.
           to raise_error(Dependabot::NotImplemented, "Grouped updates do not currently support rebasing.")
+      end
+    end
+
+    describe "when ignores match the dependency name" do
+      let(:requested_dependencies) { ["dummy-pkg-b"] }
+      let(:ignore_conditions) { [{ "dependency-name" => "dummy-pkg-b", "version-requirement" => ">= 0" }] }
+
+      it "does not pass any ignore rules to the checker as they aren't supported" do
+        updater.run
+        expect(Dependabot::Bundler::UpdateChecker).to have_received(:new).with(
+          dependency: anything,
+          dependency_files: anything,
+          repo_contents_path: anything,
+          credentials: anything,
+          ignored_versions: [],
+          security_advisories: anything,
+          raise_on_ignored: anything,
+          requirements_update_strategy: anything,
+          options: anything
+        ).once
       end
     end
   end

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe Dependabot::Job do
       it "registers the experiments with Dependabot::Experiments" do
         job
         expect(Dependabot::Experiments.enabled?(:kebab_case)).to be_truthy
-        expect(Dependabot::Experiments.enabled?(:simpe)).to be_falsey
+        expect(Dependabot::Experiments.enabled?(:simple)).to be_falsey
       end
     end
 

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Dependabot::Service do
 
     it "delegates to @client" do
       expect(mock_client).
-        to have_received(:create_pull_request).with(job_id, dependencies, dependency_files, base_sha, pr_message)
+        to have_received(:create_pull_request).with(job_id, dependencies, dependency_files, base_sha, pr_message, false)
     end
 
     it "memoizes a shorthand summary of the PR" do


### PR DESCRIPTION
### ⚠️ This is an experimental spike ⚠️ 

The purpose of this is spike is to create an isolated code line to reimplement `Dependabot::Update#run`  without taking on the need to verify our prototype work as strictly as the production implementation.

It is important to fail-fast on our proposed strategy and test our service's assumptions about PRs without investing more time in refactoring the existing code to make way for a new architecture that we can't be sure will actually work out.

**This should not be considered indicative of the final architecture**

### The Approach

This spike explores grouping in a naive, ecosystem-agnostic way by using the `Dependabot::Updater` class to drive collecting up the Dependency changes required by a particular group rule - for now we assume a rule of '*', i.e. group everything - and then executing a single `FileUpdater` and PR creation invocation on the aggregate changes.

For purposes of simplicity, we have disabled concerns around managing the lifecycle of PRs, i.e. superseding and rebasing existing PR, as well as set aside Security-only update strategies since they are already special-cased.

### Goals

1. Flush out general refactors required in the `updater/` code to improve quality, test coverage, etc
2. Determine architectural changes required to `Dependabot::Updater` to better isolate the `UpdateChecker` and `FileUpdater` steps to break the assumption they are always 1:1
3. Provide a walking skeleton we can attach further experiments within `common/lib` to in order to test our hypothesis without waiting on (1) and (2) to ship

### Non-goals

1. Write production quality-code
    - This is a highly experimental spike, if we do eventually merge it for continued testing it will remain behind an experiment flag and remain isolated in such a way it cannot impact existing code.
    - This should also be considered a throw-away prototype, so using this in our own scripts is **highly discouraged** and will not be supported.
2. Address the `dry-run` script
    - https://github.com/dependabot/dependabot-core/pull/5867 spikes out this strategy in the `dry-run` script as part of an earlier experiment
    - We might further the #5867 spike to do some more exploration, but it should be considered a feed-in to this work which will take priority
    - Once we have settled the `Dependabot::Updater` architecture we will figure out how to best maintain the `dry-run` script as the two overlap heavily