### PR TITLE
Restore performance of Docker update checker

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -100,7 +100,7 @@ module Dependabot
         version_tag = Tag.new(version)
         return unless version_tag.comparable?
 
-        latest_tag = fetch_latest_version(version_tag)
+        latest_tag = latest_tag_from(version)
 
         old_v = version_tag.numeric_version
         latest_v = latest_tag.numeric_version
@@ -118,15 +118,19 @@ module Dependabot
       end
 
       def latest_version_from(version)
-        @versions ||= {}
-        return @versions[version] if @versions.key?(version)
+        latest_tag_from(version).name
+      end
 
-        @versions[version] = fetch_latest_version(Tag.new(version)).name
+      def latest_tag_from(version)
+        @tags ||= {}
+        return @tags[version] if @tags.key?(version)
+
+        @tags[version] = fetch_latest_tag(Tag.new(version))
       end
 
       # NOTE: It's important that this *always* returns a version (even if
       # it's the existing one) as it is what we later check the digest of.
-      def fetch_latest_version(version_tag)
+      def fetch_latest_tag(version_tag)
         return version_tag unless version_tag.comparable?
 
         # Prune out any downgrade tags before checking for pre-releases


### PR DESCRIPTION
~I think this is a regression of #6748.~

EDIT: Just checked, and not a regression of that PR, actually. Unsure for how long we've been this slow.

Logic was going directly through `fetch_latest_version`, which is not memoized.

This make the slow logic (`fetch_` methods) only run once.

Before:

```
$ time bin/dry-run.rb docker dsp-testing/dependabot-core-4419 --cache files
=> reading dependency files from cache manifest: ./dry-run/dsp-testing/dependabot-core-4419/cache-manifest-docker.json
=> parsing dependency files
=> updating 1 dependencies: node

=== node (10.9.2-alpine)
 => checking for updates 1/1
 => latest available version is 19.8.1-alpine
 => latest allowed version is 19.8.1-alpine
 => requirements to unlock: own
 => requirements update strategy: 
 => bump node from 10.9.2-alpine to 19.8.1-alpine

    ± Dockerfile
    ~~~
    --- /tmp/original20230331-1009-u02hzp	2023-03-31 17:44:40.486502002 +0000
    +++ /tmp/updated20230331-1009-k11ysl	2023-03-31 17:44:40.486502002 +0000
    @@ -1,4 +1,4 @@
    -FROM node:10.9.2-alpine AS BUILD
    +FROM node:19.8.1-alpine AS BUILD
     
     RUN apk add --no-cache git
     
    @@ -10,7 +10,7 @@
     
     COPY . .
     
    -FROM node:10.9.3-alpine
    +FROM node:19.8.1-alpine
     
     ENV NODE_PATH=/dependabot/node_modules
     
    ~~~
    3 insertions (+), 3 deletions (-)
🌍 Total requests made: '0'

real	3m49.418s
user	3m33.243s
sys	0m1.429s
```

After:

```
$ time bin/dry-run.rb docker dsp-testing/dependabot-core-4419 --cache files
=> reading dependency files from cache manifest: ./dry-run/dsp-testing/dependabot-core-4419/cache-manifest-docker.json
=> parsing dependency files
=> updating 1 dependencies: node

=== node (10.9.2-alpine)
 => checking for updates 1/1
 => latest available version is 19.8.1-alpine
 => latest allowed version is 19.8.1-alpine
 => requirements to unlock: own
 => requirements update strategy: 
 => bump node from 10.9.2-alpine to 19.8.1-alpine

    ± Dockerfile
    ~~~
    --- /tmp/original20230331-1003-n4l3t6	2023-03-31 17:40:04.435552013 +0000
    +++ /tmp/updated20230331-1003-s29bv6	2023-03-31 17:40:04.437552013 +0000
    @@ -1,4 +1,4 @@
    -FROM node:10.9.2-alpine AS BUILD
    +FROM node:19.8.1-alpine AS BUILD
     
     RUN apk add --no-cache git
     
    @@ -10,7 +10,7 @@
     
     COPY . .
     
    -FROM node:10.9.3-alpine
    +FROM node:19.8.1-alpine
     
     ENV NODE_PATH=/dependabot/node_modules
     
    ~~~
    3 insertions (+), 3 deletions (-)
🌍 Total requests made: '0'

real	1m40.371s
user	1m25.322s
sys	0m1.009s
```