### PR TITLE
fix Composer CI due to "discovery" dependency change

### DIFF
--- a/composer/spec/fixtures/projects/provided_dependency/composer.json
+++ b/composer/spec/fixtures/projects/provided_dependency/composer.json
@@ -7,7 +7,7 @@
         "php-http/client-implementation": "^1.0"
     },
     "require-dev": {
-        "php-http/mock-client": "^1.1"
+        "php-http/guzzle6-adapter": "^2.0.0"
     },
     "minimum-stability": "stable"
 }


### PR DESCRIPTION
The failure seems to be due to this change: https://github.com/php-http/discovery/pull/208

Before, discovery was not providing php-http/client-implementation, but now that it is it's taking precedence in our [native helper](https://github.com/dependabot/dependabot-core/blob/e3875084e8787f7ec1c854128ef0b6b9078c877f/composer/helpers/v2/src/UpdateChecker.php#L120), returning a version of * which is invalid to our Version parser, causing the test to fail.

So I've switched to use `guzzle6-adapter` which doesn't seem to pull in `discovery`.