### PR TITLE
Annotate `pending` tests with comments

### DIFF
--- a/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/version_resolver_spec.rb
@@ -90,7 +90,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
           let(:dependency_name) { "nokogiri" }
           let(:requirements) { [] }
 
-          pending "is updated, skipped due to https://github.com/dependabot/dependabot-core/issues/2364" do
+          it "is updated" do
+            pending("skipped due to https://github.com/dependabot/dependabot-core/issues/2364")
             expect(subject.version).to eq(Gem::Version.new("1.10.9"))
           end
         end
@@ -122,7 +123,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
               "bundler_specified_and_required.lock"
             end
 
-            pending "skipped due to https://github.com/dependabot/dependabot-core/issues/2364" do
+            it "is nil" do
+              pending("skipped due to https://github.com/dependabot/dependabot-core/issues/2364")
               is_expected.to be_nil
             end
           end
@@ -430,7 +432,8 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::VersionResolver do
             source: nil
           }]
         end
-        pending "skipped due to https://github.com/dependabot/dependabot-core/issues/2364" do
+        it "is nil" do
+          pending("skipped due to https://github.com/dependabot/dependabot-core/issues/2364")
           is_expected.to be_nil
         end
       end

--- a/composer/spec/dependabot/composer/update_checker_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker_spec.rb
@@ -475,9 +475,8 @@ RSpec.describe Dependabot::Composer::UpdateChecker do
       context "where the blocking dependency is a git dependency" do
         let(:project_name) { "git_source_conflict_at_latest" }
 
-        pending "is the highest resolvable version" do
-          # It would be nice if this worked, but currently Composer ignores
-          # resolvability requirements for git dependencies.
+        it "is the highest resolvable version" do
+          pending("composer currently ignores resolvability requirements for git dependencies.")
           expect(latest_resolvable_version).to eq(Gem::Version.new("2.1.7"))
         end
       end

--- a/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser/repositories_finder_spec.rb
@@ -111,7 +111,8 @@ RSpec.describe Dependabot::Gradle::FileParser::RepositoriesFinder do
       context "that get URLs from a variable" do
         let(:buildfile_fixture_name) { "variable_repos_build.gradle" }
 
-        pending "includes the additional declarations" do
+        it "includes the additional declarations" do
+          pending("silenced due to persistent Gradle bug, see commit 08122f9 for context")
           expect(repository_urls).to match_array(
             %w(
               https://jcenter.bintray.com

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -2719,11 +2719,11 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
             let(:previous_version) { "3b1bb80b302c2e552685dc8a029797ec832ea7c9" }
             let(:version) { "5677730fd3b9de2eb2224b968259893e5fc9adac" }
 
-            # TODO: npm 8 silently ignores this issue and generates a broken lockfile
             context "with a npm lockfile" do
               let(:files) { project_dependency_files("npm8/git_dependency_local_file") }
 
-              pending "raises a helpful error" do
+              it "raises a helpful error" do
+                pending("npm 8 silently ignores this issue and generates a broken lockfile")
                 expect { updated_files }.
                   to raise_error(
                     Dependabot::DependencyFileNotResolvable,


### PR DESCRIPTION
Most of our `pending` tests have associated code comments. However, they're only visible when viewing the raw source, not when running `rspec`.

So this makes it visible when running tests why a particular test is pending.