### PR TITLE
Remove a Heroku workaround from early implementation

### DIFF
--- a/updater/lib/dependabot/setup.rb
+++ b/updater/lib/dependabot/setup.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-# Heroku's ruby buildpack freezes the Gemfile to prevent accidental damage
-# However, we actually *want* to manipulate Gemfiles for other repos.
-Bundler.settings.set_command_option(:frozen, "0")
-
 require "dependabot/sentry"
 Raven.configure do |config|
   config.project_root = File.expand_path("../../..", __dir__)


### PR DESCRIPTION
It looks like this workaround was added around six years ago when Dependabot ran on Heroku and needed to override some changes from its buildpack.

I don't believe we need this anymore and should clean it up as a refers to a long gone runtime environment - that said, I'm not sure removing it is the most ideal outcome.

Having it live in a setup block for the Updater definitely feels wrong as we should either not have this or have it in the initialisation hooks for the `bundler/` gem, similar to how we use `Dependabot::Utils.register_always_clone` to set ecosystem config.

@deivid-rodriguez do you have any thoughts on this?