### PR TITLE
Go: handle missing import error and submodule cloning failure error

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -611,7 +611,7 @@ module Dependabot
               CMD
             )
           rescue SharedHelpers::HelperSubprocessFailed => e
-            raise unless GIT_SUBMODULE_ERROR_REGEX && e.message.downcase.include?("submodule")
+            raise unless e.message.match(GIT_SUBMODULE_ERROR_REGEX) && e.message.downcase.include?("submodule")
 
             submodule_cloning_failed = true
             match = e.message.match(GIT_SUBMODULE_ERROR_REGEX)

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -25,7 +25,9 @@ module Dependabot
           /malformed module path/,
           /used for two different module paths/,
           # https://github.com/golang/go/issues/56494
-          /can't find reason for requirement on/
+          /can't find reason for requirement on/,
+          # import path doesn't exist
+          /package \S+ is not in GOROOT/
         ].freeze
 
         REPO_RESOLVABILITY_ERROR_REGEXES = [


### PR DESCRIPTION
Continuing the effort from #6730 to categorize known errors that we can't fix.

I'm seeing "package \S+ is not in GOROOT" quite a bit which indicates a relative import path that is not present. For instance, the package is named `web` and there's an import `web/package` where the directory `package` doesn't exist. This might be because they have generated code that isn't checked in, which is against Go conventions, so I don't think we need to try to support it: 

> once the file is generated (and tested!) it must be checked into the source code repository to be available to clients
> --https://go.dev/blog/generate

Also fixing a NilClass bug introduced in https://github.com/dependabot/dependabot-core/pull/6172. The original intent was to check for the match in this `unless`, so when an error mentioning submodules occurs but didn't match the regex it would raise an error instead of failing with the SharedHelpers exception. 