### PR TITLE
Log function too when debugging native helpers

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -97,6 +97,7 @@ module Dependabot
 
       if ENV["DEBUG_HELPERS"] == "true"
         puts env_cmd
+        puts function
         puts stdout
         puts stderr
       end


### PR DESCRIPTION
When debugging a crash, you can normally figure it out from the backtrace, but this makes it easier. And you may not always be debugging a crash, in which case a command like `ruby run.rb` is pretty contextless without the function to be run.