### PR TITLE
[Updater] Prefer to use `Dependabot::Service` directly and as an application error reporter

### DIFF
--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -69,20 +69,16 @@ module Dependabot
       service.record_update_job_error(error_type: "unknown_error", error_details: { message: err.message })
     end
 
-    def api_url
-      Environment.api_url
-    end
-
     def job_id
       Environment.job_id
     end
 
-    def job_token
-      Environment.job_token
-    end
-
     def api_client
-      @api_client ||= Dependabot::ApiClient.new(api_url, job_id, job_token)
+      @api_client ||= Dependabot::ApiClient.new(
+        Environment.api_url,
+        job_id,
+        Environment.job_token
+      )
     end
 
     def service

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -64,8 +64,7 @@ module Dependabot
       Dependabot.logger.error(err.message)
       err.backtrace.each { |line| Dependabot.logger.error(line) }
 
-      Raven.capture_exception(err, raven_context)
-
+      service.capture_exception(error: err, job: job)
       service.record_update_job_error(error_type: "unknown_error", error_details: { message: err.message })
     end
 
@@ -83,14 +82,6 @@ module Dependabot
 
     def service
       @service ||= Dependabot::Service.new(client: api_client)
-    end
-
-    private
-
-    def raven_context
-      context = { tags: {}, extra: { update_job_id: job_id } }
-      context[:tags][:package_manager] = job.package_manager if job
-      context
     end
   end
 end

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -170,8 +170,8 @@ module Dependabot
         else
           Dependabot.logger.error(error.message)
           error.backtrace.each { |line| Dependabot.logger.error line }
-          Raven.capture_exception(error, raven_context)
 
+          service.capture_exception(error: error, job: job)
           { "error-type": "unknown_error" }
         end
 

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -42,6 +42,25 @@ module Dependabot
       client.record_update_job_error(error_type: error_type, error_details: error_details)
     end
 
+    # This method wraps the Raven client as the Application error tracker
+    # the service uses to notice errors.
+    #
+    # This should be called as an alternative/in addition to record_update_job_error
+    # for cases where an error could indicate a problem with the service.
+    def capture_exception(error:, job: nil, dependency: nil, tags: {}, extra: {})
+      Raven.capture_exception(
+        error,
+        {
+          tags: tags,
+          extra: extra.merge({
+            update_job_id: job&.id,
+            package_manager: job&.package_manager,
+            dependency_name: dependency&.name
+          }.compact)
+        }
+      )
+    end
+
     def noop?
       pull_requests.empty? && errors.empty?
     end

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -3,13 +3,16 @@
 require "terminal-table"
 require "dependabot/api_client"
 
-# Wraps an API client with the current state of communications with the Dependabot Service
-# and provides an interface to summarise all actions taken.
+# This class provides an output adapter for the Dependabot Service which manages
+# communication with the private API as well as consolidated error handling.
+#
+# Currently this is the only output adapter available, but in future we may
+# support others for use with the dependabot/cli project.
 #
 module Dependabot
   class Service
     extend Forwardable
-    attr_reader :client, :events, :pull_requests, :errors
+    attr_reader :pull_requests, :errors
 
     def initialize(client:)
       @client = client
@@ -70,6 +73,8 @@ module Dependabot
     end
 
     private
+
+    attr_reader :client
 
     def pull_request_summary
       return unless pull_requests.any?

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -786,6 +786,7 @@ module Dependabot
       service.close_pull_request(job.dependencies, reason)
     end
 
+    # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     def handle_dependabot_error(error:, dependency:)
       error_details =
@@ -890,8 +891,9 @@ module Dependabot
         error_detail: error_details.fetch(:"error-detail", nil)
       )
     end
-
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
+
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/CyclomaticComplexity
     def handle_parser_error(error)

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -85,8 +85,10 @@ module Dependabot
       end
 
       # OOM errors are special cased so that we stop the update run early
-      error = { "error-type": RUN_HALTING_ERRORS.fetch(e.class) }
-      record_error(error)
+      service.record_update_job_error(
+        error_type: RUN_HALTING_ERRORS.fetch(e.class),
+        error_details: nil
+      )
     end
 
     private

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -967,7 +967,14 @@ module Dependabot
           { "error-type": "unknown_error" }
         end
 
-      record_error(error_details) if error_details
+      # TODO: Early return for Dependabot::BranchNotFound instead of assigning
+      #       nil to error_details
+      return unless error_details
+
+      service.record_update_job_error(
+        error_type: error_details.fetch(:"error-type"),
+        error_details: error_details[:"error-detail"]
+      )
     end
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/CyclomaticComplexity
@@ -982,14 +989,6 @@ module Dependabot
           }
         end,
         dependency_files.reject(&:support_file).map(&:path)
-      )
-    end
-
-    def record_error(error_details, dependency: nil)
-      service.record_update_job_error(
-        error_type: error_details.fetch(:"error-type"),
-        error_details: error_details[:"error-detail"],
-        dependency: dependency
       )
     end
   end

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -877,7 +877,11 @@ module Dependabot
           { "error-type": "unknown_error" }
         end
 
-      record_error(error_details, dependency: dependency)
+      service.record_update_job_error(
+        error_type: error_details.fetch(:"error-type"),
+        error_details: error_details[:"error-detail"],
+        dependency: dependency
+      )
 
       log_error(
         dependency: dependency,

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -339,12 +339,10 @@ module Dependabot
         "is no longer vulnerable"
       )
 
-      record_error(
-        {
-          "error-type": "security_update_not_needed",
-          "error-detail": {
-            "dependency-name": checker.dependency.name
-          }
+      service.record_update_job_error(
+        error_type: "security_update_not_needed",
+        error_details: {
+          "dependency-name": checker.dependency.name
         }
       )
     end
@@ -355,12 +353,10 @@ module Dependabot
         "were ignored for #{checker.dependency.name}"
       )
 
-      record_error(
-        {
-          "error-type": "all_versions_ignored",
-          "error-detail": {
-            "dependency-name": checker.dependency.name
-          }
+      service.record_update_job_error(
+        error_type: "all_versions_ignored",
+        error_details: {
+          "dependency-name": checker.dependency.name
         }
       )
     end
@@ -372,12 +368,10 @@ module Dependabot
         "installed version of #{checker.dependency.name} isn't known."
       )
 
-      record_error(
-        {
-          "error-type": "dependency_file_not_supported",
-          "error-detail": {
-            "dependency-name": checker.dependency.name
-          }
+      service.record_update_job_error(
+        error_type: "dependency_file_not_supported",
+        error_details: {
+          "dependency-name": checker.dependency.name
         }
       )
     end
@@ -396,15 +390,13 @@ module Dependabot
       )
       Dependabot.logger.info(earliest_fixed_version_message(lowest_non_vulnerable_version))
 
-      record_error(
-        {
-          "error-type": "security_update_not_possible",
-          "error-detail": {
-            "dependency-name": checker.dependency.name,
-            "latest-resolvable-version": latest_allowed_version,
-            "lowest-non-vulnerable-version": lowest_non_vulnerable_version,
-            "conflicting-dependencies": conflicting_dependencies
-          }
+      service.record_update_job_error(
+        error_type: "security_update_not_possible",
+        error_details: {
+          "dependency-name": checker.dependency.name,
+          "latest-resolvable-version": latest_allowed_version,
+          "lowest-non-vulnerable-version": lowest_non_vulnerable_version,
+          "conflicting-dependencies": conflicting_dependencies
         }
       )
     end
@@ -416,26 +408,22 @@ module Dependabot
         "The latest available version is #{checker.dependency.version}"
       )
 
-      record_error(
-        {
-          "error-type": "security_update_not_found",
-          "error-detail": {
-            "dependency-name": checker.dependency.name,
-            "dependency-version": checker.dependency.version
-          }
+      service.record_update_job_error(
+        error_type: "security_update_not_found",
+        error_details: {
+          "dependency-name": checker.dependency.name,
+          "dependency-version": checker.dependency.version
         },
         dependency: checker.dependency
       )
     end
 
     def record_pull_request_exists_for_latest_version(checker)
-      record_error(
-        {
-          "error-type": "pull_request_exists_for_latest_version",
-          "error-detail": {
-            "dependency-name": checker.dependency.name,
-            "dependency-version": checker.latest_version&.to_s
-          }
+      service.record_update_job_error(
+        error_type: "pull_request_exists_for_latest_version",
+        error_details: {
+          "dependency-name": checker.dependency.name,
+          "dependency-version": checker.latest_version&.to_s
         },
         dependency: checker.dependency
       )
@@ -449,12 +437,11 @@ module Dependabot
           "dependency-removed": dep.fetch("dependency-removed", nil)
         }.compact
       end
-      record_error(
-        {
-          "error-type": "pull_request_exists_for_security_update",
-          "error-detail": {
-            "updated-dependencies": updated_dependencies
-          }
+
+      service.record_update_job_error(
+        error_type: "pull_request_exists_for_security_update",
+        error_details: {
+          "updated-dependencies": updated_dependencies
         }
       )
     end

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -988,10 +988,6 @@ module Dependabot
       )
     end
 
-    def error_context(dependency)
-      { dependency_name: dependency.name, update_job_id: job.id }
-    end
-
     def record_error(error_details, dependency: nil)
       service.record_update_job_error(
         error_type: error_details.fetch(:"error-type"),

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Dependabot::FileFetcherCommand do
   let(:job_id) { "123123" }
 
   before do
-    allow(job).to receive(:job_id).and_return(job_id)
-    allow(job).to receive(:job_token).and_return("job_token")
-    allow(job).to receive(:api_client).and_return(api_client)
+    allow(Dependabot::Environment).to receive(:job_id).and_return(job_id)
+    allow(Dependabot::Environment).to receive(:job_token).and_return("job_token")
+    allow(Dependabot::ApiClient).to receive(:new).and_return(api_client)
 
     allow(api_client).to receive(:mark_job_as_processed)
     allow(api_client).to receive(:record_update_job_error)

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Dependabot::Updater do
         updater.run
 
         expect(service).to have_received(:record_update_job_error).
-          with({ error_type: "out_of_disk", error_details: nil, dependency: nil })
+          with({ error_type: "out_of_disk", error_details: nil})
       end
     end
 

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -2519,16 +2519,23 @@ RSpec.describe Dependabot::Updater do
   end
 
   def build_service
-    instance_double(
-      Dependabot::Service,
+    # Stub out a client so we don't hit the internet
+    api_client = instance_double(
+      Dependabot::ApiClient,
       create_pull_request: nil,
       update_pull_request: nil,
       close_pull_request: nil,
       mark_job_as_processed: nil,
       update_dependency_list: nil,
-      record_update_job_error: nil,
-      errors: []
+      record_update_job_error: nil
     )
+
+    service = Dependabot::Service.new(
+      client: api_client
+    )
+    allow(service).to receive(:record_update_job_error)
+
+    service
   end
 
   def build_job(requested_dependencies: nil, allowed_updates: default_allowed_updates, # rubocop:disable Metrics/MethodLength

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -295,8 +295,7 @@ RSpec.describe Dependabot::Updater do
               error_type: "dependency_file_not_supported",
               error_details: {
                 "dependency-name": "dummy-pkg-b"
-              },
-              dependency: nil
+              }
             }
           )
           expect(Dependabot.logger).
@@ -380,8 +379,7 @@ RSpec.describe Dependabot::Updater do
                     "requirement" => "= 1.2.0"
                   }
                 ]
-              },
-              dependency: nil
+              }
             }
           )
           expect(Dependabot.logger).
@@ -425,8 +423,7 @@ RSpec.describe Dependabot::Updater do
                 "latest-resolvable-version": "1.1.0",
                 "lowest-non-vulnerable-version": nil,
                 "conflicting-dependencies": []
-              },
-              dependency: nil
+              }
             }
           )
           expect(Dependabot.logger).
@@ -1016,8 +1013,7 @@ RSpec.describe Dependabot::Updater do
                 "dependency-name": "dummy-pkg-b",
                 "dependency-version": "1.2.0"
               ]
-            },
-            dependency: nil
+            }
           )
         expect(Dependabot.logger).
           to receive(:info).
@@ -1167,8 +1163,7 @@ RSpec.describe Dependabot::Updater do
                   "dependency-removed": true
                 }
               ]
-            },
-            dependency: nil
+            }
           )
         expect(Dependabot.logger).
           to receive(:info).
@@ -1556,7 +1551,6 @@ RSpec.describe Dependabot::Updater do
                   error_details: {
                     "dependency-name": "dummy-pkg-b"
                   },
-                  dependency: nil
                 }
               )
               expect(Dependabot.logger).
@@ -1593,8 +1587,7 @@ RSpec.describe Dependabot::Updater do
                   error_type: "security_update_not_needed",
                   error_details: {
                     "dependency-name": "dummy-pkg-b"
-                  },
-                  dependency: nil
+                  }
                 }
               )
               expect(Dependabot.logger).

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Dependabot::Updater do
         updater.run
 
         expect(service).to have_received(:record_update_job_error).
-          with({ error_type: "out_of_disk", error_details: nil})
+          with({ error_type: "out_of_disk", error_details: nil })
       end
     end
 
@@ -1549,7 +1549,7 @@ RSpec.describe Dependabot::Updater do
                   error_type: "all_versions_ignored",
                   error_details: {
                     "dependency-name": "dummy-pkg-b"
-                  },
+                  }
                 }
               )
               expect(Dependabot.logger).

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1297,8 +1297,7 @@ RSpec.describe Dependabot::Updater do
 
               expect(service).to receive(:record_update_job_error).with(
                 error_type: "dependency_file_not_parseable",
-                error_details: anything,
-                dependency: nil
+                error_details: anything
               )
               expect(service).to receive(:errors).and_return([anything])
               expect(service).to_not receive(:close_pull_request)
@@ -1637,8 +1636,7 @@ RSpec.describe Dependabot::Updater do
           to receive(:record_update_job_error).
           with(
             error_type: "unknown_error",
-            error_details: nil,
-            dependency: nil
+            error_details: nil
           )
 
         updater.run
@@ -1678,8 +1676,7 @@ RSpec.describe Dependabot::Updater do
             to receive(:record_update_job_error).
             with(
               error_type: "dependency_file_not_found",
-              error_details: { "file-path": "path/to/file" },
-              dependency: nil
+              error_details: { "file-path": "path/to/file" }
             )
 
           updater.run
@@ -1720,8 +1717,7 @@ RSpec.describe Dependabot::Updater do
             to receive(:record_update_job_error).
             with(
               error_type: "branch_not_found",
-              error_details: { "branch-name": "my_branch" },
-              dependency: nil
+              error_details: { "branch-name": "my_branch" }
             )
 
           updater.run
@@ -1762,8 +1758,7 @@ RSpec.describe Dependabot::Updater do
             to receive(:record_update_job_error).
             with(
               error_type: "dependency_file_not_parseable",
-              error_details: { "file-path": "path/to/file", message: "a" },
-              dependency: nil
+              error_details: { "file-path": "path/to/file", message: "a" }
             )
 
           updater.run
@@ -1804,8 +1799,7 @@ RSpec.describe Dependabot::Updater do
             to receive(:record_update_job_error).
             with(
               error_type: "path_dependencies_not_reachable",
-              error_details: { dependencies: ["bad_gem"] },
-              dependency: nil
+              error_details: { dependencies: ["bad_gem"] }
             )
 
           updater.run

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1300,6 +1300,12 @@ RSpec.describe Dependabot::Updater do
               allow(updater).to receive(:dependency_files).
                 and_raise(Dependabot::DependencyFileNotParseable.new("path/to/file"))
 
+              expect(service).to receive(:record_update_job_error).with(
+                error_type: "dependency_file_not_parseable",
+                error_details: anything,
+                dependency: nil
+              )
+              expect(service).to receive(:errors).and_return([anything])
               expect(service).to_not receive(:close_pull_request)
 
               updater.run
@@ -2520,7 +2526,8 @@ RSpec.describe Dependabot::Updater do
       close_pull_request: nil,
       mark_job_as_processed: nil,
       update_dependency_list: nil,
-      record_update_job_error: nil
+      record_update_job_error: nil,
+      errors: []
     )
   end
 


### PR DESCRIPTION
This is another clear-the-way PR for #6663 [[Prototype] Generating grouped update PRs](https://github.com/dependabot/dependabot-core/pull/6663).

Previous PR: https://github.com/dependabot/dependabot-core/pull/6810

The `Dependabot::Updater` class implements quite a lot of private methods to assist error handling. As we start to break the updater out into individual strategy classes which handle discrete operations, many of them need to share these methods.

This PR clears the way to start breaking the logic apart primarily via three changes:
- Stop maintaining a cache of errors inside `Dependabot::Updater`. This isn't used in any significant way, we can just use `Dependabot::Service#errors` as a substitute in the one place we need to check if any errors have happened.
- Prefer to use `service. record_update_job_error` _directly_ instead of creating an "error_detail" hash to use the `Dependabot::Updater#record_error` private method, which has been removed
- Refactor error capturing via Sentry/Raven unto the `Dependabot::Service` class so it has an explicit receiver that binds it to the backend service and accepts `Dependabot` objects as arguments

This will allow each individual strategy class to be passed the service so the various `record_foo_error` helper private methods can be moved without dragging more duplicate private methods in.

### Other Changes

There are a few small tidy ups made alongside these changes:
- Remove an unused `error_context` method on `Dependabot::Updater`
- Remove unused accessors on `Dependabot::Service`, notably disallow using its `Dependabot::ApiClient` directly