### PR TITLE
Give a useful message when DependencyFileNotFound is raised

### DIFF
--- a/common/lib/dependabot/config/file_fetcher.rb
+++ b/common/lib/dependabot/config/file_fetcher.rb
@@ -40,7 +40,7 @@ module Dependabot
         end
 
         unless self.class.required_files_in?(fetched_files.map(&:name))
-          raise Dependabot::DependencyFileNotFound, self.class.required_files_message
+          raise Dependabot::DependencyFileNotFound.new(nil, self.class.required_files_message)
         end
 
         fetched_files

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -80,7 +80,7 @@ module Dependabot
 
     def initialize(file_path, msg = nil)
       @file_path = file_path
-      super(msg)
+      super("#{file_path} not found" || msg)
     end
 
     def file_name


### PR DESCRIPTION
We were always instantiating this exception with an empty message. Now we provide the path that was not found by default.