### PR TITLE
[Updater] Establish the Updater::Operations pattern, Extract UpdateAllVersions as the first strategy class

### DIFF
--- a/updater/lib/dependabot/updater/operations.rb
+++ b/updater/lib/dependabot/updater/operations.rb
@@ -30,10 +30,10 @@ module Dependabot
         UpdateAllVersions
       ]
 
-      def self.operation_for(job:)
+      def self.class_for(job:)
         raise ArgumentError, "Expected Dependabot::Job, got #{job.class}" unless job.is_a?(Dependabot::Job)
 
-        OPERATIONS.first { |op| op.applies_to?(job: job) }
+        OPERATIONS.find { |op| op.applies_to?(job: job) }
       end
     end
   end

--- a/updater/lib/dependabot/updater/operations.rb
+++ b/updater/lib/dependabot/updater/operations.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "dependabot/updater/operations/update_all_versions"
+
 # This module is responsible for determining which Operation a Job is requesting
 # the Updater to perform.
 #
@@ -21,8 +23,17 @@
 module Dependabot
   class Updater
     module Operations
-      def self.operation_for(_job:)
-        nil
+      # We check if each operation ::applies_to? a given job, returning the first
+      # that does, so these Operations should be ordered so that those with most
+      # specific preconditions go before those with more permissive checks.
+      OPERATIONS = [
+        UpdateAllVersions
+      ]
+
+      def self.operation_for(job:)
+        raise ArgumentError, "Expected Dependabot::Job, got #{job.class}" unless job.is_a?(Dependabot::Job)
+
+        OPERATIONS.first { |op| op.applies_to?(job: job) }
       end
     end
   end

--- a/updater/lib/dependabot/updater/operations.rb
+++ b/updater/lib/dependabot/updater/operations.rb
@@ -11,9 +11,6 @@ require "dependabot/updater/operations/update_all_versions"
 #
 # Consider the following guidelines when working on Operation classes:
 #
-# - Operations act on the principal of least knowledge prefering to cherry pick
-#   arguments from the Dependabot::Job so their contract is explicit.
-#
 # - Operations *should not have optional parameters*, prefer to create a new
 #   class instead of adding branching to an existing one.
 #

--- a/updater/lib/dependabot/updater/operations.rb
+++ b/updater/lib/dependabot/updater/operations.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# This module is responsible for determining which Operation a Job is requesting
+# the Updater to perform.
+#
+# The design goal for this module is to make these classes easy to understand,
+# maintain and extend so we can eventually support community-contributed
+# alternatives or ecosystem-specific implementations.
+#
+# Consider the following guidelines when working on Operation classes:
+#
+# - Operations act on the principal of least knowledge prefering to cherry pick
+#   arguments from the Dependabot::Job so their contract is explicit.
+#
+# - Operations *should not have optional parameters*, prefer to create a new
+#   class instead of adding branching to an existing one.
+#
+# - Operations should prefer to share logic by composition, there is no base
+#   class. We want to avoid implicit or indirect behaviour as much as possible.
+#
+module Dependabot
+  class Updater
+    module Operations
+      def self.operation_for(_job:)
+        nil
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -23,6 +23,7 @@ module Dependabot
 
         def perform
           Dependabot.logger.info("Starting update job for #{job.source.repo}")
+          Dependabot.logger.info("Checking all dependencies for version updates...")
           dependencies.each { |dep| check_and_create_pr_with_error_handling(dep) }
         end
 

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -4,23 +4,432 @@ module Dependabot
   class Updater
     module Operations
       class UpdateAllVersions
-        attr_reader :job, :updater
-
         def self.applies_to?(job:)
           return false if job.security_updates_only?
           return false if job.updating_a_pull_request?
-          return false if job.dependencies.any?
+          return false if job.dependencies&.any?
 
           true
         end
 
-        def initialize(job:, service:, dependency_snapshot:)
-          @job = job
+        def initialize(service:, job:, dependency_snapshot:, error_handler:)
           @service = service
+          @job = job
           @dependency_snapshot = dependency_snapshot
+          @error_handler = error_handler
+          # TODO: Collect @created_pull_requests on the Job object?
+          @created_pull_requests = []
         end
 
-        def perform; end
+        def perform
+          Dependabot.logger.info("Starting update job for #{job.source.repo}")
+          dependencies.each { |dep| check_and_create_pr_with_error_handling(dep) }
+        end
+
+        private
+
+        attr_reader :job,
+                    :service,
+                    :dependency_snapshot,
+                    :error_handler,
+                    :created_pull_requests
+
+        # rubocop:disable Metrics/PerceivedComplexity
+        def dependencies
+          all_deps = dependency_snapshot.dependencies
+
+          # Tell the backend about the current dependencies on the target branch
+          service.update_dependency_list(dependency_snapshot: dependency_snapshot)
+
+          # Rebases and security updates have dependencies, version updates don't
+          if job.dependencies
+            # Gradle, Maven and Nuget dependency names can be case-insensitive and
+            # the dependency name in the security advisory often doesn't match what
+            # users have specified in their manifest.
+            #
+            # It's technically possibly to publish case-sensitive npm packages to a
+            # private registry but shouldn't cause problems here as job.dependencies
+            # is set either from an existing PR rebase/recreate or a security
+            # advisory.
+            job_dependencies = job.dependencies.map(&:downcase)
+            return all_deps.select do |dep|
+              job_dependencies.include?(dep.name.downcase)
+            end
+          end
+
+          allowed_deps = all_deps.select { |d| job.allowed_update?(d) }
+          # Return dependencies in a random order, with top-level dependencies
+          # considered first so that dependency runs which time out don't always hit
+          # the same dependencies
+          allowed_deps = allowed_deps.shuffle unless ENV["UPDATER_DETERMINISTIC"]
+
+          if all_deps.any? && allowed_deps.none?
+            Dependabot.logger.info("Found no dependencies to update after filtering allowed " \
+                                   "updates")
+          end
+
+          # Consider updating vulnerable deps first. Only consider the first 10,
+          # though, to ensure they don't take up the entire update run
+          deps = allowed_deps.select { |d| job.vulnerable?(d) }.sample(10) +
+                 allowed_deps.reject { |d| job.vulnerable?(d) }
+
+          deps
+        rescue StandardError => e
+          error_handler.handle_parser_error(e)
+          []
+        end
+        # rubocop:enable Metrics/PerceivedComplexity
+
+        def check_and_create_pr_with_error_handling(dependency)
+          check_and_create_pull_request(dependency)
+        rescue Dependabot::InconsistentRegistryResponse => e
+          error_handler.log_error(
+            dependency: dependency,
+            error: e,
+            error_type: "inconsistent_registry_response",
+            error_detail: e.message
+          )
+        rescue StandardError => e
+          error_handler.handle_dependabot_error(error: e, dependency: dependency)
+        end
+
+        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/MethodLength
+        def check_and_create_pull_request(dependency)
+          checker = update_checker_for(dependency, raise_on_ignored: raise_on_ignored?(dependency))
+
+          log_checking_for_update(dependency)
+
+          return if all_versions_ignored?(dependency, checker)
+
+          # If the dependency isn't vulnerable or we can't know for sure we won't be
+          # able to know if the updated dependency fixes any advisories
+          if job.security_updates_only?
+            unless checker.vulnerable?
+              # The current dependency isn't vulnerable if the version is correct and
+              # can be matched against the advisories affected versions
+              if checker.version_class.correct?(checker.dependency.version)
+                return record_security_update_not_needed_error(checker)
+              end
+
+              return record_dependency_file_not_supported_error(checker)
+            end
+            return record_security_update_ignored(checker) unless job.allowed_update?(dependency)
+          end
+
+          if checker.up_to_date?
+            # The current version is still vulnerable and  Dependabot can't find a
+            # published or compatible non-vulnerable version, this can happen if the
+            # fixed version hasn't been published yet or the published version isn't
+            # compatible with the current enviroment (e.g. python version) or
+            # version (uses a different version suffix for gradle/maven)
+            return record_security_update_not_found(checker) if job.security_updates_only?
+
+            return log_up_to_date(dependency)
+          end
+
+          if pr_exists_for_latest_version?(checker)
+            record_pull_request_exists_for_latest_version(checker) if job.security_updates_only?
+            return Dependabot.logger.info(
+              "Pull request already exists for #{checker.dependency.name} " \
+              "with latest version #{checker.latest_version}"
+            )
+          end
+
+          requirements_to_unlock = requirements_to_unlock(checker)
+          log_requirements_for_update(requirements_to_unlock, checker)
+
+          if requirements_to_unlock == :update_not_possible
+            return record_security_update_not_possible_error(checker) if job.security_updates_only? && job.dependencies
+
+            return Dependabot.logger.info(
+              "No update possible for #{dependency.name} #{dependency.version}"
+            )
+          end
+
+          updated_deps = checker.updated_dependencies(
+            requirements_to_unlock: requirements_to_unlock
+          )
+
+          # Prevent updates that don't end up fixing any security advisories,
+          # blocking any updates where dependabot-core updates to a vulnerable
+          # version. This happens for npm/yarn subdendencies where Dependabot has no
+          # control over the target version. Related issue:
+          # https://github.com/github/dependabot-api/issues/905
+          if job.security_updates_only? &&
+             updated_deps.none? { |d| job.security_fix?(d) }
+            return record_security_update_not_possible_error(checker)
+          end
+
+          if (existing_pr = existing_pull_request(updated_deps))
+            # Create a update job error to prevent dependabot-api from creating a
+            # update_not_possible error, this is likely caused by a update job retry
+            # so should be invisible to users (as the first job completed with a pull
+            # request)
+            record_pull_request_exists_for_security_update(existing_pr) if job.security_updates_only?
+
+            deps = existing_pr.map do |dep|
+              if dep.fetch("dependency-removed", false)
+                "#{dep.fetch('dependency-name')}@removed"
+              else
+                "#{dep.fetch('dependency-name')}@#{dep.fetch('dependency-version')}"
+              end
+            end
+
+            return Dependabot.logger.info(
+              "Pull request already exists for #{deps.join(', ')}"
+            )
+          end
+
+          if peer_dependency_should_update_instead?(checker.dependency.name, updated_deps)
+            return Dependabot.logger.info(
+              "No update possible for #{dependency.name} #{dependency.version} " \
+              "(peer dependency can be updated)"
+            )
+          end
+
+          updated_files = generate_dependency_files_for(updated_deps)
+          updated_deps = updated_deps.reject do |d|
+            next false if d.name == checker.dependency.name
+            next true if d.top_level? && d.requirements == d.previous_requirements
+
+            d.version == d.previous_version
+          end
+          create_pull_request(updated_deps, updated_files)
+        end
+        # rubocop:enable Metrics/MethodLength
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/PerceivedComplexity
+
+        def log_up_to_date(dependency)
+          Dependabot.logger.info(
+            "No update needed for #{dependency.name} #{dependency.version}"
+          )
+        end
+
+        def raise_on_ignored?(dependency)
+          job.security_updates_only? || ignore_conditions_for(dependency).any?
+        end
+
+        def ignore_conditions_for(dep)
+          update_config_ignored_versions(job.ignore_conditions, dep)
+        end
+
+        def update_config_ignored_versions(ignore_conditions, dep)
+          ignore_conditions = ignore_conditions.map do |ic|
+            Dependabot::Config::IgnoreCondition.new(
+              dependency_name: ic["dependency-name"],
+              versions: [ic["version-requirement"]].compact,
+              update_types: ic["update-types"]
+            )
+          end
+          Dependabot::Config::UpdateConfig.
+            new(ignore_conditions: ignore_conditions).
+            ignored_versions_for(dep, security_updates_only: job.security_updates_only?)
+        end
+
+        def update_checker_for(dependency, raise_on_ignored:)
+          Dependabot::UpdateCheckers.for_package_manager(job.package_manager).new(
+            dependency: dependency,
+            dependency_files: dependency_snapshot.dependency_files,
+            repo_contents_path: job.repo_contents_path,
+            credentials: job.credentials,
+            ignored_versions: ignore_conditions_for(dependency),
+            security_advisories: security_advisories_for(dependency),
+            raise_on_ignored: raise_on_ignored,
+            requirements_update_strategy: job.requirements_update_strategy,
+            options: job.experiments
+          )
+        end
+
+        def file_updater_for(dependencies)
+          Dependabot::FileUpdaters.for_package_manager(job.package_manager).new(
+            dependencies: dependencies,
+            dependency_files: dependency_snapshot.dependency_files,
+            repo_contents_path: job.repo_contents_path,
+            credentials: job.credentials,
+            options: job.experiments
+          )
+        end
+
+        def security_advisories_for(dep)
+          relevant_advisories =
+            job.security_advisories.
+            select { |adv| adv.fetch("dependency-name").casecmp(dep.name).zero? }
+
+          relevant_advisories.map do |adv|
+            vulnerable_versions = adv["affected-versions"] || []
+            safe_versions = (adv["patched-versions"] || []) +
+                            (adv["unaffected-versions"] || [])
+
+            Dependabot::SecurityAdvisory.new(
+              dependency_name: dep.name,
+              package_manager: job.package_manager,
+              vulnerable_versions: vulnerable_versions,
+              safe_versions: safe_versions
+            )
+          end
+        end
+
+        def log_checking_for_update(dependency)
+          Dependabot.logger.info(
+            "Checking if #{dependency.name} #{dependency.version} needs updating"
+          )
+          log_ignore_conditions(dependency)
+        end
+
+        def log_ignore_conditions(dep)
+          conditions = job.ignore_conditions.
+                       select { |ic| name_match?(ic["dependency-name"], dep.name) }
+          return if conditions.empty?
+
+          Dependabot.logger.info("Ignored versions:")
+          conditions.each do |ic|
+            unless ic["version-requirement"].nil?
+              Dependabot.logger.info("  #{ic['version-requirement']} - from #{ic['source']}")
+            end
+
+            ic["update-types"]&.each do |update_type|
+              msg = "  #{update_type} - from #{ic['source']}"
+              msg += " (doesn't apply to security update)" if job.security_updates_only?
+              Dependabot.logger.info(msg)
+            end
+          end
+        end
+
+        def name_match?(name1, name2)
+          WildcardMatcher.match?(
+            job.name_normaliser.call(name1),
+            job.name_normaliser.call(name2)
+          )
+        end
+
+        def all_versions_ignored?(dependency, checker)
+          Dependabot.logger.info("Latest version is #{checker.latest_version}")
+          false
+        rescue Dependabot::AllVersionsIgnored
+          Dependabot.logger.info("All updates for #{dependency.name} were ignored")
+
+          # Report this error to the backend to create an update job error
+          raise if job.security_updates_only?
+
+          true
+        end
+
+        def pr_exists_for_latest_version?(checker)
+          latest_version = checker.latest_version&.to_s
+          return false if latest_version.nil?
+
+          job.existing_pull_requests.
+            select { |pr| pr.count == 1 }.
+            map(&:first).
+            select { |pr| pr.fetch("dependency-name") == checker.dependency.name }.
+            any? { |pr| pr.fetch("dependency-version", nil) == latest_version }
+        end
+
+        def existing_pull_request(updated_dependencies)
+          new_pr_set = Set.new(
+            updated_dependencies.map do |dep|
+              {
+                "dependency-name" => dep.name,
+                "dependency-version" => dep.version,
+                "dependency-removed" => dep.removed? ? true : nil
+              }.compact
+            end
+          )
+
+          job.existing_pull_requests.find { |pr| Set.new(pr) == new_pr_set } ||
+            created_pull_requests.find { |pr| Set.new(pr) == new_pr_set }
+        end
+
+        def requirements_to_unlock(checker)
+          if job.lockfile_only? || !checker.requirements_unlocked_or_can_be?
+            if checker.can_update?(requirements_to_unlock: :none) then :none
+            else
+              :update_not_possible
+            end
+          elsif checker.can_update?(requirements_to_unlock: :own) then :own
+          elsif checker.can_update?(requirements_to_unlock: :all) then :all
+          else
+            :update_not_possible
+          end
+        end
+
+        def log_requirements_for_update(requirements_to_unlock, checker)
+          Dependabot.logger.info("Requirements to unlock #{requirements_to_unlock}")
+
+          return unless checker.respond_to?(:requirements_update_strategy)
+
+          Dependabot.logger.info(
+            "Requirements update strategy #{checker.requirements_update_strategy}"
+          )
+        end
+
+        # If a version update for a peer dependency is possible we should
+        # defer to the PR that will be created for it to avoid duplicate PRs.
+        def peer_dependency_should_update_instead?(dependency_name, updated_deps)
+          # This doesn't apply to security updates as we can't rely on the
+          # peer dependency getting updated.
+          return false if job.security_updates_only?
+
+          updated_deps.
+            reject { |dep| dep.name == dependency_name }.
+            any? do |dep|
+              next true if existing_pull_request([dep])
+
+              original_peer_dep = ::Dependabot::Dependency.new(
+                name: dep.name,
+                version: dep.previous_version,
+                requirements: dep.previous_requirements,
+                package_manager: dep.package_manager
+              )
+              update_checker_for(original_peer_dep, raise_on_ignored: false).
+                can_update?(requirements_to_unlock: :own)
+            end
+        end
+
+        def generate_dependency_files_for(updated_dependencies)
+          if updated_dependencies.count == 1
+            updated_dependency = updated_dependencies.first
+            Dependabot.logger.info("Updating #{updated_dependency.name} from " \
+                                   "#{updated_dependency.previous_version} to " \
+                                   "#{updated_dependency.version}")
+          else
+            dependency_names = updated_dependencies.map(&:name)
+            Dependabot.logger.info("Updating #{dependency_names.join(', ')}")
+          end
+
+          # Ignore dependencies that are tagged as information_only. These will be
+          # updated indirectly as a result of a parent dependency update and are
+          # only included here to be included in the PR info.
+          deps_to_update = updated_dependencies.reject(&:informational_only?)
+          updater = file_updater_for(deps_to_update)
+          updater.updated_dependency_files
+        end
+
+        def create_pull_request(dependencies, updated_dependency_files)
+          Dependabot.logger.info("Submitting #{dependencies.map(&:name).join(', ')} " \
+                                 "pull request for creation")
+
+          dependency_change = Dependabot::DependencyChange.new(
+            job: job,
+            dependencies: dependencies,
+            updated_dependency_files: updated_dependency_files
+          )
+
+          service.create_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
+
+          created_pull_requests << dependencies.map do |dep|
+            {
+              "dependency-name" => dep.name,
+              "dependency-version" => dep.version,
+              "dependency-removed" => dep.removed? ? true : nil
+            }.compact
+          end
+        end
       end
     end
   end

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -41,22 +41,6 @@ module Dependabot
           # Tell the backend about the current dependencies on the target branch
           service.update_dependency_list(dependency_snapshot: dependency_snapshot)
 
-          # Rebases and security updates have dependencies, version updates don't
-          if job.dependencies
-            # Gradle, Maven and Nuget dependency names can be case-insensitive and
-            # the dependency name in the security advisory often doesn't match what
-            # users have specified in their manifest.
-            #
-            # It's technically possibly to publish case-sensitive npm packages to a
-            # private registry but shouldn't cause problems here as job.dependencies
-            # is set either from an existing PR rebase/recreate or a security
-            # advisory.
-            job_dependencies = job.dependencies.map(&:downcase)
-            return all_deps.select do |dep|
-              job_dependencies.include?(dep.name.downcase)
-            end
-          end
-
           allowed_deps = all_deps.select { |d| job.allowed_update?(d) }
           # Return dependencies in a random order, with top-level dependencies
           # considered first so that dependency runs which time out don't always hit
@@ -64,16 +48,10 @@ module Dependabot
           allowed_deps = allowed_deps.shuffle unless ENV["UPDATER_DETERMINISTIC"]
 
           if all_deps.any? && allowed_deps.none?
-            Dependabot.logger.info("Found no dependencies to update after filtering allowed " \
-                                   "updates")
+            Dependabot.logger.info("Found no dependencies to update after filtering allowed updates")
           end
 
-          # Consider updating vulnerable deps first. Only consider the first 10,
-          # though, to ensure they don't take up the entire update run
-          deps = allowed_deps.select { |d| job.vulnerable?(d) }.sample(10) +
-                 allowed_deps.reject { |d| job.vulnerable?(d) }
-
-          deps
+          allowed_deps
         rescue StandardError => e
           error_handler.handle_parser_error(e)
           []

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Dependabot
+  class Updater
+    module Operations
+      class UpdateAllVersions
+        attr_reader :job, :updater
+
+        def self.applies_to?(job:)
+          return false if job.security_updates_only?
+          return false if job.updating_a_pull_request?
+          return false if job.dependencies.any?
+
+          true
+        end
+
+        def initialize(job:, service:, dependency_snapshot:)
+          @job = job
+          @service = service
+          @dependency_snapshot = dependency_snapshot
+        end
+
+        def perform; end
+      end
+    end
+  end
+end

--- a/updater/spec/dependabot/updater/operations_spec.rb
+++ b/updater/spec/dependabot/updater/operations_spec.rb
@@ -6,7 +6,7 @@ require "dependabot/updater/operations"
 require "spec_helper"
 
 RSpec.describe Dependabot::Updater::Operations do
-  describe "operation_for" do
+  describe "::class_for" do
     it "returns nil if no operation matches" do
       # We always expect jobs that update a pull request to specify their
       # existing dependency changes, a job with this set of conditions
@@ -17,7 +17,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             dependencies: [],
                             is_a?: true)
 
-      expect(described_class.operation_for(job: job)).to be_nil
+      expect(described_class.class_for(job: job)).to be_nil
     end
 
     it "returns the UpdateAllVersions when the Job is for a fresh, non-security update with no dependencies" do
@@ -27,11 +27,11 @@ RSpec.describe Dependabot::Updater::Operations do
                             dependencies: [],
                             is_a?: true)
 
-      expect(described_class.operation_for(job: job)).to be(Dependabot::Updater::Operations::UpdateAllVersions)
+      expect(described_class.class_for(job: job)).to be(Dependabot::Updater::Operations::UpdateAllVersions)
     end
 
     it "raises an argument error with anything other than a Dependabot::Job" do
-      expect { described_class.operation_for(job: Object.new) }.to raise_error(ArgumentError)
+      expect { described_class.class_for(job: Object.new) }.to raise_error(ArgumentError)
     end
   end
 end

--- a/updater/spec/dependabot/updater/operations_spec.rb
+++ b/updater/spec/dependabot/updater/operations_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "dependabot/job"
+require "dependabot/updater/operations"
+
+require "spec_helper"
+
+RSpec.describe Dependabot::Updater::Operations do
+  describe "operation_for" do
+    it "returns nil if no operation matches" do
+      # We always expect jobs that update a pull request to specify their
+      # existing dependency changes, a job with this set of conditions
+      # should never exist.
+      job = instance_double(Dependabot::Job,
+                            security_updates_only?: false,
+                            updating_a_pull_request?: true,
+                            dependencies: [],
+                            is_a?: true)
+
+      expect(described_class.operation_for(job: job)).to be_nil
+    end
+
+    it "returns the UpdateAllVersions when the Job is for a fresh, non-security update with no dependencies" do
+      job = instance_double(Dependabot::Job,
+                            security_updates_only?: false,
+                            updating_a_pull_request?: false,
+                            dependencies: [],
+                            is_a?: true)
+
+      expect(described_class.operation_for(job: job)).to be(Dependabot::Updater::Operations::UpdateAllVersions)
+    end
+
+    it "raises an argument error with anything other than a Dependabot::Job" do
+      expect { described_class.operation_for(job: Object.new) }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
This change is downstream of https://github.com/dependabot/dependabot-core/pull/6865 and https://github.com/dependabot/dependabot-core/pull/6847 which should both merge first

This is another clear-the-way PR for #6663 [[Prototype] Generating grouped update PRs](https://github.com/dependabot/dependabot-core/pull/6663).

In order to introduce Grouped Updates, we need to clean up the distinct business objects involved in a single Dependabot "Operation" in order to avoid hard-to-reason about branching at different points in the code line.

This PR introduces the `Dependabot::Operations` module which acts as a way to isolate each distinct type of Update we do to avoid us switching from a Version- to Security-update strategy within methods.

It then uses this pattern to extract the logic required to do _just_ a "fresh" Version Update as a distinct operation class, failing over to the "legacy" implementation for all other jobs to help us de-risk the change.

The guts of this change are best looked reviewed via these specific commits:
- 018fad2d6f1b7e0fa14a7b7b3336614ec4864421 This copy-pastes **all** of the methods from `Dependabot::Updater` that are required to pass the test suite with no modifications
- 3f6ac3ad443b85dbb5d70db61e91b28292719494 In this commit, the `dependencies` method which parses and filters the job's dependency files has all logic related to Security updates and rebasing existing PRs removed
- 3f6ac3ad443b85dbb5d70db61e91b28292719494 Removes all remaining Security-update specific code

I ran the full test suite at each step to maintain confidence I wasn't changing behaviour.

### Notes

This PR is not as DRY as it could be, there are likely some more copy-pasted methods that could be extracted to classes that the `Dependabot::Updater` can pass into the `Operation::UpdateAllVersions` class.

I decided not to go too far with the de-duplication until we've:
- De-risked shipping the coarse cut-over to verify there's no surprises from removing the Security- and rebase-specific logic
- Extracted at least one more Operation to give us a better sense of what is/isn't common between them in order to avoid adding indirection on anything we don't actually use in more than one case