### PR TITLE
Tag image before pushing

### DIFF
--- a/.github/workflows/images-fork.yml
+++ b/.github/workflows/images-fork.yml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Push fork image
         run: |
+          docker tag "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}" "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}:$TAG"
           docker push "ghcr.io/dependabot/dependabot-updater-${{ matrix.suite.ecosystem }}:$TAG"
 
       - name: Set summary


### PR DESCRIPTION
I just tried the "fork images" workflow and it's not working with the new setup with split images.

I think it's missing tagging the image before pushing it.
