### PR TITLE
Create dedicated section for maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,15 +244,6 @@ missing some functionality and are therefore not supported. You have to clone th
 repository manually and use the `Reopen in Container` or `Open Folder in Container...`
 command.
 
-## Releasing
-
-Triggering the jobs that will push the new gems is done by following the steps below.
-
-- Ensure you have the latest merged changes:  `git checkout main` and `git pull`
-- Generate an updated `CHANGELOG`, `version.rb`, and the rest of the needed commands:  `bin/bump-version.rb patch`
-- Edit the `CHANGELOG` file and remove any entries that aren't needed
-- Run the commands that were output by running `bin/bump-version.rb patch`
-
 ## Architecture
 
 Dependabot Core is a collection of Ruby packages (gems), which contain the
@@ -383,3 +374,18 @@ recurring payments from Europe, check them out.
 [support]: https://support.github.com/
 [vsc-dev-containers]: https://code.visualstudio.com/docs/devcontainers/containers
 [vsc-dev-containers-ext]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
+
+## Notes for project maintainers
+
+<details><summary>:book: Release guide</summary>
+<p>
+
+  Triggering the jobs that will push the new gems is done by following the steps below.
+
+  - Ensure you have the latest merged changes:  `git checkout main` and `git pull`
+  - Generate an updated `CHANGELOG`, `version.rb`, and the rest of the needed commands:  `bin/bump-version.rb patch`
+  - Edit the `CHANGELOG` file and remove any entries that aren't needed
+  - Run the commands that were output by running `bin/bump-version.rb patch`
+
+</p>
+</details>


### PR DESCRIPTION
The release guide is only helpful for maintainers, it's visual noise for everyone else. So let's:
1. Create a dedicated section for maintainers following the format from https://github.com/dependabot/fetch-metadata/blob/aea2135c95039f05c64436f1d14638c300e10b2b/README.md#L177-L211
2. Move the release notes there

Later on we may have additional things to add under the maintainers section, for example what commands to run to merge Dependabot PR's that are failing due to needing to run `cd /updater && bundle install`, but let's land this first.