### PR TITLE
fix segments not working for Docker ecosystem

### DIFF
--- a/docker/lib/dependabot/docker/version.rb
+++ b/docker/lib/dependabot/docker/version.rb
@@ -27,6 +27,10 @@ module Dependabot
         @release_part.to_semver
       end
 
+      def segments
+        @release_part.segments
+      end
+
       attr_reader :release_part
 
       def <=>(other)

--- a/docker/spec/dependabot/docker/version_spec.rb
+++ b/docker/spec/dependabot/docker/version_spec.rb
@@ -37,4 +37,14 @@ RSpec.describe Dependabot::Docker::Version do
       expect(described_class.new("11.0.16.1").to_semver).to eq("11.0.16.1")
     end
   end
+
+  describe "#segments" do
+    it "returns segments for standard versions" do
+      expect(described_class.new("2.4.2").segments).to eq([2, 4, 2])
+    end
+
+    it "ignores java versions" do
+      expect(described_class.new("11.0.16_8").segments).to eq([11, 0, 16])
+    end
+  end
 end


### PR DESCRIPTION
We need to be able to see if an update was a major bump for a feature we're working on. So I wanted to use `segments` to do that. Something like `if before.segments.first == after.segments.first` would tell us it was not a major bump.

The Docker Version class segment method had a NilClass error due to the special handling of Java versions. I've hooked it up simply to return the `@release_part`'s segments since that's the part we care about at the moment.