### PR TITLE
Avoid some "Files not changed!" errors in Docker

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -49,7 +49,11 @@ module Dependabot
       end
 
       def version_can_update?(*)
-        !version_up_to_date?
+        if digest_requirements.any?
+          !digest_up_to_date?
+        else
+          !version_up_to_date?
+        end
       end
 
       def version_up_to_date?
@@ -59,9 +63,7 @@ module Dependabot
                           version_tag_up_to_date?(req.fetch(:source, {})[:tag]) == false
                         end
 
-        # Otherwise, if the Dockerfile specifies a digest check that that is
-        # up-to-date
-        digest_up_to_date?
+        true
       end
 
       def version_tag_up_to_date?(version)

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -79,11 +79,10 @@ module Dependabot
       end
 
       def digest_up_to_date?
-        dependency.requirements.all? do |req|
-          next true unless req.fetch(:source)[:digest]
-          next true unless (new_digest = digest_of(dependency.version))
+        digest_requirements.all? do |req|
+          next true unless updated_digest
 
-          req.fetch(:source).fetch(:digest) == new_digest
+          req.fetch(:source).fetch(:digest) == updated_digest
         end
       end
 
@@ -334,7 +333,7 @@ module Dependabot
         if @raise_on_ignored &&
            filter_lower_versions(filtered).empty? &&
            filter_lower_versions(candidate_tags).any? &&
-           digest_up_to_date?
+           digest_requirements.none?
           raise AllVersionsIgnored
         end
 
@@ -345,6 +344,12 @@ module Dependabot
         versions_array = tags.map { |tag| comparable_version_from(tag) }
         versions_array.
           select { |version| version > comparable_version_from(Tag.new(dependency.version)) }
+      end
+
+      def digest_requirements
+        dependency.requirements.select do |requirement|
+          requirement.dig(:source, :digest)
+        end
       end
     end
   end

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -180,6 +180,31 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
       it { is_expected.to be true }
     end
+
+    context "when the 'latest' version is newer, and API does not provide digests but there's a digest requirement" do
+      let(:dependency_name) { "ubi8/ubi-minimal" }
+      let(:source) do
+        {
+          registry: "registry.access.redhat.com",
+          digest: "3f32ebba0cbf3849a48372d4fc3a4ce70816f248d39eb50da7ea5f15c7f9d120"
+        }
+      end
+      let(:version) { "8.5" }
+      let(:tags_fixture_name) { "ubi-minimal.json" }
+      let(:headers_response) do
+        fixture("docker", "registry_manifest_headers", "generic.json")
+      end
+      let(:repo_url) { "https://registry.access.redhat.com/v2/ubi8/ubi-minimal/" }
+
+      before do
+        stub_request(:get, repo_url + "tags/list").
+          and_return(status: 200, body: registry_tags)
+        stub_tag_with_no_digest("8.7")
+        stub_tag_with_no_digest("8.7-1049")
+      end
+
+      it { is_expected.to be false }
+    end
   end
 
   describe "#latest_version" do


### PR DESCRIPTION
If a Dockerfile is using a version+SHA reference of an image coming from a registry that does not provide digests, we initially think an update is possible, but then fail to update the Dockerfile because we cannot really know which SHA we should update to.

For example, with the following Dockerfile
    
```Dockerfile
FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5@sha256:3f32ebba0cbf3849a48372d4fc3a4ce70816f248d39eb50da7ea5f15c7f9d120
```

We get:

```
$ bin/dry-run.rb docker dsp-testing/dependabot-core-4419 --cache files
warning: parser/current is loading parser/ruby31, which recognizes 3.1.4-compliant syntax, but you are running 3.1.3.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> reading dependency files from cache manifest: ./dry-run/dsp-testing/dependabot-core-4419/cache-manifest-docker.json
=> parsing dependency files
=> updating 1 dependencies: ubi8/ubi-minimal

=== ubi8/ubi-minimal (8.5)
 => checking for updates 1/1
 => latest available version is 8.7
 => latest allowed version is 8.7
 => requirements to unlock: own
 => requirements update strategy: 
/home/dependabot/dependabot-core/docker/lib/dependabot/docker/file_updater.rb:66:in `updated_dockerfile_content': Expected content to change! (RuntimeError)
	from /home/dependabot/dependabot-core/docker/lib/dependabot/docker/file_updater.rb:33:in `block in updated_dependency_files'
	from /home/dependabot/dependabot-core/docker/lib/dependabot/docker/file_updater.rb:22:in `each'
	from /home/dependabot/dependabot-core/docker/lib/dependabot/docker/file_updater.rb:22:in `updated_dependency_files'
	from bin/dry-run.rb:747:in `block in <main>'
	from bin/dry-run.rb:655:in `each'
	from bin/dry-run.rb:655:in `<main>'
```

To fix this, we tweak `up_to_date?` checker detection to return `:update_not_possible` in this particular case and avoid the unexpected error.

With this change, the update is properly skipped:

```
$ bin/dry-run.rb docker dsp-testing/dependabot-core-4419 --cache files
warning: parser/current is loading parser/ruby31, which recognizes 3.1.4-compliant syntax, but you are running 3.1.3.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
=> reading dependency files from cache manifest: ./dry-run/dsp-testing/dependabot-core-4419/cache-manifest-docker.json
=> parsing dependency files
=> updating 1 dependencies: ubi8/ubi-minimal

=== ubi8/ubi-minimal (8.5)
 => checking for updates 1/1
 => latest available version is 8.7
 => latest allowed version is 8.7
 => requirements to unlock: update_not_possible
 => requirements update strategy: 
    (no update possible 🙅‍♀️)
🌍 Total requests made: '0'
```