### PR TITLE
Go: fix NilClass error when directory doesn't have a go.mod file

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -15,6 +15,8 @@ module Dependabot
       end
 
       def package_manager_version
+        return nil unless go_mod
+
         {
           ecosystem: "gomod",
           package_managers: {


### PR DESCRIPTION
Fixes NoMethodError error introduced just now in #6658

```
NoMethodError
undefined method `content' for nil:NilClass

            "gomod" => go_mod.content.match(/^go\s(\d+\.\d+)/)&.captures&.first || "unknown"
```

This is being caused by misconfigured dependabot.yml where `go.mod` is not present in the directory. I'm kind of surprised we don't raise an exception sooner since it's listed in `required_files_in?`. 