### PR TITLE
Fix updating reusable workflows in .github repos

### DIFF
--- a/common/lib/dependabot/source.rb
+++ b/common/lib/dependabot/source.rb
@@ -5,7 +5,7 @@ module Dependabot
     GITHUB_SOURCE = %r{
       (?<provider>github)
       (?:\.com)[/:]
-      (?<repo>[\w.-]+/(?:(?!\.git|\.\s)[\w.-])+)
+      (?<repo>[\w.-]+/(?:[\w.-])+)
       (?:(?:/tree|/blob)/(?<branch>[^/]+)/(?<directory>.*)[\#|/])?
     }x
 
@@ -14,28 +14,28 @@ module Dependabot
       (?<username>[^@]+@)*
       (?<host>[^/]+)
       [/:]
-      (?<repo>[\w.-]+/(?:(?!\.git|\.\s)[\w.-])+)
+      (?<repo>[\w.-]+/(?:[\w.-])+)
       (?:(?:/tree|/blob)/(?<branch>[^/]+)/(?<directory>.*)[\#|/])?
     }x
 
     GITLAB_SOURCE = %r{
       (?<provider>gitlab)
       (?:\.com)[/:]
-      (?<repo>[^/]+/(?:(?!\.git)[^/])+((?!/tree|/blob/|/-)/[^/]+)?)
+      (?<repo>[^/]+/(?:[^/])+((?!/tree|/blob/|/-)/[^/]+)?)
       (?:(?:/tree|/blob)/(?<branch>[^/]+)/(?<directory>.*)[\#|/].*)?
     }x
 
     BITBUCKET_SOURCE = %r{
       (?<provider>bitbucket)
       (?:\.org)[/:]
-      (?<repo>[\w.-]+/(?:(?!\.git|\.\s)[\w.-])+)
+      (?<repo>[\w.-]+/(?:[\w.-])+)
       (?:(?:/src)/(?<branch>[^/]+)/(?<directory>.*)[\#|/])?
     }x
 
     AZURE_SOURCE = %r{
       (?<provider>azure)
       (?:\.com)[/:]
-      (?<repo>[\w.-]+/([\w.-]+/)?(?:_git/)(?:(?!\.git|\.\s)[\w.-])+)
+      (?<repo>[\w.-]+/([\w.-]+/)?(?:_git/)(?:[\w.-])+)
     }x
 
     CODECOMMIT_SOURCE = %r{
@@ -70,7 +70,7 @@ module Dependabot
 
       new(
         provider: captures.fetch("provider"),
-        repo: captures.fetch("repo"),
+        repo: captures.fetch("repo").delete_suffix(".git").delete_suffix("."),
         directory: captures.fetch("directory"),
         branch: captures.fetch("branch")
       )
@@ -87,7 +87,7 @@ module Dependabot
 
       new(
         provider: "github",
-        repo: captures.fetch("repo"),
+        repo: captures.fetch("repo").delete_suffix(".git").delete_suffix("."),
         directory: captures.fetch("directory"),
         branch: captures.fetch("branch"),
         hostname: captures.fetch("host"),

--- a/common/spec/dependabot/source_spec.rb
+++ b/common/spec/dependabot/source_spec.rb
@@ -102,6 +102,13 @@ RSpec.describe Dependabot::Source do
         its(:directory) { is_expected.to be_nil }
       end
 
+      context "with a .github repo" do
+        let(:url) { "https://github.com/org/.github" }
+        its(:provider) { is_expected.to eq("github") }
+        its(:repo) { is_expected.to eq("org/.github") }
+        its(:directory) { is_expected.to be_nil }
+      end
+
       context "with no directory" do
         let(:url) { "https://github.com/org/abc/tree/master/readme.md" }
         its(:provider) { is_expected.to eq("github") }
@@ -189,6 +196,13 @@ RSpec.describe Dependabot::Source do
         let(:url) { "<a href=\"https://ghes.mycorp.com/org/abc\">" }
         its(:provider) { is_expected.to eq("github") }
         its(:repo) { is_expected.to eq("org/abc") }
+        its(:directory) { is_expected.to be_nil }
+      end
+
+      context "with a .github repo" do
+        let(:url) { "https://ghes.mycorp.com/org/.github" }
+        its(:provider) { is_expected.to eq("github") }
+        its(:repo) { is_expected.to eq("org/.github") }
         its(:directory) { is_expected.to be_nil }
       end
 


### PR DESCRIPTION
Accounting for trailing `.git` was causing false negatives for `.github` repositories.

Fixes #6841.