### PR TITLE
No need to explicitly configure option now that it's the default

### DIFF
--- a/cargo/Dockerfile
+++ b/cargo/Dockerfile
@@ -5,7 +5,6 @@ USER root
 # Install Rust
 ENV RUSTUP_HOME=/opt/rust \
   CARGO_HOME=/opt/rust \
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse \
   PATH="${PATH}:/opt/rust/bin"
 RUN mkdir -p "$RUSTUP_HOME" && chown dependabot:dependabot "$RUSTUP_HOME"
 


### PR DESCRIPTION
Blocked until Rust 1.70 lands, that's when they plan to change this (which we'll need to confirm).
--

We added this in Rust `1.68` via https://github.com/dependabot/dependabot-core/pull/6995 as we needed it earlier, but the `rust` project has since made this the default behavior.

So this removes the explicit configuration of the option.