### PR TITLE
Do not nil out the PR message for jobs updating a PR

### DIFF
--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -21,8 +21,6 @@ module Dependabot
     end
 
     def pr_message
-      # If we are updating an existing PullRequest, we do not generate a new message as part of the change
-      return nil if job.updating_a_pull_request?
       return @pr_message if defined?(@pr_message)
 
       @pr_message = Dependabot::PullRequestCreator::MessageBuilder.new(

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -92,35 +92,17 @@ RSpec.describe Dependabot::DependencyChange do
       allow(Dependabot::PullRequestCreator::MessageBuilder).to receive(:new).and_return(message_builder_mock)
     end
 
-    context "when the change is for a new pull request" do
-      before do
-        allow(job).to receive(:updating_a_pull_request?).and_return(false)
-      end
+    it "delegates to the Dependabot::PullRequestCreator::MessageBuilder with the correct configuration" do
+      expect(Dependabot::PullRequestCreator::MessageBuilder).
+        to receive(:new).with(
+          source: github_source,
+          files: updated_dependency_files,
+          dependencies: dependencies,
+          credentials: job_credentials,
+          commit_message_options: commit_message_options
+        )
 
-      it "delegates to the Dependabot::PullRequestCreator::MessageBuilder with the correct configuration" do
-        expect(Dependabot::PullRequestCreator::MessageBuilder).
-          to receive(:new).with(
-            source: github_source,
-            files: updated_dependency_files,
-            dependencies: dependencies,
-            credentials: job_credentials,
-            commit_message_options: commit_message_options
-          )
-
-        expect(dependency_change.pr_message).to eql("Hello World!")
-      end
-    end
-
-    context "when the change is updating an existing pull request" do
-      before do
-        allow(job).to receive(:updating_a_pull_request?).and_return(true)
-      end
-
-      it "it does not invoke Dependabot::PullRequestCreator::MessageBuilder" do
-        expect(Dependabot::PullRequestCreator::MessageBuilder).not_to receive(:new)
-
-        expect(dependency_change.pr_message).to be_nil
-      end
+      expect(dependency_change.pr_message).to eql("Hello World!")
     end
   end
 


### PR DESCRIPTION
This fixes a bug introduced in #6792.

The newly introduced `DependencyChange` class made an assumption that any content created as result of a Job which had  `updating_a_pull_request?` should not generate a `pr_message` object as the ApiClient historically did not accept a `pr_message` argument.

In reality, we have this scenario when `updating_a_pull_request?` is true to consider:
https://github.com/dependabot/dependabot-core/blob/a196e04c7f7ef580fdc1da66952c87e53cfb6da3/updater/lib/dependabot/updater.rb#L196-L201

In a scenario where we close the existing PR and create a new one, the `nil` PR message blocks the API accepting the request.