### PR TITLE
Fix "no files were updated!" errors in workspaces

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -186,7 +186,7 @@ module Dependabot
           end
 
           # TODO: Update the npm 6 updater to use these args as we currently
-          # do the same in the js updater helper, we've kept it seperate for
+          # do the same in the js updater helper, we've kept it separate for
           # the npm 7 rollout
           install_args = top_level_dependencies.map { |dependency| npm_install_args(dependency) }
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -241,8 +241,8 @@ module Dependabot
         #
         # Other npm flags:
         # - `--force` ignores checks for platform (os, cpu) and engines
-        # - `--dry-run=false` the updater sets a global .npmrc with dry-run:
-        #   true to work around an issue in npm 6, we don't want that here
+        # - `--dry-run=false` the updater sets a global .npmrc with `dry-run: true`
+        #   to work around an issue in npm 6, we don't want that here
         # - `--ignore-scripts` disables prepare and prepack scripts which are
         #   run when installing git dependencies
         def run_npm_install_lockfile_only(*install_args)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -176,48 +176,28 @@ module Dependabot
             dependency_in_package_json?(dependency)
           end
 
-          # NOTE: When updating a dependency in a nested workspace project we
-          # need to run `npm install` without any arguments to update the root
-          # level lockfile after having updated the nested packages package.json
-          # requirement, otherwise npm will add the dependency as a new
-          # top-level dependency to the root lockfile.
-          install_args = ""
-          if dependencies_in_current_package_json
-            # TODO: Update the npm 6 updater to use these args as we currently
-            # do the same in the js updater helper, we've kept it seperate for
-            # the npm 7 rollout
-            install_args = top_level_dependencies.map { |dependency| npm_install_args(dependency) }
+          unless dependencies_in_current_package_json
+            # NOTE: When updating a dependency in a nested workspace project, npm
+            # will add the dependency as a new top-level dependency to the root
+            # lockfile. To overcome this, we save the content before the update,
+            # and then re-run `npm install` after the update against the previous
+            # content to remove that
+            previous_package_json = File.read(package_json.name)
           end
 
-          # NOTE: npm options
-          # - `--force` ignores checks for platform (os, cpu) and engines
-          # - `--dry-run=false` the updater sets a global .npmrc with dry-run:
-          #   true to work around an issue in npm 6, we don't want that here
-          # - `--ignore-scripts` disables prepare and prepack scripts which are
-          #   run when installing git dependencies
-          command = [
-            "npm",
-            "install",
-            *install_args,
-            "--force",
-            "--dry-run",
-            "false",
-            "--ignore-scripts",
-            "--package-lock-only"
-          ].join(" ")
+          # TODO: Update the npm 6 updater to use these args as we currently
+          # do the same in the js updater helper, we've kept it seperate for
+          # the npm 7 rollout
+          install_args = top_level_dependencies.map { |dependency| npm_install_args(dependency) }
 
-          fingerprint = [
-            "npm",
-            "install",
-            "<install_args>",
-            "--force",
-            "--dry-run",
-            "false",
-            "--ignore-scripts",
-            "--package-lock-only"
-          ].join(" ")
+          run_npm_install_lockfile_only(*install_args)
 
-          SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
+          unless dependencies_in_current_package_json
+            File.write(package_json.name, previous_package_json)
+
+            run_npm_install_lockfile_only
+          end
+
           { lockfile_basename => File.read(lockfile_basename) }
         end
 
@@ -254,6 +234,41 @@ module Dependabot
             NpmAndYarn::FileParser::DEPENDENCY_TYPES.inject({}) do |deps, type|
               deps.merge(parsed_package_json[type] || {})
             end
+        end
+
+        # Runs `npm install` with `--package-lock-only` flag to update the
+        # lockfiile.
+        #
+        # Other npm flags:
+        # - `--force` ignores checks for platform (os, cpu) and engines
+        # - `--dry-run=false` the updater sets a global .npmrc with dry-run:
+        #   true to work around an issue in npm 6, we don't want that here
+        # - `--ignore-scripts` disables prepare and prepack scripts which are
+        #   run when installing git dependencies
+        def run_npm_install_lockfile_only(*install_args)
+          command = [
+            "npm",
+            "install",
+            *install_args,
+            "--force",
+            "--dry-run",
+            "false",
+            "--ignore-scripts",
+            "--package-lock-only"
+          ].join(" ")
+
+          fingerprint = [
+            "npm",
+            "install",
+            install_args.empty? ? "" : "<install_args>",
+            "--force",
+            "--dry-run",
+            "false",
+            "--ignore-scripts",
+            "--package-lock-only"
+          ].join(" ")
+
+          SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
         end
 
         def npm_install_args(dependency)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -265,6 +265,28 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
     end
   end
 
+  context "workspace with outdated deps not in root package.json" do
+    let(:dependency_name) { "@swc/core" }
+    let(:version) { "1.3.44" }
+    let(:previous_version) { "1.3.40" }
+    let(:requirements) do
+      [{
+        file: "packages/bump-version-for-cron/package.json",
+        requirement: "^1.3.37",
+        groups: ["dependencies"],
+        source: nil
+      }]
+    end
+    let(:previous_requirements) { requirements }
+
+    let(:files) { project_dependency_files("npm8/workspace_outdated_deps_not_in_root_package_json") }
+
+    it "updates" do
+      expect(JSON.parse(updated_npm_lock_content)["packages"]["node_modules/@swc/core"]["version"]).
+        to eq("1.3.44")
+    end
+  end
+
   %w(npm6 npm8).each do |npm_version|
     describe "#{npm_version} updates" do
       let(:files) { project_dependency_files("#{npm_version}/simple") }

--- a/npm_and_yarn/spec/fixtures/projects/npm8/workspace_outdated_deps_not_in_root_package_json/bump-version-for-cron/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/workspace_outdated_deps_not_in_root_package_json/bump-version-for-cron/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@k8slens/bump-version-for-cron",
+  "version": "6.5.0-alpha.1",
+  "description": "CLI to bump the version to during a cron daily alpha release",
+  "license": "MIT",
+  "private": false,
+  "devDependencies": {
+    "@swc/core": "^1.3.37"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm8/workspace_outdated_deps_not_in_root_package_json/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/workspace_outdated_deps_not_in_root_package_json/package-lock.json
@@ -1,0 +1,211 @@
+{
+  "name": "lens-monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lens-monorepo",
+      "workspaces": [
+        "bump-version-for-cron"
+      ]
+    },
+    "bump-version-for-cron": {
+      "name": "@k8slens/bump-version-for-cron",
+      "version": "6.5.0-alpha.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@swc/core": "^1.3.37"
+      }
+    },
+    "node_modules/@k8slens/bump-version-for-cron": {
+      "resolved": "bump-version-for-cron",
+      "link": true
+    },
+    "node_modules/@swc/core": {
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.40.tgz",
+      "integrity": "sha512-ZQJ+NID24PQkPIHnbO2B68YNQ6aMEyDz6dcsZucpRK4r7+aPqQ2yVLaqFcQU9VcGMyo4JJydmokzyTr1roWPIQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.3.40",
+        "@swc/core-darwin-x64": "1.3.40",
+        "@swc/core-linux-arm-gnueabihf": "1.3.40",
+        "@swc/core-linux-arm64-gnu": "1.3.40",
+        "@swc/core-linux-arm64-musl": "1.3.40",
+        "@swc/core-linux-x64-gnu": "1.3.40",
+        "@swc/core-linux-x64-musl": "1.3.40",
+        "@swc/core-win32-arm64-msvc": "1.3.40",
+        "@swc/core-win32-ia32-msvc": "1.3.40",
+        "@swc/core-win32-x64-msvc": "1.3.40"
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.40.tgz",
+      "integrity": "sha512-x4JHshTVB2o5xOedLL54/jsKkfUlsMw25tNM5fWkehiKWXlQuxEasl5/roceAFETWm8mEESuL8pWgZaiyTDl4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.40.tgz",
+      "integrity": "sha512-2QaW9HtlvatiQscQACVIyKtj+vAEFEC6Tn+8rqxm8ikYHUD33M/FVXGWEvMLTI7T3P25zjhs+toAlLsjHgfzQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.40.tgz",
+      "integrity": "sha512-cJPgSg8222gezj5Db2S8PNvcALJLokvXqvFjyzRR253SMFFkq9JKWk0uwO3wg8i8jhe78xMB6EO6AteQqFWvCg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.40.tgz",
+      "integrity": "sha512-s76n4/vpQzV7dpS703m1WnCxyG7OfGk+EeJf+KEl/m6KP7c5MHHOLOf8hpagI/QI1H8jb9j1ADqNu2C7tEUR8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.40.tgz",
+      "integrity": "sha512-aTkeImCq1WrkljAQNnqlbk/1ermotONkBl11GH7Ia+8yhsmgt8ZiNBIi0tJ5UjdfXDtnl58Iek43Vo8LWaPUKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.40.tgz",
+      "integrity": "sha512-ZsfVlzXSXvNZBuK1fCrenoLSLVv0Zk7OdmkAG9cWN3bKkc/ynxO+6njXLEKWfv9bRfDBXhxifyHGOVOQlIFIAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.40.tgz",
+      "integrity": "sha512-5GgMuadbd6fhHg/+7W25i+9OQTW4nTMGECias0BNPlcW8nnohzSphpj5jLI/Ub5bWzMwE2hua6e2uiZ17rTySg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.40.tgz",
+      "integrity": "sha512-TqiK28eaK3YOKSp8iESlrrbSzDGRQqM0zR4hvCgfHwL4L1BPh/M0aIMC/vyYh2gqpz2quyNqgi/DxoZ2+WxlUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.40.tgz",
+      "integrity": "sha512-PqtCXFs5+ZbrfFe1VZAcCl8k9h47wE65mKDhDvZ9/SQhXxZX2+f5mUGXuH4G5rA0CyijsVpHnpA/5rqE7f2Sxw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.40.tgz",
+      "integrity": "sha512-73DGsjsJYSzmoRbfomPj5jcQawtK2H0bCDi/1wgfl8NKVOuzrq+PpaTry3lzx+gvTHxUX6mUHV22i7C9ITL74Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm8/workspace_outdated_deps_not_in_root_package_json/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/workspace_outdated_deps_not_in_root_package_json/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lens-monorepo",
+  "private": true,
+
+  "workspaces": [
+    "bump-version-for-cron"
+  ]
+}


### PR DESCRIPTION
When updating a dependency not included in the root `package.json` file, and that only requires `package-lock.json` changes, we ended up running `npm install --lockfile-only` (without explicit `package@version` arg), and that would result in no lockfile changes and the above error.

We need to force the update through a `package@version` CLI argument. However, as it was already explained on a comment, in this case this causes a new dependency to be added to the top level `package.json` file, which is not desirable. To workaround that, we save the original `package.json` content, and restore it after the upgrade and re-run `npm install --lockfile-only` again to bring the lockfile in sync.