### PR TITLE
[Updater] Update the service's dependency metadata in one place

### DIFF
--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -24,6 +24,9 @@ module Dependabot
         return service.mark_job_as_processed(Environment.job_definition["base_commit_sha"])
       end
 
+      # Update the service's metadata about this project
+      service.update_dependency_list(dependency_snapshot: dependency_snapshot)
+
       # TODO: Pull fatal error handling handling up into this class
       #
       # As above, we can remove the responsibility for handling fatal/job halting

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -588,9 +588,6 @@ module Dependabot
     def dependencies
       all_deps = dependency_snapshot.dependencies
 
-      # Tell the backend about the current dependencies on the target branch
-      service.update_dependency_list(dependency_snapshot: dependency_snapshot)
-
       # Rebases and security updates have dependencies, version updates don't
       if job.dependencies
         # Gradle, Maven and Nuget dependency names can be case-insensitive and

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -70,9 +70,6 @@ module Dependabot
         def dependencies
           all_deps = dependency_snapshot.dependencies
 
-          # Tell the backend about the current dependencies on the target branch
-          service.update_dependency_list(dependency_snapshot: dependency_snapshot)
-
           allowed_deps = all_deps.select { |d| job.allowed_update?(d) }
           # Return dependencies in a random order, with top-level dependencies
           # considered first so that dependency runs which time out don't always hit

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -38,9 +38,6 @@ module Dependabot
         def dependencies
           all_deps = dependency_snapshot.dependencies
 
-          # Tell the backend about the current dependencies on the target branch
-          service.update_dependency_list(dependency_snapshot: dependency_snapshot)
-
           allowed_deps = all_deps.select { |d| job.allowed_update?(d) }
           # Return dependencies in a random order, with top-level dependencies
           # considered first so that dependency runs which time out don't always hit

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Dependabot::UpdateFilesCommand do
     instance_double(Dependabot::Service,
                     capture_exception: nil,
                     mark_job_as_processed: nil,
-                    record_update_job_error: nil)
+                    record_update_job_error: nil,
+                    update_dependency_list: nil)
   end
   let(:job_definition) do
     JSON.parse(fixture("file_fetcher_output/output.json"))
@@ -43,6 +44,13 @@ RSpec.describe Dependabot::UpdateFilesCommand do
       expect(dummy_runner).to receive(:run)
       expect(service).to receive(:mark_job_as_processed).
         with(base_commit_sha)
+
+      perform_job
+    end
+
+    it "sends dependency metadata to the service" do
+      expect(service).to receive(:update_dependency_list).
+        with(dependency_snapshot: an_instance_of(Dependabot::DependencySnapshot))
 
       perform_job
     end

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -66,17 +66,6 @@ RSpec.describe Dependabot::Updater do
       updater.run
     end
 
-    it "updates the update config's dependency list" do
-      job = build_job
-      service = build_service
-      updater = build_updater(service: service, job: job)
-
-      expect(service).to receive(:update_dependency_list).
-        with(dependency_snapshot: an_instance_of(Dependabot::DependencySnapshot))
-
-      updater.run
-    end
-
     it "updates only the dependencies that need updating" do
       stub_update_checker
 
@@ -2261,7 +2250,6 @@ RSpec.describe Dependabot::Updater do
       update_pull_request: nil,
       close_pull_request: nil,
       mark_job_as_processed: nil,
-      update_dependency_list: nil,
       record_update_job_error: nil
     )
 


### PR DESCRIPTION
Follows up on #6906 

Now we've established the fast-fail approach to Dependency parsing in production, this PR makes a small follow-up change to relay the outcome of the parsing to the service as metadata we use to maintain an understanding of the current state of the project to immediately after the parsing takes place.

This will remove the need to perform this call in each operation class, avoiding repetition.