### PR TITLE
run all CI on Gemfile or Gemfile.lock change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,58 +55,68 @@ jobs:
             bundler:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'bundler/**'
             cargo:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'cargo/**'
             common:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - '.github/workflows/ci.yml'
             composer:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'composer/**'
             docker:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'docker/**'
             elm:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'elm/**'
             git_submodules:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'git_submodules/**'
             github_actions:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'github_actions/**'
             go_modules:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'go_modules/**'
               - '.github/workflows/ci.yml'
             gradle:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'maven/**'
@@ -114,41 +124,48 @@ jobs:
             hex:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'hex/**'
             maven:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'maven/**'
               - '.github/workflows/ci.yml'
             npm_and_yarn:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'npm_and_yarn/**'
             nuget:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'nuget/**'
             pub:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - '.github/workflows/ci.yml'
               - 'pub/**'
             python:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - 'python/**'
               - '.github/workflows/ci.yml'
             terraform:
               - Dockerfile.updater-core
               - 'common/**'
+              - 'updater/Gemfil*'
               - 'omnibus/**'
               - 'terraform/**'
               - '.github/workflows/ci.yml'

--- a/updater/Gemfile
+++ b/updater/Gemfile
@@ -21,7 +21,7 @@ gem "dependabot-python", path: "../python"
 gem "dependabot-terraform", path: "../terraform"
 
 gem "http", "~> 5.1"
-gem "octokit", "6.0.1"
+gem "octokit", "6.1.0"
 gem "sentry-raven", "~> 3.1"
 gem "terminal-table", "~> 3.0.2"
 

--- a/updater/Gemfile
+++ b/updater/Gemfile
@@ -21,7 +21,7 @@ gem "dependabot-python", path: "../python"
 gem "dependabot-terraform", path: "../terraform"
 
 gem "http", "~> 5.1"
-gem "octokit", "6.1.0"
+gem "octokit", "6.0.1"
 gem "sentry-raven", "~> 3.1"
 gem "terminal-table", "~> 3.0.2"
 


### PR DESCRIPTION
One of our tests starting failing out of nowhere and slowed us down a bit. We found this was due to a fairly minor Octokit change in https://github.com/dependabot/dependabot-core/pull/6826. 

To catch this sort of thing sooner, we should be running all CI whenever the updater Gemfile or lock changes. 

I wasn't sure if `updater/Gemfile*` would pick up both, so I opted for `updater/Gemfil*`. 