### PR TITLE
Introduce Dependabot::DependencyChange as a wrapper for updater output plus metadata

### DIFF
--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -73,7 +73,7 @@ module Dependabot
       body = {
         data: {
           "dependency-names": dependency_change.dependencies.map(&:name),
-          "updated-dependency-files": dependency_change.updated_dependency_files,
+          "updated-dependency-files": dependency_change.updated_dependency_files_hash,
           "base-commit-sha": base_commit_sha
         }
       }

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -52,10 +52,9 @@ module Dependabot
       Job.new(job_data.merge(token: job_token))
     end
 
-    def create_pull_request(dependencies, updated_dependency_files,
-                            base_commit_sha, pr_message)
+    def create_pull_request(dependency_change, base_commit_sha)
       api_url = "#{base_url}/update_jobs/#{job_id}/create_pull_request"
-      data = create_pull_request_data(dependencies, updated_dependency_files, base_commit_sha, pr_message)
+      data = create_pull_request_data(dependency_change, base_commit_sha)
       response = http_client.post(api_url, json: { data: data })
       raise ApiError, response.body if response.code >= 400
     rescue HTTP::ConnectionError, OpenSSL::SSL::SSLError
@@ -67,12 +66,12 @@ module Dependabot
     end
 
     # TODO: Determine if we should regenerate the PR message within core for updates
-    def update_pull_request(dependencies, updated_dependency_files, base_commit_sha)
+    def update_pull_request(dependency_change, base_commit_sha)
       api_url = "#{base_url}/update_jobs/#{job_id}/update_pull_request"
       body = {
         data: {
-          "dependency-names": dependencies.map(&:name),
-          "updated-dependency-files": updated_dependency_files,
+          "dependency-names": dependency_change.dependencies.map(&:name),
+          "updated-dependency-files": dependency_change.updated_dependency_files,
           "base-commit-sha": base_commit_sha
         }
       }
@@ -192,9 +191,9 @@ module Dependabot
       sleep(rand(3.0..10.0)) && retry
     end
 
-    def create_pull_request_data(dependencies, updated_dependency_files, base_commit_sha, pr_message)
+    def create_pull_request_data(dependency_change, base_commit_sha)
       data = {
-        dependencies: dependencies.map do |dep|
+        dependencies: dependency_change.dependencies.map do |dep|
           {
             name: dep.name,
             "previous-version": dep.previous_version,
@@ -205,14 +204,14 @@ module Dependabot
             removed: dep.removed? ? true : nil
           }.compact)
         end,
-        "updated-dependency-files": updated_dependency_files,
+        "updated-dependency-files": dependency_change.updated_dependency_files_hash,
         "base-commit-sha": base_commit_sha
       }
-      return data unless pr_message
+      return data unless dependency_change.pr_message
 
-      data["commit-message"] = pr_message.commit_message
-      data["pr-title"] = pr_message.pr_name
-      data["pr-body"] = pr_message.pr_message
+      data["commit-message"] = dependency_change.pr_message.commit_message
+      data["pr-title"] = dependency_change.pr_message.pr_name
+      data["pr-body"] = dependency_change.pr_message.pr_message
       data
     end
   end

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -52,6 +52,7 @@ module Dependabot
       Job.new(job_data.merge(token: job_token))
     end
 
+    # TODO: Make `base_commit_sha` part of Dependabot::DependencyChange
     def create_pull_request(dependency_change, base_commit_sha)
       api_url = "#{base_url}/update_jobs/#{job_id}/create_pull_request"
       data = create_pull_request_data(dependency_change, base_commit_sha)
@@ -65,6 +66,7 @@ module Dependabot
       sleep(rand(3.0..10.0)) && retry
     end
 
+    # TODO: Make `base_commit_sha` part of Dependabot::DependencyChange
     # TODO: Determine if we should regenerate the PR message within core for updates
     def update_pull_request(dependency_change, base_commit_sha)
       api_url = "#{base_url}/update_jobs/#{job_id}/update_pull_request"

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -208,7 +208,17 @@ module Dependabot
         end,
         "updated-dependency-files": dependency_change.updated_dependency_files_hash,
         "base-commit-sha": base_commit_sha
-      }
+      }.merge({
+        # TODO: Replace this flag with a group-rule object
+        #
+        # In future this should be something like:
+        #    "group-rule": dependency_change.group_rule_hash
+        #
+        # This will allow us to pass back the rule id and other parameters
+        # to allow Dependabot API to augment PR creation and associate it
+        # with the rule for rebasing, etc.
+        "grouped-update": dependency_change.grouped_update? ? true : nil
+      }.compact)
       return data unless dependency_change.pr_message
 
       data["commit-message"] = dependency_change.pr_message.commit_message

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -3,9 +3,9 @@
 # This class describes a change to the project's Dependencies which has been
 # determined by a Dependabot operation.
 #
-# It includes a list of changed Dependabot::Dependency objects, the
-# Dependabot::DependencyFile objects which contain the diff to be applied along
-# with any Dependabot::GroupRule that was used to generate the change.
+# It includes a list of changed Dependabot::Dependency objects, an array of
+# Dependabot::DependencyFile objects which contain the changes to be applied
+# along with any Dependabot::GroupRule that was used to generate the change.
 #
 # This class provides methods for presenting the change set which can be used
 # by adapters to create a Pull Request, apply the changes on disk, etc.
@@ -53,6 +53,13 @@ module Dependabot
 
     def updated_dependency_files_hash
       updated_dependency_files.map(&:to_h)
+    end
+
+    # FIXME: This is a placeholder for using a concrete GroupRule object to create
+    # as grouped rule hash to pass to the Dependabot API client. For now, we just
+    # use a flag on whether a rule has been assigned to the change.
+    def grouped_update?
+      !!@group_rule
     end
 
     private

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# This class describes a change to the project's Dependencies which has been
+# determined by a Dependabot operation.
+#
+# It includes a list of changed Dependabot::Dependency objects, the
+# Dependabot::DependencyFile objects which contain the diff to be applied along
+# with any Dependabot::GroupRule that was used to generate the change.
+#
+# This class provides methods for presenting the change set which can be used
+# by adapters to create a Pull Request, apply the changes on disk, etc.
+module Dependabot
+  class DependencyChange
+    attr_reader :job, :dependencies, :updated_dependency_files
+
+    def initialize(job:, dependencies:, updated_dependency_files:, group_rule: nil)
+      @job = job
+      @dependencies = dependencies
+      @updated_dependency_files = updated_dependency_files
+      @group_rule = group_rule
+    end
+
+    def to_set
+      dependency_set
+    end
+
+    def pr_message
+      return @pr_message if defined?(@pr_message)
+
+      @pr_message = Dependabot::PullRequestCreator::MessageBuilder.new(
+        source: job.source,
+        dependencies: dependencies,
+        files: updated_dependency_files,
+        credentials: job.credentials,
+        commit_message_options: job.commit_message_options,
+        # This ensures that PR messages we build replace github.com links with
+        # a redirect that stop markdown enriching them into mentions on the source
+        # repository.
+        #
+        # TODO: Promote this value to a constant or similar once we have
+        # updated core to avoid surprise outcomes if this is unset.
+        github_redirection_service: "github-redirect.dependabot.com"
+      ).message
+    end
+
+    def humanized
+      dependencies.map do |dependency|
+        "#{dependency.name} ( from #{dependency.previous_version} to #{dependency.version} )"
+      end.join(", ")
+    end
+
+    def updated_dependency_files_hash
+      updated_dependency_files.map(&:to_h)
+    end
+
+    private
+
+    def dependency_set
+      @dependency_set ||= Set.new(
+        dependencies.map do |dep|
+          {
+            "dependency-name" => dep.name,
+            "dependency-version" => dep.version,
+            "dependency-removed" => dep.removed? ? true : nil
+          }.compact
+        end
+      )
+    end
+  end
+end

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -20,10 +20,6 @@ module Dependabot
       @group_rule = group_rule
     end
 
-    def to_set
-      dependency_set
-    end
-
     def pr_message
       # If we are updating an existing PullRequest, we do not generate a new message as part of the change
       return nil if job.updating_a_pull_request?
@@ -60,20 +56,6 @@ module Dependabot
     # use a flag on whether a rule has been assigned to the change.
     def grouped_update?
       !!@group_rule
-    end
-
-    private
-
-    def dependency_set
-      @dependency_set ||= Set.new(
-        dependencies.map do |dep|
-          {
-            "dependency-name" => dep.name,
-            "dependency-version" => dep.version,
-            "dependency-removed" => dep.removed? ? true : nil
-          }.compact
-        end
-      )
     end
   end
 end

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -25,6 +25,8 @@ module Dependabot
     end
 
     def pr_message
+      # If we are updating an existing PullRequest, we do not generate a new message as part of the change
+      return nil if job.updating_a_pull_request?
       return @pr_message if defined?(@pr_message)
 
       @pr_message = Dependabot::PullRequestCreator::MessageBuilder.new(

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -19,14 +19,14 @@ module Dependabot
 
     def_delegators :client, :fetch_job, :mark_job_as_processed, :update_dependency_list, :record_package_manager_version
 
-    def create_pull_request(dependencies, updated_dependency_files, base_commit_sha, pr_message)
-      client.create_pull_request(dependencies, updated_dependency_files, base_commit_sha, pr_message)
-      @pull_requests << [humanize(dependencies), :created]
+    def create_pull_request(dependency_change, base_commit_sha)
+      client.create_pull_request(dependency_change, base_commit_sha)
+      @pull_requests << [dependency_change.humanized, :created]
     end
 
-    def update_pull_request(dependencies, updated_dependency_files, base_commit_sha)
-      client.update_pull_request(dependencies, updated_dependency_files, base_commit_sha)
-      @pull_requests << [humanize(dependencies), :updated]
+    def update_pull_request(dependency_change, base_commit_sha)
+      client.update_pull_request(dependency_change, base_commit_sha)
+      @pull_requests << [dependency_change.humanized, :updated]
     end
 
     def close_pull_request(dependency_name, reason)

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -127,6 +127,11 @@ module Dependabot
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
     # rubocop:disable Metrics/MethodLength
+    #
+    # TODO: Push checks on dependencies into Dependabot::DependencyChange
+    #
+    # Some of this logic would make more sense as interrogations of the
+    # DependencyChange as we build it up step-by-step.
     def check_and_update_pull_request(dependencies)
       if dependencies.count != job.dependencies.count
         close_pull_request(reason: :dependency_removed) unless errors.any?

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -58,8 +58,16 @@ RSpec.describe Dependabot::ApiClient do
     end
     let(:dependency_files) do
       [
-        { name: "Gemfile", content: "some things" },
-        { name: "Gemfile.lock", content: "more things" }
+        Dependabot::DependencyFile.new(
+          name: "Gemfile",
+          content: "some things",
+          directory: "/"
+        ),
+        Dependabot::DependencyFile.new(
+          name: "Gemfile.lock",
+          content: "more things",
+          directory: "/"
+        )
       ]
     end
     let(:create_pull_request_url) do
@@ -175,8 +183,16 @@ RSpec.describe Dependabot::ApiClient do
     end
     let(:dependency_files) do
       [
-        { name: "Gemfile", content: "some things" },
-        { name: "Gemfile.lock", content: "more things" }
+        Dependabot::DependencyFile.new(
+          name: "Gemfile",
+          content: "some things",
+          directory: "/"
+        ),
+        Dependabot::DependencyFile.new(
+          name: "Gemfile.lock",
+          content: "more things",
+          directory: "/"
+        )
       ]
     end
     let(:update_pull_request_url) do

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -124,4 +124,23 @@ RSpec.describe Dependabot::DependencyChange do
       end
     end
   end
+
+  describe "#grouped_update?" do
+    it "is false by default" do
+      expect(dependency_change.grouped_update?).to be false
+    end
+
+    context "when a group rule is assigned" do
+      it "is true" do
+        rule = described_class.new(
+          job: job,
+          dependencies: dependencies,
+          updated_dependency_files: updated_dependency_files,
+          group_rule: anything # For now the group_rule parameter is treated permissively as any non-nil value
+        )
+
+        expect(rule.grouped_update?).to be true
+      end
+    end
+  end
 end

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency_change"
+require "dependabot/job"
+
+RSpec.describe Dependabot::DependencyChange do
+  subject(:dependency_change) do
+    described_class.new(
+      job: job,
+      dependencies: dependencies,
+      updated_dependency_files: updated_dependency_files
+    )
+  end
+
+  let(:job) do
+    instance_double(Dependabot::Job)
+  end
+
+  let(:dependencies) do
+    [
+      Dependabot::Dependency.new(
+        name: "business",
+        package_manager: "bundler",
+        version: "1.8.0",
+        previous_version: "1.7.0",
+        requirements: [
+          { file: "Gemfile", requirement: "~> 1.8.0", groups: [], source: nil }
+        ],
+        previous_requirements: [
+          { file: "Gemfile", requirement: "~> 1.7.0", groups: [], source: nil }
+        ]
+      )
+    ]
+  end
+
+  let(:updated_dependency_files) do
+    [
+      Dependabot::DependencyFile.new(
+        name: "Gemfile",
+        content: fixture("bundler/original/Gemfile"),
+        directory: "/"
+      ),
+      Dependabot::DependencyFile.new(
+        name: "Gemfile.lock",
+        content: fixture("bundler/original/Gemfile.lock"),
+        directory: "/"
+      )
+    ]
+  end
+
+  describe "#pr_message" do
+    let(:github_source) do
+      {
+        "provider" => "github",
+        "repo" => "dependabot-fixtures/dependabot-test-ruby-package",
+        "directory" => "/",
+        "branch" => nil,
+        "api-endpoint" => "https://api.github.com/",
+        "hostname" => "github.com"
+      }
+    end
+
+    let(:job_credentials) do
+      [
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "github-token"
+        },
+        { "type" => "random", "secret" => "codes" }
+      ]
+    end
+
+    let(:commit_message_options) do
+      {
+        include_scope: true,
+        prefix: "[bump]",
+        prefix_development: "[bump-dev]"
+      }
+    end
+
+    let(:message_builder_mock) do
+      instance_double(Dependabot::PullRequestCreator::MessageBuilder, message: "Hello World!")
+    end
+
+    before do
+      allow(job).to receive(:source).and_return(github_source)
+      allow(job).to receive(:credentials).and_return(job_credentials)
+      allow(job).to receive(:commit_message_options).and_return(commit_message_options)
+      allow(Dependabot::PullRequestCreator::MessageBuilder).to receive(:new).and_return(message_builder_mock)
+    end
+
+    it "delegates to the Dependabot::PullRequestCreator::MessageBuilder with the correct configuration" do
+      expect(Dependabot::PullRequestCreator::MessageBuilder).
+        to receive(:new).with(
+          source: github_source,
+          files: updated_dependency_files,
+          dependencies: dependencies,
+          credentials: job_credentials,
+          commit_message_options: commit_message_options,
+          github_redirection_service: "github-redirect.dependabot.com"
+        )
+
+      expect(dependency_change.pr_message).to eql("Hello World!")
+    end
+  end
+end

--- a/updater/spec/dependabot/integration_spec.rb
+++ b/updater/spec/dependabot/integration_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "Dependabot Updates" do
 
     it "updates dependencies correctly" do
       expect(api_client).
-        to receive(:create_pull_request) do |deps, files, commit_sha|
+        to receive(:create_pull_request) do |dependency_change, commit_sha|
           dep = Dependabot::Dependency.new(
             name: "dummy-pkg-b",
             package_manager: "bundler",
@@ -164,8 +164,8 @@ RSpec.describe "Dependabot Updates" do
                 file: "Gemfile" }
             ]
           )
-          expect(deps).to eql([dep])
-          expect(files).to eq(
+          expect(dependency_change.dependencies).to eql([dep])
+          expect(dependency_change.updated_dependency_files_hash).to eq(
             [
               {
                 "name" => "Gemfile",
@@ -334,7 +334,7 @@ RSpec.describe "Dependabot Updates" do
 
     it "updates dependencies correctly" do
       expect(api_client).
-        to receive(:create_pull_request) do |deps, files, commit_sha|
+        to receive(:create_pull_request) do |dependency_change, commit_sha|
           dep = Dependabot::Dependency.new(
             name: "dummy-git-dependency",
             package_manager: "bundler",
@@ -365,8 +365,8 @@ RSpec.describe "Dependabot Updates" do
                 file: "Gemfile" }
             ]
           )
-          expect(deps).to eql([dep])
-          expect(files).to eq(
+          expect(dependency_change.dependencies).to eql([dep])
+          expect(dependency_change.updated_dependency_files_hash).to eq(
             [
               {
                 "name" => "Gemfile",

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -31,34 +31,36 @@ RSpec.describe Dependabot::Updater do
       service = build_service(job: job)
       updater = build_updater(service: service, job: job)
 
-      dependencies = [have_attributes(name: "dummy-pkg-b")]
-      updated_dependency_files = [
-        {
-          "name" => "Gemfile",
-          "content" => fixture("bundler/updated/Gemfile"),
-          "directory" => "/",
-          "type" => "file",
-          "mode" => "100644",
-          "support_file" => false,
-          "content_encoding" => "utf-8",
-          "deleted" => false,
-          "operation" => "update"
-        },
-        {
-          "name" => "Gemfile.lock",
-          "content" => fixture("bundler/updated/Gemfile.lock"),
-          "directory" => "/",
-          "type" => "file",
-          "mode" => "100644",
-          "support_file" => false,
-          "content_encoding" => "utf-8",
-          "deleted" => false,
-          "operation" => "update"
-        }
-      ]
-      base_commit_sha = "sha"
-
-      expect(service).to receive(:create_pull_request).with(anything, base_commit_sha)
+      expect(service).to receive(:create_pull_request) do |dependency_change, base_commit_sha|
+        expect(dependency_change.dependencies.first).to have_attributes(name: "dummy-pkg-b")
+        expect(dependency_change.updated_dependency_files_hash).to eql(
+          [
+            {
+              "name" => "Gemfile",
+              "content" => fixture("bundler/updated/Gemfile"),
+              "directory" => "/",
+              "type" => "file",
+              "mode" => "100644",
+              "support_file" => false,
+              "content_encoding" => "utf-8",
+              "deleted" => false,
+              "operation" => "update"
+            },
+            {
+              "name" => "Gemfile.lock",
+              "content" => fixture("bundler/updated/Gemfile.lock"),
+              "directory" => "/",
+              "type" => "file",
+              "mode" => "100644",
+              "support_file" => false,
+              "content_encoding" => "utf-8",
+              "deleted" => false,
+              "operation" => "update"
+            }
+          ]
+        )
+        expect(base_commit_sha).to eql("sha")
+      end
 
       updater.run
     end

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Dependabot::Updater do
     # FIXME: This spec fails (when run outside Dockerfile.updater-core) because mode is being changed to 100666
     it "updates dependencies correctly" do
       stub_update_checker
-      stub_pr_message_building
 
       job = build_job
       service = build_service(job: job)
@@ -111,38 +110,6 @@ RSpec.describe Dependabot::Updater do
       updater = build_updater(service: service, job: job)
 
       expect(service).to receive(:create_pull_request).once
-
-      updater.run
-    end
-
-    it "builds pull request message" do
-      stub_update_checker
-
-      job = build_job
-      service = build_service(job: job)
-      updater = build_updater(service: service, job: job)
-
-      expect(Dependabot::PullRequestCreator::MessageBuilder).
-        to receive(:new).with(
-          source: job.source,
-          files: an_instance_of(Array),
-          dependencies: an_instance_of(Array),
-          credentials: [
-            {
-              "type" => "git_source",
-              "host" => "github.com",
-              "username" => "x-access-token",
-              "password" => "github-token"
-            },
-            { "type" => "random", "secret" => "codes" }
-          ],
-          commit_message_options: {
-            include_scope: true,
-            prefix: "[bump]",
-            prefix_development: "[bump-dev]"
-          },
-          github_redirection_service: "github-redirect.dependabot.com"
-        )
 
       updater.run
     end
@@ -2342,7 +2309,6 @@ RSpec.describe Dependabot::Updater do
       context "with a bundler 2 project" do
         it "updates dependencies correctly" do
           stub_update_checker
-          stub_pr_message_building
 
           job = build_job(
             experiments: {
@@ -2680,10 +2646,5 @@ RSpec.describe Dependabot::Updater do
     allow(update_checker).to receive(:can_update?).with(requirements_to_unlock: :own).and_return(true, false)
     allow(update_checker).to receive(:can_update?).with(requirements_to_unlock: :all).and_return(false)
     update_checker
-  end
-
-  def stub_pr_message_building
-    builder = double(Dependabot::PullRequestCreator::MessageBuilder, message: nil)
-    allow(Dependabot::PullRequestCreator::MessageBuilder).to receive(:new).and_return(builder)
   end
 end


### PR DESCRIPTION
This PR introduces a new [Dependabot::DependencyChange](https://github.com/dependabot/dependabot-core/pull/6792/files#diff-1df7c2253c7a813b8528a05529986fe5d2f7ac95cf2e9d5d6c65db463fc28aba) class which wraps a set of `Dependabot::Dependency` and `Dependabot::DependencyFile` objects which constitute the outcome of a `Dependabot::Updater` operation.

### Rationale

As part of the [prototype](https://github.com/dependabot/dependabot-core/pull/6663/files#diff-1f8c3901647148d6f9fbda3a5c943490beb28c1291f21a3b6713471e0c39902bR42-R62) effort, Rubocop flagged the growing number of parameters being passed down into the API Client - effectively the 'output' class for the Updater - when we started adding in new placeholders for the concept of a "Group Rule".

This problem indicates we have a missing abstraction between the operation to generate a change and the components when then transform it for output via Dependabot API.

Our next major planned refactor is to turn the `Dependabot::Updater` operations into concrete classes so each combination of major job branches is represented by a single, well-defined class for a fresh Version Update, a rebase of an existing Version PR, a new Security Update, etc, etc.

The `Dependabot::DependencyChange` class is a bottom-up refactor that adds a new abstraction which reduces the amount of parameters we need to pass while also providing a starting point for the output of these new operation classes to force a wedge between the part of the Updater which constructs change sets and the part which processes them into PRs so we can start to expose the injection site for grouping behaviours.

### Changes

Originally I intended the `Dependabot::DependencyChange` to be built up over the course of the `Dependabot::Updater#check_and_create_pull_request` and `Dependabot::Updater#check_and_update_pull_request` methods, allowing more of the logic which combs and filters the "updated_deps" list to be moved into the class itself.

I still think this might be worth doing, but I walked it back as it resulted in a substantial number of test stub rewrites which made me lose confidence in the change.

For now, the only major responsibility the `Dependabot::DependencyChange` class extracts from the Updater is responsibility for constructing the Pull Request message object, which it does by being aware of the `Dependabot::Job`. 

I think there are some logical threads that follow on from this to incorporate things like the `@created_pull_requests` and `@errors` sets unto the job so the change set is capable of answering questions about wither it duplicates or supersedes existing work - but I've left that for now to de-risk introducing this interface and avoid delaying splitting the `Dependabot::Updater` out further.