### PR TITLE
Bump latest version to reflect current release

### DIFF
--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
       let(:dependency_name) { "golang.org/x/net" }
 
       it "picks the latest version" do
-        expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("0.7.0"))
+        expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("0.8.0"))
       end
     end
 


### PR DESCRIPTION
This being out of date caused a [CI failure](https://github.com/dependabot/dependabot-core/actions/runs/4346810196/jobs/7594010245) in another branch. It'd be great to make this a static target, but I'm not sure what our process is for locking the version down.