### PR TITLE
Improve `dry-run.rb` diffs

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -274,12 +274,16 @@ def show_diff(original_file, updated_file)
   updated_tmp_file.write(updated_file.content)
   updated_tmp_file.close
 
-  diff = `diff -u #{original_tmp_file.path} #{updated_tmp_file.path}`
+  diff = `diff -u #{original_tmp_file.path} #{updated_tmp_file.path}`.lines
+  added_lines = diff.count { |line| line.start_with?("+") }
+  removed_lines = diff.count { |line| line.start_with?("-") }
+
   puts
   puts "    ± #{original_file.name}"
   puts "    ~~~"
-  puts diff.lines.map { |line| "    " + line }.join
+  puts diff.map { |line| "    " + line }.join
   puts "    ~~~"
+  puts "    #{added_lines} insertions (+), #{removed_lines} deletions (-)"
 end
 
 def cached_read(name)

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -274,7 +274,7 @@ def show_diff(original_file, updated_file)
   updated_tmp_file.write(updated_file.content)
   updated_tmp_file.close
 
-  diff = `diff #{original_tmp_file.path} #{updated_tmp_file.path}`
+  diff = `diff -u #{original_tmp_file.path} #{updated_tmp_file.path}`
   puts
   puts "    ± #{original_file.name}"
   puts "    ~~~"


### PR DESCRIPTION
* Use a unified diff format, much easier to read, and everyone is more used to it.
* Include a stats summary of added and deleted lines.