### PR TITLE
build(deps): bump yarn from 3.2.3 to 3.4.1

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 ENV DEPENDABOT_HOME /home/dependabot
 ### JAVASCRIPT
-ARG YARN_VERSION=3.5.0
+ARG YARN_VERSION=3.4.1
 
 # Install Node and npm
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 ENV DEPENDABOT_HOME /home/dependabot
 ### JAVASCRIPT
+ARG YARN_VERSION=3.5.0
 
 # Install Node and npm
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
@@ -13,7 +14,7 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
 
 # Install yarn berry and set it to a stable version
 RUN corepack enable \
-  && corepack prepare yarn@3.2.3 --activate
+  && corepack prepare yarn@$YARN_VERSION --activate
 
 USER dependabot
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
@@ -34,8 +35,7 @@ ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
 # END: HACKY WORKAROUND FOR NPM GIT INSTALLS SPAWNING CHILD PROCESS
 
-# Our native helpers pull in yarn 1, so we need to reset the version globally to
-# 3.2.3.
-RUN corepack prepare yarn@3.2.3 --activate
+# Our native helpers pull in yarn 1, so we need to reset the version globally
+RUN corepack prepare yarn@$YARN_VERSION --activate
 
 COPY --chown=dependabot:dependabot npm_and_yarn ${DEPENDABOT_HOME}/npm_and_yarn


### PR DESCRIPTION
I do not know what version we are targeting. Can we upgrade to the latest `3.x` version if CI passes? 

If the intention is to stay within `3.2.x`, I can create a separate PR  as we're also behind in that range