### PR TITLE
Refactor npm ecosystem lockfile parsing

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -217,14 +217,7 @@ module Dependabot
       end
 
       def semver_version_for(lockfile_details)
-        lock_version = lockfile_details&.fetch("version", nil)
-
-        # This line is to guard against improperly formatted versions in a
-        # lockfile, such as additional characters. NPM/yarn fixes these when
-        # running an update, so we can safely ignore these versions.
-        return unless version_class.correct?(lock_version)
-
-        lock_version
+        version_class.semver_for(lockfile_details&.fetch("version", ""))
       end
 
       def source_for(name, requirement, lockfile_details)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
@@ -18,6 +18,10 @@ module Dependabot
           raise Dependabot::DependencyFileNotParseable, @dependency_file.path
         end
 
+        def dependencies
+          recursively_fetch_dependencies(parsed)
+        end
+
         def details(dependency_name, _requirement, manifest_name)
           if Helpers.npm_version(@dependency_file.content) == "npm8"
             # NOTE: npm 8 sometimes doesn't install workspace dependencies in the
@@ -31,6 +35,44 @@ module Dependabot
         end
 
         private
+
+        def recursively_fetch_dependencies(object_with_dependencies)
+          dependency_set = Dependabot::NpmAndYarn::FileParser::DependencySet.new
+
+          dependencies = object_with_dependencies["dependencies"]
+          dependencies ||= object_with_dependencies.fetch("packages", {}).transform_keys do |name|
+            name.delete_prefix("node_modules/")
+          end
+
+          dependencies.each do |name, details|
+            next if name.empty? # v3 lockfiles include an empty key holding info of the current package
+
+            version = Version.semver_for(details["version"])
+            next unless version
+
+            dependency_args = {
+              name: name,
+              version: version,
+              package_manager: "npm_and_yarn",
+              requirements: []
+            }
+
+            if details["bundled"]
+              dependency_args[:subdependency_metadata] =
+                [{ npm_bundled: details["bundled"] }]
+            end
+
+            if details["dev"]
+              dependency_args[:subdependency_metadata] =
+                [{ production: !details["dev"] }]
+            end
+
+            dependency_set << Dependency.new(**dependency_args)
+            dependency_set += recursively_fetch_dependencies(details)
+          end
+
+          dependency_set
+        end
 
         def node_modules_path(manifest_name, dependency_name)
           return "node_modules/#{dependency_name}" if manifest_name == "package.json"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
@@ -11,8 +11,8 @@ module Dependabot
           @dependency_file = dependency_file
         end
 
-        def parse
-          JSON.parse(@dependency_file.content)
+        def parsed
+          @parsed ||= JSON.parse(@dependency_file.content)
         rescue JSON::ParserError
           raise Dependabot::DependencyFileNotParseable, @dependency_file.path
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require "dependabot/errors"
+require "dependabot/npm_and_yarn/helpers"
 
 module Dependabot
   module NpmAndYarn
@@ -15,6 +16,27 @@ module Dependabot
           @parsed ||= JSON.parse(@dependency_file.content)
         rescue JSON::ParserError
           raise Dependabot::DependencyFileNotParseable, @dependency_file.path
+        end
+
+        def details(dependency_name, _requirement, manifest_name)
+          if Helpers.npm_version(@dependency_file.content) == "npm8"
+            # NOTE: npm 8 sometimes doesn't install workspace dependencies in the
+            # workspace folder so we need to fallback to checking top-level
+            nested_details = parsed.dig("packages", node_modules_path(manifest_name, dependency_name))
+            details = nested_details || parsed.dig("packages", "node_modules/#{dependency_name}")
+            details&.slice("version", "resolved", "integrity", "dev")
+          else
+            parsed.dig("dependencies", dependency_name)
+          end
+        end
+
+        private
+
+        def node_modules_path(manifest_name, dependency_name)
+          return "node_modules/#{dependency_name}" if manifest_name == "package.json"
+
+          workspace_path = manifest_name.gsub("/package.json", "")
+          File.join(workspace_path, "node_modules", dependency_name)
         end
       end
     end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "json"
+require "dependabot/errors"
+
+module Dependabot
+  module NpmAndYarn
+    class FileParser
+      class JsonLock
+        def initialize(dependency_file)
+          @dependency_file = dependency_file
+        end
+
+        def parse
+          JSON.parse(@dependency_file.content)
+        rescue JSON::ParserError
+          raise Dependabot::DependencyFileNotParseable, @dependency_file.path
+        end
+      end
+    end
+  end
+end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "dependabot/shared_helpers"
+require "dependabot/errors"
+require "dependabot/npm_and_yarn/native_helpers"
+
+module Dependabot
+  module NpmAndYarn
+    class FileParser
+      class YarnLock
+        def initialize(dependency_file)
+          @dependency_file = dependency_file
+        end
+
+        def parse
+          SharedHelpers.in_a_temporary_directory do
+            File.write("yarn.lock", @dependency_file.content)
+
+            SharedHelpers.run_helper_subprocess(
+              command: NativeHelpers.helper_path,
+              function: "yarn:parseLockfile",
+              args: [Dir.pwd]
+            )
+          rescue SharedHelpers::HelperSubprocessFailed
+            raise Dependabot::DependencyFileNotParseable, @dependency_file.path
+          end
+        end
+      end
+    end
+  end
+end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
@@ -12,8 +12,8 @@ module Dependabot
           @dependency_file = dependency_file
         end
 
-        def parse
-          SharedHelpers.in_a_temporary_directory do
+        def parsed
+          @parsed ||= SharedHelpers.in_a_temporary_directory do
             File.write("yarn.lock", @dependency_file.content)
 
             SharedHelpers.run_helper_subprocess(

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
@@ -25,6 +25,22 @@ module Dependabot
             raise Dependabot::DependencyFileNotParseable, @dependency_file.path
           end
         end
+
+        def details(dependency_name, requirement, _manifest_name)
+          details_candidates =
+            parsed.
+            select { |k, _| k.split(/(?<=\w)\@/)[0] == dependency_name }
+
+          # If there's only one entry for this dependency, use it, even if
+          # the requirement in the lockfile doesn't match
+          if details_candidates.one?
+            details_candidates.first.last
+          else
+            details_candidates.find do |k, _|
+              k.scan(/(?<=\w)\@(?:npm:)?([^\s,]+)/).flatten.include?(requirement)
+            end&.last
+          end
+        end
       end
     end
   end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/version.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/version.rb
@@ -25,6 +25,17 @@ module Dependabot
         version.to_s.match?(ANCHORED_VERSION_PATTERN)
       end
 
+      def self.semver_for(version)
+        # The next two lines are to guard against improperly formatted
+        # versions in a lockfile, such as an empty string or additional
+        # characters. NPM/yarn fixes these when running an update, so we can
+        # safely ignore these versions.
+        return if version == ""
+        return unless correct?(version)
+
+        version
+      end
+
       def initialize(version)
         @version_string = version.to_s
         version = version.gsub(/^v/, "") if version.is_a?(String)


### PR DESCRIPTION
As I start looking into pnpm, I noticed that some classes have mixed concerns including code specific to yarn and npm, and are going to get much worse when adding pnpm.

This PR tries to improve this situation by extracting package manager specific classes to deal with parsing lockfiles.

