### PR TITLE
Downgrade octokit (common) to 6.0.1

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday-retry", "2.0.0"
   spec.add_dependency "gitlab", "4.19.0"
   spec.add_dependency "nokogiri", "~> 1.8"
-  spec.add_dependency "octokit", ">= 4.6", "< 7.0"
+  spec.add_dependency "octokit", ">= 4.6", "< 6.1"
   spec.add_dependency "parser", ">= 2.5", "< 4.0"
   spec.add_dependency "toml-rb", ">= 1.1.2", "< 3.0"
 

--- a/updater/Gemfile
+++ b/updater/Gemfile
@@ -21,7 +21,7 @@ gem "dependabot-python", path: "../python"
 gem "dependabot-terraform", path: "../terraform"
 
 gem "http", "~> 5.1"
-gem "octokit", "6.1.0"
+gem "octokit", "6.0.1"
 gem "sentry-raven", "~> 3.1"
 gem "terminal-table", "~> 3.0.2"
 

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
     nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    octokit (6.1.0)
+    octokit (6.0.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     parallel (1.22.1)
@@ -308,7 +308,7 @@ DEPENDENCIES
   dependabot-terraform!
   http (~> 5.1)
   licensed (~> 4.2)
-  octokit (= 6.1.0)
+  octokit (= 6.0.1)
   rspec (~> 3.12)
   rubocop (~> 1.48.0)
   rubocop-performance (~> 1.16.0)


### PR DESCRIPTION
The last bump to octokit in common was in https://github.com/dependabot/dependabot-core/pull/5954