### PR TITLE
Go: update psuedo-versions to released versions

### DIFF
--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -25,7 +25,6 @@ module Dependabot
           /module .*: git ls-remote .*: exit status 128/m
         ].freeze
         INVALID_VERSION_REGEX = /version "[^"]+" invalid/m
-        PSEUDO_VERSION_REGEX = /\b\d{14}-[0-9a-f]{12}$/
 
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, security_advisories:, raise_on_ignored: false,
@@ -52,8 +51,6 @@ module Dependabot
         attr_reader :dependency, :dependency_files, :credentials, :ignored_versions, :security_advisories
 
         def fetch_latest_version
-          return dependency.version if PSEUDO_VERSION_REGEX.match?(dependency.version)
-
           candidate_versions = available_versions
           candidate_versions = filter_prerelease_versions(candidate_versions)
           candidate_versions = filter_ignored_versions(candidate_versions)
@@ -62,8 +59,6 @@ module Dependabot
         end
 
         def fetch_lowest_security_fix_version
-          return dependency.version if PSEUDO_VERSION_REGEX.match?(dependency.version)
-
           relevant_versions = available_versions
           relevant_versions = filter_prerelease_versions(relevant_versions)
           relevant_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(relevant_versions,

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -25,6 +25,7 @@ module Dependabot
           /module .*: git ls-remote .*: exit status 128/m
         ].freeze
         INVALID_VERSION_REGEX = /version "[^"]+" invalid/m
+        PSEUDO_VERSION_REGEX = /\b\d{14}-[0-9a-f]{12}$/
 
         def initialize(dependency:, dependency_files:, credentials:,
                        ignored_versions:, security_advisories:, raise_on_ignored: false,
@@ -54,6 +55,8 @@ module Dependabot
           candidate_versions = available_versions
           candidate_versions = filter_prerelease_versions(candidate_versions)
           candidate_versions = filter_ignored_versions(candidate_versions)
+          # Adding the psuedo-version to the list to avoid downgrades
+          candidate_versions << dependency.version if PSEUDO_VERSION_REGEX.match?(dependency.version)
 
           candidate_versions.max
         end

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -142,14 +142,11 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
       end
     end
 
-    context "for a Git pseudo-version with newer revisions available" do
+    context "for a Git pseudo-version that is later than all releases" do
       let(:dependency_version) { "1.2.0-pre2.0.20181018214848-1f3e41dce654" }
 
-      pending "updates to newer commits to master" do
-        # This is rolling back to an earlier commit since `go list` is only showing
-        # tagged versions. This is not what we want, Dependabot will be rolling back many repos
-        # to earlier commits.
-        expect(finder.latest_version).to eq("1.2.0-pre2")
+      it "doesn't downgrade the dependency" do
+        expect(finder.latest_version).to eq(dependency_version)
       end
     end
 

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
       end
     end
 
-    context "for a Git pseudo-version with releases available" do
+    context "for a Git pseudo-version with pre-releases available" do
       let(:dependency_version) { "1.0.0-20181018214848-ab544413d0d3" }
 
       it "returns the latest pre-release" do
@@ -149,6 +149,15 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
         # Here there was the choice to go to v1.1.0 or v1.2.0 pre-release, and it chose
         # the largest since being on a pre-release means all pre-releases are considered.
         expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("1.2.0-pre2"))
+      end
+    end
+
+    context "for a Git psuedo-version with releases available" do
+      let(:dependency_version) { "0.0.0-20201021035429-f5854403a974" }
+      let(:dependency_name) { "golang.org/x/net" }
+
+      it "picks the latest version" do
+        expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("0.7.0"))
       end
     end
 
@@ -381,6 +390,40 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
 
       it "doesn't return to the vulnerable version" do
         expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("1.0.6"))
+      end
+    end
+
+    context "with a Git pseudo-version and releases available" do
+      let(:dependency_version) { "0.0.0-20201021035429-f5854403a974" }
+      let(:dependency_name) { "golang.org/x/net" }
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: "golang.org/x/net",
+            package_manager: "go_modules",
+            vulnerable_versions: ["< 0.6.0"]
+          )
+        ]
+      end
+
+      it "picks the minimum version that isn't vulnerable" do
+        expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("0.6.0"))
+      end
+
+      context "with a pseudo-version as the patched version" do
+        let(:security_advisories) do
+          [
+            Dependabot::SecurityAdvisory.new(
+              dependency_name: "golang.org/x/net",
+              package_manager: "go_modules",
+              safe_versions: ["0.0.0-20220906165146-f3363e06e74c"]
+            )
+          ]
+        end
+
+        it "picks the minimum version that is safe" do
+          expect(finder.lowest_security_fix_version).to eq(Dependabot::GoModules::Version.new("0.1.0"))
+        end
       end
     end
 

--- a/go_modules/spec/dependabot/go_modules/version_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/version_spec.rb
@@ -112,4 +112,19 @@ RSpec.describe Dependabot::GoModules::Version do
       end
     end
   end
+
+  describe "<=>" do
+    # These identifiers come from the Go docs: https://go.dev/ref/mod#pseudo-versions
+    it "sorts major versions correctly" do
+      expect(described_class.new("v1.0.0-20231231120000-abcdefabcdef")).to be < described_class.new("v1.0.0")
+    end
+
+    it "sorts pre-release versions correctly" do
+      expect(described_class.new("v1.0.0-pre2.0.20231231120000-abcdefabcdef")).to be < described_class.new("v1.0.0-pre2")
+    end
+
+    it "sorts minor versions correctly" do
+      expect(described_class.new("v1.0.1-20231231120000-abcdefabcdef")).to be < described_class.new("v1.0.1")
+    end
+  end
 end

--- a/go_modules/spec/dependabot/go_modules/version_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/version_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Dependabot::GoModules::Version do
   describe "<=>" do
     # These identifiers come from the Go docs: https://go.dev/ref/mod#pseudo-versions
     it "sorts major versions correctly" do
-      expect(described_class.new("v1.0.0-20231231120000-abcdefabcdef")).to be < described_class.new("v1.0.0")
+      expect(described_class.new("v1.0.0-0.20231231120000-abcdefabcdef")).to be < described_class.new("v1.0.0")
     end
 
     it "sorts pre-release versions correctly" do
@@ -125,7 +125,7 @@ RSpec.describe Dependabot::GoModules::Version do
     end
 
     it "sorts minor versions correctly" do
-      expect(described_class.new("v1.0.1-20231231120000-abcdefabcdef")).to be < described_class.new("v1.0.1")
+      expect(described_class.new("v1.0.1-0.20231231120000-abcdefabcdef")).to be < described_class.new("v1.0.1")
     end
   end
 end

--- a/go_modules/spec/dependabot/go_modules/version_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/version_spec.rb
@@ -120,7 +120,8 @@ RSpec.describe Dependabot::GoModules::Version do
     end
 
     it "sorts pre-release versions correctly" do
-      expect(described_class.new("v1.0.0-pre2.0.20231231120000-abcdefabcdef")).to be < described_class.new("v1.0.0-pre2")
+      expect(described_class.new("v1.0.0-pre2.0.20231231120000-abcdefabcdef")).to be >
+                                                                                  described_class.new("v1.0.0-pre2")
     end
 
     it "sorts minor versions correctly" do


### PR DESCRIPTION
Currently Dependabot doesn't touch Go pseudo-versions, they're handled as if they were pinned on a revision like other ecosystems.

However, the Go tooling generates pre-release identifiers that are semver compliant. That means Dependabot does have enough information to bump a pseudo-version like `v1.0.1-<date>-<hash>` to a tagged `v1.0.1`. 

This PR allows the update to continue, and adds the pseudo-version to the list of candidates to avoid downgrades, in the event the user is pinned to a newer version than is currently released.

This will *not* update the dependency to a non-released pseudo-version, only pseudo to released.

Note: I will need to update the Go smoke test.