### PR TITLE
Fix typo: potentials -> potential

### DIFF
--- a/bundler/helpers/v2/lib/functions/lockfile_updater.rb
+++ b/bundler/helpers/v2/lib/functions/lockfile_updater.rb
@@ -171,7 +171,7 @@ module Functions
       end
 
       # If there are specific dependencies we can unlock, unlock them
-      return dependencies_to_unlock.append(*potentials_deps) if potentials_deps.any?
+      return dependencies_to_unlock.append(*potential_deps) if potential_deps.any?
 
       # Fall back to unlocking *all* sub-dependencies. This is required
       # because Bundler's SolveFailure objects don't include enough


### PR DESCRIPTION
Fix a typo that showed up in a job run

```
      return dependencies_to_unlock.append(*potentials_deps) if potentials_deps.any?
                                                                ^^^^^^^^^^^^^^^
Did you mean?  potential_deps
```