### PR TITLE
speed up Docker smoke test

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -373,7 +373,8 @@ module Dependabot
             "https://#{registry_hostname}",
             user: registry_credentials&.fetch("username", nil),
             password: registry_credentials&.fetch("password", nil),
-            read_timeout: 10
+            read_timeout: 10,
+            http_options: { proxy: ENV['HTTPS_PROXY'] }
           )
       end
 


### PR DESCRIPTION
Docker uses a library that calls `find_proxy` which is slow for our smoke tests, for some reason. This sets the proxy explicitly so it speeds up significantly. It currently takes over 5 minutes. Locally with this change it now runs in 15 seconds.