### PR TITLE
Add package manager as a tag in error contexts

### DIFF
--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -65,10 +65,11 @@ module Dependabot
       Raven.capture_exception(
         error,
         {
-          tags: tags,
+          tags: tags.merge({
+            package_manager: job&.package_manager
+          }.compact),
           extra: extra.merge({
             update_job_id: job&.id,
-            package_manager: job&.package_manager,
             dependency_name: dependency&.name
           }.compact)
         }


### PR DESCRIPTION
This fixes an issue introduced in https://github.com/dependabot/dependabot-core/pull/6846

We previously passed `job.package_manager` in two places, in [one](https://github.com/dependabot/dependabot-core/pull/6846/files#diff-0ae3ea6b30ef21b78d5b11abdd5a8b478e3df86e9c2d681c88fc4d03f49e170bL94-L98) as a 'tag' and in [another](https://github.com/dependabot/dependabot-core/pull/6846/files#diff-b18ee444afdafa5177657bddd586b0097d8d8f631729850ed2afd5b6eb573e5aL997-L1007) as part of the 'extra' hash.

In #6846, this logic was consolidated but package_manager was only passed in the `extra` hash meaning that Sentry no longer hydrates it as a searchable value. This PR fixes this by correctly passing it as a `tag` for _all_ captured errors, if the Job is available.