### PR TITLE
Don't ever update GitHub Actions unless they are actually pinned 

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -46,7 +46,13 @@ module Dependabot
 
         uses_strings.each do |string|
           # TODO: Support Docker references and path references
-          dependency_set << build_github_dependency(file, string) if string.match?(GITHUB_REPO_REFERENCE)
+          next unless string.match?(GITHUB_REPO_REFERENCE)
+
+          dep = build_github_dependency(file, string)
+          git_checker = Dependabot::GitCommitChecker.new(dependency: dep, credentials: credentials)
+          next unless git_checker.pinned?
+
+          dependency_set << dep
         end
 
         dependency_set

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
                 ref: "v1.1.0",
                 branch: nil
               },
-              metadata: { declaration_string: "actions/aws/ec2@master" }
+              metadata: { declaration_string: "actions/aws/ec2@v1.0.0" }
             }, {
               requirement: nil,
               groups: [],
@@ -127,7 +127,7 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
                 ref: "v1.1.0",
                 branch: nil
               },
-              metadata: { declaration_string: "actions/aws@master" }
+              metadata: { declaration_string: "actions/aws@v1.0.0" }
             }],
             previous_requirements: [{
               requirement: nil,
@@ -136,10 +136,10 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
               source: {
                 type: "git",
                 url: "https://github.com/actions/aws",
-                ref: "master",
+                ref: "v1.0.0",
                 branch: nil
               },
-              metadata: { declaration_string: "actions/aws/ec2@master" }
+              metadata: { declaration_string: "actions/aws/ec2@v1.0.0" }
             }, {
               requirement: nil,
               groups: [],
@@ -147,10 +147,10 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
               source: {
                 type: "git",
                 url: "https://github.com/actions/aws",
-                ref: "master",
+                ref: "v1.0.0",
                 branch: nil
               },
-              metadata: { declaration_string: "actions/aws@master" }
+              metadata: { declaration_string: "actions/aws@v1.0.0" }
             }],
             package_manager: "github_actions"
           )

--- a/github_actions/spec/fixtures/workflow_files/workflow.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
 
     - name: Use Node.js 10.x
-      uses: actions/setup-node@master
+      uses: actions/setup-node@v1
       with:
         version: 10.x
 

--- a/github_actions/spec/fixtures/workflow_files/workflow_monorepo.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_monorepo.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
 
     - name: Use Node.js 10.x
-      uses: actions/aws/ec2@master
+      uses: actions/aws/ec2@v1.0.0
       with:
         version: 10.x
 
@@ -28,6 +28,6 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Use Node.js ${{matrix.node}}.x
-      uses: actions/aws@master
+      uses: actions/aws@v1.0.0
       with:
         version: ${{matrix.node}}.x


### PR DESCRIPTION
The change in Dependency combine logic at #6082 surfaced a bug where if a Github Action is referencing two different branches in the same workflow, Dependabot would create a PR unifying it to a single branch, while is not what the user wants.

The fix is to ignore any `uses:` references which include a reference that should not be updated, like a branch name not named like a version (like `master` or `stable`).

In addition to fixing this bug, this change also allows Dependabot to create PRs for mixed situations like the following, where the version is updated and the others are left alone:

```yaml
uses: dtolnay/rust-toolchain@master
# ...
uses: dtolnay/rust-toolchain@stable
# ...
uses: dtolnay/rust-toolchain@1.42
```

or the following, where the SHA is updated and the others are left alone:

```yaml
uses: dtolnay/rust-toolchain@master
# ...
uses: dtolnay/rust-toolchain@stable
# ...
uses: dtolnay/rust-toolchain@df6c627e2064a425669c08e51ed613bb3f013c69
```

There's a change in behavior for other mixed cases like

```yaml
uses: dtolnay/rust-toolchain@master
# ...
uses: dtolnay/rust-toolchain@1.42
# ...
uses: dtolnay/rust-toolchain@df6c627e2064a425669c08e51ed613bb3f013c69
```

Before Dependabot would find no updates, while now it will update both the SHA-pinned and the version-pinned lines to the latest _version_. I'm unclear about why users would pin some workflows and not others, so I'm fine with making this change and listen to any users that don't actually want this. My expectation is that this will help users catch situations where they were unintentionally using multiple styles and help them unify those.

Fixes #6739.