### PR TITLE
[Updater] Introduce a DependencyChangeBuilder class to complete encapsulation of diff generation

### DIFF
--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -34,9 +34,9 @@ module Dependabot
     end
 
     def run
-      updated_deps = updated_dependencies
-      updated_files = generate_dependency_files_for(updated_deps)
-      updated_deps = updated_deps.reject do |d|
+      updated_files = generate_dependency_files
+      # Remove any unchanged dependencies from the updated list
+      updated_deps = updated_dependencies.reject do |d|
         # Avoid rejecting the source dependency
         next false if source_dependency_name && d.name == source_dependency_name
         next true if d.top_level? && d.requirements == d.previous_requirements
@@ -68,7 +68,7 @@ module Dependabot
       change_source
     end
 
-    def generate_dependency_files_for(updated_dependencies)
+    def generate_dependency_files
       if updated_dependencies.count == 1
         updated_dependency = updated_dependencies.first
         Dependabot.logger.info("Updating #{updated_dependency.name} from " \
@@ -82,9 +82,8 @@ module Dependabot
       # Ignore dependencies that are tagged as information_only. These will be
       # updated indirectly as a result of a parent dependency update and are
       # only included here to be included in the PR info.
-      deps_to_update = updated_dependencies.reject(&:informational_only?)
-      updater = file_updater_for(deps_to_update)
-      updater.updated_dependency_files
+      relevant_dependencies = updated_dependencies.reject(&:informational_only?)
+      file_updater_for(relevant_dependencies).updated_dependency_files
     end
 
     def file_updater_for(dependencies)

--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "dependabot/dependency"
+require "dependabot/dependency_change"
+require "dependabot/file_updaters"
+require "dependabot/group_rule"
+
+# This class is responsible for generating a DependencyChange for a given
+# set of dependencies and dependency files.
+#
+# This class should be used via the `create_from` method with the following
+# arguments:
+# - job:
+#     The Dependabot::Job object the change is originated by
+# - dependency_files:
+#     The list dependency files we aim to modify as part of this change
+# - updated_dependencies:
+#     The set of dependency updates to be applied to the dependency files
+# - change_source:
+#     A change can be generated from either a single 'lead' Dependency or
+#     a GroupRule
+module Dependabot
+  class DependencyChangeBuilder
+
+    def self.create_from(**kwargs)
+      new(**kwargs).run
+    end
+
+    def initialize(job:, dependency_files:, updated_dependencies:, change_source:)
+      @job = job
+      @dependency_files = dependency_files
+      @updated_dependencies = updated_dependencies
+      @change_source = change_source
+    end
+
+    def run
+      updated_deps = updated_dependencies
+      updated_files = generate_dependency_files_for(updated_deps)
+      updated_deps = updated_deps.reject do |d|
+        # Avoid rejecting the source dependency
+        next false if source_dependency_name && d.name == source_dependency_name
+        next true if d.top_level? && d.requirements == d.previous_requirements
+
+        d.version == d.previous_version
+      end
+
+      Dependabot::DependencyChange.new(
+        job: job,
+        dependencies: updated_deps,
+        updated_dependency_files: updated_files,
+        group_rule: source_group_rule
+      )
+    end
+
+    private
+
+    attr_reader :job, :dependency_files, :updated_dependencies, :change_source
+
+    def source_dependency_name
+      return nil unless change_source.is_a? Dependabot::Dependency
+
+      change_source.name
+    end
+
+    def source_group_rule
+      return nil unless change_source.is_a? Dependabot::GroupRule
+
+      change_source
+    end
+
+    def generate_dependency_files_for(updated_dependencies)
+      if updated_dependencies.count == 1
+        updated_dependency = updated_dependencies.first
+        Dependabot.logger.info("Updating #{updated_dependency.name} from " \
+                               "#{updated_dependency.previous_version} to " \
+                               "#{updated_dependency.version}")
+      else
+        dependency_names = updated_dependencies.map(&:name)
+        Dependabot.logger.info("Updating #{dependency_names.join(', ')}")
+      end
+
+      # Ignore dependencies that are tagged as information_only. These will be
+      # updated indirectly as a result of a parent dependency update and are
+      # only included here to be included in the PR info.
+      deps_to_update = updated_dependencies.reject(&:informational_only?)
+      updater = file_updater_for(deps_to_update)
+      updater.updated_dependency_files
+    end
+
+    def file_updater_for(dependencies)
+      Dependabot::FileUpdaters.for_package_manager(job.package_manager).new(
+        dependencies: dependencies,
+        dependency_files: dependency_files,
+        repo_contents_path: job.repo_contents_path,
+        credentials: job.credentials,
+        options: job.experiments
+      )
+    end
+  end
+end

--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -21,7 +21,6 @@ require "dependabot/group_rule"
 #     a GroupRule
 module Dependabot
   class DependencyChangeBuilder
-
     def self.create_from(**kwargs)
       new(**kwargs).run
     end

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "dependabot/config/ignore_condition"
+require "dependabot/config/update_config"
 require "dependabot/experiments"
 require "dependabot/source"
 require "wildcard_matcher"

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "dependabot/config/ignore_condition"
-require "dependabot/config/update_config"
 require "dependabot/dependency_change"
 require "dependabot/environment"
 require "dependabot/experiments"

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -5,7 +5,6 @@ require "dependabot/dependency_change_builder"
 require "dependabot/environment"
 require "dependabot/experiments"
 require "dependabot/file_fetchers"
-require "dependabot/file_updaters"
 require "dependabot/logger"
 require "dependabot/python"
 require "dependabot/terraform"
@@ -594,35 +593,6 @@ module Dependabot
         requirements_update_strategy: job.requirements_update_strategy,
         options: job.experiments
       )
-    end
-
-    def file_updater_for(dependencies)
-      Dependabot::FileUpdaters.for_package_manager(job.package_manager).new(
-        dependencies: dependencies,
-        dependency_files: dependency_snapshot.dependency_files,
-        repo_contents_path: job.repo_contents_path,
-        credentials: job.credentials,
-        options: job.experiments
-      )
-    end
-
-    def generate_dependency_files_for(updated_dependencies)
-      if updated_dependencies.count == 1
-        updated_dependency = updated_dependencies.first
-        Dependabot.logger.info("Updating #{updated_dependency.name} from " \
-                               "#{updated_dependency.previous_version} to " \
-                               "#{updated_dependency.version}")
-      else
-        dependency_names = updated_dependencies.map(&:name)
-        Dependabot.logger.info("Updating #{dependency_names.join(', ')}")
-      end
-
-      # Ignore dependencies that are tagged as information_only. These will be
-      # updated indirectly as a result of a parent dependency update and are
-      # only included here to be included in the PR info.
-      deps_to_update = updated_dependencies.reject(&:informational_only?)
-      updater = file_updater_for(deps_to_update)
-      updater.updated_dependency_files
     end
 
     def create_pull_request(dependency_change)

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -122,7 +122,6 @@ module Dependabot
     end
 
     # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
     # rubocop:disable Metrics/MethodLength
     def check_and_update_pull_request(dependencies)
@@ -203,7 +202,6 @@ module Dependabot
       end
     end
     # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
     # rubocop:enable Metrics/MethodLength
 

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -86,56 +86,43 @@ module Dependabot
             requirements_to_unlock: requirements_to_unlock
           )
 
-          updated_files = generate_dependency_files_for(updated_deps)
-          updated_deps = updated_deps.reject do |d|
-            next false if d.name == checker.dependency.name
-            next true if d.top_level? && d.requirements == d.previous_requirements
-
-            d.version == d.previous_version
-          end
+          dependency_change = Dependabot::DependencyChangeBuilder.create_from(
+            job: job,
+            dependency_files: dependency_snapshot.dependency_files,
+            updated_dependencies: updated_deps,
+            change_source: checker.dependency
+          )
 
           # NOTE: Gradle, Maven and Nuget dependency names can be case-insensitive
           # and the dependency name in the security advisory often doesn't match
           # what users have specified in their manifest.
           job_dependencies = job.dependencies.map(&:downcase)
-          if updated_deps.map(&:name).map(&:downcase) != job_dependencies
+          if dependency_change.dependencies.map(&:name).map(&:downcase) != job_dependencies
             # The dependencies being updated have changed. Close the existing
             # multi-dependency PR and try creating a new one.
             close_pull_request(reason: :dependencies_changed)
-            create_pull_request(updated_deps, updated_files)
-          elsif existing_pull_request(updated_deps)
+            create_pull_request(dependency_change)
+          elsif existing_pull_request(dependency_change.dependencies)
             # The existing PR is for this version. Update it.
-            update_pull_request(updated_deps, updated_files)
+            update_pull_request(dependency_change)
           else
             # The existing PR is for a previous version. Supersede it.
-            create_pull_request(updated_deps, updated_files)
+            create_pull_request(dependency_change)
           end
         end
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/PerceivedComplexity
 
-        def create_pull_request(dependencies, updated_dependency_files)
-          Dependabot.logger.info("Submitting #{dependencies.map(&:name).join(', ')} " \
+        def create_pull_request(dependency_change)
+          Dependabot.logger.info("Submitting #{dependency_change.dependencies.map(&:name).join(', ')} " \
                                  "pull request for creation")
-
-          dependency_change = Dependabot::DependencyChange.new(
-            job: job,
-            dependencies: dependencies,
-            updated_dependency_files: updated_dependency_files
-          )
 
           service.create_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
         end
 
-        def update_pull_request(dependencies, updated_dependency_files)
-          Dependabot.logger.info("Submitting #{dependencies.map(&:name).join(', ')} " \
+        def update_pull_request(dependency_change)
+          Dependabot.logger.info("Submitting #{dependency_change.dependencies.map(&:name).join(', ')} " \
                                  "pull request for update")
-
-          dependency_change = Dependabot::DependencyChange.new(
-            job: job,
-            dependencies: dependencies,
-            updated_dependency_files: updated_dependency_files
-          )
 
           service.update_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
         end
@@ -161,16 +148,6 @@ module Dependabot
             security_advisories: job.security_advisories_for(dependency),
             raise_on_ignored: raise_on_ignored,
             requirements_update_strategy: job.requirements_update_strategy,
-            options: job.experiments
-          )
-        end
-
-        def file_updater_for(dependencies)
-          Dependabot::FileUpdaters.for_package_manager(job.package_manager).new(
-            dependencies: dependencies,
-            dependency_files: dependency_snapshot.dependency_files,
-            repo_contents_path: job.repo_contents_path,
-            credentials: job.credentials,
             options: job.experiments
           )
         end
@@ -225,25 +202,6 @@ module Dependabot
           )
 
           job.existing_pull_requests.find { |pr| Set.new(pr) == new_pr_set }
-        end
-
-        def generate_dependency_files_for(updated_dependencies)
-          if updated_dependencies.count == 1
-            updated_dependency = updated_dependencies.first
-            Dependabot.logger.info("Updating #{updated_dependency.name} from " \
-                                   "#{updated_dependency.previous_version} to " \
-                                   "#{updated_dependency.version}")
-          else
-            dependency_names = updated_dependencies.map(&:name)
-            Dependabot.logger.info("Updating #{dependency_names.join(', ')}")
-          end
-
-          # Ignore dependencies that are tagged as information_only. These will be
-          # updated indirectly as a result of a parent dependency update and are
-          # only included here to be included in the PR info.
-          deps_to_update = updated_dependencies.reject(&:informational_only?)
-          updater = file_updater_for(deps_to_update)
-          updater.updated_dependency_files
         end
       end
     end

--- a/updater/spec/dependabot/dependency_change_builder_spec.rb
+++ b/updater/spec/dependabot/dependency_change_builder_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency_change_builder"
+require "dependabot/job"
+
+RSpec.describe Dependabot::DependencyChangeBuilder do
+  let(:job) do
+    instance_double(Dependabot::Job,
+                    package_manager: "bundler",
+                    repo_contents_path: nil,
+                    credentials: [
+                      {
+                        "type" => "git_source",
+                        "host" => "github.com",
+                        "username" => "x-access-token",
+                        "password" => "github-token"
+                      }
+                    ],
+                    experiments: {})
+  end
+
+  let(:dependency_files) do
+    [
+      Dependabot::DependencyFile.new(
+        name: "Gemfile",
+        content: fixture("bundler/original/Gemfile"),
+        directory: "/"
+      ),
+      Dependabot::DependencyFile.new(
+        name: "Gemfile.lock",
+        content: fixture("bundler/original/Gemfile.lock"),
+        directory: "/"
+      )
+    ]
+  end
+
+  let(:updated_dependencies) do
+    [
+      Dependabot::Dependency.new(
+        name: "dummy-pkg-b",
+        package_manager: "bundler",
+        version: "1.2.0",
+        previous_version: "1.1.0",
+        requirements: [
+          {
+            file: "Gemfile",
+            requirement: "~> 1.2.0",
+            groups: [],
+            source: nil
+          }
+        ],
+        previous_requirements: [
+          {
+            file: "Gemfile",
+            requirement: "~> 1.1.0",
+            groups: [],
+            source: nil
+          }
+        ]
+      )
+    ]
+  end
+
+  describe "::create_from" do
+    subject(:create_change) do
+      described_class.create_from(
+        job: job,
+        dependency_files: dependency_files,
+        updated_dependencies: updated_dependencies,
+        change_source: change_source
+      )
+    end
+
+    context "when the source is a lead dependency" do
+      let(:change_source) do
+        Dependabot::Dependency.new(
+          name: "dummy-pkg-b",
+          package_manager: "bundler",
+          version: "1.1.0",
+          requirements: [
+            {
+              file: "Gemfile",
+              requirement: "~> 1.1.0",
+              groups: [],
+              source: nil
+            }
+          ]
+        )
+      end
+
+      it "creates a new DependencyChange with the updated files" do
+        dependency_change = create_change
+
+        expect(dependency_change).to be_a(Dependabot::DependencyChange)
+        expect(dependency_change.dependencies).to eql(updated_dependencies)
+        expect(dependency_change.updated_dependency_files.map(&:name)).to eql(["Gemfile", "Gemfile.lock"])
+        expect(dependency_change).not_to be_grouped_update
+
+        gemfile = dependency_change.updated_dependency_files.find { |file| file.name == "Gemfile" }
+        expect(gemfile.content).to eql(fixture("bundler/updated/Gemfile"))
+
+        lockfile = dependency_change.updated_dependency_files.find { |file| file.name == "Gemfile.lock" }
+        expect(lockfile.content).to eql(fixture("bundler/updated/Gemfile.lock"))
+      end
+    end
+
+    context "when the source is a group rule" do
+      let(:change_source) do
+        Dependabot::GroupRule.new(name: "dummy-pkg-*")
+      end
+
+      it "creates a new DependencyChange flagged as a grouped update" do
+        dependency_change = create_change
+
+        expect(dependency_change).to be_a(Dependabot::DependencyChange)
+        expect(dependency_change).to be_grouped_update
+      end
+    end
+  end
+end

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -410,7 +410,7 @@ RSpec.describe Dependabot::Updater do
           updater = build_updater(service: service, job: job)
 
           expect(checker).to receive(:up_to_date?).and_return(true)
-          expect(updater).to_not receive(:generate_dependency_files_for)
+          expect(Dependabot::DependencyChangeBuilder).to_not receive(:create_from)
           expect(service).to_not receive(:create_pull_request)
           expect(service).to receive(:record_update_job_error).
             with(
@@ -789,7 +789,7 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(updater).to_not receive(:generate_dependency_files_for)
+          expect(Dependabot::DependencyChangeBuilder).to_not receive(:create_from)
           expect(service).to_not receive(:create_pull_request)
 
           updater.run
@@ -895,7 +895,7 @@ RSpec.describe Dependabot::Updater do
         updater = build_updater(service: service, job: job)
 
         expect(checker).to_not receive(:can_update?)
-        expect(updater).to_not receive(:generate_dependency_files_for)
+        expect(Dependabot::DependencyChangeBuilder).to_not receive(:create_from)
         expect(service).to_not receive(:create_pull_request)
         expect(service).to_not receive(:record_update_job_error)
         expect(Dependabot.logger).
@@ -924,7 +924,7 @@ RSpec.describe Dependabot::Updater do
 
         expect(checker).to receive(:up_to_date?).and_return(false, false)
         expect(checker).to receive(:can_update?).and_return(true, false)
-        expect(updater).to_not receive(:generate_dependency_files_for)
+        expect(Dependabot::DependencyChangeBuilder).to_not receive(:create_from)
         expect(service).to_not receive(:create_pull_request)
         expect(service).to_not receive(:record_update_job_error)
         expect(Dependabot.logger).
@@ -961,7 +961,7 @@ RSpec.describe Dependabot::Updater do
 
         expect(checker).to receive(:up_to_date?).and_return(false)
         expect(checker).to receive(:can_update?).and_return(true)
-        expect(updater).to_not receive(:generate_dependency_files_for)
+        expect(Dependabot::DependencyChangeBuilder).to_not receive(:create_from)
         expect(service).to_not receive(:create_pull_request)
         expect(service).to receive(:record_update_job_error).
           with(
@@ -1006,7 +1006,7 @@ RSpec.describe Dependabot::Updater do
         updater = build_updater(service: service, job: job)
 
         expect(checker).to_not receive(:can_update?)
-        expect(updater).to_not receive(:generate_dependency_files_for)
+        expect(Dependabot::DependencyChangeBuilder).to_not receive(:create_from)
         expect(service).to_not receive(:create_pull_request)
         expect(service).to receive(:record_update_job_error).
           with(
@@ -1105,7 +1105,7 @@ RSpec.describe Dependabot::Updater do
 
         expect(checker).to receive(:up_to_date?).and_return(false)
         expect(checker).to receive(:can_update?).and_return(true)
-        expect(updater).to_not receive(:generate_dependency_files_for)
+        expect(Dependabot::DependencyChangeBuilder).to_not receive(:create_from)
         expect(service).to_not receive(:create_pull_request)
         expect(service).to receive(:record_update_job_error).
           with(


### PR DESCRIPTION
We've started the process of isolating the main updater operations into concrete classes by extracting the codelines for:
- Creating fresh updates for all out of date dependencies
- Refreshing an existing PR for a single out of date dependency

Next we plan to do the same for [Security update workflows](https://github.com/dependabot/dependabot-core/pull/6961), but before this we're focusing on removing duplicate code and extracting business objects to encapsulate some of the concerns. ( https://github.com/dependabot/dependabot-core/pull/6991, https://github.com/dependabot/dependabot-core/pull/6989 ).

This pull request completes the work we started a while back where we introduced a `DependencyChange` object which describes the outcome of an operation in terms of the dependencies that have been updated, the updated dependency files, the base SHA it was generated from, etc.

Until now this was just a value class which was used to simplify the interface with the Service/Client layer, but this Pull Request moves the abstraction further up into the shared logic of **actually generating** the changed files and filtering the dependencies **we attempted to update** to just the list that **did update**.

By consolidating this behaviour in a DependencyChangeBuilder, we can remove a significant amount of duplication.