### PR TITLE
fix Yarn 1 erroring on parent npmrc files with undefined vars

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -367,6 +367,10 @@ module Dependabot
             File.write(file.name, updated_content)
           end
 
+          clean_npmrc_in_path(yarn_lock)
+        end
+
+        def clean_npmrc_in_path(yarn_lock)
           # Berry does not read npmrc files.
           return if Helpers.yarn_berry?(yarn_lock)
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -366,6 +366,21 @@ module Dependabot
             updated_content = sanitized_package_json_content(updated_content)
             File.write(file.name, updated_content)
           end
+
+          # Berry does not read npmrc files.
+          return if Helpers.yarn_berry?(yarn_lock)
+
+          # Find .npmrc files in parent directories and remove variables in them
+          # to avoid errors when running yarn 1.
+          dirs = Dir.getwd.split("/")
+          dirs.pop
+          while dirs.any?
+            npmrc = dirs.join("/") + "/.npmrc"
+            break unless File.exist?(npmrc)
+
+            File.write(npmrc, File.read(npmrc).gsub(/\$\{.*\}/, ""))
+            dirs.pop
+          end
         end
 
         def write_lockfiles


### PR DESCRIPTION
If a repo has multiple .npmrc files, Dependabot only rewrites one of them to remove variables. NPM doesn't seem to have an issue with this, I assume it's just expanding undefined vars to `""`, but Yarn 1 is not ok with that and errors.

To fix this, I've added some code to rewrite all of the .npmrc files and remove the variables. 

Still trying to figure out if there's a way to test this in this project, I have a CLI test that is passing with this change.