### PR TITLE
Remove checkbox for searching for duplicates

### DIFF
--- a/.github/ISSUE_TEMPLATE/tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yml
@@ -2,14 +2,6 @@ name: ⚙ Tech Debt
 description: Tech debt is for code improvements that do not change the user-facing behavior (ie, neither adding features nor fixing bugs).
 labels: "T: tech-debt ⚙️"
 body:
-  - type: checkboxes
-    attributes:
-      label: Is there an existing issue for this?
-      description: Please search existing issues to avoid creating duplicates.
-      options:
-        - label: I have searched the existing issues
-          required: true
-
   - type: textarea
     attributes:
       label: Code improvement description


### PR DESCRIPTION
Tech Debt issues are rarely filed by n00bs, but almost always by folks already familiar with the project.

Because they tend to be more knowledgable, they generally are already aware of duplicates, so this just gets in the way.