### PR TITLE
improve worst case image build time

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -1,104 +1,13 @@
-FROM ubuntu:20.04 as builder
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-### SYSTEM DEPENDENCIES
-
-ENV DEBIAN_FRONTEND="noninteractive" \
-  LC_ALL="en_US.UTF-8" \
-  LANG="en_US.UTF-8"
-
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends \
-    build-essential \
-    ca-certificates \
-    curl \
-    zlib1g-dev \
-    libyaml-dev \
-    libgdbm-dev \
-    bison \
-    tzdata \
-    zip \
-    unzip \
-    locales \
-    make \
-    libssl-dev \
-    libbz2-dev \
-    libffi-dev \
-    libreadline-dev \
-    libncurses5-dev \
-    xz-utils \
-    tk-dev \
-  && locale-gen en_US.UTF-8
-
-### RUBY
-
 # When bumping Ruby minor, need to also add the previous version to `bundler/helpers/v{1,2}/monkey_patches/definition_ruby_version_patch.rb`
-ARG RUBY_VERSION=3.1.4
-ARG RUBY_INSTALL_VERSION=0.9.0
+FROM ruby:3.1.4 as builder
 
 # When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
 # Generally simplest to match the bundler version to the one that comes by default with whatever Ruby version we install.
 # This way other projects that import this library don't have to futz around with installing new / unexpected bundler versions.
 ARG BUNDLER_V2_VERSION=2.4.10
 
-# Install Ruby, update RubyGems, and install Bundler
-RUN mkdir -p /tmp/ruby-install \
- && cd /tmp/ruby-install \
- && curl -fsSL "https://github.com/postmodern/ruby-install/archive/v$RUBY_INSTALL_VERSION.tar.gz" -o ruby-install-$RUBY_INSTALL_VERSION.tar.gz  \
- && tar -xzvf ruby-install-$RUBY_INSTALL_VERSION.tar.gz \
- && cd ruby-install-$RUBY_INSTALL_VERSION/ \
- && make \
- && ./bin/ruby-install -j4 --system --cleanup ruby $RUBY_VERSION -- --disable-install-doc \
- && gem install bundler -v $BUNDLER_V2_VERSION --no-document \
- && rm -rf /var/lib/gems/*/cache/* \
- && rm -rf /tmp/ruby-install
-
-ENV HOME="/home/dependabot"
-WORKDIR ${HOME}
-
-# Place a git shim ahead of git on the path to rewrite git arguments to use HTTPS.
-ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-amd64.tar.gz"
-RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
-
-COPY .rubocop.yml .rubocop.yml
-COPY .ruby-version .ruby-version
-COPY omnibus omnibus
-COPY updater/Gemfile updater/Gemfile.lock dependabot-updater/
-
-COPY common/Gemfile common/dependabot-common.gemspec common/
-COPY common/lib/dependabot.rb common/lib/dependabot.rb
-COPY bundler/Gemfile bundler/dependabot-bundler.gemspec bundler/
-COPY cargo/Gemfile cargo/dependabot-cargo.gemspec cargo/
-COPY composer/Gemfile composer/dependabot-composer.gemspec composer/
-COPY docker/Gemfile docker/dependabot-docker.gemspec docker/
-COPY elm/Gemfile elm/dependabot-elm.gemspec elm/
-COPY git_submodules/Gemfile git_submodules/dependabot-git_submodules.gemspec git_submodules/
-COPY github_actions/Gemfile github_actions/dependabot-github_actions.gemspec github_actions/
-COPY go_modules/Gemfile go_modules/dependabot-go_modules.gemspec go_modules/
-COPY gradle/Gemfile gradle/dependabot-gradle.gemspec gradle/
-COPY hex/Gemfile hex/dependabot-hex.gemspec hex/
-COPY maven/Gemfile maven/dependabot-maven.gemspec maven/
-COPY npm_and_yarn/Gemfile npm_and_yarn/dependabot-npm_and_yarn.gemspec npm_and_yarn/
-COPY nuget/Gemfile nuget/dependabot-nuget.gemspec nuget/
-COPY pub/Gemfile pub/dependabot-pub.gemspec pub/
-COPY python/Gemfile python/dependabot-python.gemspec python/
-COPY terraform/Gemfile terraform/dependabot-terraform.gemspec terraform/
-
-# prevent having all the source in every ecosystem image
-RUN for ecosystem in git_submodules terraform github_actions hex elm docker nuget maven gradle cargo composer go_modules python pub npm_and_yarn bundler; do \
-      mkdir -p $ecosystem/lib/dependabot; \
-      touch $ecosystem/lib/dependabot/$ecosystem.rb; \
-    done
-
-WORKDIR $HOME/dependabot-updater
-
-RUN bundle config set --local path 'vendor' && \
-bundle config set --local frozen 'true' && \
-bundle config set --local without 'development' && \
-bundle install && \
-rm -rf ~/.bundle
+RUN gem install bundler -v $BUNDLER_V2_VERSION --no-document \
+ && rm -rf /var/lib/gems/*/cache/*
 
 FROM ubuntu:20.04
 
@@ -148,20 +57,61 @@ RUN if ! getent group "$USER_GID"; then groupadd --gid "$USER_GID" dependabot ; 
 # This avoids downloading large files not necessary for the dependabot scripts
 ENV GIT_LFS_SKIP_SMUDGE=1
 
-COPY --from=builder /opt /opt
+# Bring in Ruby and Bundler from the builder image
 COPY --from=builder --chown=dependabot:dependabot /usr/local /usr/local
-COPY --from=builder --chown=dependabot:dependabot /home/dependabot /home/dependabot
+
+ENV HOME="/home/dependabot"
+WORKDIR ${HOME}
+
+# Place a git shim ahead of git on the path to rewrite git arguments to use HTTPS.
+ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-amd64.tar.gz"
+RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
+
+COPY .rubocop.yml .rubocop.yml
+COPY .ruby-version .ruby-version
+COPY omnibus omnibus
+COPY updater/Gemfile updater/Gemfile.lock dependabot-updater/
+
+COPY common/Gemfile common/dependabot-common.gemspec common/
+COPY common/lib/dependabot.rb common/lib/dependabot.rb
+COPY bundler/Gemfile bundler/dependabot-bundler.gemspec bundler/
+COPY cargo/Gemfile cargo/dependabot-cargo.gemspec cargo/
+COPY composer/Gemfile composer/dependabot-composer.gemspec composer/
+COPY docker/Gemfile docker/dependabot-docker.gemspec docker/
+COPY elm/Gemfile elm/dependabot-elm.gemspec elm/
+COPY git_submodules/Gemfile git_submodules/dependabot-git_submodules.gemspec git_submodules/
+COPY github_actions/Gemfile github_actions/dependabot-github_actions.gemspec github_actions/
+COPY go_modules/Gemfile go_modules/dependabot-go_modules.gemspec go_modules/
+COPY gradle/Gemfile gradle/dependabot-gradle.gemspec gradle/
+COPY hex/Gemfile hex/dependabot-hex.gemspec hex/
+COPY maven/Gemfile maven/dependabot-maven.gemspec maven/
+COPY npm_and_yarn/Gemfile npm_and_yarn/dependabot-npm_and_yarn.gemspec npm_and_yarn/
+COPY nuget/Gemfile nuget/dependabot-nuget.gemspec nuget/
+COPY pub/Gemfile pub/dependabot-pub.gemspec pub/
+COPY python/Gemfile python/dependabot-python.gemspec python/
+COPY terraform/Gemfile terraform/dependabot-terraform.gemspec terraform/
+
+# prevent having all the source in every ecosystem image
+RUN for ecosystem in git_submodules terraform github_actions hex elm docker nuget maven gradle cargo composer go_modules python pub npm_and_yarn bundler; do \
+    mkdir -p $ecosystem/lib/dependabot; \
+    touch $ecosystem/lib/dependabot/$ecosystem.rb; \
+  done
 
 ENV DEPENDABOT_HOME /home/dependabot
+WORKDIR $DEPENDABOT_HOME/dependabot-updater
 
-# Add project
+RUN bundle config set --local path 'vendor' && \
+bundle config set --local frozen 'true' && \
+bundle config set --local without 'development' && \
+bundle install && \
+rm -rf ~/.bundle
+
+# Add project after bundle install to avoid re-installing gems when only the project code changes
 COPY --chown=dependabot:dependabot LICENSE $DEPENDABOT_HOME
 COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 
 ENV PATH="$HOME/bin:$PATH"
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
-
-WORKDIR $DEPENDABOT_HOME/dependabot-updater
 
 CMD ["bin/run"]

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -53,6 +53,7 @@ RUN if ! getent group "$USER_GID"; then groupadd --gid "$USER_GID" dependabot ; 
   && useradd --uid "${USER_UID}" --gid "${USER_GID}" -m dependabot \
   && mkdir -p /opt && chown dependabot:dependabot /opt && chgrp dependabot /etc/ssl/certs && chmod g+w /etc/ssl/certs
 
+USER dependabot
 ENV HOME=/home/dependabot
 WORKDIR $HOME
 
@@ -112,5 +113,7 @@ COPY --chown=dependabot:dependabot updater $HOME/dependabot-updater
 
 ENV PATH="$HOME/bin:$PATH"
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
+
+USER root
 
 CMD ["bin/run"]

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -53,7 +53,6 @@ RUN if ! getent group "$USER_GID"; then groupadd --gid "$USER_GID" dependabot ; 
   && useradd --uid "${USER_UID}" --gid "${USER_GID}" -m dependabot \
   && mkdir -p /opt && chown dependabot:dependabot /opt && chgrp dependabot /etc/ssl/certs && chmod g+w /etc/ssl/certs
 
-USER dependabot
 ENV HOME=/home/dependabot
 WORKDIR $HOME
 

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -1,14 +1,3 @@
-# When bumping Ruby minor, need to also add the previous version to `bundler/helpers/v{1,2}/monkey_patches/definition_ruby_version_patch.rb`
-FROM ruby:3.1.4 as builder
-
-# When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
-# Generally simplest to match the bundler version to the one that comes by default with whatever Ruby version we install.
-# This way other projects that import this library don't have to futz around with installing new / unexpected bundler versions.
-ARG BUNDLER_V2_VERSION=2.4.10
-
-RUN gem install bundler -v $BUNDLER_V2_VERSION --no-document \
- && rm -rf /var/lib/gems/*/cache/*
-
 FROM ubuntu:20.04
 
 LABEL org.opencontainers.image.source="https://github.com/dependabot/dependabot-core"
@@ -61,9 +50,6 @@ WORKDIR $DEPENDABOT_HOME
 # This avoids downloading large files not necessary for the dependabot scripts
 ENV GIT_LFS_SKIP_SMUDGE=1
 
-# Bring in Ruby and Bundler from the builder image
-COPY --from=builder --chown=dependabot:dependabot /usr/local /usr/local
-
 # Place a git shim ahead of git on the path to rewrite git arguments to use HTTPS.
 ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-amd64.tar.gz"
 RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
@@ -100,11 +86,21 @@ RUN for ecosystem in git_submodules terraform github_actions hex elm docker nuge
 
 WORKDIR $DEPENDABOT_HOME/dependabot-updater
 
-RUN bundle config set --local path 'vendor' && \
-bundle config set --local frozen 'true' && \
-bundle config set --local without 'development' && \
-bundle install && \
-rm -rf ~/.bundle
+# When bumping Ruby minor, need to also add the previous version to `bundler/helpers/v{1,2}/monkey_patches/definition_ruby_version_patch.rb`
+COPY --from=ruby:3.1.4 --chown=dependabot:dependabot /usr/local /usr/local
+
+# When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
+# Generally simplest to match the bundler version to the one that comes by default with whatever Ruby version we install.
+# This way other projects that import this library don't have to futz around with installing new / unexpected bundler versions.
+ARG BUNDLER_V2_VERSION=2.4.10
+
+RUN gem install bundler -v $BUNDLER_V2_VERSION --no-document && \
+ rm -rf /var/lib/gems/*/cache/* && \
+ bundle config set --local path 'vendor' && \
+ bundle config set --local frozen 'true' && \
+ bundle config set --local without 'development' && \
+ bundle install && \
+ rm -rf ~/.bundle
 
 # Add project after bundle install to avoid re-installing gems when only the project code changes
 COPY --chown=dependabot:dependabot LICENSE $DEPENDABOT_HOME

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -54,8 +54,8 @@ RUN if ! getent group "$USER_GID"; then groupadd --gid "$USER_GID" dependabot ; 
   && mkdir -p /opt && chown dependabot:dependabot /opt && chgrp dependabot /etc/ssl/certs && chmod g+w /etc/ssl/certs
 
 USER dependabot
-ENV HOME=/home/dependabot
-WORKDIR $HOME
+ENV DEPENDABOT_HOME="/home/dependabot"
+WORKDIR $DEPENDABOT_HOME
 
 # Disable automatic pulling of files stored with Git LFS
 # This avoids downloading large files not necessary for the dependabot scripts
@@ -98,7 +98,7 @@ RUN for ecosystem in git_submodules terraform github_actions hex elm docker nuge
     touch $ecosystem/lib/dependabot/$ecosystem.rb; \
   done
 
-WORKDIR $HOME/dependabot-updater
+WORKDIR $DEPENDABOT_HOME/dependabot-updater
 
 RUN bundle config set --local path 'vendor' && \
 bundle config set --local frozen 'true' && \
@@ -107,15 +107,13 @@ bundle install && \
 rm -rf ~/.bundle
 
 # Add project after bundle install to avoid re-installing gems when only the project code changes
-COPY --chown=dependabot:dependabot LICENSE $HOME
-COPY --chown=dependabot:dependabot common $HOME/common
-COPY --chown=dependabot:dependabot updater $HOME/dependabot-updater
+COPY --chown=dependabot:dependabot LICENSE $DEPENDABOT_HOME
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 
-ENV PATH="$HOME/bin:$PATH"
+ENV PATH="$DEPENDABOT_HOME/bin:$PATH"
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 
 USER root
-
-RUN chown -R dependabot:dependabot $HOME
 
 CMD ["bin/run"]

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -53,6 +53,10 @@ RUN if ! getent group "$USER_GID"; then groupadd --gid "$USER_GID" dependabot ; 
   && useradd --uid "${USER_UID}" --gid "${USER_GID}" -m dependabot \
   && mkdir -p /opt && chown dependabot:dependabot /opt && chgrp dependabot /etc/ssl/certs && chmod g+w /etc/ssl/certs
 
+USER dependabot
+ENV HOME=/home/dependabot
+WORKDIR $HOME
+
 # Disable automatic pulling of files stored with Git LFS
 # This avoids downloading large files not necessary for the dependabot scripts
 ENV GIT_LFS_SKIP_SMUDGE=1
@@ -60,36 +64,33 @@ ENV GIT_LFS_SKIP_SMUDGE=1
 # Bring in Ruby and Bundler from the builder image
 COPY --from=builder --chown=dependabot:dependabot /usr/local /usr/local
 
-ENV HOME="/home/dependabot"
-WORKDIR ${HOME}
-
 # Place a git shim ahead of git on the path to rewrite git arguments to use HTTPS.
 ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-amd64.tar.gz"
 RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
 
-COPY .rubocop.yml .rubocop.yml
-COPY .ruby-version .ruby-version
-COPY omnibus omnibus
-COPY updater/Gemfile updater/Gemfile.lock dependabot-updater/
+COPY --chown=dependabot:dependabot .rubocop.yml .rubocop.yml
+COPY --chown=dependabot:dependabot .ruby-version .ruby-version
+COPY --chown=dependabot:dependabot omnibus omnibus
+COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock dependabot-updater/
 
-COPY common/Gemfile common/dependabot-common.gemspec common/
-COPY common/lib/dependabot.rb common/lib/dependabot.rb
-COPY bundler/Gemfile bundler/dependabot-bundler.gemspec bundler/
-COPY cargo/Gemfile cargo/dependabot-cargo.gemspec cargo/
-COPY composer/Gemfile composer/dependabot-composer.gemspec composer/
-COPY docker/Gemfile docker/dependabot-docker.gemspec docker/
-COPY elm/Gemfile elm/dependabot-elm.gemspec elm/
-COPY git_submodules/Gemfile git_submodules/dependabot-git_submodules.gemspec git_submodules/
-COPY github_actions/Gemfile github_actions/dependabot-github_actions.gemspec github_actions/
-COPY go_modules/Gemfile go_modules/dependabot-go_modules.gemspec go_modules/
-COPY gradle/Gemfile gradle/dependabot-gradle.gemspec gradle/
-COPY hex/Gemfile hex/dependabot-hex.gemspec hex/
-COPY maven/Gemfile maven/dependabot-maven.gemspec maven/
-COPY npm_and_yarn/Gemfile npm_and_yarn/dependabot-npm_and_yarn.gemspec npm_and_yarn/
-COPY nuget/Gemfile nuget/dependabot-nuget.gemspec nuget/
-COPY pub/Gemfile pub/dependabot-pub.gemspec pub/
-COPY python/Gemfile python/dependabot-python.gemspec python/
-COPY terraform/Gemfile terraform/dependabot-terraform.gemspec terraform/
+COPY --chown=dependabot:dependabot common/Gemfile common/dependabot-common.gemspec common/
+COPY --chown=dependabot:dependabot common/lib/dependabot.rb common/lib/dependabot.rb
+COPY --chown=dependabot:dependabot bundler/Gemfile bundler/dependabot-bundler.gemspec bundler/
+COPY --chown=dependabot:dependabot cargo/Gemfile cargo/dependabot-cargo.gemspec cargo/
+COPY --chown=dependabot:dependabot composer/Gemfile composer/dependabot-composer.gemspec composer/
+COPY --chown=dependabot:dependabot docker/Gemfile docker/dependabot-docker.gemspec docker/
+COPY --chown=dependabot:dependabot elm/Gemfile elm/dependabot-elm.gemspec elm/
+COPY --chown=dependabot:dependabot git_submodules/Gemfile git_submodules/dependabot-git_submodules.gemspec git_submodules/
+COPY --chown=dependabot:dependabot github_actions/Gemfile github_actions/dependabot-github_actions.gemspec github_actions/
+COPY --chown=dependabot:dependabot go_modules/Gemfile go_modules/dependabot-go_modules.gemspec go_modules/
+COPY --chown=dependabot:dependabot gradle/Gemfile gradle/dependabot-gradle.gemspec gradle/
+COPY --chown=dependabot:dependabot hex/Gemfile hex/dependabot-hex.gemspec hex/
+COPY --chown=dependabot:dependabot maven/Gemfile maven/dependabot-maven.gemspec maven/
+COPY --chown=dependabot:dependabot npm_and_yarn/Gemfile npm_and_yarn/dependabot-npm_and_yarn.gemspec npm_and_yarn/
+COPY --chown=dependabot:dependabot nuget/Gemfile nuget/dependabot-nuget.gemspec nuget/
+COPY --chown=dependabot:dependabot pub/Gemfile pub/dependabot-pub.gemspec pub/
+COPY --chown=dependabot:dependabot python/Gemfile python/dependabot-python.gemspec python/
+COPY --chown=dependabot:dependabot terraform/Gemfile terraform/dependabot-terraform.gemspec terraform/
 
 # prevent having all the source in every ecosystem image
 RUN for ecosystem in git_submodules terraform github_actions hex elm docker nuget maven gradle cargo composer go_modules python pub npm_and_yarn bundler; do \
@@ -97,8 +98,7 @@ RUN for ecosystem in git_submodules terraform github_actions hex elm docker nuge
     touch $ecosystem/lib/dependabot/$ecosystem.rb; \
   done
 
-ENV DEPENDABOT_HOME /home/dependabot
-WORKDIR $DEPENDABOT_HOME/dependabot-updater
+WORKDIR $HOME/dependabot-updater
 
 RUN bundle config set --local path 'vendor' && \
 bundle config set --local frozen 'true' && \
@@ -107,9 +107,9 @@ bundle install && \
 rm -rf ~/.bundle
 
 # Add project after bundle install to avoid re-installing gems when only the project code changes
-COPY --chown=dependabot:dependabot LICENSE $DEPENDABOT_HOME
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
-COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
+COPY --chown=dependabot:dependabot LICENSE $HOME
+COPY --chown=dependabot:dependabot common $HOME/common
+COPY --chown=dependabot:dependabot updater $HOME/dependabot-updater
 
 ENV PATH="$HOME/bin:$PATH"
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -86,6 +86,7 @@ RUN for ecosystem in git_submodules terraform github_actions hex elm docker nuge
 
 WORKDIR $DEPENDABOT_HOME/dependabot-updater
 
+# Install Ruby from official Docker image
 # When bumping Ruby minor, need to also add the previous version to `bundler/helpers/v{1,2}/monkey_patches/definition_ruby_version_patch.rb`
 COPY --from=ruby:3.1.4 --chown=dependabot:dependabot /usr/local /usr/local
 

--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -116,4 +116,6 @@ ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 
 USER root
 
+RUN chown -R dependabot:dependabot $HOME
+
 CMD ["bin/run"]

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -157,7 +157,8 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
       let(:dependency_name) { "golang.org/x/net" }
 
       it "picks the latest version" do
-        expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("0.8.0"))
+        # This makes actual requests so we should use a VCR cassette
+        expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("0.9.0"))
       end
     end
 

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -157,8 +157,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
       let(:dependency_name) { "golang.org/x/net" }
 
       it "picks the latest version" do
-        # This makes actual requests so we should use a VCR cassette
-        expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("0.9.0"))
+        expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("0.8.0"))
       end
     end
 


### PR DESCRIPTION
In #5356 we switched away from a PPA since it wasn't keeping up with new versions of Ruby. Ruby-install was good but building from source is slow, and it seems like we break the cache more often than we care to.

This approach is to copy Ruby et al from the official Ruby Docker image which should stay up-to-date. This allows us to skip the build to save time, and we can stay on our current version of Ubuntu by copying out the binaries. This also saves ~100MB from somewhere, the `bundler` image is now around 640MB for me. 

I had to move the `bundle install` out since it didn't seem to like to be run on a different version of Ubuntu? I'm not sure, but even with less parallelism this is very fast locally. Submitting as Draft to test against CI, check the speed, and get feedback.