### PR TITLE
Adjust poetry/pyproject python version to match installed in version resolver

### DIFF
--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -227,6 +227,7 @@ module Dependabot
         def updated_pyproject_content(updated_requirement:)
           content = pyproject.content
           content = sanitize_pyproject_content(content)
+          content = update_python_requirement(content)
           content = freeze_other_dependencies(content)
           content = set_target_dependency_req(content, updated_requirement)
           content
@@ -235,6 +236,7 @@ module Dependabot
         def sanitized_pyproject_content
           content = pyproject.content
           content = sanitize_pyproject_content(content)
+          content = update_python_requirement(content)
           content
         end
 
@@ -242,6 +244,12 @@ module Dependabot
           Python::FileUpdater::PyprojectPreparer.
             new(pyproject_content: pyproject_content).
             sanitize
+        end
+
+        def update_python_requirement(pyproject_content)
+          Python::FileUpdater::PyprojectPreparer.
+            new(pyproject_content: pyproject_content).
+            update_python_requirement(language_version_manager.python_major_minor)
         end
 
         def freeze_other_dependencies(pyproject_content)

--- a/python/spec/fixtures/pyproject_files/poetry_exact_requirement.toml
+++ b/python/spec/fixtures/pyproject_files/poetry_exact_requirement.toml
@@ -8,5 +8,5 @@ authors = ["Dependabot <support@dependabot.com>"]
 description = "Various small python projects."
 
 [tool.poetry.dependencies]
-python = "*"
+python = "3.11.1"
 requests = "2.18.0"


### PR DESCRIPTION
Resolves this error when checking for updates when a specific python version is pinned in pyproject.toml. We want it to match the version that pre-installed with the updater rather than dynamically installing a different patch release.

```
Dependabot::SharedHelpers::HelperSubprocessFailed: The currently activated Python version 3.11.2 is not supported by the project (3.11.1). Trying to find and use a compatible version.

Poetry was unable to find a compatible version. If you have one, you can explicitly use it via the "env use" command.
 ./lib/dependabot/python/update_checker/poetry_version_resolver.rb:349:in `run_poetry_command'
 ./lib/dependabot/python/update_checker/poetry_version_resolver.rb:167:in `run_poetry_update_command'
```