### PR TITLE
Clarify TODO comment

### DIFF
--- a/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pipenv_version_resolver.rb
@@ -239,8 +239,10 @@ module Dependabot
             raise DependencyFileNotResolvable, msg
           end
 
-          # NOTE: Pipenv masks the actualy error, see this issue for updates:
+          # NOTE: Pipenv masks the actual error, see this issue for updates:
           # https://github.com/pypa/pipenv/issues/2791
+          # TODO: This may no longer be reproducible on latest pipenv, see linked issue,
+          # so investigate when we next bump to newer pipenv...
           handle_pipenv_installation_error(error.message) if error.message.match?(PIPENV_INSTALLATION_ERROR_REGEX)
 
           # Raise an unhandled error, as this could be a problem with


### PR DESCRIPTION
Unfortunately, bumping to the latest version of `pipenv` is currently blocked on us dropping support for Python 3.6:
* https://github.com/dependabot/dependabot-core/pull/6104#issuecomment-1397616478

So for now let's clarify the comment with a TODO... 

This whole bit of code may also get redone if we switch the interface we use:
* https://github.com/dependabot/dependabot-core/issues/6836

But for now let's capture some notes until we can devote more time to this.