### PR TITLE
handle Node out of memory errors

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -117,6 +117,13 @@ module Dependabot
         process_termsig: process.termsig
       }
 
+      if stderr.include?("JavaScript heap out of memory")
+        raise HelperSubprocessFailed.new(
+          message: "JavaScript heap out of memory",
+          error_context: error_context
+        )
+      end
+
       response = JSON.parse(stdout)
       return response["result"] if process.success?
 


### PR DESCRIPTION
In Yarn 1 we're seeing calls to the Yarn library run out of memory. I was able to reproduce the error using `yarn upgrade` and it led me to this issue: https://github.com/yarnpkg/yarn/issues/8734

This PR simply makes it easier for us to identify errors that are caused by the Node helper running out of memory for the npm_and_yarn ecosystem. We might want to follow this up with an error class that is more specific. Or if anyone has a good idea for an existing one, let me know. The OutOfMemory exception is a halting error, and doesn't exactly capture what is going on here. 