### PR TITLE
Add links to issue tracker / changelog to gemspecs

### DIFF
--- a/bundler/dependabot-bundler.gemspec
+++ b/bundler/dependabot-bundler.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = []
 

--- a/cargo/dependabot-cargo.gemspec
+++ b/cargo/dependabot-cargo.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = Dir["lib/**/*"]
 

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = "https://github.com/dependabot/dependabot-core"
   spec.license      = "Nonstandard" # License Zero Prosperity Public License
 
+  spec.metadata = {
+    "issue_tracker_uri" => "https://github.com/dependabot/dependabot-core/issues",
+    "changelog_uri" => "https://github.com/dependabot/dependabot-core/blob/main/CHANGELOG.md"
+  }
+
   spec.require_path = "lib"
   spec.files        = []
 

--- a/composer/dependabot-composer.gemspec
+++ b/composer/dependabot-composer.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = []
 

--- a/docker/dependabot-docker.gemspec
+++ b/docker/dependabot-docker.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = Dir["lib/**/*"]
 

--- a/elm/dependabot-elm.gemspec
+++ b/elm/dependabot-elm.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = Dir["lib/**/*"]
 

--- a/git_submodules/dependabot-git_submodules.gemspec
+++ b/git_submodules/dependabot-git_submodules.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = Dir["lib/**/*"]
 

--- a/github_actions/dependabot-github_actions.gemspec
+++ b/github_actions/dependabot-github_actions.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = Dir["lib/**/*"]
 

--- a/go_modules/dependabot-go_modules.gemspec
+++ b/go_modules/dependabot-go_modules.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = []
 

--- a/gradle/dependabot-gradle.gemspec
+++ b/gradle/dependabot-gradle.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = Dir["lib/**/*"]
 

--- a/hex/dependabot-hex.gemspec
+++ b/hex/dependabot-hex.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = []
 

--- a/maven/dependabot-maven.gemspec
+++ b/maven/dependabot-maven.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = Dir["lib/**/*"]
 

--- a/npm_and_yarn/dependabot-npm_and_yarn.gemspec
+++ b/npm_and_yarn/dependabot-npm_and_yarn.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = []
 

--- a/nuget/dependabot-nuget.gemspec
+++ b/nuget/dependabot-nuget.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = Dir["lib/**/*"]
 

--- a/omnibus/dependabot-omnibus.gemspec
+++ b/omnibus/dependabot-omnibus.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = ["lib/dependabot/omnibus.rb"]
 

--- a/pub/dependabot-pub.gemspec
+++ b/pub/dependabot-pub.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = Dir["lib/**/*"]
 

--- a/python/dependabot-python.gemspec
+++ b/python/dependabot-python.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = []
 

--- a/terraform/dependabot-terraform.gemspec
+++ b/terraform/dependabot-terraform.gemspec
@@ -14,6 +14,11 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
+  spec.metadata = {
+    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "changelog_uri" => common_gemspec.metadata["changelog_uri"]
+  }
+
   spec.require_path = "lib"
   spec.files        = []
 


### PR DESCRIPTION
In particular adding the changelog metadata makes Dependabot PR's show the changelog contents when it creates PRs.

For now I pointed them all at the same changelog because we don't maintain separate changelogs/issue trackers for the individual sub-gems. Easy enough to change later if needed.