### PR TITLE
Update test expectation to match latest `blinker` release

### DIFF
--- a/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
           expect(updated_files.map(&:name)).to eq(%w(Pipfile Pipfile.lock))
 
           expect(json_lockfile["default"]["raven"]["version"]).to eq("==6.7.0")
-          expect(json_lockfile["default"]["blinker"]["version"]).to eq("==1.5")
+          expect(json_lockfile["default"]["blinker"]["version"]).to eq("==1.6")
         end
       end
 


### PR DESCRIPTION
This is failing on `main` because `blinker` `1.6` just dropped: https://github.com/pallets-eco/blinker/blob/main/CHANGES.rst#version-16

Ideally we'd update the test to not depend on the version, but mocking may be non-trivial if a native helper is used here.

Besides, `blinker` is updating less than 1x per year, and it's trivial to see what broke in CI and update it.