### PR TITLE
avoid find_proxy which is slow

### DIFF
--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -143,7 +143,11 @@ module Dependabot
 
     def http_client
       client = HTTP.auth(job_token)
-      proxy = URI(base_url).find_proxy
+      if ENV["HTTPS_PROXY"]
+        proxy = URI(ENV["HTTPS_PROXY"])
+      else
+        proxy = URI(base_url).find_proxy
+      end
       unless proxy.nil?
         args = [proxy.host, proxy.port, proxy.user, proxy.password].compact
         client = client.via(*args)

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -143,11 +143,7 @@ module Dependabot
 
     def http_client
       client = HTTP.auth(job_token)
-      if ENV["HTTPS_PROXY"]
-        proxy = URI(ENV["HTTPS_PROXY"])
-      else
-        proxy = URI(base_url).find_proxy
-      end
+      proxy = ENV["HTTPS_PROXY"] ? URI(ENV["HTTPS_PROXY"]) : URI(base_url).find_proxy
       unless proxy.nil?
         args = [proxy.host, proxy.port, proxy.user, proxy.password].compact
         client = client.via(*args)


### PR DESCRIPTION
This is the same change as in #6853. @Nishnha noted that there was another `find_proxy` I missed. Turned out that it's probably the same issue, and by avoiding it we save even more time!

On my machine it made the Go test go from 1:35 to :25! 🤯 