### PR TITLE
bump Cargo version

### DIFF
--- a/cargo/Dockerfile
+++ b/cargo/Dockerfile
@@ -5,11 +5,12 @@ USER root
 # Install Rust
 ENV RUSTUP_HOME=/opt/rust \
   CARGO_HOME=/opt/rust \
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse \
   PATH="${PATH}:/opt/rust/bin"
 RUN mkdir -p "$RUSTUP_HOME" && chown dependabot:dependabot "$RUSTUP_HOME"
 
 USER dependabot
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.66.0 --profile minimal
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.68.2 --profile minimal
 
 # Configure cargo to use Git CLI so the Git shim works
 RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo/config.toml


### PR DESCRIPTION
Bump rust, use the new [CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse](https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol) option.

