### PR TITLE
Inline updater specs

### DIFF
--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -21,8 +21,6 @@ RSpec.describe Dependabot::Updater do
     )
   end
 
-  let(:logger) { double(Logger) }
-
   def service
     @service ||=
       instance_double(
@@ -38,10 +36,9 @@ RSpec.describe Dependabot::Updater do
   end
 
   before do
+    allow(Dependabot.logger).to receive(:info)
+    allow(Dependabot.logger).to receive(:error)
     allow_any_instance_of(Dependabot::ApiClient).to receive(:record_package_manager_version)
-    allow(Dependabot).to receive(:logger).and_return(logger)
-    allow(logger).to receive(:info)
-    allow(logger).to receive(:error)
 
     allow(Dependabot::Environment).to receive(:token).and_return("some_token")
     allow(Dependabot::Environment).to receive(:job_id).and_return(1)
@@ -259,10 +256,10 @@ RSpec.describe Dependabot::Updater do
     end
 
     it "logs the current and latest versions" do
-      expect(logger).
+      expect(Dependabot.logger).
         to receive(:info).
         with("<job_1> Checking if dummy-pkg-b 1.1.0 needs updating")
-      expect(logger).
+      expect(Dependabot.logger).
         to receive(:info).
         with("<job_1> Latest version is 1.2.0")
       updater.run
@@ -276,10 +273,10 @@ RSpec.describe Dependabot::Updater do
       end
 
       it "logs the update requirements and strategy" do
-        expect(logger).
+        expect(Dependabot.logger).
           to receive(:info).
           with("<job_1> Requirements to unlock own")
-        expect(logger).
+        expect(Dependabot.logger).
           to receive(:info).
           with("<job_1> Requirements update strategy bump_versions")
         updater.run
@@ -290,7 +287,7 @@ RSpec.describe Dependabot::Updater do
       let(:allowed_updates) { [{ "dependency-name" => "typoed-dep-name" }] }
 
       it "logs the current and latest versions" do
-        expect(logger).
+        expect(Dependabot.logger).
           to receive(:info).
           with("<job_1> Found no dependencies to update after filtering " \
                "allowed updates")
@@ -347,7 +344,7 @@ RSpec.describe Dependabot::Updater do
               }
             }
           )
-          expect(logger).
+          expect(Dependabot.logger).
             to receive(:info).with(
               "<job_1> Dependabot can't update vulnerable dependencies for " \
               "projects without a lockfile or pinned version requirement as " \
@@ -423,7 +420,7 @@ RSpec.describe Dependabot::Updater do
               }
             }
           )
-          expect(logger).
+          expect(Dependabot.logger).
             to receive(:info).with(
               "<job_1> The latest possible version that can be installed is " \
               "1.2.0 because of the following conflicting dependency:\n" \
@@ -454,7 +451,7 @@ RSpec.describe Dependabot::Updater do
               }
             }
           )
-          expect(logger).
+          expect(Dependabot.logger).
             to receive(:info).with(
               "<job_1> The latest possible version of dummy-pkg-b that can be " \
               "installed is 1.1.0"
@@ -477,7 +474,7 @@ RSpec.describe Dependabot::Updater do
                 "dependency-version": "1.1.0"
               }
             )
-          expect(logger).
+          expect(Dependabot.logger).
             to receive(:info).
             with(
               "<job_1> Dependabot can't find a published or compatible " \
@@ -532,12 +529,12 @@ RSpec.describe Dependabot::Updater do
         end
 
         it "logs the errors" do
-          expect(logger).
+          expect(Dependabot.logger).
             to receive(:info).
             with(
               "<job_1> All updates for dummy-pkg-a were ignored"
             )
-          expect(logger).
+          expect(Dependabot.logger).
             to receive(:info).
             with(
               "<job_1> All updates for dummy-pkg-b were ignored"
@@ -879,7 +876,7 @@ RSpec.describe Dependabot::Updater do
           expect(updater).to_not receive(:generate_dependency_files_for)
           expect(service).to_not receive(:create_pull_request)
           expect(service).to_not receive(:record_update_job_error)
-          expect(logger).
+          expect(Dependabot.logger).
             to receive(:info).
             with("<job_1> Pull request already exists for dummy-pkg-b " \
                  "with latest version 1.2.0")
@@ -900,7 +897,7 @@ RSpec.describe Dependabot::Updater do
           expect(updater).to_not receive(:generate_dependency_files_for)
           expect(service).to_not receive(:create_pull_request)
           expect(service).to_not receive(:record_update_job_error)
-          expect(logger).
+          expect(Dependabot.logger).
             to receive(:info).
             with("<job_1> Pull request already exists for dummy-pkg-b@1.2.0")
           updater.run
@@ -937,7 +934,7 @@ RSpec.describe Dependabot::Updater do
                 ]
               }
             )
-          expect(logger).
+          expect(Dependabot.logger).
             to receive(:info).
             with("<job_1> Pull request already exists for dummy-pkg-b@1.2.0")
           updater.run
@@ -971,7 +968,7 @@ RSpec.describe Dependabot::Updater do
                 "dependency-version": "1.2.0"
               }
             )
-          expect(logger).
+          expect(Dependabot.logger).
             to receive(:info).
             with("<job_1> Pull request already exists for dummy-pkg-b " \
                  "with latest version 1.2.0")
@@ -1069,7 +1066,7 @@ RSpec.describe Dependabot::Updater do
               ]
             }
           )
-        expect(logger).
+        expect(Dependabot.logger).
           to receive(:info).
           with("<job_1> Pull request already exists for dummy-pkg-c@1.4.0, dummy-pkg-b@removed")
         updater.run
@@ -1134,7 +1131,7 @@ RSpec.describe Dependabot::Updater do
 
             it "closes the pull request" do
               expect(service).to receive(:close_pull_request).once
-              expect(logger).
+              expect(Dependabot.logger).
                 to receive(:info).with(
                   "<job_1> Dependency no longer allowed to update dummy-pkg-b 1.1.0"
                 )
@@ -1339,7 +1336,7 @@ RSpec.describe Dependabot::Updater do
                   }
                 }
               )
-              expect(logger).
+              expect(Dependabot.logger).
                 to receive(:info).with(
                   "<job_1> Dependabot cannot update to the required version as all " \
                   "versions were ignored for dummy-pkg-b"
@@ -1370,7 +1367,7 @@ RSpec.describe Dependabot::Updater do
                   }
                 }
               )
-              expect(logger).
+              expect(Dependabot.logger).
                 to receive(:info).with(
                   "<job_1> no security update needed as dummy-pkg-b " \
                   "is no longer vulnerable"
@@ -1811,7 +1808,7 @@ RSpec.describe Dependabot::Updater do
     end
 
     it "does not log empty ignore conditions" do
-      expect(logger).
+      expect(Dependabot.logger).
         not_to receive(:info).
         with(/Ignored versions:/)
       updater.run
@@ -1836,24 +1833,24 @@ RSpec.describe Dependabot::Updater do
 
       it "logs ignored versions" do
         updater.run
-        expect(logger).
+        expect(Dependabot.logger).
           to have_received(:info).
           with(/Ignored versions:/)
       end
 
       it "logs ignore conditions" do
         updater.run
-        expect(logger).
+        expect(Dependabot.logger).
           to have_received(:info).
           with("<job_1>   >= 1.a, < 2.0.0 - from @dependabot ignore command")
       end
 
       it "logs ignored update types" do
         updater.run
-        expect(logger).
+        expect(Dependabot.logger).
           to have_received(:info).
           with("<job_1>   version-update:semver-patch - from .github/dependabot.yaml")
-        expect(logger).
+        expect(Dependabot.logger).
           to have_received(:info).
           with("<job_1>   version-update:semver-minor - from .github/dependabot.yaml")
       end
@@ -1874,14 +1871,14 @@ RSpec.describe Dependabot::Updater do
 
       it "logs ignored versions" do
         updater.run
-        expect(logger).
+        expect(Dependabot.logger).
           to have_received(:info).
           with(/Ignored versions:/)
       end
 
       it "logs ignored update types" do
         updater.run
-        expect(logger).
+        expect(Dependabot.logger).
           to have_received(:info).
           with(
             "<job_1>   version-update:semver-patch - from .github/dependabot.yaml (doesn't apply to security update)"

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1952,8 +1952,6 @@ RSpec.describe Dependabot::Updater do
           service = build_service(job: job)
           updater = build_updater(service: service, job: job)
 
-          # allow(updater).to receive(:dependency_files).and_raise(error)
-
           expect(service).
             to receive(:record_update_job_error).
             with(
@@ -1983,8 +1981,6 @@ RSpec.describe Dependabot::Updater do
           job = build_job
           service = build_service(job: job)
           updater = build_updater(service: service, job: job)
-
-          # allow(updater).to receive(:dependency_files).and_raise(error)
 
           expect(service).
             to receive(:record_update_job_error).

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1934,7 +1934,6 @@ RSpec.describe Dependabot::Updater do
         end
       end
 
-      # FIXME: This test is expecting an error to be raised, but that's not happening
       context "but it's a Dependabot::DependencyFileNotResolvable" do
         let(:error) { Dependabot::DependencyFileNotResolvable.new("message") }
 
@@ -1967,7 +1966,6 @@ RSpec.describe Dependabot::Updater do
         end
       end
 
-      # FIXME: This test is expecting an error to be raised, but that's not happening
       context "but it's a Dependabot::DependencyFileNotEvaluatable" do
         let(:error) { Dependabot::DependencyFileNotEvaluatable.new("message") }
 
@@ -2000,7 +1998,6 @@ RSpec.describe Dependabot::Updater do
         end
       end
 
-      # FIXME: This test is expecting an error to be raised, but that's not happening
       context "but it's a Dependabot::InconsistentRegistryResponse" do
         let(:error) { Dependabot::InconsistentRegistryResponse.new("message") }
 
@@ -2025,7 +2022,6 @@ RSpec.describe Dependabot::Updater do
         end
       end
 
-      # FIXME: This test is expecting an error to be raised, but that's not happening
       context "but it's a Dependabot::GitDependenciesNotReachable" do
         let(:error) do
           Dependabot::GitDependenciesNotReachable.new("https://example.com")
@@ -2058,7 +2054,6 @@ RSpec.describe Dependabot::Updater do
         end
       end
 
-      # FIXME: This test is expecting an error to be raised, but that's not happening
       context "but it's a Dependabot::GitDependencyReferenceNotFound" do
         let(:error) do
           Dependabot::GitDependencyReferenceNotFound.new("some_dep")
@@ -2091,7 +2086,6 @@ RSpec.describe Dependabot::Updater do
         end
       end
 
-      # FIXME: This test is expecting an error to be raised, but that's not happening
       context "but it's a Dependabot::GoModulePathMismatch" do
         let(:error) do
           Dependabot::GoModulePathMismatch.new("/go.mod", "foo", "bar")
@@ -2128,7 +2122,6 @@ RSpec.describe Dependabot::Updater do
         end
       end
 
-      # FIXME: This test is expecting an error to be raised, but that's not happening
       context "but it's a Dependabot::PrivateSourceAuthenticationFailure" do
         let(:error) do
           Dependabot::PrivateSourceAuthenticationFailure.new("some.example.com")
@@ -2161,7 +2154,6 @@ RSpec.describe Dependabot::Updater do
         end
       end
 
-      # FIXME: This test is expecting an error to be raised, but that's not happening
       context "but it's a Dependabot::SharedHelpers::HelperSubprocessFailed" do
         let(:error) do
           Dependabot::SharedHelpers::HelperSubprocessFailed.new(

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dependabot::Updater do
       job: job,
       dependency_files: dependency_files,
       base_commit_sha: "sha",
-      repo_contents_path: repo_contents_path
+      repo_contents_path: nil
     )
   end
 
@@ -58,7 +58,15 @@ RSpec.describe Dependabot::Updater do
         "api-endpoint" => "https://api.github.com/",
         "hostname" => "github.com"
       },
-      credentials: credentials,
+      credentials: [
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "github-token"
+        },
+        { "type" => "random", "secret" => "codes" }
+      ],
       lockfile_only: false,
       requirements_update_strategy: nil,
       update_subdependencies: false,
@@ -66,9 +74,9 @@ RSpec.describe Dependabot::Updater do
       vendor_dependencies: false,
       experiments: experiments,
       commit_message_options: {
-        "prefix" => commit_message_prefix,
-        "prefix-development" => commit_message_prefix_development,
-        "include-scope" => commit_message_include_scope
+        "prefix" => "[bump]",
+        "prefix-development" => "[bump-dev]",
+        "include-scope" => true
       },
       security_updates_only: security_updates_only
     )
@@ -79,7 +87,6 @@ RSpec.describe Dependabot::Updater do
   let(:security_advisories) { [] }
   let(:ignore_conditions) { [] }
   let(:security_updates_only) { false }
-  let(:ignore_conditions) { [] }
   let(:allowed_updates) do
     [
       {
@@ -92,22 +99,7 @@ RSpec.describe Dependabot::Updater do
       }
     ]
   end
-  let(:credentials) do
-    [
-      {
-        "type" => "git_source",
-        "host" => "github.com",
-        "username" => "x-access-token",
-        "password" => "github-token"
-      },
-      { "type" => "random", "secret" => "codes" }
-    ]
-  end
   let(:experiments) { {} }
-  let(:repo_contents_path) { nil }
-  let(:commit_message_prefix) { "[bump]" }
-  let(:commit_message_prefix_development) { "[bump-dev]" }
-  let(:commit_message_include_scope) { true }
 
   let(:checker) { double(Dependabot::Bundler::UpdateChecker) }
   before do
@@ -670,8 +662,16 @@ RSpec.describe Dependabot::Updater do
         expect(Dependabot::Bundler::FileUpdater).to receive(:new).with(
           dependencies: [dependency],
           dependency_files: dependency_files,
-          repo_contents_path: repo_contents_path,
-          credentials: credentials,
+          repo_contents_path: nil,
+          credentials: [
+            {
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "github-token"
+            },
+            { "type" => "random", "secret" => "codes" }
+          ],
           options: { cloning: true }
         ).and_call_original
         expect(service).to receive(:create_pull_request).once
@@ -756,11 +756,19 @@ RSpec.describe Dependabot::Updater do
           source: job.source,
           files: an_instance_of(Array),
           dependencies: an_instance_of(Array),
-          credentials: credentials,
+          credentials: [
+            {
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "github-token"
+            },
+            { "type" => "random", "secret" => "codes" }
+          ],
           commit_message_options: {
-            include_scope: commit_message_include_scope,
-            prefix: commit_message_prefix,
-            prefix_development: commit_message_prefix_development
+            include_scope: true,
+            prefix: "[bump]",
+            prefix_development: "[bump-dev]"
           },
           github_redirection_service: "github-redirect.dependabot.com"
         )
@@ -1691,9 +1699,17 @@ RSpec.describe Dependabot::Updater do
       it "passes the experiments to the FileParser as options" do
         expect(Dependabot::Bundler::FileParser).to receive(:new).with(
           dependency_files: dependency_files,
-          repo_contents_path: repo_contents_path,
+          repo_contents_path: nil,
           source: job.source,
-          credentials: credentials,
+          credentials: [
+            {
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "github-token"
+            },
+            { "type" => "random", "secret" => "codes" }
+          ],
           reject_external_code: job.reject_external_code?,
           options: { large_hadron_collider: true }
         ).and_call_original
@@ -1705,8 +1721,16 @@ RSpec.describe Dependabot::Updater do
         expect(Dependabot::Bundler::FileUpdater).to receive(:new).with(
           dependencies: [dependency],
           dependency_files: dependency_files,
-          repo_contents_path: repo_contents_path,
-          credentials: credentials,
+          repo_contents_path: nil,
+          credentials: [
+            {
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "github-token"
+            },
+            { "type" => "random", "secret" => "codes" }
+          ],
           options: { large_hadron_collider: true }
         ).and_call_original
 

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -14,75 +14,72 @@ RSpec.describe Dependabot::Updater do
   def build_job(requested_dependencies: nil, allowed_updates: default_allowed_updates,
                 existing_pull_requests: [], ignore_conditions: [], security_advisories: [],
                 experiments: {}, updating_a_pull_request: false, security_updates_only: false)
-    @build_job ||=
-      Dependabot::Job.new(
-        token: "token",
-        dependencies: requested_dependencies,
-        allowed_updates: allowed_updates,
-        existing_pull_requests: existing_pull_requests,
-        ignore_conditions: ignore_conditions,
-        security_advisories: security_advisories,
-        package_manager: "bundler",
-        source: {
-          "provider" => "github",
-          "repo" => "dependabot-fixtures/dependabot-test-ruby-package",
-          "directory" => "/",
-          "branch" => nil,
-          "api-endpoint" => "https://api.github.com/",
-          "hostname" => "github.com"
+    Dependabot::Job.new(
+      token: "token",
+      dependencies: requested_dependencies,
+      allowed_updates: allowed_updates,
+      existing_pull_requests: existing_pull_requests,
+      ignore_conditions: ignore_conditions,
+      security_advisories: security_advisories,
+      package_manager: "bundler",
+      source: {
+        "provider" => "github",
+        "repo" => "dependabot-fixtures/dependabot-test-ruby-package",
+        "directory" => "/",
+        "branch" => nil,
+        "api-endpoint" => "https://api.github.com/",
+        "hostname" => "github.com"
+      },
+      credentials: [
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "github-token"
         },
-        credentials: [
-          {
-            "type" => "git_source",
-            "host" => "github.com",
-            "username" => "x-access-token",
-            "password" => "github-token"
-          },
-          {
-            "type" => "random",
-            "secret" => "codes"
-          }
-        ],
-        lockfile_only: false,
-        requirements_update_strategy: nil,
-        update_subdependencies: false,
-        updating_a_pull_request: updating_a_pull_request,
-        vendor_dependencies: false,
-        experiments: experiments,
-        commit_message_options: {
-          "prefix" => "[bump]",
-          "prefix-development" => "[bump-dev]",
-          "include-scope" => true
-        },
-        security_updates_only: security_updates_only
-      )
+        {
+          "type" => "random",
+          "secret" => "codes"
+        }
+      ],
+      lockfile_only: false,
+      requirements_update_strategy: nil,
+      update_subdependencies: false,
+      updating_a_pull_request: updating_a_pull_request,
+      vendor_dependencies: false,
+      experiments: experiments,
+      commit_message_options: {
+        "prefix" => "[bump]",
+        "prefix-development" => "[bump-dev]",
+        "include-scope" => true
+      },
+      security_updates_only: security_updates_only
+    )
   end
   # rubocop:enable Metrics/MethodLength
 
   def build_updater(service: build_service, job: build_job, dependency_files: default_dependency_files)
-    @build_updater ||=
-      Dependabot::Updater.new(
-        service: service,
-        job_id: 1,
-        job: job,
-        dependency_files: dependency_files,
-        base_commit_sha: "sha",
-        repo_contents_path: nil
-      )
+    Dependabot::Updater.new(
+      service: service,
+      job_id: 1,
+      job: job,
+      dependency_files: dependency_files,
+      base_commit_sha: "sha",
+      repo_contents_path: nil
+    )
   end
 
   def build_service(job: build_job)
-    @build_service ||=
-      instance_double(
-        Dependabot::Service,
-        get_job: job,
-        create_pull_request: nil,
-        update_pull_request: nil,
-        close_pull_request: nil,
-        mark_job_as_processed: nil,
-        update_dependency_list: nil,
-        record_update_job_error: nil
-      )
+    instance_double(
+      Dependabot::Service,
+      get_job: job,
+      create_pull_request: nil,
+      update_pull_request: nil,
+      close_pull_request: nil,
+      mark_job_as_processed: nil,
+      update_dependency_list: nil,
+      record_update_job_error: nil
+    )
   end
 
   def default_dependency_files

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -40,9 +40,6 @@ RSpec.describe Dependabot::Updater do
     allow(Dependabot.logger).to receive(:error)
     allow_any_instance_of(Dependabot::ApiClient).to receive(:record_package_manager_version)
 
-    allow(Dependabot::Environment).to receive(:token).and_return("some_token")
-    allow(Dependabot::Environment).to receive(:job_id).and_return(1)
-
     stub_request(:get, "https://index.rubygems.org/versions").
       to_return(status: 200, body: fixture("rubygems-index"))
     stub_request(:get, "https://index.rubygems.org/info/dummy-pkg-a").

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -896,7 +896,7 @@ RSpec.describe Dependabot::Updater do
       updater.run
     end
 
-    # FIXME: This spec fails (locally) because mode is being changed to 100666
+    # FIXME: This spec fails (when run outside Dockerfile.updater-core) because mode is being changed to 100666
     it "updates dependencies correctly" do
       job = build_job
       service = build_service(job: job)
@@ -2309,7 +2309,7 @@ RSpec.describe Dependabot::Updater do
         ).twice
       end
 
-      # FIXME: This spec fails (locally) because mode is being changed to 100666
+      # FIXME: This spec fails (when run outside Dockerfile.updater-core) because mode is being changed to 100666
       context "with a bundler 2 project" do
         it "updates dependencies correctly" do
           job = build_job(

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe Dependabot::Updater do
 
     allow(Dependabot::Environment).to receive(:token).and_return("some_token")
     allow(Dependabot::Environment).to receive(:job_id).and_return(1)
+
+    stub_request(:get, "https://index.rubygems.org/versions").
+      to_return(status: 200, body: fixture("rubygems-index"))
+    stub_request(:get, "https://index.rubygems.org/info/dummy-pkg-a").
+      to_return(status: 200, body: fixture("rubygems-info-a"))
+    stub_request(:get, "https://index.rubygems.org/info/dummy-pkg-b").
+      to_return(status: 200, body: fixture("rubygems-info-b"))
   end
 
   let(:job) do
@@ -183,14 +190,6 @@ RSpec.describe Dependabot::Updater do
       allow_any_instance_of(Bundler::CompactIndexClient::Updater).
         to receive(:etag_for).
         and_return("")
-
-      stub_request(:get, "https://index.rubygems.org/versions").
-        to_return(status: 200, body: fixture("rubygems-index"))
-
-      stub_request(:get, "https://index.rubygems.org/info/dummy-pkg-a").
-        to_return(status: 200, body: fixture("rubygems-info-a"))
-      stub_request(:get, "https://index.rubygems.org/info/dummy-pkg-b").
-        to_return(status: 200, body: fixture("rubygems-info-b"))
 
       message_builder = double(Dependabot::PullRequestCreator::MessageBuilder)
       allow(Dependabot::PullRequestCreator::MessageBuilder).to receive(:new).and_return(message_builder)


### PR DESCRIPTION
### 🖼️ Context
While trying to make changes to the updater logic, it's become apparent that our tests have become difficult to work with. This is a first pass at inlining setup so that tests can be reasoned about as individual units.

The approach here is generally:
* Remove `let` statements which are not overridden
* Stub calls to `Dependabot.logger`
* Exract setup of `job`, `service` and `updater` objects into callable methods
* Use :point_up: to bring setup into individual specs