### PR TITLE
fix: mark version with "preview" extension as pre-release (#6151)

### DIFF
--- a/gradle/lib/dependabot/gradle/version.rb
+++ b/gradle/lib/dependabot/gradle/version.rb
@@ -21,7 +21,7 @@ module Dependabot
         "a" => 1, "alpha"     => 1,
         "b" => 2, "beta"      => 2,
         "m" => 3, "milestone" => 3,
-        "rc" => 4, "cr" => 4, "pr" => 4,
+        "rc" => 4, "cr" => 4, "pr" => 4, "preview" => 5,
         "snapshot" => 5, "dev" => 5,
         "ga" => 6, "" => 6, "final" => 6,
         "sp" => 7

--- a/gradle/spec/dependabot/gradle/version_spec.rb
+++ b/gradle/spec/dependabot/gradle/version_spec.rb
@@ -78,6 +78,11 @@ RSpec.describe Dependabot::Gradle::Version do
       it { is_expected.to eq(false) }
     end
 
+    context "with jre and preview" do
+      let(:version_string) { "12.1.0.jre11-preview" }
+      it { is_expected.to eq(true) }
+    end
+
     context "with a pre-release" do
       let(:version_string) { "2.10.0.pr3" }
       it { is_expected.to eq(true) }


### PR DESCRIPTION
May the fix doesn't help for all variants, but it works as other versions extensions.
The version "12.1.0.jre11-preview" is now detected as pre-release.