### PR TITLE
Allow updating digest only when tag is up to date

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -66,17 +66,18 @@ module Dependabot
       end
 
       def version_up_to_date?
-        # If the tag isn't up-to-date then we can definitely update
-        return false if version_tag_up_to_date? == false
-
-        true
+        if digest_requirements.any?
+          version_tag_up_to_date? && digest_up_to_date?
+        else
+          version_tag_up_to_date?
+        end
       end
 
       def version_tag_up_to_date?
         version = dependency.version
         return unless version
 
-        return unless version_tag.comparable?
+        return true unless version_tag.comparable?
 
         latest_tag = latest_tag_from(version)
 

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -30,8 +30,17 @@ module Dependabot
       def updated_requirements
         dependency.requirements.map do |req|
           updated_source = req.fetch(:source).dup
-          updated_source[:digest] = updated_digest if req[:source][:digest]
-          updated_source[:tag] = latest_version_from(req[:source][:tag]) if req[:source][:tag]
+
+          tag = req[:source][:tag]
+          digest = req[:source][:digest]
+
+          if tag
+            updated_tag = latest_version_from(tag)
+            updated_source[:tag] = updated_tag
+            updated_source[:digest] = digest_of(updated_tag) if digest
+          elsif digest
+            updated_source[:digest] = digest_of("latest")
+          end
 
           req.merge(source: updated_source)
         end

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -59,9 +59,6 @@ module Dependabot
       def version_up_to_date?
         # If the tag isn't up-to-date then we can definitely update
         return false if version_tag_up_to_date?(dependency.version) == false
-        return false if dependency.requirements.any? do |req|
-                          version_tag_up_to_date?(req.fetch(:source, {})[:tag]) == false
-                        end
 
         true
       end

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -58,15 +58,15 @@ module Dependabot
 
       def version_up_to_date?
         # If the tag isn't up-to-date then we can definitely update
-        return false if version_tag_up_to_date?(dependency.version) == false
+        return false if version_tag_up_to_date? == false
 
         true
       end
 
-      def version_tag_up_to_date?(version)
+      def version_tag_up_to_date?
+        version = dependency.version
         return unless version
 
-        version_tag = Tag.new(version)
         return unless version_tag.comparable?
 
         latest_tag = latest_tag_from(version)
@@ -340,15 +340,19 @@ module Dependabot
       end
 
       def filter_lower_versions(tags)
-        versions_array = tags.map { |tag| comparable_version_from(tag) }
-        versions_array.
-          select { |version| version > comparable_version_from(Tag.new(dependency.version)) }
+        tags.select do |tag|
+          comparable_version_from(tag) > comparable_version_from(version_tag)
+        end
       end
 
       def digest_requirements
         dependency.requirements.select do |requirement|
           requirement.dig(:source, :digest)
         end
+      end
+
+      def version_tag
+        @version_tag ||= Tag.new(dependency.version)
       end
     end
   end

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -62,6 +62,24 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       and_return(status: 200, headers: JSON.parse(headers_response).except("docker_content_digest"))
   end
 
+  describe "#up_to_date?" do
+    subject { checker.up_to_date? }
+
+    context "given an out of date digest and an up to date tag" do
+      let(:version) { "17.10" }
+      let(:source) { { digest: "old_digest", tag: "17.10" } }
+
+      before do
+        new_headers =
+          fixture("docker", "registry_manifest_headers", "generic.json")
+        stub_request(:head, repo_url + "manifests/17.10").
+          and_return(status: 200, body: "", headers: JSON.parse(new_headers))
+      end
+
+      it { is_expected.to be_falsy }
+    end
+  end
+
   describe "#can_update?" do
     subject { checker.can_update?(requirements_to_unlock: :own) }
 

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -75,21 +75,6 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it { is_expected.to be_falsey }
     end
 
-    context "given an outdated requirement" do
-      let(:version) { "17.10" }
-
-      before do
-        dependency.requirements << {
-          requirement: nil,
-          groups: [],
-          file: "Dockerfile.other",
-          source: { tag: "17.04" }
-        }
-      end
-
-      it { is_expected.to be_truthy }
-    end
-
     context "given a purely numeric version" do
       let(:version) { "1234567890" }
       it { is_expected.to be_truthy }

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -1008,7 +1008,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       before do
         new_headers =
           fixture("docker", "registry_manifest_headers", "generic.json")
-        stub_request(:head, repo_url + "manifests/17.10").
+        stub_request(:head, repo_url + "manifests/latest").
           and_return(status: 200, body: "", headers: JSON.parse(new_headers))
       end
 


### PR DESCRIPTION
With the following `Dockerfile`

```Dockerfile
FROM ubuntu:22.04@sha256:817cfe4672284dcbfee885b1a66094fd907630d610cab329114d036716be49ba
```

Before:

```
$ bin/dry-run.rb docker reload/php-fpm --cache files  --dep ubuntu
=> reading dependency files from cache manifest: ./dry-run/reload/php-fpm/cache-manifest-docker.json
=> parsing dependency files
=> updating 1 dependencies: ubuntu

=== ubuntu (22.04)
 => checking for updates 1/1
 => latest available version is 22.04
    (no update needed as it's already up-to-date)
🌍 Total requests made: '0'
```

After:

```
$ bin/dry-run.rb docker reload/php-fpm --cache files  --dep ubuntu
=> reading dependency files from cache manifest: ./dry-run/reload/php-fpm/cache-manifest-docker.json
=> parsing dependency files
=> updating 1 dependencies: ubuntu

=== ubuntu (22.04)
 => checking for updates 1/1
 => latest available version is 22.04
 => latest allowed version is 22.04
 => requirements to unlock: own
 => requirements update strategy: 
 => bump ubuntu from `817cfe4` to `67211c1`

    ± Dockerfile
    ~~~
    --- /tmp/original20230403-52-nus8o8	2023-04-03 17:55:30.192681007 +0000
    +++ /tmp/updated20230403-52-o4f2tb	2023-04-03 17:55:30.192681007 +0000
    @@ -1 +1 @@
    -FROM ubuntu:22.04@sha256:817cfe4672284dcbfee885b1a66094fd907630d610cab329114d036716be49ba
    +FROM ubuntu:22.04@sha256:67211c14fa74f070d27cc59d69a7fa9aeff8e28ea118ef3babc295a0428a6d21
    ~~~
    2 insertions (+), 2 deletions (-)
🌍 Total requests made: '0'
```