### PR TITLE
Rely on previously-defined constant

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -207,7 +207,7 @@ jobs:
         gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
         tar xzvf *.tar.gz >/dev/null 2>&1
         ./dependabot --version
-        URL=https://api.github.com/repos/dependabot/smoke-tests/contents/tests/smoke-${{ matrix.suite.name }}.yaml
+        URL=https://api.github.com/repos/dependabot/smoke-tests/contents/tests/smoke-${{ matrix.suite.name }}.yaml?ref=use-redirect-dot-github
         curl $(gh api $URL --jq .download_url) -o smoke.yaml
 
     # Download the Proxy cache. The job is ideally 100% cached so no real calls are made.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -207,7 +207,7 @@ jobs:
         gh release download --repo dependabot/cli -p "*linux-amd64.tar.gz"
         tar xzvf *.tar.gz >/dev/null 2>&1
         ./dependabot --version
-        URL=https://api.github.com/repos/dependabot/smoke-tests/contents/tests/smoke-${{ matrix.suite.name }}.yaml?ref=use-redirect-dot-github
+        URL=https://api.github.com/repos/dependabot/smoke-tests/contents/tests/smoke-${{ matrix.suite.name }}.yaml
         curl $(gh api $URL --jq .download_url) -o smoke.yaml
 
     # Download the Proxy cache. The job is ideally 100% cached so no real calls are made.

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -26,7 +26,7 @@ module Dependabot
       def initialize(source:, dependencies:, files:, credentials:,
                      pr_message_header: nil, pr_message_footer: nil,
                      commit_message_options: {}, vulnerabilities_fixed: {},
-                     github_redirection_service:)
+                     github_redirection_service: DEFAULT_GITHUB_REDIRECTION_SERVICE)
         @dependencies               = dependencies
         @files                      = files
         @source                     = source

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -30,14 +30,7 @@ module Dependabot
         dependencies: dependencies,
         files: updated_dependency_files,
         credentials: job.credentials,
-        commit_message_options: job.commit_message_options,
-        # This ensures that PR messages we build replace github.com links with
-        # a redirect that stop markdown enriching them into mentions on the source
-        # repository.
-        #
-        # TODO: Promote this value to a constant or similar once we have
-        # updated core to avoid surprise outcomes if this is unset.
-        github_redirection_service: "github-redirect.dependabot.com"
+        commit_message_options: job.commit_message_options
       ).message
     end
 

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -104,8 +104,7 @@ RSpec.describe Dependabot::DependencyChange do
             files: updated_dependency_files,
             dependencies: dependencies,
             credentials: job_credentials,
-            commit_message_options: commit_message_options,
-            github_redirection_service: "github-redirect.dependabot.com"
+            commit_message_options: commit_message_options
           )
 
         expect(dependency_change.pr_message).to eql("Hello World!")


### PR DESCRIPTION
The DEFAULT_GITHUB_REDIRECTION_SERVICE has been the default argument for PullRequestCreator, but I think it can also serve the same purpose in PullRequestCreator::MessageBuilder.