### PR TITLE
fix some smoke tests skipping due to filters

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -23,8 +23,8 @@ jobs:
           - { path: composer, name: composer, ecosystem: composer }
           - { path: docker, name: docker, ecosystem: docker }
           - { path: elm, name: elm, ecosystem: elm }
-          - { path: git_submodules, name: git_submodules, ecosystem: gitsubmodule }
-          - { path: github_actions, name: github_actions, ecosystem: github-actions }
+          - { path: git_submodules, name: submodules, ecosystem: gitsubmodule }
+          - { path: github_actions, name: actions, ecosystem: github-actions }
           - { path: go_modules, name: go, ecosystem: gomod }
           - { path: gradle, name: gradle, ecosystem: gradle }
           - { path: hex, name: hex, ecosystem: mix }
@@ -47,6 +47,12 @@ jobs:
       id: changes
       with:
         filters: |
+          actions:
+            - .github/workflows/smoke.yml
+            - Dockerfile.updater-core
+            - 'common/**'
+            - 'updater/**'
+            - 'github_actions/**'
           bundler:
             - .github/workflows/smoke.yml
             - Dockerfile.updater-core
@@ -77,18 +83,6 @@ jobs:
             - 'common/**'
             - 'updater/**'
             - 'elm/**'
-          git_submodules:
-            - .github/workflows/smoke.yml
-            - Dockerfile.updater-core
-            - 'common/**'
-            - 'updater/**'
-            - 'git_submodules/**'
-          github_actions:
-            - .github/workflows/smoke.yml
-            - Dockerfile.updater-core
-            - 'common/**'
-            - 'updater/**'
-            - 'github_actions/**'
           go:
             - .github/workflows/smoke.yml
             - Dockerfile.updater-core
@@ -161,6 +155,12 @@ jobs:
             - 'common/**'
             - 'updater/**'
             - 'pub/**'
+          submodules:
+            - .github/workflows/smoke.yml
+            - Dockerfile.updater-core
+            - 'common/**'
+            - 'updater/**'
+            - 'git_submodules/**'
           terraform:
             - .github/workflows/smoke.yml
             - Dockerfile.updater-core

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -23,8 +23,8 @@ jobs:
           - { path: composer, name: composer, ecosystem: composer }
           - { path: docker, name: docker, ecosystem: docker }
           - { path: elm, name: elm, ecosystem: elm }
-          - { path: git_submodules, name: submodules, ecosystem: gitsubmodule }
-          - { path: github_actions, name: actions, ecosystem: github-actions }
+          - { path: git_submodules, name: git_submodules, ecosystem: gitsubmodule }
+          - { path: github_actions, name: github_actions, ecosystem: github-actions }
           - { path: go_modules, name: go, ecosystem: gomod }
           - { path: gradle, name: gradle, ecosystem: gradle }
           - { path: hex, name: hex, ecosystem: mix }


### PR DESCRIPTION
I noticed some smoke tests were skipping incorrectly due to their name not matching up with the filter name. This brings it in-line with `ci.yml`. 