### PR TITLE
Fix reinstalling `npm_and_yarn` native helper dependencies

### DIFF
--- a/npm_and_yarn/helpers/build
+++ b/npm_and_yarn/helpers/build
@@ -22,4 +22,4 @@ cp -r \
   "$install_dir"
 
 cd "$install_dir"
-npm ci --no-audit --fetch-timeout=600000 --fetch-retries=5
+npm ci --no-audit --fetch-timeout=600000 --fetch-retries=5 --no-dry-run


### PR DESCRIPTION
During image build, this works because `dry-run` is not yet set in configuration. But if you re-run it inside the development container after, for example, changing the version of a native dependencies, it no longer installs anything.

Avoid `dry-run` mode explicitly to prevent this.