### PR TITLE
Remove `git clone` instructions from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,21 +43,6 @@ In addition to this library, you may be interested in the [dependabot-script][de
 which provides a collection of scripts that use this library to update dependencies on GitHub Enterprise, GitLab,
 BitBucket or Azure DevOps.
 
-## Cloning the repository
-Clone the repository with Git using:
-
-```
-git clone https://github.com/dependabot/dependabot-core.git
-```
-
-On Windows this might fail with "Filename too long". To solve this, run the
-following commands in the cloned Git repository:
-
-1. `git config core.longpaths true`
-2. `git reset --hard`
-
-You can read more about this in the [Git for Windows wiki](https://github.com/git-for-windows/git/wiki/Git-cannot-create-a-file-or-directory-with-a-long-path).
-
 ## Setup
 
 To run all of Dependabot Core, you'll need Ruby, Python, PHP, Elixir, Node, Go,


### PR DESCRIPTION
No need to waste space on cloning instructions:
1. Anyone reading this will almost always be familiar with how `git` works. If not, most of the rest of this won't make sense to them either.
2. Cloning makes sense for development, but not for someone just wanting to run Dependabot... for that we'd rather push them to another tool.
3. The windows error will loudly fail, as opposed to silently failing. When I googled that error, one of the top results was a stackOverflow answer showing exactly this answer.

So let's remove this so we can focus the reader's attention on higher-value topics.