### PR TITLE
Fix the call order when pulling through cred metadata

### DIFF
--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -58,11 +58,9 @@ module Dependabot
     end
 
     def self.new_update_job(job_id:, job_definition:, repo_contents_path: nil)
-      attrs = standardise_keys(job_definition["job"]).tap do |job_hash|
-        # The Updater should NOT have access to credentials. Let's use metadata, which
-        # can be used by the proxy for matching and applying the real credentials
-        job_hash[:credentials] = job_hash.delete(:credentials_metadata) || []
-      end.slice(*PERMITTED_KEYS)
+      job_hash = standardise_keys(job_definition["job"])
+      attrs = job_hash.slice(*PERMITTED_KEYS)
+      attrs[:credentials] = job_hash[:credentials_metadata]
 
       new(attrs.merge(id: job_id, repo_contents_path: repo_contents_path))
     end

--- a/updater/spec/dependabot/integration_spec.rb
+++ b/updater/spec/dependabot/integration_spec.rb
@@ -128,11 +128,9 @@ RSpec.describe "Dependabot Updates" do
           "hostname" => "github.com",
           "branch" => nil
         },
-        "credentials" => [{
+        "credentials-metadata" => [{
           "type" => "git_source",
-          "host" => "github.com",
-          "username" => "x-access-token",
-          "password" => "github-token"
+          "host" => "github.com"
         }],
         "lockfile_only" => false,
         "requirements_update_strategy" => nil,
@@ -317,11 +315,9 @@ RSpec.describe "Dependabot Updates" do
           "hostname" => "github.com",
           "branch" => nil
         },
-        "credentials" => [{
+        "credentials-metadata" => [{
           "type" => "git_source",
-          "host" => "github.com",
-          "username" => "x-access-token",
-          "password" => test_access_token
+          "host" => "github.com"
         }],
         "lockfile_only" => false,
         "requirements_update_strategy" => nil,


### PR DESCRIPTION
Fast-follow on https://github.com/dependabot/dependabot-core/pull/6843

The previous fix only remediated for the wrong key case being used, but by regressing the call order it didn't account for the fact that the `slice` operation no longer includes the `credentials` key.

This is a split-the-difference fix which uses the new call order so the `credentials` are injected to a filtered attribute list that uses a single `PERMITTED_KEYS` list but are pulled from a version of the hash that is pre-filtered **and** standardised.