### PR TITLE
Generate proper PR summary table for docker digest updates

### DIFF
--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -132,6 +132,8 @@ module Dependabot
     end
 
     def humanized_version
+      return if removed?
+
       if version.match?(/^[0-9a-f]{40}$/)
         return new_ref if ref_changed? && new_ref
 

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -34,7 +34,7 @@ module Dependabot
 
     def humanized
       dependencies.map do |dependency|
-        "#{dependency.name} ( from #{dependency.previous_version} to #{dependency.version} )"
+        "#{dependency.name} ( from #{dependency.humanized_previous_version} to #{dependency.humanized_version} )"
       end.join(", ")
     end
 

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -165,11 +165,5 @@ module Dependabot
       snip = max - 3
       string.length > max ? "#{string[0...snip]}..." : string
     end
-
-    def humanize(dependencies)
-      dependencies.map do |dependency|
-        "#{dependency.name} ( from #{dependency.previous_version} to #{dependency.version} )"
-      end.join(", ")
-    end
   end
 end

--- a/updater/spec/dependabot/integration_spec.rb
+++ b/updater/spec/dependabot/integration_spec.rb
@@ -398,8 +398,8 @@ RSpec.describe "Dependabot Updates" do
         expect(log_message).to include(
           "created",
           "dummy-git-dependency",
-          "from 20151f9b67c8a04461fa0ee28385b6187b86587b",
-          "to c0e25c2eb332122873f73acb3b61fb2e261cfd8f"
+          "from v1.0.0",
+          "to v1.1.0"
         )
       end
 


### PR DESCRIPTION
Before:

```
$ script/dependabot update docker dsp-testing/dependabot-core-5758
# ...
updater | 2023/04/04 13:11:52 INFO Results:
updater | +---------------------------------------------------------------------+
updater | |                 Changes to Dependabot Pull Requests                 |
updater | +---------+-----------------------------------------------------------+
updater | | created | docker/library/ruby ( from 2.7.6-buster to 3.2.2-buster ) |
updater | | created | ubuntu ( from focal to focal )                            |
updater | +---------+-----------------------------------------------------------+
proxy | time="2023-04-04T13:11:52Z" level=info msg="4/28 calls cached (14%)"
```

After:

```
$ script/dependabot update docker dsp-testing/dependabot-core-5758
# ...
updater | 2023/04/04 13:09:40 INFO Results:
updater | +---------------------------------------------------------------------+
updater | |                 Changes to Dependabot Pull Requests                 |
updater | +---------+-----------------------------------------------------------+
updater | | created | docker/library/ruby ( from 2.7.6-buster to 3.2.2-buster ) |
updater | | created | ubuntu ( from `450e066` to `24a0df4` )                    |
updater | +---------+-----------------------------------------------------------+
proxy | time="2023-04-04T13:09:40Z" level=info msg="4/28 calls cached (14%)"
```

The description is now consistent with PR titles and bodies.