### PR TITLE
[Updater] Start splitting the Updater by extracting DependencySnapshot as an input class

### DIFF
--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "base64"
+require "dependabot/file_parsers"
+
+# This class describes the dependencies obtained from a project at a specific commit SHA
+# including both the Dependabot::DependencyFile objects at that reference as well as
+# means to parse them into a set of Dependabot::Dependency objects.
+#
+# This class is the input for a Dependabot::Updater process with Dependabot::DependencyChange
+# representing the output.
+module Dependabot
+  class DependencySnapshot
+    # TODO: Enforce non-nil values for job_definition["base64_dependency_files"]
+    #       and job_definition["base_commit_sha"]
+    #
+    # We historically tolerate nil values for both these keys from the `job_definition`
+    # but it doesn't seem like we should. Rather than introduce a behaviour change
+    # as part of the change introducing this class, let's do it as a follow-up.
+    def self.create_from_job_definition(job:, job_definition:)
+      decoded_dependency_files = job_definition.fetch("base64_dependency_files", []).map do |a|
+        file = Dependabot::DependencyFile.new(**a.transform_keys(&:to_sym))
+        file.content = Base64.decode64(file.content).force_encoding("utf-8") unless file.binary? && !file.deleted?
+        file
+      end
+
+      new(
+        job: job,
+        base_commit_sha: job_definition.fetch("base_commit_sha", nil),
+        dependency_files: decoded_dependency_files
+      )
+    end
+
+    attr_reader :base_commit_sha, :dependency_files
+
+    def initialize(job:, base_commit_sha:, dependency_files:)
+      @job = job
+      @base_commit_sha = base_commit_sha
+      @dependency_files = dependency_files
+    end
+
+    def dependencies
+      return @dependencies if defined?(@dependencies)
+
+      parse_files!
+    end
+
+    private
+
+    attr_reader :job
+
+    # TODO: Parse files during instantiation?
+    #
+    # To avoid having to re-home Dependabot::Updater#handle_parser_error,
+    # we perform the parsing lazily when the `dependencies` method is first
+    # referenced.
+    #
+    # We have some unusual behaviour where we handle a parse error by
+    # returning an empty dependency array in Dependabot::Updater#dependencies
+    # in order to 'fall through' to an error outcome elsewhere in the class.
+    #
+    # Given this uncertainity, and the need to significantly refactor tests,
+    # it makes sense to introduce this shim and then deal with the call
+    # site once we've split out the downstream behaviour in the updater.
+    #
+    def parse_files!
+      @dependencies = dependency_file_parser.parse
+    end
+
+    def dependency_file_parser
+      Dependabot::FileParsers.for_package_manager(job.package_manager).new(
+        dependency_files: dependency_files,
+        repo_contents_path: job.repo_contents_path,
+        source: job.source,
+        credentials: job.credentials,
+        reject_external_code: job.reject_external_code?,
+        options: job.experiments
+      )
+    end
+  end
+end

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -43,6 +43,19 @@ module Dependabot
       client.record_update_job_error(error_type: error_type, error_details: error_details)
     end
 
+    def update_dependency_list(dependency_snapshot:)
+      dependency_payload = dependency_snapshot.dependencies.map do |dep|
+        {
+          name: dep.name,
+          version: dep.version,
+          requirements: dep.requirements
+        }
+      end
+      dependency_file_paths = dependency_snapshot.dependency_files.reject(&:support_file).map(&:path)
+
+      client.update_dependency_list(dependency_payload, dependency_file_paths)
+    end
+
     # This method wraps the Raven client as the Application error tracker
     # the service uses to notice errors.
     #

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "raven"
 require "terminal-table"
 require "dependabot/api_client"
 

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-require "raven"
 require "dependabot/config/ignore_condition"
 require "dependabot/config/update_config"
 require "dependabot/dependency_change"
 require "dependabot/environment"
 require "dependabot/experiments"
 require "dependabot/file_fetchers"
-require "dependabot/file_parsers"
 require "dependabot/file_updaters"
 require "dependabot/logger"
 require "dependabot/python"
@@ -55,11 +53,14 @@ module Dependabot
       Octokit::Unauthorized => "octokit_unauthorized"
     }.freeze
 
-    def initialize(service:, job:, dependency_files:, base_commit_sha:)
+    # To do work, this class needs three arguments:
+    # - The Dependabot::Service to send events and outcomes to
+    # - The Dependabot::Job that describes the work to be done
+    # - The Dependabot::DependencySnapshot which encapsulates the starting state of the project
+    def initialize(service:, job:, dependency_snapshot:)
       @service = service
       @job = job
-      @dependency_files = dependency_files
-      @base_commit_sha = base_commit_sha
+      @dependency_snapshot = dependency_snapshot
       # TODO: Collect @created_pull_requests on the Job object?
       @created_pull_requests = []
     end
@@ -94,7 +95,7 @@ module Dependabot
     private
 
     attr_accessor :created_pull_requests
-    attr_reader :service, :job, :dependency_files, :base_commit_sha
+    attr_reader :service, :job, :dependency_snapshot
 
     def check_and_create_pr_with_error_handling(dependency)
       check_and_create_pull_request(dependency)
@@ -604,7 +605,7 @@ module Dependabot
 
     # rubocop:disable Metrics/PerceivedComplexity
     def dependencies
-      all_deps = dependency_file_parser.parse
+      all_deps = dependency_snapshot.dependencies
 
       # Tell the backend about the current dependencies on the target branch
       update_dependency_list(all_deps)
@@ -648,21 +649,10 @@ module Dependabot
     end
     # rubocop:enable Metrics/PerceivedComplexity
 
-    def dependency_file_parser
-      Dependabot::FileParsers.for_package_manager(job.package_manager).new(
-        dependency_files: dependency_files,
-        repo_contents_path: job.repo_contents_path,
-        source: job.source,
-        credentials: job.credentials,
-        reject_external_code: job.reject_external_code?,
-        options: job.experiments
-      )
-    end
-
     def update_checker_for(dependency, raise_on_ignored:)
       Dependabot::UpdateCheckers.for_package_manager(job.package_manager).new(
         dependency: dependency,
-        dependency_files: dependency_files,
+        dependency_files: dependency_snapshot.dependency_files,
         repo_contents_path: job.repo_contents_path,
         credentials: job.credentials,
         ignored_versions: ignore_conditions_for(dependency),
@@ -676,7 +666,7 @@ module Dependabot
     def file_updater_for(dependencies)
       Dependabot::FileUpdaters.for_package_manager(job.package_manager).new(
         dependencies: dependencies,
-        dependency_files: dependency_files,
+        dependency_files: dependency_snapshot.dependency_files,
         repo_contents_path: job.repo_contents_path,
         credentials: job.credentials,
         options: job.experiments
@@ -755,7 +745,7 @@ module Dependabot
         updated_dependency_files: updated_dependency_files
       )
 
-      service.create_pull_request(dependency_change, base_commit_sha)
+      service.create_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
 
       created_pull_requests << dependencies.map do |dep|
         {
@@ -776,7 +766,7 @@ module Dependabot
         updated_dependency_files: updated_dependency_files
       )
 
-      service.update_pull_request(dependency_change, base_commit_sha)
+      service.update_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
     end
 
     def close_pull_request(reason:)
@@ -984,7 +974,7 @@ module Dependabot
             requirements: dep.requirements
           }
         end,
-        dependency_files.reject(&:support_file).map(&:path)
+        dependency_snapshot.dependency_files.reject(&:support_file).map(&:path)
       )
     end
   end

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -608,7 +608,7 @@ module Dependabot
       all_deps = dependency_snapshot.dependencies
 
       # Tell the backend about the current dependencies on the target branch
-      update_dependency_list(all_deps)
+      service.update_dependency_list(dependency_snapshot: dependency_snapshot)
 
       # Rebases and security updates have dependencies, version updates don't
       if job.dependencies
@@ -964,19 +964,6 @@ module Dependabot
       )
     end
     # rubocop:enable Metrics/MethodLength
-
-    def update_dependency_list(dependencies)
-      service.update_dependency_list(
-        dependencies.map do |dep|
-          {
-            name: dep.name,
-            version: dep.version,
-            requirements: dep.requirements
-          }
-        end,
-        dependency_snapshot.dependency_files.reject(&:support_file).map(&:path)
-      )
-    end
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe Dependabot::UpdateFilesCommand do
         with(
           service: service,
           job: an_object_having_attributes(id: job_id, repo_contents_path: nil),
-          dependency_files: anything,
-          base_commit_sha: base_commit_sha
+          dependency_snapshot: an_object_having_attributes(base_commit_sha: base_commit_sha)
         ).
         and_return(dummy_runner)
       expect(dummy_runner).to receive(:run)
@@ -59,8 +58,7 @@ RSpec.describe Dependabot::UpdateFilesCommand do
           with(
             service: service,
             job: an_object_having_attributes(id: job_id, repo_contents_path: repo_contents_path),
-            dependency_files: anything,
-            base_commit_sha: base_commit_sha
+            dependency_snapshot: an_object_having_attributes(base_commit_sha: base_commit_sha)
           ).
           and_return(dummy_runner)
         expect(dummy_runner).to receive(:run)

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -5,6 +5,7 @@ require "bundler/compact_index_client"
 require "bundler/compact_index_client/updater"
 require "dependabot/dependency"
 require "dependabot/dependency_file"
+require "dependabot/dependency_snapshot"
 require "dependabot/file_fetchers"
 require "dependabot/updater"
 require "dependabot/service"
@@ -1292,7 +1293,8 @@ RSpec.describe Dependabot::Updater do
               service = build_service
               updater = build_updater(service: service, job: job)
 
-              allow(updater).to receive(:dependency_files).
+              # TODO: Move this stub unto Dependabot::DependencySnapshot once it is better integrated
+              allow(Dependabot::FileParsers).to receive_message_chain(:for_package_manager, :new, :parse).
                 and_raise(Dependabot::DependencyFileNotParseable.new("path/to/file"))
 
               expect(service).to receive(:record_update_job_error).with(
@@ -1613,7 +1615,8 @@ RSpec.describe Dependabot::Updater do
         service = build_service
         updater = build_updater(service: service, job: job)
 
-        allow(updater).to receive(:dependency_files).and_raise(error)
+        # TODO: Move this stub unto Dependabot::DependencySnapshot once it is better integrated
+        allow(Dependabot::FileParsers).to receive_message_chain(:for_package_manager, :new, :parse).and_raise(error)
 
         expect(Raven).to receive(:capture_exception)
 
@@ -1630,7 +1633,8 @@ RSpec.describe Dependabot::Updater do
         service = build_service
         updater = build_updater(service: service, job: job)
 
-        allow(updater).to receive(:dependency_files).and_raise(error)
+        # TODO: Move this stub unto Dependabot::DependencySnapshot once it is better integrated
+        allow(Dependabot::FileParsers).to receive_message_chain(:for_package_manager, :new, :parse).and_raise(error)
 
         expect(service).
           to receive(:record_update_job_error).
@@ -1653,7 +1657,8 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          allow(updater).to receive(:dependency_files).and_raise(error)
+          # TODO: Move this stub unto Dependabot::DependencySnapshot once it is better integrated
+          allow(Dependabot::FileParsers).to receive_message_chain(:for_package_manager, :new, :parse).and_raise(error)
 
           expect(Raven).to_not receive(:capture_exception)
 
@@ -1670,7 +1675,8 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          allow(updater).to receive(:dependency_files).and_raise(error)
+          # TODO: Move this stub unto Dependabot::DependencySnapshot once it is better integrated
+          allow(Dependabot::FileParsers).to receive_message_chain(:for_package_manager, :new, :parse).and_raise(error)
 
           expect(service).
             to receive(:record_update_job_error).
@@ -1694,7 +1700,8 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          allow(updater).to receive(:dependency_files).and_raise(error)
+          # TODO: Move this stub unto Dependabot::DependencySnapshot once it is better integrated
+          allow(Dependabot::FileParsers).to receive_message_chain(:for_package_manager, :new, :parse).and_raise(error)
 
           expect(Raven).to_not receive(:capture_exception)
 
@@ -1711,7 +1718,8 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          allow(updater).to receive(:dependency_files).and_raise(error)
+          # TODO: Move this stub unto Dependabot::DependencySnapshot once it is better integrated
+          allow(Dependabot::FileParsers).to receive_message_chain(:for_package_manager, :new, :parse).and_raise(error)
 
           expect(service).
             to receive(:record_update_job_error).
@@ -1735,7 +1743,8 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          allow(updater).to receive(:dependency_files).and_raise(error)
+          # TODO: Move this stub unto Dependabot::DependencySnapshot once it is better integrated
+          allow(Dependabot::FileParsers).to receive_message_chain(:for_package_manager, :new, :parse).and_raise(error)
 
           expect(Raven).to_not receive(:capture_exception)
 
@@ -1752,7 +1761,8 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          allow(updater).to receive(:dependency_files).and_raise(error)
+          # TODO: Move this stub unto Dependabot::DependencySnapshot once it is better integrated
+          allow(Dependabot::FileParsers).to receive_message_chain(:for_package_manager, :new, :parse).and_raise(error)
 
           expect(service).
             to receive(:record_update_job_error).
@@ -1776,7 +1786,8 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          allow(updater).to receive(:dependency_files).and_raise(error)
+          # TODO: Move this stub unto Dependabot::DependencySnapshot once it is better integrated
+          allow(Dependabot::FileParsers).to receive_message_chain(:for_package_manager, :new, :parse).and_raise(error)
 
           expect(Raven).to_not receive(:capture_exception)
 
@@ -1793,7 +1804,8 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          allow(updater).to receive(:dependency_files).and_raise(error)
+          # TODO: Move this stub unto Dependabot::DependencySnapshot once it is better integrated
+          allow(Dependabot::FileParsers).to receive_message_chain(:for_package_manager, :new, :parse).and_raise(error)
 
           expect(service).
             to receive(:record_update_job_error).
@@ -2485,8 +2497,11 @@ RSpec.describe Dependabot::Updater do
     Dependabot::Updater.new(
       service: service,
       job: job,
-      dependency_files: dependency_files,
-      base_commit_sha: "sha"
+      dependency_snapshot: Dependabot::DependencySnapshot.new(
+        job: job,
+        dependency_files: dependency_files,
+        base_commit_sha: "sha"
+      )
     )
   end
 

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -71,36 +71,8 @@ RSpec.describe Dependabot::Updater do
       service = build_service
       updater = build_updater(service: service, job: job)
 
-      dependencies = [
-        {
-          name: "dummy-pkg-a",
-          version: "2.0.0",
-          requirements: [
-            {
-              file: "Gemfile",
-              requirement: "~> 2.0.0",
-              groups: [:default],
-              source: nil
-            }
-          ]
-        },
-        {
-          name: "dummy-pkg-b",
-          version: "1.1.0",
-          requirements: [
-            {
-              file: "Gemfile",
-              requirement: "~> 1.1.0",
-              groups: [:default],
-              source: nil
-            }
-          ]
-        }
-      ]
-      dependency_files = ["/Gemfile", "/Gemfile.lock"]
-
-      expect(service).
-        to receive(:update_dependency_list).with(dependencies, dependency_files)
+      expect(service).to receive(:update_dependency_list).
+        with(dependency_snapshot: an_instance_of(Dependabot::DependencySnapshot))
 
       updater.run
     end


### PR DESCRIPTION
This is another clear-the-way PR for #6663 [[Prototype] Generating grouped update PRs](https://github.com/dependabot/dependabot-core/pull/6663).

Depends on https://github.com/dependabot/dependabot-core/pull/6846

A Dependabot update process has three broad steps:

1. Fetch the files we need from the repository
2. Parse the fetched files into a set of dependency information Dependabot can work with
3. Iterate over the dependency update to make changes to the fetched files which are pushed back to the repo

Currently, step(1) is performed as a single command so we do not need to provide repository credentials to the Update step and it hands files over to step(2) by encoding them into a 'job definition' along with the workload description it used to fetch them.

As we start to break the `Dependabot::Updater` class out into a set of components we can compose to create grouped updates, one difficulty is that step(2) is performed lazily inside `Dependabot::Updater#dependencies` which ostensibly functions like a getter method but in reality mixes the responsibility of parsing the files with filtering them according to the update strategy to be performed.

### Changes

This PR introduces a new `DependencySnapshot` object which encapsulates the responsibility of retrieving and decoding the files from step(2) and correctly hydrating them into `Dependabot::Dependency` objects to result in a value class which describes the starting state of the update.

### Rationale

This value class is used like a shim right now, with the parsing still being performed lazily inside `Dependabot::Updater#dependencies` in order to minimise the blast radius of refactoring the code, so initially it only provides value by reducing the number of arguments `Dependabot::Updater` requires, but it sets us up for two fast-follows:
- We can now start splitting out "operation" classes which take on a subset of the overall `Dependabot::Updater` class responsibilities which accept this object as an argument and proactively evaluate it to start refactoring the call site and flushing out assumptions about performing the parse/filter in a single method.
- Once we've figured out how to remove some implicit assumptions around the parse/filter method call order, we can push the responsibility of handling parser errors entirely out of the Updater into a discrete precondition which will extract a test surface out of `Dependabot::Updater` and make it easier to reason about.