### PR TITLE
Add OCI source annotation to updater core image

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -101,6 +101,8 @@ rm -rf ~/.bundle
 
 FROM ubuntu:20.04
 
+LABEL org.opencontainers.image.source="https://github.com/dependabot/dependabot-core"
+
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND="noninteractive" \


### PR DESCRIPTION
This will help Dependabot include relevant change details when it opens PRs against this image. Support was added in https://github.com/dependabot/dependabot-core/pull/6864.

I'm not sure if we also need to add this label to each ecosystem image. I'll followup with that change if this doesn't have the expected result.