### PR TITLE
Escape the branch name for the branch_url

### DIFF
--- a/common/spec/dependabot/pull_request_updater/github_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/github_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Dependabot::PullRequestUpdater::Github do
   let(:json_header) { { "Content-Type" => "application/json" } }
   let(:watched_repo_url) { "https://api.github.com/repos/#{source.repo}" }
   let(:pull_request_url) { watched_repo_url + "/pulls/#{pull_request_number}" }
-  let(:branch_url) { watched_repo_url + "/branches/" + branch_name }
+  let(:branch_url) { watched_repo_url + "/branches/" + CGI.escape(branch_name) }
   let(:business_repo_url) { "https://api.github.com/repos/gocardless/business" }
   let(:branch_name) { "dependabot/ruby/business-1.5.0" }
 


### PR DESCRIPTION
Oktokit began URL escaping the branch name which caused our stubs to miss calls. This fixes the common ci tests.