### PR TITLE
Attempt to detect OutOfDisk errors when cloning repos

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -95,6 +95,8 @@ module Dependabot
       rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
         if e.message.include?("fatal: Remote branch #{target_branch} not found in upstream origin")
           raise Dependabot::BranchNotFound, target_branch
+        elsif e.message.include?("No space left on device")
+          raise Dependabot::OutOfDisk
         end
 
         raise Dependabot::RepoNotFound, source

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -1578,6 +1578,21 @@ RSpec.describe Dependabot::FileFetchers::Base do
           expect(`ls #{repo_contents_path}`).to include("README")
         end
       end
+
+      context "when the repo exceeds available disk space" do
+        it "raises an out of disk error" do
+          allow(Dependabot::SharedHelpers).
+            to receive(:run_shell_command).
+            and_raise(
+              Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                message: "fatal: write error: No space left on device",
+                error_context: {}
+              )
+            )
+
+          expect { subject }.to raise_error(Dependabot::OutOfDisk)
+        end
+      end
     end
   end
 

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -144,6 +144,11 @@ module Dependabot
             "error-type": "dependency_file_not_found",
             "error-detail": { "file-path": error.file_path }
           }
+        when Dependabot::OutOfDisk
+          {
+            "error-type": "out_of_disk",
+            "error-detail": {}
+          }
         when Dependabot::PathDependenciesNotReachable
           {
             "error-type": "path_dependencies_not_reachable",


### PR DESCRIPTION
Failures from cloning a repo assume a repo access error by default. This causes confusion when the error is something else. I suspect OutOfDisk is the culprit for an issue I'm looking into so this adds detection for that.