### PR TITLE
Properly support the Updater project in the dev shell

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -10,6 +10,10 @@ RUN apt-get update \
     ltrace \
     gdb \
     shellcheck \
+    # Required for updater/ development
+    libgit2-dev \
+    cmake \
+    pkg-config \
   && rm -rf /var/lib/apt/lists/*
 USER dependabot
 
@@ -21,10 +25,12 @@ RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/main/vimrc-vanilla
 ARG HOME=/home/dependabot
 ARG CODE_DIR=${HOME}/dependabot-core
 
+# Prepare the common & omnibus gems
 COPY --chown=dependabot:dependabot common/Gemfile common/dependabot-common.gemspec ${CODE_DIR}/common/
 COPY --chown=dependabot:dependabot common/lib/dependabot.rb ${CODE_DIR}/common/lib/
 COPY --chown=dependabot:dependabot omnibus/Gemfile omnibus/dependabot-omnibus.gemspec ${CODE_DIR}/omnibus/
 
+# Prepare the ecosystem gems
 COPY --chown=dependabot:dependabot bundler/Gemfile bundler/dependabot-bundler.gemspec ${CODE_DIR}/bundler/
 COPY --chown=dependabot:dependabot cargo/Gemfile cargo/dependabot-cargo.gemspec ${CODE_DIR}/cargo/
 COPY --chown=dependabot:dependabot composer/Gemfile composer/dependabot-composer.gemspec ${CODE_DIR}/composer/
@@ -41,6 +47,9 @@ COPY --chown=dependabot:dependabot nuget/Gemfile nuget/dependabot-nuget.gemspec 
 COPY --chown=dependabot:dependabot python/Gemfile python/dependabot-python.gemspec ${CODE_DIR}/python/
 COPY --chown=dependabot:dependabot pub/Gemfile pub/dependabot-pub.gemspec ${CODE_DIR}/pub/
 COPY --chown=dependabot:dependabot terraform/Gemfile terraform/dependabot-terraform.gemspec ${CODE_DIR}/terraform/
+
+# Prepare the updater project
+COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock ${CODE_DIR}/updater/
 
 WORKDIR ${CODE_DIR}
 

--- a/bin/docker-dev-shell
+++ b/bin/docker-dev-shell
@@ -234,6 +234,7 @@ docker run --rm -ti \
   -v "$(pwd)/updater/spec:$CODE_DIR/updater/spec" \
   --name "$CONTAINER_NAME" \
   --env "LOCAL_GITHUB_ACCESS_TOKEN=$LOCAL_GITHUB_ACCESS_TOKEN" \
+  --env "DEPENDABOT_TEST_ACCESS_TOKEN" \
   "${DOCKER_OPTS[@]}" \
   --cap-add=SYS_PTRACE \
   "$IMAGE_NAME" "${CONTAINER_ARGS[@]}"

--- a/updater/README.md
+++ b/updater/README.md
@@ -11,30 +11,37 @@ GitHub network, and so is not generally accessible.
 
 ## Setup
 
-You will need to provide the build a Personal Access Token to access the GitHub Package Registry to retrieve
-dependency containers.
+To work on the Updater, you will need to start a Docker dev shell. The bundler
+shell will suffice
 
-[Create a token](https://github.com/settings/tokens/new) with the `packages:read` scope and set it in your environment
-as `GPR_TOKEN`
-
-Run the setup script:
-
-```
-script/setup
+```zsh
+➜ bin/docker-dev-shell bundler
+[dependabot-core-dev] ~/dependabot-core $ cd updater/
+[dependabot-core-dev] ~/dependabot-core/updater $ bundle
 ```
 
 ## Tests
 
-We run [rspec](https://rspec.info/) tests inside a Docker container for this project:
+We run [rspec](https://rspec.info/) tests in the docker dev shell:
 
-```
-script/test
+```zsh
+[dependabot-core-dev] ~/dependabot-core/updater $ bundle exec rspec
 ```
 
 You can run an individual test file like so:
 
+```zsh
+[dependabot-core-dev] ~/dependabot-core/updater $ bundle exec rspec spec/dependabot/integration_spec.rb
 ```
-script/test spec/dependabot/integration_spec.rb
+
+A small number of tests hit the GitHub API, so you will need to set the envvar
+`DEPENDABOT_TEST_ACCESS_TOKEN` with a Personal Access Token with the full `repo`
+scope.
+
+```zsh
+export DEPENDABOT_TEST_ACCESS_TOKEN=ghp_xxx
+# The DEPENDABOT_TEST_ACCESS_TOKEN will be forwarded to the dev shell container
+➜ bin/docker-dev-shell bundler
 ```
 
 ### VCR
@@ -50,18 +57,14 @@ If you are adding a new test that makes network calls, please ensure you record 
 
 If you've added a new test which has the `vcr: true` metadata, you can record a fixture for just those changes like so:
 
+```zsh
+[dependabot-core-dev] ~/dependabot-core/updater $ VCR=new_episodes bundle exec rspec
 ```
-VCR=new_episodes DEPENDABOT_TEST_ACCESS_TOKEN=<redacted> script/test
-```
-
-`DEPENDABOT_TEST_ACCESS_TOKEN` will need to be a Personal Access Token with the full `repo` scope.
 
 #### Updating existing fixtures
 
 If you need to upadate existing fixtures, you can use the `all` flag like so:
 
+```zsh
+[dependabot-core-dev] ~/dependabot-core/updater $ VCR=new_episodes bundle exec rspec
 ```
-VCR=all DEPENDABOT_TEST_ACCESS_TOKEN=<redacted> bundle exec rspec spec
-```
-
-As above, you will need a PAT with the full `repo` scope

--- a/updater/README.md
+++ b/updater/README.md
@@ -39,7 +39,9 @@ A small number of tests hit the GitHub API, so you will need to set the envvar
 scope.
 
 ```zsh
-export DEPENDABOT_TEST_ACCESS_TOKEN=ghp_xxx
+# keep secrets from being stored in shell history by prefixing with a space
+export HISTCONTROL=ignorespace
+export  DEPENDABOT_TEST_ACCESS_TOKEN=ghp_xxx
 # The DEPENDABOT_TEST_ACCESS_TOKEN will be forwarded to the dev shell container
 ➜ bin/docker-dev-shell bundler
 ```


### PR DESCRIPTION
Supersedes https://github.com/dependabot/dependabot-core/pull/6626

This updates the `Dockerfile.development` with the additional requirements needed to bundle and test the `updater/` project inside the `bin/docker-dev-shell` and aligns the README with this workflow.