### PR TITLE
fix: improve yarn@^1 subdependency update success

### DIFF
--- a/npm_and_yarn/helpers/lib/yarn/subdependency-updater.js
+++ b/npm_and_yarn/helpers/lib/yarn/subdependency-updater.js
@@ -5,7 +5,7 @@ const Config = require("@dependabot/yarn-lib/lib/config").default;
 const { EventReporter } = require("@dependabot/yarn-lib/lib/reporters");
 const Lockfile = require("@dependabot/yarn-lib/lib/lockfile").default;
 const fixDuplicates = require("./fix-duplicates");
-const { LightweightAdd, LightweightInstall } = require("./helpers");
+const { LightweightInstall, LOCKFILE_ENTRY_REGEX } = require("./helpers");
 const { parse } = require("./lockfile-parser");
 const stringify =
   require("@dependabot/yarn-lib/lib/lockfile/stringify").default;
@@ -21,43 +21,10 @@ function recoverVersionComments(oldLockfile, newLockfile) {
     .replace(nodeRegex, () => oldMatch(nodeRegex) || "");
 }
 
-// Installs exact version and returns lockfile entry
-async function getLockfileEntryForUpdate(depName, depVersion) {
-  const directory = fs.mkdtempSync(`${os.tmpdir()}${path.sep}`);
-  const readFile = (fileName) =>
-    fs.readFileSync(path.join(directory, fileName)).toString();
-
-  const flags = {
-    ignoreScripts: true,
-    ignoreWorkspaceRootCheck: true,
-    ignoreEngines: true,
-    ignorePlatform: true,
-  };
-  const reporter = new EventReporter();
-  const config = new Config(reporter);
-  await config.init({
-    cwd: directory,
-    nonInteractive: true,
-    enableDefaultRc: true,
-    extraneousYarnrcFiles: [".yarnrc"],
-  });
-
-  // Empty lockfile
-  const lockfile = await Lockfile.fromDirectory(directory, reporter);
-
-  const arg = [`${depName}@${depVersion}`];
-  await new LightweightAdd(arg, flags, config, reporter, lockfile).init();
-
-  const lockfileObject = await parse(directory);
-  const noHeader = true;
-  const enableLockfileVersions = false;
-  return stringify(lockfileObject, noHeader, enableLockfileVersions);
-}
-
 async function updateDependencyFile(
   directory,
   lockfileName,
-  updatedDependency
+  dependencies
 ) {
   const readFile = (fileName) =>
     fs.readFileSync(path.join(directory, fileName)).toString();
@@ -76,23 +43,27 @@ async function updateDependencyFile(
     enableDefaultRc: true,
     extraneousYarnrcFiles: [".yarnrc"],
   });
+  const noHeader = !Boolean(originalYarnLock.match(/^# THIS IS AN AU/m));
   config.enableLockfileVersions = Boolean(originalYarnLock.match(/^# yarn v/m));
-  const depName = updatedDependency && updatedDependency.name;
-  const depVersion = updatedDependency && updatedDependency.version;
 
   // SubDependencyVersionResolver relies on the install finding the latest
   // version of a sub-dependency that's been removed from the lockfile
   // YarnLockFileUpdater passes a specific version to be updated
-  if (depName && depVersion) {
-    const lockfileEntryForUpdate = await getLockfileEntryForUpdate(
-      depName,
-      depVersion
+  const lockfileObject = await parse(directory);
+  for (const [entry, pkg] of Object.entries(lockfileObject)) {
+    const [_, depName] = entry.match(
+      LOCKFILE_ENTRY_REGEX
     );
-    const lockfileContent = `${originalYarnLock}\n${lockfileEntryForUpdate}`;
-
-    const dedupedYarnLock = fixDuplicates(lockfileContent, depName);
-    fs.writeFileSync(path.join(directory, lockfileName), dedupedYarnLock);
+    if (dependencies.some(dependency => dependency.name === depName)) {
+      delete lockfileObject[entry];
+    }
   }
+
+  let newLockFileContent = await stringify(lockfileObject, noHeader, config.enableLockfileVersions);
+  for (const dependency of dependencies) {
+    newLockFileContent = fixDuplicates(newLockFileContent, dependency.name);
+  }
+  fs.writeFileSync(path.join(directory, lockfileName), newLockFileContent);
 
   const lockfile = await Lockfile.fromDirectory(directory, reporter);
   const install = new LightweightInstall(flags, config, reporter, lockfile);

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -203,7 +203,7 @@ module Dependabot
           SharedHelpers.run_helper_subprocess(
             command: NativeHelpers.helper_path,
             function: "yarn:updateSubdependency",
-            args: [Dir.pwd, lockfile_name, sub_dependencies.first.to_h]
+            args: [Dir.pwd, lockfile_name, sub_dependencies.map(&:to_h)]
           )
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -95,7 +95,7 @@ module Dependabot
               SharedHelpers.run_helper_subprocess(
                 command: NativeHelpers.helper_path,
                 function: "yarn:updateSubdependency",
-                args: [Dir.pwd, lockfile_name]
+                args: [Dir.pwd, lockfile_name, [dependency.to_h]]
               )
             end
           end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -1098,7 +1098,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           parsed_package1_npm_lock = JSON.parse(package1_npm_lock.content)
 
           expect(package3_yarn_lock.content).
-            to include("extend@~2.0.0:\n  version \"2.0.1\"")
+            to include("extend@~2.0.0:\n  version \"2.0.2\"")
 
           # TODO: Change this to 2.0.1 once npm supports updating to specific
           # sub dependency versions
@@ -3382,14 +3382,14 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         let(:files) { project_dependency_files("yarn/no_lockfile_change") }
 
         let(:dependency_name) { "acorn" }
-        let(:version) { "5.7.3" }
+        let(:version) { "5.7.4" }
         let(:previous_version) { "5.1.1" }
         let(:requirements) { [] }
         let(:previous_requirements) { [] }
 
         it "updates the version" do
           expect(updated_yarn_lock.content).
-            to include(%(acorn@^5.0.0, acorn@^5.1.2:\n  version "5.7.3"))
+            to include(%(acorn@^5.0.0, acorn@^5.1.2:\n  version "5.7.4"))
         end
       end
 
@@ -3681,7 +3681,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         let(:files) { project_dependency_files("yarn/multiple_sub_dependencies") }
 
         let(:dependency_name) { "js-yaml" }
-        let(:version) { "3.12.0" }
+        let(:version) { "3.14.1" }
         let(:previous_version) { "3.9.0" }
         let(:requirements) { [] }
         let(:previous_requirements) { nil }
@@ -3690,7 +3690,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
           expect(updated_files.map(&:name)).to match_array(["yarn.lock"])
           expect(updated_yarn_lock.content).
             to include("js-yaml@^3.10.0, js-yaml@^3.4.6, js-yaml@^3.9.0:\n" \
-                       '  version "3.12.0"')
+                       '  version "3.14.1"')
         end
       end
 


### PR DESCRIPTION
Previously the logic attempted fresh installs of package@version and copied the generated lockfile contents across to force a dependency realignment.  This was sometimes flawed as "version" could somehow (didn't figure this out) sometimes be a pinned version, resulting in a noop lockfile change for a dependency bump that was definitely possible.

The new logic is much more straightfoward IMO, we take the existing lockfile.  Remove all entries that map to the given package that also resolve to the suspect version and then just run "yarn" again and take the resultant lockfile.

This logic is mirroring my implementation in `uuaw` --> https://github.com/MarshallOfSound/uuaw which aimed to automatically fix `yarn audit` security alerts which dependabot failed to solve automatically.  I figured it would be better for everyone if I could somehow take the logic that worked in `uuaw` and mirror it into dependabot-core so here we are.

There is currently one unsolved low audit output on `electron/website` that I was using to test this change.  Specifically dependabot currently reports it is unable to fix it, with this change it successfully bumps the version.  Command:

```bash
bin/dry-run.rb --dep=@sideway/formula npm_and_yarn electron/website
```

Notably as well this new logic almost exactly aligns with the `npm6` logic in `updateDependencyFile` so consistency is good too 👍 

Tests all pass locally for `npm_and_yarn`