### PR TITLE
fix Go "no longer vulnerable" due to bad SHA detection

### DIFF
--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -84,7 +84,6 @@ module Dependabot
       def default_source
         { type: "default", source: dependency.name }
       end
-
     end
   end
 end

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -68,11 +68,9 @@ module Dependabot
         raise NotImplementedError
       end
 
-      # Override the base class's check for whether this is a git dependency,
-      # since not all dep git dependencies have a SHA version (sometimes their
-      # version is the tag)
+      # Go only supports semver and semver-compliant pseudo-versions, so it can't be a SHA.
       def existing_version_is_sha?
-        git_dependency?
+        false
       end
 
       def version_from_tag(tag)
@@ -83,23 +81,10 @@ module Dependabot
         tag&.fetch(:tag)
       end
 
-      def git_dependency?
-        git_commit_checker.git_dependency?
-      end
-
       def default_source
         { type: "default", source: dependency.name }
       end
 
-      def git_commit_checker
-        @git_commit_checker ||=
-          GitCommitChecker.new(
-            dependency: dependency,
-            credentials: credentials,
-            ignored_versions: ignored_versions,
-            raise_on_ignored: raise_on_ignored
-          )
-      end
     end
   end
 end

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -175,11 +175,11 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
       let(:dependency_version) { "0.0.0-20180826012351-8a410e7b638d" }
       let(:requirements) do
         [{
-           file: "go.mod",
-           requirement: dependency_version,
-           groups: [],
-           source: { type: "git", source: dependency_name }
-         }]
+          file: "go.mod",
+          requirement: dependency_version,
+          groups: [],
+          source: { type: "git", source: dependency_name }
+        }]
       end
 
       it "returns true" do

--- a/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker_spec.rb
@@ -140,4 +140,51 @@ RSpec.describe Dependabot::GoModules::UpdateChecker do
       end
     end
   end
+
+  describe "#vulnerable?" do
+    subject(:vulnerable?) { checker.vulnerable? }
+
+    let(:dependency_version) { "1.0.0" }
+    let(:security_advisories) do
+      [
+        Dependabot::SecurityAdvisory.new(
+          dependency_name: dependency_name,
+          package_manager: "go_modules",
+          vulnerable_versions: ["< 1.0.1"]
+        )
+      ]
+    end
+
+    context "when the current version is vulnerable" do
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current version is not vulnerable" do
+      let(:dependency_version) { "1.0.1" }
+
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when it's a vulnerable pseudo-version" do
+      # Go generates pseudo-versions which are comparable, so we can tell if
+      # it is vulnerable, unlike other ecosystems that allow bare SHAs.
+      let(:dependency_version) { "0.0.0-20180826012351-8a410e7b638d" }
+      let(:requirements) do
+        [{
+           file: "go.mod",
+           requirement: dependency_version,
+           groups: [],
+           source: { type: "git", source: dependency_name }
+         }]
+      end
+
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I noticed one of my personal Go repos was still not getting the security update for golang.org/x/net after #6713. 

The issue is that the GitCommit checker is identifying some Go pseudo-versions as Git SHAs (like `v0.0.0-20180826012351-8a410e7b638d`) but others are not Git SHAs (like `v0.0.0-20201021035429-f5854403a974`). There must be a bug in this code identifying dependency sources as git: 

https://github.com/dependabot/dependabot-core/blob/cddd02aa8b8dc44ab0580b139c8ceafb45e97aa2/go_modules/lib/dependabot/go_modules/file_parser.rb#L38-L42

That causes `checker.vulnerable?` to return false here: 

https://github.com/dependabot/dependabot-core/blob/7196bb00a2e52d0d2ed167d1964ddab7e88dc1fe/common/lib/dependabot/update_checkers/base.rb#L137-L138

Which then leads to the "no longer vulnerable" message here:

https://github.com/dependabot/dependabot-core/blob/85342df046ed66fa6258d4002e7ec6b209e27918/updater/lib/dependabot/updater.rb#L220-L228

In Go, a Git dependency can't appear in `go.mod`, it's always a pseudo-version which is comparable, so the comment above 

> Can't (currently) detect whether git dependencies are vulnerable

doesn't apply to Go.

By returning false in `existing_version_is_sha?` we ensure the updater code will not assume the dependency is no longer vulnerable due to being on a Go pseudo-version.

I think there's also the case to remove all of the "git source" code in file_parser.rb since, again, Git dependencies in Go are always comparable. But I'll leave that for another day!