### PR TITLE
Support updating docker format image dependencies in a helm values file

### DIFF
--- a/docker/spec/fixtures/helm/yaml/mixed-image.yaml
+++ b/docker/spec/fixtures/helm/yaml/mixed-image.yaml
@@ -1,0 +1,7 @@
+foo:
+  image: nginx:1.14.2
+
+bar:
+  image:
+    repository: 'canonical/ubuntu'
+    tag: 18.04


### PR DESCRIPTION
We are able to parse image dependencies like this from a helm file:
```
image: nginx:1.14.2
```

But when we update a helm file we expected it to be formatted as:
```
image:
  repository: nginx
  tag: 1.14.2
```

This change attempts to perform the update with both formats for helm files.

Is there an official name for these different ways of specifying a docker image? I don't know the specifics here but this fixes an issue that came in through support.