### PR TITLE
Fix updating some references when having multiple Dockerfiles

### DIFF
--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -56,81 +56,63 @@ module Dependabot
       end
 
       def updated_dockerfile_content(file)
-        updated_content =
-          if specified_with_digest?(file)
-            update_digest_and_tag(file)
-          else
-            update_tag(file)
-          end
+        old_sources = previous_sources(file)
+        new_sources = sources(file)
+
+        updated_content = file.content
+
+        old_sources.zip(new_sources).each do |old_source, new_source|
+          updated_content =
+            if specified_with_digest?(old_source)
+              update_digest_and_tag(updated_content, old_source, new_source)
+            else
+              update_tag(updated_content, old_source, new_source)
+            end
+        end
 
         raise "Expected content to change!" if updated_content == file.content
 
         updated_content
       end
 
-      def update_digest_and_tag(file)
-        old_declaration_regex = /^#{FROM_REGEX}\s+.*@#{old_digest(file)}/
+      def update_digest_and_tag(previous_content, old_source, new_source)
+        old_digest = old_source[:digest]
+        new_digest = new_source[:digest]
 
-        file.content.gsub(old_declaration_regex) do |old_dec|
+        old_tag = old_source[:tag]
+        new_tag = new_source[:tag]
+
+        old_declaration_regex = /^#{FROM_REGEX}\s+.*@#{old_digest}/
+
+        previous_content.gsub(old_declaration_regex) do |old_dec|
           old_dec.
-            gsub("@#{old_digest(file)}", "@#{new_digest(file)}").
-            gsub(":#{dependency.previous_version}",
-                 ":#{dependency.version}")
+            gsub("@#{old_digest}", "@#{new_digest}").
+            gsub(":#{old_tag}", ":#{new_tag}")
         end
       end
 
-      def update_tag(file)
-        old_tags = old_tags(file)
-        return if old_tags.empty?
+      def update_tag(previous_content, old_source, new_source)
+        old_tag = old_source[:tag]
+        new_tag = new_source[:tag]
 
-        modified_content = file.content
-
-        new_tags = new_tags(file)
-
-        old_tags.zip(new_tags).each do |old_tag, new_tag|
-          new_tag ||= new_tags.first
-
-          old_declaration =
-            if private_registry_url(file) then "#{private_registry_url(file)}/"
-            else
-              ""
-            end
-          old_declaration += "#{dependency.name}:#{old_tag}"
-          escaped_declaration = Regexp.escape(old_declaration)
-
-          old_declaration_regex =
-            %r{^#{FROM_REGEX}\s+(docker\.io/)?#{escaped_declaration}(?=\s|$)}
-
-          modified_content = modified_content.
-                             gsub(old_declaration_regex) do |old_dec|
-            old_dec.gsub(":#{old_tag}", ":#{new_tag}")
+        old_declaration =
+          if private_registry_url(old_source) then "#{private_registry_url(old_source)}/"
+          else
+            ""
           end
+        old_declaration += "#{dependency.name}:#{old_tag}"
+        escaped_declaration = Regexp.escape(old_declaration)
+
+        old_declaration_regex =
+          %r{^#{FROM_REGEX}\s+(docker\.io/)?#{escaped_declaration}(?=\s|$)}
+
+        previous_content.gsub(old_declaration_regex) do |old_dec|
+          old_dec.gsub(":#{old_tag}", ":#{new_tag}")
         end
-
-        modified_content
       end
 
-      def specified_with_digest?(file)
-        dependency.
-          requirements.
-          find { |r| r[:file] == file.name }.
-          fetch(:source)[:digest]
-      end
-
-      def new_digest(file)
-        return unless specified_with_digest?(file)
-
-        dependency.requirements.
-          find { |r| r[:file] == file.name }.
-          fetch(:source).fetch(:digest)
-      end
-
-      def old_digest(file)
-        return unless specified_with_digest?(file)
-
-        dependency.previous_requirements.
-          find { |r| r[:file] == file.name }.
-          fetch(:source).fetch(:digest)
+      def specified_with_digest?(source)
+        source[:digest]
       end
 
       def new_tags(file)
@@ -143,10 +125,16 @@ module Dependabot
           map { |r| r.fetch(:source)[:tag] }
       end
 
-      def private_registry_url(file)
-        dependency.requirements.
-          find { |r| r[:file] == file.name }.
-          fetch(:source)[:registry]
+      def private_registry_url(source)
+        source[:registry]
+      end
+
+      def sources(file)
+        requirements(file).map { |r| r.fetch(:source) }
+      end
+
+      def previous_sources(file)
+        previous_requirements(file).map { |r| r.fetch(:source) }
       end
 
       def updated_yaml_content(file)

--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -134,15 +134,12 @@ module Dependabot
       end
 
       def new_tags(file)
-        dependency.requirements.
-          select { |r| r[:file] == file.name }.
+        requirements(file).
           map { |r| r.fetch(:source)[:tag] }
       end
 
       def old_tags(file)
-        dependency.
-          previous_requirements.
-          select { |r| r[:file] == file.name }.
+        previous_requirements(file).
           map { |r| r.fetch(:source)[:tag] }
       end
 
@@ -207,22 +204,28 @@ module Dependabot
       end
 
       def old_yaml_images(file)
-        dependency.
-          previous_requirements.
-          select { |r| r[:file] == file.name }.map do |r|
-            prefix = r.fetch(:source)[:registry] ? "#{r.fetch(:source)[:registry]}/" : ""
-            digest = r.fetch(:source)[:digest] ? "@#{r.fetch(:source)[:digest]}" : ""
-            tag = r.fetch(:source)[:tag] ? ":#{r.fetch(:source)[:tag]}" : ""
-            "#{prefix}#{dependency.name}#{tag}#{digest}"
-          end
+        previous_requirements(file).map do |r|
+          prefix = r.fetch(:source)[:registry] ? "#{r.fetch(:source)[:registry]}/" : ""
+          digest = r.fetch(:source)[:digest] ? "@#{r.fetch(:source)[:digest]}" : ""
+          tag = r.fetch(:source)[:tag] ? ":#{r.fetch(:source)[:tag]}" : ""
+          "#{prefix}#{dependency.name}#{tag}#{digest}"
+        end
       end
 
       def old_helm_tags(file)
-        dependency.
-          previous_requirements.
-          select { |r| r[:file] == file.name }.map do |r|
-            r.fetch(:source)[:tag] || ""
-          end
+        previous_requirements(file).map do |r|
+          r.fetch(:source)[:tag] || ""
+        end
+      end
+
+      def requirements(file)
+        dependency.requirements.
+          select { |r| r[:file] == file.name }
+      end
+
+      def previous_requirements(file)
+        dependency.previous_requirements.
+          select { |r| r[:file] == file.name }
       end
     end
   end

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -118,12 +118,20 @@ RSpec.describe Dependabot::Docker::FileUpdater do
           name: "node",
           version: "10.9.4-alpine",
           previous_version: "10.9.2-alpine",
-          requirements: [{
-            requirement: nil,
-            groups: [],
-            file: "Dockerfile",
-            source: { tag: "10.9.4-alpine" }
-          }],
+          requirements: [
+            {
+              requirement: nil,
+              groups: [],
+              file: "Dockerfile",
+              source: { tag: "10.9.4-alpine" }
+            },
+            {
+              requirement: nil,
+              groups: [],
+              file: "Dockerfile",
+              source: { tag: "10.9.4-alpine" }
+            }
+          ],
           previous_requirements: [
             {
               requirement: nil,
@@ -331,6 +339,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             groups: [],
             file: "Dockerfile",
             source: {
+              tag: "17.10",
               digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
                       "ca97eba880ebf600d68608"
             }
@@ -340,6 +349,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             groups: [],
             file: "Dockerfile",
             source: {
+              tag: "12.04.5",
               digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
                       "dfc38288cf73aa07485005"
             }
@@ -502,7 +512,8 @@ RSpec.describe Dependabot::Docker::FileUpdater do
               file: "custom-name",
               source: {
                 digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86" \
-                        "ca97eba880ebf600d68608"
+                        "ca97eba880ebf600d68608",
+                tag: "17.10"
               }
             }],
             previous_requirements: [{
@@ -511,7 +522,8 @@ RSpec.describe Dependabot::Docker::FileUpdater do
               file: "custom-name",
               source: {
                 digest: "sha256:18305429afa14ea462f810146ba44d4363ae76e4c8" \
-                        "dfc38288cf73aa07485005"
+                        "dfc38288cf73aa07485005",
+                tag: "12.04.5"
               }
             }],
             package_manager: "docker"


### PR DESCRIPTION
If we have multiple Dockerfiles with mixed formats and outdated versions, we may end up updating some references incorrectly. For example, with 2 Dockerfiles both with out of date versions (but not the same), and one of them including a SHA.

In that case, the version including a SHA would not get updated, resulting in an invalid version+SHA combinatation.

This PR fixes that.

Before:

```
$ bin/dry-run.rb docker reload/php-fpm --cache files --dep composer
=> reading dependency files from cache manifest: ./dry-run/reload/php-fpm/cache-manifest-docker.json
=> parsing dependency files
=> updating 1 dependencies: composer

=== composer (2.3)
 => checking for updates 1/1
 => latest available version is 2.5
 => latest allowed version is 2.5
 => requirements to unlock: own
 => requirements update strategy:
 => bump composer from 2.3 to 2.5

    ± Dockerfile
    ~~~
    --- /tmp/original20230331-143-5m086t        2023-03-31 23:30:28.987301004 +0000
    +++ /tmp/updated20230331-143-bwbsea 2023-03-31 23:30:28.988301004 +0000
    @@ -1 +1 @@
    -FROM composer:2.4@sha256:802e02693f9e22a169012cae11f45b076e01216f6e3c8f3c2390cb8df50f71a9 AS composer
    +FROM composer:2.4@sha256:7ac744b7fab81c0662c13163b9570a0a2c9e0667bc23bc15957182e4e808fd20 AS composer
    ~~~
    2 insertions (+), 2 deletions (-)

    ± Dockerfile.other
    ~~~
    --- /tmp/original20230331-143-a0w8hk        2023-03-31 23:30:28.989301004 +0000
    +++ /tmp/updated20230331-143-sajm0p 2023-03-31 23:30:28.990301004 +0000
    @@ -1 +1 @@
    -FROM composer:2.3
    +FROM composer:2.5
    ~~~
    2 insertions (+), 2 deletions (-)
🌍 Total requests made: '0'
```

After:

```
$ bin/dry-run.rb docker reload/php-fpm --cache files --dep composer
=> reading dependency files from cache manifest: ./dry-run/reload/php-fpm/cache-manifest-docker.json
=> parsing dependency files
=> updating 1 dependencies: composer

=== composer (2.3)
 => checking for updates 1/1
 => latest available version is 2.5
 => latest allowed version is 2.5
 => requirements to unlock: own
 => requirements update strategy:
 => bump composer from 2.3 to 2.5

    ± Dockerfile
    ~~~
    --- /tmp/original20230331-138-stdx9p        2023-03-31 23:29:42.997158011 +0000
    +++ /tmp/updated20230331-138-zdysm  2023-03-31 23:29:42.997158011 +0000
    @@ -1 +1 @@
    -FROM composer:2.4@sha256:802e02693f9e22a169012cae11f45b076e01216f6e3c8f3c2390cb8df50f71a9 AS composer
    +FROM composer:2.5@sha256:7ac744b7fab81c0662c13163b9570a0a2c9e0667bc23bc15957182e4e808fd20 AS composer
    ~~~
    2 insertions (+), 2 deletions (-)

    ± Dockerfile.other
    ~~~
    --- /tmp/original20230331-138-kidy0v        2023-03-31 23:29:42.998158011 +0000
    +++ /tmp/updated20230331-138-6eq1r4 2023-03-31 23:29:42.998158011 +0000
    @@ -1 +1 @@
    -FROM composer:2.3
    +FROM composer:2.5
    ~~~
    2 insertions (+), 2 deletions (-)
🌍 Total requests made: '0'
```