### PR TITLE
Use latest Python 3.10 and 3.11 as of 2023-02-23

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,9 +1,9 @@
-ARG PY_3_11=3.11.1
-ARG PY_3_10=3.10.9
+ARG PY_3_11=3.11.2
+ARG PY_3_10=3.10.10
 ARG PY_3_9=3.9.16
 ARG PY_3_8=3.8.16
 ARG PY_3_7=3.7.16
-ARG PYENV_VERSION=v2.3.9
+ARG PYENV_VERSION=v2.3.13
 
 FROM ghcr.io/dependabot/dependabot-updater-core as python-core
 ARG PY_3_11

--- a/python/helpers/build
+++ b/python/helpers/build
@@ -18,8 +18,8 @@ cp -r \
   "$install_dir"
 
 cd "$install_dir"
-PYENV_VERSION=3.11.1 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"
-PYENV_VERSION=3.10.9 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"
+PYENV_VERSION=3.11.2 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"
+PYENV_VERSION=3.10.10 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"
 PYENV_VERSION=3.9.16 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"
 PYENV_VERSION=3.8.16 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"
 PYENV_VERSION=3.7.16 pyenv exec pip --disable-pip-version-check install --use-pep517 -r "requirements.txt"

--- a/python/lib/dependabot/python/python_versions.rb
+++ b/python/lib/dependabot/python/python_versions.rb
@@ -4,7 +4,7 @@ module Dependabot
   module Python
     module PythonVersions
       PRE_INSTALLED_PYTHON_VERSIONS = %w(
-        3.11.1
+        3.11.2
       ).freeze
 
       # Due to an OpenSSL issue we can only install the following versions in
@@ -13,8 +13,8 @@ module Dependabot
       #
       # WARNING: 3.9.3 is purposefully omitted as it was recalled: https://www.python.org/downloads/release/python-393/
       SUPPORTED_VERSIONS = %w(
-        3.11.1 3.11.0
-        3.10.9 3.10.8 3.10.7 3.10.6 3.10.5 3.10.4 3.10.3 3.10.2 3.10.1 3.10.0
+        3.11.2 3.11.1 3.11.0
+        3.10.10 3.10.9 3.10.8 3.10.7 3.10.6 3.10.5 3.10.4 3.10.3 3.10.2 3.10.1 3.10.0
         3.9.16 3.9.15 3.9.14 3.9.13 3.9.12 3.9.11 3.9.10 3.9.9 3.9.8 3.9.7 3.9.6 3.9.5 3.9.4 3.9.2 3.9.1 3.9.0
         3.8.16 3.8.15 3.8.14 3.8.13 3.8.12 3.8.11 3.8.10 3.8.9 3.8.8 3.8.7 3.8.6 3.8.5 3.8.4 3.8.3 3.8.2 3.8.1 3.8.0
         3.7.16 3.7.15 3.7.14 3.7.13 3.7.12 3.7.11 3.7.10 3.7.9 3.7.8 3.7.7 3.7.6 3.7.5 3.7.4 3.7.3 3.7.2 3.7.1 3.7.0

--- a/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pipenv_version_resolver_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipenvVersionResolver do
                 to start_with("Dependabot detected the following Python")
               expect(error.message).to include("3.4.*")
               expect(error.message).
-                to include("supported in Dependabot: 3.11.1, 3.11.0, 3.10.9, 3.10.8")
+                to include("supported in Dependabot: 3.11.2, 3.11.1, 3.11.0, 3.10.10, 3.10.9, 3.10.8")
             end
         end
       end


### PR DESCRIPTION
Updates default versions to 3.10.10 and 3.11.2. Things moved around a bit since I opened #6375 and #6404 but I think these changes cover it.