### PR TITLE
[Updater] Stub the upate checker for security ignore tests

### DIFF
--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -2131,6 +2131,9 @@ RSpec.describe Dependabot::Updater do
         service = build_service
         updater = build_updater(service: service, job: job)
 
+        checker = stub_update_checker
+        allow(checker).to receive(:latest_version).and_raise(Dependabot::AllVersionsIgnored)
+
         updater.run
         expect(Dependabot.logger).
           to have_received(:info).
@@ -2151,6 +2154,9 @@ RSpec.describe Dependabot::Updater do
         )
         service = build_service
         updater = build_updater(service: service, job: job)
+
+        checker = stub_update_checker
+        allow(checker).to receive(:latest_version).and_raise(Dependabot::AllVersionsIgnored)
 
         updater.run
 


### PR DESCRIPTION
We rescue `StandardError` in a few places out of necessity to avoid an exception attempting to update one Dependency killing the job without trying others that may be more successful.

A consequence of this is we don't always see the "real" error when testing error outcomes and in splitting the Updater out, I've been by-passing the `StandardError` rescue statements as a smoke test to make sure I hadn't missed anything.

In doing so, I found two mystery VCR warnings. It turns out these two tests were trying to hit the internet as they didn't stub the UpdateChecker as was convention in other tests. The ultimately didn't need to as any error being rescued resulted in the right outcome, but it confused my refactor.

I'm fixing this in isolation since it's a small-test only glitch.