### PR TITLE
add timestamp to logger

### DIFF
--- a/updater/lib/dependabot/logger/formats.rb
+++ b/updater/lib/dependabot/logger/formats.rb
@@ -6,10 +6,11 @@ require "logger"
 # the global log helper defined in common/lib/dependabot/logger.rb
 module Dependabot
   module Logger
+    TIME_FORMAT = "%Y/%m/%d %H:%M:%S"
+
     class BasicFormatter < ::Logger::Formatter
-      # Strip out timestamps as these are included in the runner's logger
       def call(severity, _datetime, _progname, msg)
-        "#{severity} #{msg2str(msg)}\n"
+        "#{Time.now.strftime(TIME_FORMAT)} #{severity} #{msg2str(msg)}\n"
       end
     end
 
@@ -23,6 +24,7 @@ module Dependabot
 
       def call(severity, _datetime, _progname, msg)
         [
+          Time.now.strftime(TIME_FORMAT),
           severity,
           job_prefix,
           msg2str(msg)

--- a/updater/lib/dependabot/setup.rb
+++ b/updater/lib/dependabot/setup.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 
+require "dependabot/logger"
+require "dependabot/logger/formats"
+require "dependabot/environment"
+
+Dependabot.logger = Logger.new($stdout).tap do |logger|
+  logger.level = Dependabot::Environment.log_level
+  logger.formatter = Dependabot::Logger::BasicFormatter.new
+end
+
 require "dependabot/sentry"
 Raven.configure do |config|
+  config.logger = Dependabot.logger
   config.project_root = File.expand_path("../../..", __dir__)
 
   config.app_dirs_pattern = %r{(
@@ -28,15 +38,6 @@ Raven.configure do |config|
   )}x
 
   config.processors += [ExceptionSanitizer]
-end
-
-require "dependabot/logger"
-require "dependabot/logger/formats"
-require "dependabot/environment"
-
-Dependabot.logger = Logger.new($stdout).tap do |logger|
-  logger.level = Dependabot::Environment.log_level
-  logger.formatter = Dependabot::Logger::BasicFormatter.new
 end
 
 # We configure `Dependabot::Utils.register_always_clone` for some ecosystems. In


### PR DESCRIPTION
To help track down freezes and performance issues it's helpful if every line has a consistent timestamp. This matches the timestamp format that the proxy uses. 

Before:

```
updater | I, [2023-03-17T11:39:57.488735 #911]  INFO -- sentry: ** [Raven] Raven 3.1.2 configured not to capture errors: DSN not set
updater | INFO Starting job processing
```

After:

```
updater | 2023/03/17 11:43:56 INFO Raven 3.1.2 configured not to capture errors: DSN not set
updater | 2023/03/17 11:43:58 INFO Starting job processing
```

