### PR TITLE
Properly memoize nil digests from registry API

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -262,10 +262,13 @@ module Dependabot
           rescue *transient_docker_errors => e
             attempt ||= 1
             attempt += 1
-            return if attempt > 3 && e.is_a?(DockerRegistry2::NotFound)
-            raise if attempt > 3
+            if attempt > 3 && e.is_a?(DockerRegistry2::NotFound)
+              nil
+            else
+              raise if attempt > 3
 
-            retry
+              retry
+            end
           end
       rescue DockerRegistry2::RegistryAuthenticationException,
              RestClient::Forbidden


### PR DESCRIPTION
Before:

```
$ time bin/dry-run.rb docker dsp-testing/dependabot-core-4419 --cache files
=> reading dependency files from cache manifest: ./dry-run/dsp-testing/dependabot-core-4419/cache-manifest-docker.json
=> parsing dependency files
=> updating 1 dependencies: ubuntu

=== ubuntu (12.04.5)
 => checking for updates 1/1
 => latest available version is 23.04
 => latest allowed version is 23.04
 => requirements to unlock: own
 => requirements update strategy: 
/home/dependabot/dependabot-core/docker/lib/dependabot/docker/file_updater.rb:66:in `updated_dockerfile_content': Expected content to change! (RuntimeError)
	from /home/dependabot/dependabot-core/docker/lib/dependabot/docker/file_updater.rb:33:in `block in updated_dependency_files'
	from /home/dependabot/dependabot-core/docker/lib/dependabot/docker/file_updater.rb:22:in `each'
	from /home/dependabot/dependabot-core/docker/lib/dependabot/docker/file_updater.rb:22:in `updated_dependency_files'
	from bin/dry-run.rb:747:in `block in <main>'
	from bin/dry-run.rb:655:in `each'
	from bin/dry-run.rb:655:in `<main>'

real	7m9.554s
user	0m10.859s
sys	0m4.036s
```

After

```
$ time bin/dry-run.rb docker dsp-testing/dependabot-core-4419 --cache files
=> reading dependency files from cache manifest: ./dry-run/dsp-testing/dependabot-core-4419/cache-manifest-docker.json
=> parsing dependency files
=> updating 1 dependencies: ubuntu

=== ubuntu (12.04.5)
 => checking for updates 1/1
 => latest available version is 23.04
 => latest allowed version is 23.04
 => requirements to unlock: own
 => requirements update strategy: 
/home/dependabot/dependabot-core/docker/lib/dependabot/docker/file_updater.rb:66:in `updated_dockerfile_content': Expected content to change! (RuntimeError)
	from /home/dependabot/dependabot-core/docker/lib/dependabot/docker/file_updater.rb:33:in `block in updated_dependency_files'
	from /home/dependabot/dependabot-core/docker/lib/dependabot/docker/file_updater.rb:22:in `each'
	from /home/dependabot/dependabot-core/docker/lib/dependabot/docker/file_updater.rb:22:in `updated_dependency_files'
	from bin/dry-run.rb:747:in `block in <main>'
	from bin/dry-run.rb:655:in `each'
	from bin/dry-run.rb:655:in `<main>'

real	0m16.357s
user	0m1.339s
sys	0m1.089s
```