### PR TITLE
Discourage filing issues about Alerts / Dependency Graph

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -5,8 +5,10 @@ body:
   - type: markdown
     attributes:
       value: |
+        This issue-tracker is meant for issues related to Dependabot's updating logic, a good rule of thumb is that if you have questions about the _diff_ in a PR, it belongs here.
+
+        Issues related to security alerts or Dependency Graph should instead be filed as a [Code Security discussion](https://github.com/orgs/community/discussions/categories/code-security).
         For support on the GitHub-integrated Dependabot service, please contact [GitHub support](https://support.github.com/).
-        This issue-tracker is meant for issues related to Dependabot's updating logic, a good rule of thumb is that if you have questions about the _diff_ in a PR, it belongs here, otherwise the GitHub support team is best equipped to help you.
 
         The more information you can provide, the easier it will be to reproduce the issue and find a fix.
 


### PR DESCRIPTION
We get the occasional issue about Alerts / Dependency Graph, and they're out of scope for both this issue tracker and the team that watches the issue tracker... ie, there's nothing we can do.

So let's point folks in the right direction from the get-go.