### PR TITLE
Inherit required ruby/rubygems version from `common`

### DIFF
--- a/omnibus/dependabot-omnibus.gemspec
+++ b/omnibus/dependabot-omnibus.gemspec
@@ -15,7 +15,9 @@ Gem::Specification.new do |spec|
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = common_gemspec.required_ruby_version
+  spec.required_rubygems_version = common_gemspec.required_ruby_version
+
   spec.require_path = "lib"
   spec.files        = ["lib/dependabot/omnibus.rb"]
 


### PR DESCRIPTION
The `omnibus` gem here is composed of all the subgems for each package manager / ecosystem. And those subgems already specify a minimum ruby/rubygems version as inherited from `common`. So specifying it here doesn't actually change the requirement, it just advertises better what's already required.