### PR TITLE
allow Ruby 3.2.0 updates to work

### DIFF
--- a/bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb
@@ -10,7 +10,7 @@ module BundlerDefinitionRubyVersionPatch
         Gem::Specification.new("Ruby\0", requested_version)
     end
 
-    %w(2.5.3 2.6.10 2.7.7 3.0.5 3.2.0 3.2.1).each do |version|
+    %w(2.5.3 2.6.10 2.7.7 3.0.5 3.2.1).each do |version|
       sources.metadata_source.specs << Gem::Specification.new("Ruby\0", version)
     end
 

--- a/bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb
@@ -10,7 +10,7 @@ module BundlerDefinitionRubyVersionPatch
         Gem::Specification.new("Ruby\0", requested_version)
     end
 
-    %w(2.5.3 2.6.10 2.7.7 3.0.5 3.2.0).each do |version|
+    %w(2.5.3 2.6.10 2.7.7 3.0.5 3.2.0 3.2.1).each do |version|
       sources.metadata_source.specs << Gem::Specification.new("Ruby\0", version)
     end
 

--- a/bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/definition_ruby_version_patch.rb
@@ -10,7 +10,7 @@ module BundlerDefinitionRubyVersionPatch
         Gem::Specification.new("Ruby\0", requested_version)
     end
 
-    %w(2.5.3 2.6.10 2.7.7 3.0.5).each do |version|
+    %w(2.5.3 2.6.10 2.7.7 3.0.5 3.2.0).each do |version|
       sources.metadata_source.specs << Gem::Specification.new("Ruby\0", version)
     end
 


### PR DESCRIPTION
While we're [deliberating on how to proceed with Ruby 3.2.0](https://github.com/dependabot/dependabot-core/pull/6436), we're seeing some updates failing due to requirements on it. So to fix that we can add that version here to get PRs flowing again. 