### PR TITLE
fix Faraday find_proxy slowness

### DIFF
--- a/common/lib/dependabot/clients/github_with_retries.rb
+++ b/common/lib/dependabot/clients/github_with_retries.rb
@@ -89,6 +89,12 @@ module Dependabot
         access_tokens << nil if access_tokens.empty?
         access_tokens.uniq!
 
+        # Explicitly set the proxy if one is set in the environment
+        # as Faraday's find_proxy is very slow.
+        Octokit.configure do |c|
+          c.proxy = ENV["HTTPS_PROXY"] if ENV["HTTPS_PROXY"]
+        end
+
         Octokit.middleware = Faraday::RackBuilder.new do |builder|
           builder.use Faraday::Retry::Middleware, exceptions: RETRYABLE_ERRORS, max: max_retries || 3
 


### PR DESCRIPTION
I noticed significant delay at the start of gathering data for the PR. I tracked this down to Faraday's feature of finding a proxy in the environment. For whatever reason it's very slow for us in our smoke tests, and possibly production. 

To fix it, I've set the proxy explicitly from the environment, if it's set there. If it's not, it will again fall back to the old behavior. So if anyone is relying on that, it should still work.
