### PR TITLE
Extract log helper methods into a Logger::Formatter, Push the `job_id` into the Job object

### DIFF
--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -49,7 +49,7 @@ module Dependabot
           :vendor_dependencies, :security_updates_only
         )
 
-      Job.new(job_data.merge(token: job_token))
+      Job.new(job_data.merge(id: job_id, token: job_token))
     end
 
     # TODO: Make `base_commit_sha` part of Dependabot::DependencyChange

--- a/updater/lib/dependabot/environment.rb
+++ b/updater/lib/dependabot/environment.rb
@@ -10,9 +10,12 @@ module Dependabot
       @job_token ||= environment_variable("DEPENDABOT_JOB_TOKEN")
     end
 
+    def self.debug_enabled?
+      @debug_enabled ||= job_debug_enabled? || environment_debug_enabled?
+    end
+
     def self.api_url
-      default = "http://localhost:3001"
-      @api_url ||= environment_variable("DEPENDABOT_API_URL", default)
+      @api_url ||= environment_variable("DEPENDABOT_API_URL", "http://localhost:3001")
     end
 
     def self.job_path
@@ -35,7 +38,7 @@ module Dependabot
       @job_definition ||= JSON.parse(File.read(job_path))
     end
 
-    def self.environment_variable(variable_name, default = :_undefined)
+    private_class_method def self.environment_variable(variable_name, default = :_undefined)
       return ENV.fetch(variable_name, default) unless default == :_undefined
 
       ENV.fetch(variable_name) do
@@ -43,6 +46,12 @@ module Dependabot
       end
     end
 
-    private_class_method :environment_variable
+    private_class_method def self.job_debug_enabled?
+      !!job_definition.dig("job", "debug")
+    end
+
+    private_class_method def self.environment_debug_enabled?
+      !!environment_variable("DEPENDABOT_DEBUG", false)
+    end
   end
 end

--- a/updater/lib/dependabot/environment.rb
+++ b/updater/lib/dependabot/environment.rb
@@ -14,6 +14,10 @@ module Dependabot
       @debug_enabled ||= job_debug_enabled? || environment_debug_enabled?
     end
 
+    def self.log_level
+      debug_enabled? ? :debug : :info
+    end
+
     def self.api_url
       @api_url ||= environment_variable("DEPENDABOT_API_URL", "http://localhost:3001")
     end

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -94,7 +94,7 @@ module Dependabot
           :commit_message_options, :security_updates_only
         )
 
-      @job ||= Job.new(attrs)
+      @job ||= Job.new(attrs.merge(id: job_id))
     end
 
     def file_fetcher

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -29,10 +29,10 @@ module Dependabot
         @base_commit_sha ||= "unknown"
         if Octokit::RATE_LIMITED_ERRORS.include?(e.class)
           remaining = rate_limit_error_remaining(e)
-          logger_error("Repository is rate limited, attempting to retry in " \
-                       "#{remaining}s")
+          Dependabot.logger.error("Repository is rate limited, attempting to retry in " \
+                                  "#{remaining}s")
         else
-          logger_error("Error during file fetching; aborting")
+          Dependabot.logger.error("Error during file fetching; aborting")
         end
         handle_file_fetcher_error(e)
         service.mark_job_as_processed(@base_commit_sha)
@@ -167,8 +167,8 @@ module Dependabot
             }
           }
         else
-          logger_error error.message
-          error.backtrace.each { |line| logger_error line }
+          Dependabot.logger.error(error.message)
+          error.backtrace.each { |line| Dependabot.logger.error line }
           Raven.capture_exception(error, raven_context)
 
           { "error-type": "unknown_error" }
@@ -196,11 +196,11 @@ module Dependabot
     # connectivity through the proxy is established which can take 10-15s on
     # the first request in some customer's environments.
     def connectivity_check
-      logger_info("Connectivity check starting")
+      Dependabot.logger.info("Connectivity check starting")
       github_connectivity_client(job).repository(job.source.repo)
-      logger_info("Connectivity check successful")
+      Dependabot.logger.info("Connectivity check successful")
     rescue StandardError => e
-      logger_error("Connectivity check failed: #{e.message}")
+      Dependabot.logger.error("Connectivity check failed: #{e.message}")
     end
 
     def github_connectivity_client(job)

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -18,14 +18,15 @@ module Dependabot
   class Job
     TOP_LEVEL_DEPENDENCY_TYPES = %w(direct production development).freeze
 
-    attr_reader :token, :dependencies, :package_manager, :ignore_conditions,
+    attr_reader :id, :token, :dependencies, :package_manager, :ignore_conditions,
                 :existing_pull_requests, :source, :credentials,
                 :requirements_update_strategy, :security_advisories,
                 :allowed_updates, :vendor_dependencies, :security_updates_only
 
     # NOTE: "attributes" are fetched and injected at run time from both
-    # dependabot-api and dependabot-backend using the UpdateJobPrivateSerializer
+    # dependabot-api using the UpdateJobPrivateSerializer
     def initialize(attributes)
+      @id                           = attributes.fetch(:id)
       @allowed_updates              = attributes.fetch(:allowed_updates)
       @commit_message_options       = attributes.fetch(:commit_message_options, {})
       @credentials                  = attributes.fetch(:credentials, [])

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -23,7 +23,7 @@ module Dependabot
                 :requirements_update_strategy, :security_advisories,
                 :allowed_updates, :vendor_dependencies, :security_updates_only
 
-    # NOTE: "attributes" are fetched and injected at run time from both
+    # NOTE: "attributes" are fetched and injected at run time from
     # dependabot-api using the UpdateJobPrivateSerializer
     def initialize(attributes)
       @id                           = attributes.fetch(:id)

--- a/updater/lib/dependabot/logger/formats.rb
+++ b/updater/lib/dependabot/logger/formats.rb
@@ -14,18 +14,32 @@ module Dependabot
     end
 
     class JobFormatter < ::Logger::Formatter
+      CLI_ID = "cli"
+      UNKNOWN_ID = "unknown_id"
+
       def initialize(job_id)
         @job_id = job_id
       end
 
       def call(severity, _datetime, _progname, msg)
-        "#{severity} <job_#{job_id}> #{msg2str(msg)}\n"
+        [
+          severity,
+          job_prefix,
+          msg2str(msg)
+        ].compact.join(" ") + "\n"
       end
 
       private
 
-      def job_id
-        @job_id || "unknown_id"
+      def job_prefix
+        return @job_prefix if defined? @job_prefix
+        # The dependabot/cli tool uses a placeholder value since it does not
+        # have an actual Job ID issued by the service.
+        #
+        # Let's just omit the prefix if this is the case.
+        return @job_prefix = nil if @job_id == CLI_ID
+
+        @job_prefix = "<job_#{@job_id || UNKNOWN_ID}>"
       end
     end
   end

--- a/updater/lib/dependabot/logger/formats.rb
+++ b/updater/lib/dependabot/logger/formats.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "logger"
+
+# Provides Logger::Formatter classes specific to the Updater project to augment
+# the global log helper defined in common/lib/dependabot/logger.rb
+module Dependabot
+  module Logger
+    class BasicFormatter < ::Logger::Formatter
+      # Strip out timestamps as these are included in the runner's logger
+      def call(severity, _datetime, _progname, msg)
+        "#{severity} #{msg2str(msg)}\n"
+      end
+    end
+
+    class JobFormatter < ::Logger::Formatter
+      def initialize(job_id)
+        @job_id = job_id
+      end
+
+      def call(severity, _datetime, _progname, msg)
+        "#{severity} <job_#{job_id}> #{msg2str(msg)}\n"
+      end
+
+      private
+
+      def job_id
+        @job_id || "unknown_id"
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/setup.rb
+++ b/updater/lib/dependabot/setup.rb
@@ -30,18 +30,13 @@ Raven.configure do |config|
   config.processors += [ExceptionSanitizer]
 end
 
-require "logger"
 require "dependabot/logger"
-
-class LoggerFormatter < Logger::Formatter
-  # Strip out timestamps as these are included in the runner's logger
-  def call(severity, _datetime, _progname, msg)
-    "#{severity} #{msg2str(msg)}\n"
-  end
-end
+require "dependabot/logger/formats"
+require "dependabot/environment"
 
 Dependabot.logger = Logger.new($stdout).tap do |logger|
-  logger.formatter = LoggerFormatter.new
+  logger.level = Dependabot::Environment.log_level
+  logger.formatter = Dependabot::Logger::BasicFormatter.new
 end
 
 # We configure `Dependabot::Utils.register_always_clone` for some ecosystems. In

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -34,7 +34,7 @@ module Dependabot
           :commit_message_options, :security_updates_only
         )
 
-      @job ||= Job.new(attrs)
+      @job ||= Job.new(attrs.merge(id: job_id))
     end
 
     def dependency_files

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -72,10 +72,10 @@ module Dependabot
       return unless job
 
       if job.updating_a_pull_request?
-        logger_info("Starting PR update job for #{job.source.repo}")
+        Dependabot.logger.info("Starting PR update job for #{job.source.repo}")
         check_and_update_existing_pr_with_error_handling(dependencies)
       else
-        logger_info("Starting update job for #{job.source.repo}")
+        Dependabot.logger.info("Starting update job for #{job.source.repo}")
         dependencies.each { |dep| check_and_create_pr_with_error_handling(dep) }
       end
     rescue *RUN_HALTING_ERRORS.keys => e
@@ -146,9 +146,11 @@ module Dependabot
          dependencies.none? { |d| job.allowed_update?(d) }
         lead_dependency = dependencies.first
         if job.vulnerable?(lead_dependency)
-          logger_info("Dependency no longer allowed to update #{lead_dependency.name} #{lead_dependency.version}")
+          Dependabot.logger.info(
+            "Dependency no longer allowed to update #{lead_dependency.name} #{lead_dependency.version}"
+          )
         else
-          logger_info("No longer vulnerable #{lead_dependency.name} #{lead_dependency.version}")
+          Dependabot.logger.info("No longer vulnerable #{lead_dependency.name} #{lead_dependency.version}")
         end
         close_pull_request(reason: :up_to_date)
         return
@@ -249,7 +251,7 @@ module Dependabot
 
       if pr_exists_for_latest_version?(checker)
         record_pull_request_exists_for_latest_version(checker) if job.security_updates_only?
-        return logger_info(
+        return Dependabot.logger.info(
           "Pull request already exists for #{checker.dependency.name} " \
           "with latest version #{checker.latest_version}"
         )
@@ -261,7 +263,7 @@ module Dependabot
       if requirements_to_unlock == :update_not_possible
         return record_security_update_not_possible_error(checker) if job.security_updates_only? && job.dependencies
 
-        return logger_info(
+        return Dependabot.logger.info(
           "No update possible for #{dependency.name} #{dependency.version}"
         )
       end
@@ -295,13 +297,13 @@ module Dependabot
           end
         end
 
-        return logger_info(
+        return Dependabot.logger.info(
           "Pull request already exists for #{deps.join(', ')}"
         )
       end
 
       if peer_dependency_should_update_instead?(checker.dependency.name, updated_deps)
-        return logger_info(
+        return Dependabot.logger.info(
           "No update possible for #{dependency.name} #{dependency.version} " \
           "(peer dependency can be updated)"
         )
@@ -326,7 +328,7 @@ module Dependabot
     end
 
     def record_security_update_not_needed_error(checker)
-      logger_info(
+      Dependabot.logger.info(
         "no security update needed as #{checker.dependency.name} " \
         "is no longer vulnerable"
       )
@@ -342,7 +344,7 @@ module Dependabot
     end
 
     def record_security_update_ignored(checker)
-      logger_info(
+      Dependabot.logger.info(
         "Dependabot cannot update to the required version as all versions " \
         "were ignored for #{checker.dependency.name}"
       )
@@ -358,7 +360,7 @@ module Dependabot
     end
 
     def record_dependency_file_not_supported_error(checker)
-      logger_info(
+      Dependabot.logger.info(
         "Dependabot can't update vulnerable dependencies for projects " \
         "without a lockfile or pinned version requirement as the currently " \
         "installed version of #{checker.dependency.name} isn't known."
@@ -382,11 +384,11 @@ module Dependabot
         checker.lowest_security_fix_version&.to_s
       conflicting_dependencies = checker.conflicting_dependencies
 
-      logger_info(
+      Dependabot.logger.info(
         security_update_not_possible_message(checker, latest_allowed_version,
                                              conflicting_dependencies)
       )
-      logger_info(earliest_fixed_version_message(lowest_non_vulnerable_version))
+      Dependabot.logger.info(earliest_fixed_version_message(lowest_non_vulnerable_version))
 
       record_error(
         {
@@ -402,7 +404,7 @@ module Dependabot
     end
 
     def record_security_update_not_found(checker)
-      logger_info(
+      Dependabot.logger.info(
         "Dependabot can't find a published or compatible non-vulnerable " \
         "version for #{checker.dependency.name}. " \
         "The latest available version is #{checker.dependency.version}"
@@ -515,17 +517,17 @@ module Dependabot
     end
 
     def log_checking_for_update(dependency)
-      logger_info(
+      Dependabot.logger.info(
         "Checking if #{dependency.name} #{dependency.version} needs updating"
       )
       log_ignore_conditions(dependency)
     end
 
     def all_versions_ignored?(dependency, checker)
-      logger_info("Latest version is #{checker.latest_version}")
+      Dependabot.logger.info("Latest version is #{checker.latest_version}")
       false
     rescue Dependabot::AllVersionsIgnored
-      logger_info("All updates for #{dependency.name} were ignored")
+      Dependabot.logger.info("All updates for #{dependency.name} were ignored")
 
       # Report this error to the backend to create an update job error
       raise if job.security_updates_only?
@@ -538,31 +540,33 @@ module Dependabot
                    select { |ic| name_match?(ic["dependency-name"], dep.name) }
       return if conditions.empty?
 
-      logger_info("Ignored versions:")
+      Dependabot.logger.info("Ignored versions:")
       conditions.each do |ic|
-        logger_info("  #{ic['version-requirement']} - from #{ic['source']}") unless ic["version-requirement"].nil?
+        unless ic["version-requirement"].nil?
+          Dependabot.logger.info("  #{ic['version-requirement']} - from #{ic['source']}")
+        end
 
         ic["update-types"]&.each do |update_type|
           msg = "  #{update_type} - from #{ic['source']}"
           msg += " (doesn't apply to security update)" if job.security_updates_only?
-          logger_info(msg)
+          Dependabot.logger.info(msg)
         end
       end
     end
 
     def log_up_to_date(dependency)
-      logger_info(
+      Dependabot.logger.info(
         "No update needed for #{dependency.name} #{dependency.version}"
       )
     end
 
     def log_error(dependency:, error:, error_type:, error_detail: nil)
       if error_type == "unknown_error"
-        logger_error "Error processing #{dependency.name} (#{error.class.name})"
-        logger_error error.message
-        error.backtrace.each { |line| logger_error line }
+        Dependabot.logger.error "Error processing #{dependency.name} (#{error.class.name})"
+        Dependabot.logger.error error.message
+        error.backtrace.each { |line| Dependabot.logger.error line }
       else
-        logger_info(
+        Dependabot.logger.info(
           "Handled error whilst updating #{dependency.name}: #{error_type} " \
           "#{error_detail}"
         )
@@ -570,11 +574,11 @@ module Dependabot
     end
 
     def log_requirements_for_update(requirements_to_unlock, checker)
-      logger_info("Requirements to unlock #{requirements_to_unlock}")
+      Dependabot.logger.info("Requirements to unlock #{requirements_to_unlock}")
 
       return unless checker.respond_to?(:requirements_update_strategy)
 
-      logger_info(
+      Dependabot.logger.info(
         "Requirements update strategy #{checker.requirements_update_strategy}"
       )
     end
@@ -635,8 +639,8 @@ module Dependabot
       allowed_deps = allowed_deps.shuffle unless ENV["UPDATER_DETERMINISTIC"]
 
       if all_deps.any? && allowed_deps.none?
-        logger_info("Found no dependencies to update after filtering allowed " \
-                    "updates")
+        Dependabot.logger.info("Found no dependencies to update after filtering allowed " \
+                               "updates")
       end
 
       # Consider updating vulnerable deps first. Only consider the first 10,
@@ -732,12 +736,12 @@ module Dependabot
     def generate_dependency_files_for(updated_dependencies)
       if updated_dependencies.count == 1
         updated_dependency = updated_dependencies.first
-        logger_info("Updating #{updated_dependency.name} from " \
-                    "#{updated_dependency.previous_version} to " \
-                    "#{updated_dependency.version}")
+        Dependabot.logger.info("Updating #{updated_dependency.name} from " \
+                               "#{updated_dependency.previous_version} to " \
+                               "#{updated_dependency.version}")
       else
         dependency_names = updated_dependencies.map(&:name)
-        logger_info("Updating #{dependency_names.join(', ')}")
+        Dependabot.logger.info("Updating #{dependency_names.join(', ')}")
       end
 
       # Ignore dependencies that are tagged as information_only. These will be
@@ -749,8 +753,8 @@ module Dependabot
     end
 
     def create_pull_request(dependencies, updated_dependency_files)
-      logger_info("Submitting #{dependencies.map(&:name).join(', ')} " \
-                  "pull request for creation")
+      Dependabot.logger.info("Submitting #{dependencies.map(&:name).join(', ')} " \
+                             "pull request for creation")
 
       dependency_change = Dependabot::DependencyChange.new(
         job: job,
@@ -770,8 +774,8 @@ module Dependabot
     end
 
     def update_pull_request(dependencies, updated_dependency_files)
-      logger_info("Submitting #{dependencies.map(&:name).join(', ')} " \
-                  "pull request for update")
+      Dependabot.logger.info("Submitting #{dependencies.map(&:name).join(', ')} " \
+                             "pull request for update")
 
       dependency_change = Dependabot::DependencyChange.new(
         job: job,
@@ -784,8 +788,8 @@ module Dependabot
 
     def close_pull_request(reason:)
       reason_string = reason.to_s.tr("_", " ")
-      logger_info("Telling backend to close pull request for " \
-                  "#{job.dependencies.join(', ')} - #{reason_string}")
+      Dependabot.logger.info("Telling backend to close pull request for " \
+                             "#{job.dependencies.join(', ')} - #{reason_string}")
       service.close_pull_request(job.dependencies, reason)
     end
 
@@ -955,8 +959,8 @@ module Dependabot
         else
           raise if RUN_HALTING_ERRORS.keys.any? { |e| error.is_a?(e) }
 
-          logger_error error.message
-          error.backtrace.each { |line| logger_error line }
+          Dependabot.logger.error error.message
+          error.backtrace.each { |line| Dependabot.logger.error line }
 
           Raven.capture_exception(error, raven_context)
           { "error-type": "unknown_error" }
@@ -986,22 +990,6 @@ module Dependabot
 
     def credentials
       job.credentials
-    end
-
-    def logger_info(message)
-      Dependabot.logger.info(prefixed_log_message(message))
-    end
-
-    def logger_error(message)
-      Dependabot.logger.error(prefixed_log_message(message))
-    end
-
-    def prefixed_log_message(message)
-      message.lines.map { |line| [log_prefix, line].join(" ") }.join
-    end
-
-    def log_prefix
-      "<job_#{job_id}>" if job_id
     end
 
     def record_error(error_details, dependency: nil)

--- a/updater/spec/dependabot/environment_spec.rb
+++ b/updater/spec/dependabot/environment_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "dependabot/environment"
+
+RSpec.describe Dependabot::Environment do
+  subject(:environment) { described_class }
+
+  describe "::debug_enabled?" do
+    after do
+      # Reset the memoisation after each test
+      environment.remove_instance_variable(:@debug_enabled)
+    end
+
+    it "is false by default" do
+      allow(environment).to receive(:job_definition).and_return({})
+      allow(ENV).to receive(:fetch).with("DEPENDABOT_DEBUG", false).and_return(false)
+
+      expect(environment).not_to be_debug_enabled
+    end
+
+    it "is true if enabled in ENV" do
+      allow(environment).to receive(:job_definition).and_return({})
+      allow(ENV).to receive(:fetch).with("DEPENDABOT_DEBUG", false).and_return("true")
+
+      expect(environment).to be_debug_enabled
+    end
+
+    it "is true if enabled in the job definition" do
+      allow(environment).to receive(:job_definition).and_return({
+        "job" => { "debug" => true }
+      })
+      allow(ENV).to receive(:fetch).with("DEPENDABOT_DEBUG", false).and_return(false)
+
+      expect(environment).to be_debug_enabled
+    end
+  end
+end

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Dependabot::Job do
 
   let(:attributes) do
     {
+      id: 1,
       token: "token",
       dependencies: dependencies,
       allowed_updates: allowed_updates,

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -125,10 +125,10 @@ RSpec.describe Dependabot::Updater do
 
       expect(Dependabot.logger).
         to receive(:info).
-        with("<job_1> Checking if dummy-pkg-b 1.1.0 needs updating")
+        with("Checking if dummy-pkg-b 1.1.0 needs updating")
       expect(Dependabot.logger).
         to receive(:info).
-        with("<job_1> Latest version is 1.2.0")
+        with("Latest version is 1.2.0")
 
       updater.run
     end
@@ -207,10 +207,10 @@ RSpec.describe Dependabot::Updater do
 
         expect(Dependabot.logger).
           to receive(:info).
-          with("<job_1> Requirements to unlock own")
+          with("Requirements to unlock own")
         expect(Dependabot.logger).
           to receive(:info).
-          with("<job_1> Requirements update strategy bump_versions")
+          with("Requirements update strategy bump_versions")
 
         updater.run
       end
@@ -230,7 +230,7 @@ RSpec.describe Dependabot::Updater do
 
         expect(Dependabot.logger).
           to receive(:info).
-          with("<job_1> Found no dependencies to update after filtering " \
+          with("Found no dependencies to update after filtering " \
                "allowed updates")
         updater.run
       end
@@ -301,7 +301,7 @@ RSpec.describe Dependabot::Updater do
           )
           expect(Dependabot.logger).
             to receive(:info).with(
-              "<job_1> Dependabot can't update vulnerable dependencies for " \
+              "Dependabot can't update vulnerable dependencies for " \
               "projects without a lockfile or pinned version requirement as " \
               "the currently installed version of dummy-pkg-b isn't known."
             )
@@ -386,10 +386,10 @@ RSpec.describe Dependabot::Updater do
           )
           expect(Dependabot.logger).
             to receive(:info).with(
-              "<job_1> The latest possible version that can be installed is " \
+              "The latest possible version that can be installed is " \
               "1.2.0 because of the following conflicting dependency:\n" \
-              "<job_1> \n" \
-              "<job_1>   dummy-pkg-a (1.0.0) requires dummy-pkg-b (= 1.2.0)"
+              "\n" \
+              "  dummy-pkg-a (1.0.0) requires dummy-pkg-b (= 1.2.0)"
             )
 
           updater.run
@@ -431,7 +431,7 @@ RSpec.describe Dependabot::Updater do
           )
           expect(Dependabot.logger).
             to receive(:info).with(
-              "<job_1> The latest possible version of dummy-pkg-b that can be " \
+              "The latest possible version of dummy-pkg-b that can be " \
               "installed is 1.1.0"
             )
 
@@ -470,7 +470,7 @@ RSpec.describe Dependabot::Updater do
           expect(Dependabot.logger).
             to receive(:info).
             with(
-              "<job_1> Dependabot can't find a published or compatible " \
+              "Dependabot can't find a published or compatible " \
               "non-vulnerable version for dummy-pkg-b. " \
               "The latest available version is 1.1.0"
             )
@@ -533,12 +533,12 @@ RSpec.describe Dependabot::Updater do
           expect(Dependabot.logger).
             to receive(:info).
             with(
-              "<job_1> All updates for dummy-pkg-a were ignored"
+              "All updates for dummy-pkg-a were ignored"
             )
           expect(Dependabot.logger).
             to receive(:info).
             with(
-              "<job_1> All updates for dummy-pkg-b were ignored"
+              "All updates for dummy-pkg-b were ignored"
             )
 
           updater.run
@@ -946,7 +946,7 @@ RSpec.describe Dependabot::Updater do
           expect(service).to_not receive(:record_update_job_error)
           expect(Dependabot.logger).
             to receive(:info).
-            with("<job_1> Pull request already exists for dummy-pkg-b " \
+            with("Pull request already exists for dummy-pkg-b " \
                  "with latest version 1.2.0")
 
           updater.run
@@ -975,7 +975,7 @@ RSpec.describe Dependabot::Updater do
           expect(service).to_not receive(:record_update_job_error)
           expect(Dependabot.logger).
             to receive(:info).
-            with("<job_1> Pull request already exists for dummy-pkg-b@1.2.0")
+            with("Pull request already exists for dummy-pkg-b@1.2.0")
 
           updater.run
         end
@@ -1022,7 +1022,7 @@ RSpec.describe Dependabot::Updater do
             )
           expect(Dependabot.logger).
             to receive(:info).
-            with("<job_1> Pull request already exists for dummy-pkg-b@1.2.0")
+            with("Pull request already exists for dummy-pkg-b@1.2.0")
 
           updater.run
         end
@@ -1066,7 +1066,7 @@ RSpec.describe Dependabot::Updater do
             )
           expect(Dependabot.logger).
             to receive(:info).
-            with("<job_1> Pull request already exists for dummy-pkg-b " \
+            with("Pull request already exists for dummy-pkg-b " \
                  "with latest version 1.2.0")
 
           updater.run
@@ -1174,7 +1174,7 @@ RSpec.describe Dependabot::Updater do
           )
         expect(Dependabot.logger).
           to receive(:info).
-          with("<job_1> Pull request already exists for dummy-pkg-c@1.4.0, dummy-pkg-b@removed")
+          with("Pull request already exists for dummy-pkg-c@1.4.0, dummy-pkg-b@removed")
         updater.run
       end
     end
@@ -1270,7 +1270,7 @@ RSpec.describe Dependabot::Updater do
               expect(service).to receive(:close_pull_request).once
               expect(Dependabot.logger).
                 to receive(:info).with(
-                  "<job_1> Dependency no longer allowed to update dummy-pkg-b 1.1.0"
+                  "Dependency no longer allowed to update dummy-pkg-b 1.1.0"
                 )
 
               updater.run
@@ -1559,7 +1559,7 @@ RSpec.describe Dependabot::Updater do
               )
               expect(Dependabot.logger).
                 to receive(:info).with(
-                  "<job_1> Dependabot cannot update to the required version as all " \
+                  "Dependabot cannot update to the required version as all " \
                   "versions were ignored for dummy-pkg-b"
                 )
 
@@ -1597,7 +1597,7 @@ RSpec.describe Dependabot::Updater do
               )
               expect(Dependabot.logger).
                 to receive(:info).with(
-                  "<job_1> no security update needed as dummy-pkg-b " \
+                  "no security update needed as dummy-pkg-b " \
                   "is no longer vulnerable"
                 )
 
@@ -2416,7 +2416,7 @@ RSpec.describe Dependabot::Updater do
 
         expect(Dependabot.logger).
           to have_received(:info).
-          with("<job_1>   >= 1.a, < 2.0.0 - from @dependabot ignore command")
+          with("  >= 1.a, < 2.0.0 - from @dependabot ignore command")
       end
 
       it "logs ignored update types" do
@@ -2441,10 +2441,10 @@ RSpec.describe Dependabot::Updater do
 
         expect(Dependabot.logger).
           to have_received(:info).
-          with("<job_1>   version-update:semver-patch - from .github/dependabot.yaml")
+          with("  version-update:semver-patch - from .github/dependabot.yaml")
         expect(Dependabot.logger).
           to have_received(:info).
-          with("<job_1>   version-update:semver-minor - from .github/dependabot.yaml")
+          with("  version-update:semver-minor - from .github/dependabot.yaml")
       end
     end
 
@@ -2490,7 +2490,7 @@ RSpec.describe Dependabot::Updater do
         expect(Dependabot.logger).
           to have_received(:info).
           with(
-            "<job_1>   version-update:semver-patch - from .github/dependabot.yaml (doesn't apply to security update)"
+            "  version-update:semver-patch - from .github/dependabot.yaml (doesn't apply to security update)"
           )
       end
     end

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -2539,6 +2539,7 @@ RSpec.describe Dependabot::Updater do
                 existing_pull_requests: [], ignore_conditions: [], security_advisories: [],
                 experiments: {}, updating_a_pull_request: false, security_updates_only: false)
     Dependabot::Job.new(
+      id: 1,
       token: "token",
       dependencies: requested_dependencies,
       allowed_updates: allowed_updates,


### PR DESCRIPTION
This branch extracts a couple of tidy ups from some ongoing work to prepare the Dependabot::Updater to receive our [prototype grouped updating strategy](https://github.com/dependabot/dependabot-core/pull/6663).

While splitting the updater up into discrete classes, there were two cross-cutting pain points:
- Having pass _both_ a Job object and the job_id is counter productive and it leaves us reaching back to the `Dependabot::Environment` object as we start to extract code. 
  - This is likely going to make compartmentalisation worse as the `Environment` object should never be part of Core but some of the Updater strategies we are extracting _should_ become Core-bound eventually so ecosystems can override them
  - Solution: Let's just allow a Job to know its id?
- Writing to the `Dependabot.logger` is wrapped in `logger_info` and `logger_error` methods in two levels of abstraction, the "Command" class and the Updater itself to inject a `job_id` prefix
  - Breaking the code out means they need access to a global logger with the prefix behaviour
  - We also have some limitations in our current logging layout that means we don't use debug level message which would _really_ help both contributors and users a lot
  - Solution: Let's use Logger::Formatters to attach a presenter to the global logger we setup at the start of a job
  - Bonus points: Let's teach `Dependabot::Environment` about a debug flag so we can default to :info, but optionally invoke :debug

### Service Changes

- This branch introduces the use of a `DEPENDABOT_DEBUG` envvar, when 'true' it will set the log level to :debug.
- The job.json, aka Job Definition File, can now also pass a `job.debug = true` value to set the log level on a job-by-job basis
- The formatter is aware of github.com/dependabot/cli's [placeholder Job ID](https://github.com/dependabot/cli/blob/8f18d3681cafd6bbd5078ddfb7893ae8c227837b/internal/infra/updater.go#L25) and omits the prefix in that environment