### PR TITLE
Terraform: fix NoMethodError due to no versions in module

### DIFF
--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -80,7 +80,10 @@ module Dependabot
         response = http_get!(URI.join(base_url, "#{identifier}/versions"))
 
         JSON.parse(response.body).
-          fetch("modules").first.fetch("versions", []).
+          fetch("modules").
+          first.
+          tap { |mod| raise error("Registry returned no modules") if mod.nil? }.
+          fetch("versions", []).
           map { |release| version_class.new(release.fetch("version")) }
       end
 

--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -80,7 +80,7 @@ module Dependabot
         response = http_get!(URI.join(base_url, "#{identifier}/versions"))
 
         JSON.parse(response.body).
-          fetch("modules").first.fetch("versions").
+          fetch("modules").first.fetch("versions", []).
           map { |release| version_class.new(release.fetch("version")) }
       end
 


### PR DESCRIPTION
We're seeing this error quite a bit in the Terraform ecosystem. 

```
NoMethodError: undefined method `fetch' for nil:NilClass

          fetch("modules").first.fetch("versions").
                                ^^^^^^
  from terraform/lib/dependabot/terraform/registry_client.rb:83:in `all_module_versions'
  from terraform/lib/dependabot/terraform/update_checker.rb:73:in `all_module_versions'
  from terraform/lib/dependabot/terraform/update_checker.rb:64:in `latest_version_for_registry_dependency'
  from terraform/lib/dependabot/terraform/update_checker.rb:18:in `latest_version'
  from dependabot-updater/lib/dependabot/updater.rb:525:in `all_versions_ignored?'
  from dependabot-updater/lib/dependabot/updater.rb:222:in `check_and_create_pull_request'
  from dependabot-updater/lib/dependabot/updater.rb:103:in `check_and_create_pr_with_error_handling'
  from dependabot-updater/lib/dependabot/updater.rb:79:in `block in run'
  from dependabot-updater/lib/dependabot/updater.rb:79:in `each'
  from dependabot-updater/lib/dependabot/updater.rb:79:in `run'
  from dependabot-updater/lib/dependabot/update_files_command.rb:17:in `perform_job'
  from dependabot-updater/lib/dependabot/base_command.rb:50:in `run'
  from bin/update_files.rb:23:in `<main>'
```

It seems to be due to the module response returning no modules: `"modules": []`.

So I've added a specific nil check to throw a better error.