### PR TITLE
[Updater] Move filtering of parsed dependencies by allow rules or job dependencies

### DIFF
--- a/updater/lib/dependabot/environment.rb
+++ b/updater/lib/dependabot/environment.rb
@@ -38,6 +38,10 @@ module Dependabot
       @github_actions ||= environment_variable("GITHUB_ACTIONS", false)
     end
 
+    def self.deterministic_updates?
+      @deterministic_updates ||= environment_variable("UPDATER_DETERMINISTIC", false)
+    end
+
     def self.job_definition
       @job_definition ||= JSON.parse(File.read(job_path))
     end

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -134,6 +134,14 @@ module Dependabot
       @reject_external_code
     end
 
+    # TODO: Remove vulnerability checking
+    #
+    # This method does too much, let's make it focused on _just_ determining
+    # if the given dependency is within the configurations allowed_updates.
+    #
+    # The calling operation should be responsible for checking vulnerability
+    # separately, if required.
+    #
     # rubocop:disable Metrics/PerceivedComplexity
     def allowed_update?(dependency)
       allowed_updates.any? do |update|

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -582,34 +582,19 @@ module Dependabot
     end
 
     def dependencies
-      all_deps = dependency_snapshot.dependencies
-
       # Rebases and security updates have dependencies, version updates don't
-      if job.dependencies
-        # Gradle, Maven and Nuget dependency names can be case-insensitive and
-        # the dependency name in the security advisory often doesn't match what
-        # users have specified in their manifest.
-        #
-        # It's technically possibly to publish case-sensitive npm packages to a
-        # private registry but shouldn't cause problems here as job.dependencies
-        # is set either from an existing PR rebase/recreate or a security
-        # advisory.
-        job_dependencies = job.dependencies.map(&:downcase)
-        return all_deps.select do |dep|
-          job_dependencies.include?(dep.name.downcase)
-        end
+      return dependency_snapshot.job_dependencies if job.dependencies
+
+      if dependency_snapshot.dependencies.any? && dependency_snapshot.allowed_dependencies.none?
+        Dependabot.logger.info("Found no dependencies to update after filtering allowed updates")
+        return []
       end
 
-      allowed_deps = all_deps.select { |d| job.allowed_update?(d) }
+      allowed_deps = dependency_snapshot.allowed_dependencies
       # Return dependencies in a random order, with top-level dependencies
       # considered first so that dependency runs which time out don't always hit
       # the same dependencies
       allowed_deps = allowed_deps.shuffle unless ENV["UPDATER_DETERMINISTIC"]
-
-      if all_deps.any? && allowed_deps.none?
-        Dependabot.logger.info("Found no dependencies to update after filtering allowed " \
-                               "updates")
-      end
 
       # Consider updating vulnerable deps first. Only consider the first 10,
       # though, to ensure they don't take up the entire update run

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -594,7 +594,7 @@ module Dependabot
       # Return dependencies in a random order, with top-level dependencies
       # considered first so that dependency runs which time out don't always hit
       # the same dependencies
-      allowed_deps = allowed_deps.shuffle unless ENV["UPDATER_DETERMINISTIC"]
+      allowed_deps = allowed_deps.shuffle unless Environment.deterministic_updates?
 
       # Consider updating vulnerable deps first. Only consider the first 10,
       # though, to ensure they don't take up the entire update run

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -69,6 +69,7 @@ module Dependabot
         error_handler: error_handler
       ).perform
     rescue *ErrorHandler::RUN_HALTING_ERRORS.keys => e
+      # TODO: Drop this into Security-specific operations
       if e.is_a?(Dependabot::AllVersionsIgnored) && !job.security_updates_only?
         error = StandardError.new(
           "Dependabot::AllVersionsIgnored was unexpectedly raised for a non-security update job"

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -68,19 +68,12 @@ module Dependabot
                     :error_handler
 
         def dependencies
-          all_deps = dependency_snapshot.dependencies
-
-          allowed_deps = all_deps.select { |d| job.allowed_update?(d) }
-          # Return dependencies in a random order, with top-level dependencies
-          # considered first so that dependency runs which time out don't always hit
-          # the same dependencies
-          allowed_deps = allowed_deps.shuffle unless ENV["UPDATER_DETERMINISTIC"]
-
-          if all_deps.any? && allowed_deps.none?
+          if dependency_snapshot.dependencies.any? && dependency_snapshot.allowed_dependencies.none?
             Dependabot.logger.info("Found no dependencies to update after filtering allowed updates")
+            return []
           end
 
-          allowed_deps
+          dependency_snapshot.allowed_dependencies
         end
 
         # Returns a Dependabot::DependencyChange object that encapsulates the

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -44,18 +44,7 @@ module Dependabot
                     :created_pull_requests
 
         def dependencies
-          # Gradle, Maven and Nuget dependency names can be case-insensitive and
-          # the dependency name in the security advisory often doesn't match what
-          # users have specified in their manifest.
-          #
-          # It's technically possibly to publish case-sensitive npm packages to a
-          # private registry but shouldn't cause problems here as job.dependencies
-          # is set either from an existing PR rebase/recreate or a security
-          # advisory.
-          job_dependencies = job.dependencies.map(&:downcase)
-          dependency_snapshot.dependencies.select do |dep|
-            job_dependencies.include?(dep.name.downcase)
-          end
+          dependency_snapshot.job_dependencies
         end
 
         # rubocop:disable Metrics/AbcSize

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -44,7 +44,7 @@ module Dependabot
             return []
           end
 
-          if ENV["UPDATER_DETERMINISTIC"]
+          if Environment.deterministic_updates?
             dependency_snapshot.allowed_dependencies
           else
             dependency_snapshot.allowed_dependencies.shuffle

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -39,19 +39,14 @@ module Dependabot
                     :created_pull_requests
 
         def dependencies
-          all_deps = dependency_snapshot.dependencies
-
-          allowed_deps = all_deps.select { |d| job.allowed_update?(d) }
-          # Return dependencies in a random order, with top-level dependencies
-          # considered first so that dependency runs which time out don't always hit
-          # the same dependencies
-          allowed_deps = allowed_deps.shuffle unless ENV["UPDATER_DETERMINISTIC"]
-
-          if all_deps.any? && allowed_deps.none?
+          if dependency_snapshot.dependencies.any? && dependency_snapshot.allowed_dependencies.none?
             Dependabot.logger.info("Found no dependencies to update after filtering allowed updates")
+            return []
           end
 
-          allowed_deps
+          return dependency_snapshot.allowed_dependencies unless ENV["UPDATER_DETERMINISTIC"]
+
+          dependency_snapshot.allowed_dependencies.shuffle
         end
 
         def check_and_create_pr_with_error_handling(dependency)

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -44,9 +44,11 @@ module Dependabot
             return []
           end
 
-          return dependency_snapshot.allowed_dependencies unless ENV["UPDATER_DETERMINISTIC"]
-
-          dependency_snapshot.allowed_dependencies.shuffle
+          if ENV["UPDATER_DETERMINISTIC"]
+            dependency_snapshot.allowed_dependencies
+          else
+            dependency_snapshot.allowed_dependencies.shuffle
+          end
         end
 
         def check_and_create_pr_with_error_handling(dependency)


### PR DESCRIPTION
Before adding two more "Operation" classes for Security Updates, we should ensure that any code that is starting to be carried into every Operation class so far is de-duplicated as much as possible.

Rather than repeat logic to filter the parsed dependencies by either those that are permitted by allow_conditions or those which intersect with the job.dependencies within the Updater, I've just moved this logic unto `Dependabot::Snapshot` and slimmed down the dependencies method(s) in the various classes.