### PR TITLE
Don't consider references to catalogs in buildfiles

### DIFF
--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -224,7 +224,7 @@ module Dependabot
           blk.lines.each do |line|
             name_regex = /(id|kotlin)(\s+#{PLUGIN_ID_REGEX}|\(#{PLUGIN_ID_REGEX}\))/o
             name = line.match(name_regex)&.named_captures&.fetch("id")
-            version_regex = /version\s+['"]?(?<version>#{VSN_PART})['"]?/o
+            version_regex = /version\s+(?<version>['"]?#{VSN_PART}['"]?)/o
             version = format_plugin_version(line.match(version_regex)&.named_captures&.fetch("version"))
             next unless name && version
 
@@ -238,7 +238,7 @@ module Dependabot
       end
 
       def format_plugin_version(version)
-        version&.match?(/^\w+$/) ? "$#{version}" : version
+        quoted?(version) ? unquote(version) : "$#{version}"
       end
 
       def extra_groups(line)
@@ -400,6 +400,14 @@ module Dependabot
         dependency_files.find do |f|
           SUPPORTED_BUILD_FILE_NAMES.include?(f.name)
         end
+      end
+
+      def quoted?(string)
+        string&.match?(/^['"].*['"]$/)
+      end
+
+      def unquote(string)
+        string[1..-2]
       end
     end
   end

--- a/gradle/spec/fixtures/buildfiles/root_build.gradle.kts
+++ b/gradle/spec/fixtures/buildfiles/root_build.gradle.kts
@@ -12,6 +12,8 @@ plugins {
 
     val helmVersion = "1.6.0"
     id("org.unbroken-dome.helm") version helmVersion apply false
+
+    id("not.yet.updatable") version libs.versions.notYetUpdatable apply false
 }
 
 buildscript {


### PR DESCRIPTION
Fixes #6863.

Trully fixing this (as in, actually create correct PRs) was out of scope for the first MVP for Gradle Version Catalogs, and I don't want to continue with the business of parsing Kotlin/Java code in Ruby. The way to go for us is probably to leverage #1164.

So the way I approached this is to just avoid creating an incorrect PR by fixing the underlying bug that caused that.

## Explanation of the fix:

We do support some bare version replacements in build files, for example,

```
val helmVersion = "1.6.0"
id("org.unbroken-dome.helm") version helmVersion apply false
```

What the code used to do was checking whether the version parsed was all "word characters" or not.

If all word characters, then it's considered a property name, a value for the property is looked up, and if a value cannot be found, then the dependency is ignored.

If not all word characters, then it's considered a version number, and the dependency is only ignored if the version number is not valid.

In this case, `libs.versions.<ref>` includes dots, which are not word characters, so it does not match the regexp to be considered a property reference. As a consequence, it's considered a version number, and accepted as a dependency because `libs.versions.<ref>` is actually a valid maven version number.

I could've tweaked the regexp to accept dots for property names, but I think it's a better criteria to check whether to matched value is quoted. If it is, it's a version number, otherwise it's a property.

So I implemented that.

