### PR TITLE
Link docker image to repo via OCI source annotation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,19 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
+ARG TARGETARCH
+
+# Install regctl
+ARG REGCTL_VERSION=0.4.7
+# These are manually calculated as they are not provided by the maintainer
+ARG REGCTL_AMD64_CHECKSUM=8cabc58130279c3c93636d48633ec2763bf3f9c389dc1f693aabfe30a204d834
+ARG REGCTL_ARM64_CHECKSUM=5dc1c8430441e92dcbff75dc98a880b04027b284e541aeda5e7fc35a33255ba7
+
+ENV PATH=/opt/bin:$PATH
+RUN cd /tmp \
+  && curl -sSf -o regctl-${TARGETARCH} -L https://github.com/regclient/regclient/releases/download/v${REGCTL_VERSION}/regctl-linux-${TARGETARCH} \
+  && printf "$REGCTL_AMD64_CHECKSUM regctl-amd64\n$REGCTL_ARM64_CHECKSUM regctl-arm64\n" | sha256sum -c --ignore-missing - \
+  && mkdir /opt/bin \
+  && mv regctl-${TARGETARCH} /opt/bin/regctl \
+  && chmod o+rx /opt/bin/regctl
 
 USER dependabot
 

--- a/docker/lib/dependabot/docker/metadata_finder.rb
+++ b/docker/lib/dependabot/docker/metadata_finder.rb
@@ -2,6 +2,7 @@
 
 require "dependabot/metadata_finders"
 require "dependabot/metadata_finders/base"
+require "dependabot/shared_helpers"
 
 module Dependabot
   module Docker
@@ -9,7 +10,20 @@ module Dependabot
       private
 
       def look_up_source
-        # TODO: Find a way to add links to PRs
+        return if dependency.requirements.empty?
+
+        new_source = dependency.requirements.first[:source]
+        return unless new_source && new_source[:registry] && new_source[:tag]
+
+        image_ref = "#{new_source[:registry]}/#{dependency.name}:#{new_source[:tag]}"
+        image_details_output = SharedHelpers.run_shell_command("regctl image inspect #{image_ref}")
+        image_details = JSON.parse(image_details_output)
+        image_source = image_details.dig("config", "Labels", "org.opencontainers.image.source")
+        return unless image_source
+
+        Dependabot::Source.from_url(image_source)
+      rescue StandardError => e
+        Dependabot.logger.warn("Error looking up Docker source: #{e.message}")
         nil
       end
     end

--- a/docker/spec/dependabot/docker/metadata_finder_spec.rb
+++ b/docker/spec/dependabot/docker/metadata_finder_spec.rb
@@ -6,4 +6,118 @@ require_common_spec "metadata_finders/shared_examples_for_metadata_finders"
 
 RSpec.describe Dependabot::Docker::MetadataFinder do
   it_behaves_like "a dependency metadata finder"
+
+  let(:credentials) do
+    [{
+      "type" => "git_source",
+      "host" => "github.com",
+      "username" => "x-access-token",
+      "password" => "token"
+    }]
+  end
+
+  let(:dependency_with_source) do
+    Dependabot::Dependency.new(
+      name: "dependabot-fixtures/docker-with-source",
+      version: "v0.0.2",
+      requirements: [{
+        file: "Dockerfile",
+        requirement: nil,
+        groups: [],
+        source: { registry: "ghcr.io", tag: "v0.0.2" }
+      }],
+      package_manager: "docker"
+    )
+  end
+
+  let(:dependency_without_source) do
+    Dependabot::Dependency.new(
+      name: "dependabot-fixtures/docker-without-source",
+      version: "v0.0.1",
+      requirements: [{
+        file: "Dockerfile",
+        requirement: nil,
+        groups: [],
+        source: { registry: "ghcr.io", tag: "v0.0.1" }
+      }],
+      package_manager: "docker"
+    )
+  end
+
+  let(:finder) do
+    described_class.new(dependency: dependency, credentials: credentials)
+  end
+
+  describe "#source_url" do
+    context "with a docker image that has an OCI source annotation" do
+      let(:dependency) { dependency_with_source }
+
+      it "finds the repository" do
+        expect(finder.source_url).to eq "https://github.com/dependabot-fixtures/docker-with-source"
+      end
+    end
+
+    context "with a docker image that lacks an OCI source annotation" do
+      let(:dependency) { dependency_without_source }
+
+      it "doesn't find the repository" do
+        expect(finder.source_url).to be_nil
+      end
+    end
+
+    context "with a docker image without a tag" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "dependabot-fixtures/docker-with-source",
+          version: "v0.0.2",
+          requirements: [{
+            file: "Dockerfile",
+            requirement: nil,
+            groups: [],
+            source: { registry: "ghcr.io",
+                      digest: "sha256:389a5a9a5457ed237b05d623ddc31a42fa97811051dcd02d7ca4ad46bd3edd3e" }
+          }],
+          package_manager: "docker"
+        )
+      end
+
+      it "doesn't find the repository" do
+        expect(finder.source_url).to be_nil
+      end
+    end
+
+    context "when an error occurs inspecting the image" do
+      let(:dependency) { dependency_with_source }
+
+      before do
+        allow(Dependabot::SharedHelpers).
+          to receive(:run_shell_command).
+          and_raise("No inspections for you!")
+      end
+
+      it "doesn't find the repository" do
+        expect(finder.source_url).to be_nil
+      end
+    end
+
+    context "when the OCI source annotation isn't a valid url" do
+      let(:dependency) { dependency_with_source }
+
+      before do
+        allow(Dependabot::SharedHelpers).
+          to receive(:run_shell_command).
+          and_return({
+            config: {
+              Labels: {
+                "org.opencontainers.image.source" => "not an url"
+              }
+            }
+          }.to_json)
+      end
+
+      it "doesn't find the repository" do
+        expect(finder.source_url).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allows us to include richer metadata about the release when creating Docker update PRs (commits, release notes, repo link, etc) to address https://github.com/dependabot/dependabot-core/issues/2085. To enable support, maintainers of docker images need to add the [`org.opencontainers.image.source`](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys) label to their `Dockerfile` with the url of the source repo. Additionally, they need to tag the repo with the same tags as the published docker images. This allows Dependabot to understand which repo & commit is associated each version/tag of a docker image.

This example repo demonstrates the setup: https://github.com/dependabot-fixtures/docker-with-source

There isn't a simple registry API to read the source annotation. Instead you need to locate and download the correct blob which contains it. We could implement this ourselves but the [regctl](https://github.com/regclient/regclient) tool made this pretty easy so I've used that instead. It might be an option to replace our native registry calls in the future?

### notes
I did not implement authentication support for regctl. On the GitHub platform or using the CLI the authentication will be handled by the proxy so it isn't needed. This could be added later by anyone that needs this feature and runs dependabot outside of those methods.

It is also possible for the OCI annotations to indicate the commit associated with a docker image. If we used this, maintainers wouldn't need to add equivalent tags to their repo. I wanted to support this initially but our metadata finders don't seem to provide a paved path for this (unless I've missed something?). It would take some additional work to wire that up which we could evaluate in the future. 

