### PR TITLE
Clarify `summary`/`description` for RubyGems

### DIFF
--- a/bundler/dependabot-bundler.gemspec
+++ b/bundler/dependabot-bundler.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-bundler"
-  spec.summary      = "Ruby (bundler) support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for Ruby (bundler)"
+  spec.description  = "Dependabot-Bundler provides support for bumping Ruby (bundler) gems via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = []
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = []
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 

--- a/cargo/dependabot-cargo.gemspec
+++ b/cargo/dependabot-cargo.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-cargo"
-  spec.summary      = "Rust (Cargo) support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for Rust (Cargo)"
+  spec.description  = "Dependabot-Cargo provides support for bumping Rust (cargo) crates via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = Dir["lib/**/*"]
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = Dir["lib/**/*"]
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -4,10 +4,10 @@ require "./lib/dependabot"
 
 Gem::Specification.new do |spec|
   spec.name         = "dependabot-common"
-  spec.version      = Dependabot::VERSION
-  spec.summary      = "Shared code used between Dependabot package managers"
-  spec.description  = "Automated dependency management for Ruby, JavaScript, " \
-                      "Python, PHP, Elixir, Rust, Java, .NET, Elm and Go"
+  spec.summary      = "Shared code used across Dependabot Core"
+  spec.description  = "Dependabot-Common provides the shared code used across Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = "Dependabot"
   spec.email        = "opensource@github.com"
@@ -19,11 +19,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => "https://github.com/dependabot/dependabot-core/blob/main/CHANGELOG.md"
   }
 
-  spec.require_path = "lib"
-  spec.files        = []
-
+  spec.version = Dependabot::VERSION
   spec.required_ruby_version = ">= 3.1.0"
   spec.required_rubygems_version = ">= 3.3.7"
+
+  spec.require_path = "lib"
+  spec.files        = []
 
   spec.add_dependency "aws-sdk-codecommit", "~> 1.28"
   spec.add_dependency "aws-sdk-ecr", "~> 1.5"

--- a/composer/dependabot-composer.gemspec
+++ b/composer/dependabot-composer.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-composer"
-  spec.summary      = "PHP (Composer) support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for PHP (composer)"
+  spec.description  = "Dependabot-Composer provides support for bumping PHP (composer) libraries via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = []
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = []
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 

--- a/docker/dependabot-docker.gemspec
+++ b/docker/dependabot-docker.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-docker"
-  spec.summary      = "Docker support for dependabot-common"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for Docker"
+  spec.description  = "Dependabot-Docker provides support for bumping Docker image tags via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = Dir["lib/**/*"]
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = Dir["lib/**/*"]
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 

--- a/elm/dependabot-elm.gemspec
+++ b/elm/dependabot-elm.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-elm"
-  spec.summary      = "Elm support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for Elm"
+  spec.description  = "Dependabot-Elm provides support for bumping Elm packages via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = Dir["lib/**/*"]
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = Dir["lib/**/*"]
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 

--- a/git_submodules/dependabot-git_submodules.gemspec
+++ b/git_submodules/dependabot-git_submodules.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-git_submodules"
-  spec.summary      = "Git Submodules support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for Git Submodules"
+  spec.description  = "Dependabot-Git_Submodules provides support for bumping git submodules via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = Dir["lib/**/*"]
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = Dir["lib/**/*"]
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
   spec.add_dependency "parseconfig", "~> 1.0", "< 1.1.0"

--- a/github_actions/dependabot-github_actions.gemspec
+++ b/github_actions/dependabot-github_actions.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-github_actions"
-  spec.summary      = "GitHub Actions support for dependabot-common"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for GitHub Actions"
+  spec.description  = "Dependabot-GitHub_Actions provides support for bumping GitHub Actions via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = Dir["lib/**/*"]
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = Dir["lib/**/*"]
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 

--- a/go_modules/dependabot-go_modules.gemspec
+++ b/go_modules/dependabot-go_modules.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-go_modules"
-  spec.summary      = "Go modules support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for Go Modules"
+  spec.description  = "Dependabot-Go_Modules provides support for bumping Go Modules versions via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = []
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = []
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 

--- a/gradle/dependabot-gradle.gemspec
+++ b/gradle/dependabot-gradle.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-gradle"
-  spec.summary      = "Gradle support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for Gradle"
+  spec.description  = "Dependabot-Gradle provides support for bumping Gradle packages via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = Dir["lib/**/*"]
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = Dir["lib/**/*"]
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
   spec.add_dependency "dependabot-maven", Dependabot::VERSION

--- a/hex/dependabot-hex.gemspec
+++ b/hex/dependabot-hex.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-hex"
-  spec.summary      = "Elixir (Hex) support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for Elixir (hex)"
+  spec.description  = "Dependabot-Hex provides support for bumping Elixir (hex) packages via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = []
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = []
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 

--- a/maven/dependabot-maven.gemspec
+++ b/maven/dependabot-maven.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-maven"
-  spec.summary      = "Maven support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for Maven"
+  spec.description  = "Dependabot-Maven provides support for bumping Maven packages via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = Dir["lib/**/*"]
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = Dir["lib/**/*"]
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 

--- a/npm_and_yarn/dependabot-npm_and_yarn.gemspec
+++ b/npm_and_yarn/dependabot-npm_and_yarn.gemspec
@@ -5,9 +5,11 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-npm_and_yarn"
-  spec.summary      = "JS support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for Javascript (npm and yarn)"
+  spec.description  = "Dependabot-NPM_And_Yarn provides support for bumping Javascript (npm and yarn) libraries via " \
+                      "Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +21,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = []
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = []
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 

--- a/nuget/dependabot-nuget.gemspec
+++ b/nuget/dependabot-nuget.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-nuget"
-  spec.summary      = ".NET (NuGet) support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for .NET (NuGet)"
+  spec.description  = "Dependabot-Nuget provides support for bumping .NET (NuGet) packages via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -18,12 +19,12 @@ Gem::Specification.new do |spec|
     "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
+  spec.version = common_gemspec.version
+  spec.required_ruby_version = common_gemspec.required_ruby_version
+  spec.required_rubygems_version = common_gemspec.required_ruby_version
 
   spec.require_path = "lib"
   spec.files        = Dir["lib/**/*"]
-
-  spec.required_ruby_version = common_gemspec.required_ruby_version
-  spec.required_rubygems_version = common_gemspec.required_ruby_version
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 

--- a/omnibus/dependabot-omnibus.gemspec
+++ b/omnibus/dependabot-omnibus.gemspec
@@ -5,23 +5,23 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-omnibus"
-  spec.summary      = "Meta-package that depends on all dependabot package " \
-                      "managers"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Meta-package that provides all the gems included in Dependabot"
+  spec.description  = "Dependabot-Omnibus provides all the gems included in Dependabot. " \
+                      "Dependabot provides automated dependency updates for multiple package managers."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
   spec.homepage     = common_gemspec.homepage
   spec.license      = common_gemspec.license
 
-  spec.required_ruby_version = common_gemspec.required_ruby_version
-  spec.required_rubygems_version = common_gemspec.required_ruby_version
-
   spec.metadata = {
     "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
+
+  spec.version = common_gemspec.version
+  spec.required_ruby_version = common_gemspec.required_ruby_version
+  spec.required_rubygems_version = common_gemspec.required_ruby_version
 
   spec.require_path = "lib"
   spec.files        = ["lib/dependabot/omnibus.rb"]

--- a/pub/dependabot-pub.gemspec
+++ b/pub/dependabot-pub.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-pub"
-  spec.summary      = "Dart (pub) support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for Dart (pub)"
+  spec.description  = "Dependabot-Pub provides support for bumping Dart (pub) packages via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = Dir["lib/**/*"]
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = Dir["lib/**/*"]
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 

--- a/python/dependabot-python.gemspec
+++ b/python/dependabot-python.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-python"
-  spec.summary      = "Python support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for Python"
+  spec.description  = "Dependabot-Python provides support for bumping Python packages via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = []
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = []
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 

--- a/terraform/dependabot-terraform.gemspec
+++ b/terraform/dependabot-terraform.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |spec|
     Bundler.load_gemspec_uncached("../common/dependabot-common.gemspec")
 
   spec.name         = "dependabot-terraform"
-  spec.summary      = "Terraform support for dependabot"
-  spec.version      = common_gemspec.version
-  spec.description  = common_gemspec.description
+  spec.summary      = "Provides Dependabot support for Terraform"
+  spec.description  = "Dependabot-Terraform provides support for bumping Terraform modules via Dependabot. " \
+                      "If you want support for multiple package managers, you probably want the meta-gem " \
+                      "dependabot-omnibus."
 
   spec.author       = common_gemspec.author
   spec.email        = common_gemspec.email
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 
-  spec.require_path = "lib"
-  spec.files        = []
-
+  spec.version = common_gemspec.version
   spec.required_ruby_version = common_gemspec.required_ruby_version
   spec.required_rubygems_version = common_gemspec.required_ruby_version
+
+  spec.require_path = "lib"
+  spec.files        = []
 
   spec.add_dependency "dependabot-common", Dependabot::VERSION
 


### PR DESCRIPTION
One of the things I noticed a long time ago on RubyGems is it's not really clear how all the Dependabot gems fit together... which is mostly because their `description` metadata field all inherit from `common`.

If you're trying to get going with the Dependabot gem, it's unclear which one you actually want.

So this fixes that.