### PR TITLE
Support for nuget tools in .config/dotnet-tools.json

### DIFF
--- a/nuget/lib/dependabot/nuget/file_fetcher.rb
+++ b/nuget/lib/dependabot/nuget/file_fetcher.rb
@@ -32,6 +32,7 @@ module Dependabot
         fetched_files += packages_config_files
         fetched_files += nuget_config_files
         fetched_files << global_json if global_json
+        fetched_files << dotnet_tools_json if dotnet_tools_json
         fetched_files << packages_props if packages_props
 
         fetched_files = fetched_files.uniq
@@ -219,6 +220,12 @@ module Dependabot
 
       def global_json
         @global_json ||= fetch_file_if_present("global.json")
+      end
+
+      def dotnet_tools_json
+        @dotnet_tools_json ||= fetch_file_if_present(".config/dotnet-tools.json")
+      rescue Dependabot::DependencyFileNotFound
+        nil
       end
 
       def packages_props

--- a/nuget/lib/dependabot/nuget/file_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser.rb
@@ -15,6 +15,7 @@ module Dependabot
       require_relative "file_parser/project_file_parser"
       require_relative "file_parser/packages_config_parser"
       require_relative "file_parser/global_json_parser"
+      require_relative "file_parser/dotnet_tools_json_parser"
 
       PACKAGE_CONF_DEPENDENCY_SELECTOR = "packages > packages"
 
@@ -23,6 +24,7 @@ module Dependabot
         dependency_set += project_file_dependencies
         dependency_set += packages_config_dependencies
         dependency_set += global_json_dependencies if global_json
+        dependency_set += dotnet_tools_json_dependencies if dotnet_tools_json
         dependency_set.dependencies
       end
 
@@ -56,6 +58,12 @@ module Dependabot
         GlobalJsonParser.new(global_json: global_json).dependency_set
       end
 
+      def dotnet_tools_json_dependencies
+        return DependencySet.new unless dotnet_tools_json
+
+        DotNetToolsJsonParser.new(dotnet_tools_json: dotnet_tools_json).dependency_set
+      end
+
       def project_file_parser
         @project_file_parser ||=
           ProjectFileParser.new(dependency_files: dependency_files)
@@ -76,7 +84,8 @@ module Dependabot
           project_files -
           packages_config_files -
           nuget_configs -
-          [global_json]
+          [global_json] -
+          [dotnet_tools_json]
       end
 
       def nuget_configs
@@ -85,6 +94,10 @@ module Dependabot
 
       def global_json
         dependency_files.find { |f| f.name.casecmp("global.json").zero? }
+      end
+
+      def dotnet_tools_json
+        dependency_files.find { |f| f.name.casecmp(".config/dotnet-tools.json").zero? }
       end
 
       def check_required_files

--- a/nuget/lib/dependabot/nuget/file_parser/dotnet_tools_json_parser.rb
+++ b/nuget/lib/dependabot/nuget/file_parser/dotnet_tools_json_parser.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "json"
+
+require "dependabot/dependency"
+require "dependabot/nuget/file_parser"
+
+# For details on dotnet-tools.json files see:
+# https://learn.microsoft.com/en-us/dotnet/core/tools/local-tools-how-to-use
+module Dependabot
+  module Nuget
+    class FileParser
+      class DotNetToolsJsonParser
+        require "dependabot/file_parsers/base/dependency_set"
+
+        def initialize(dotnet_tools_json:)
+          @dotnet_tools_json = dotnet_tools_json
+        end
+
+        def dependency_set
+          dependency_set = Dependabot::FileParsers::Base::DependencySet.new
+
+          tools = parsed_dotnet_tools_json.fetch("tools", {})
+
+          raise Dependabot::DependencyFileNotParseable, dotnet_tools_json.path unless tools.is_a?(Hash)
+
+          tools.each do |dependency_name, node|
+            raise Dependabot::DependencyFileNotParseable, dotnet_tools_json.path unless node.is_a?(Hash)
+
+            version = node["version"]
+            dependency_set <<
+              Dependency.new(
+                name: dependency_name,
+                version: version,
+                package_manager: "nuget",
+                requirements: [{
+                  requirement: version,
+                  file: dotnet_tools_json.name,
+                  groups: ["dependencies"],
+                  source: nil
+                }]
+              )
+          end
+
+          dependency_set
+        end
+
+        private
+
+        attr_reader :dotnet_tools_json
+
+        def parsed_dotnet_tools_json
+          @parsed_dotnet_tools_json ||= JSON.parse(dotnet_tools_json.content)
+        rescue JSON::ParserError
+          raise Dependabot::DependencyFileNotParseable, dotnet_tools_json.path
+        end
+      end
+    end
+  end
+end

--- a/nuget/lib/dependabot/nuget/file_updater.rb
+++ b/nuget/lib/dependabot/nuget/file_updater.rb
@@ -15,6 +15,7 @@ module Dependabot
           %r{^[^/]*\.[a-z]{2}proj$},
           /^packages\.config$/i,
           /^global\.json$/i,
+          /^dotnet-tools\.json$/i,
           /^Directory\.Build\.props$/i,
           /^Directory\.Build\.targets$/i,
           /^Packages\.props$/i
@@ -56,6 +57,10 @@ module Dependabot
 
       def global_json
         dependency_files.find { |f| f.name.casecmp("global.json").zero? }
+      end
+
+      def dotnet_tools_json
+        dependency_files.find { |f| f.name.casecmp(".config/dotnet-tools.json").zero? }
       end
 
       def check_required_files
@@ -126,6 +131,13 @@ module Dependabot
             global_json.content.match(
               /"#{Regexp.escape(dependency.name)}"\s*:\s*
                "#{Regexp.escape(dependency.previous_version)}"/x
+            ).to_s
+          ]
+        elsif requirement.fetch(:file).casecmp(".config/dotnet-tools.json").zero?
+          [
+            dotnet_tools_json.content.match(
+              /"#{Regexp.escape(dependency.name)}"\s*:\s*{\s*"version"\s*:\s*
+               "#{Regexp.escape(dependency.previous_version)}"/xm
             ).to_s
           ]
         else

--- a/nuget/spec/dependabot/nuget/file_parser/dotnet_tools_json_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser/dotnet_tools_json_parser_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency_file"
+require "dependabot/source"
+require "dependabot/nuget/file_parser/dotnet_tools_json_parser"
+
+RSpec.describe Dependabot::Nuget::FileParser::DotNetToolsJsonParser do
+  let(:file) do
+    Dependabot::DependencyFile.new(name: "dotnet-tools.json", content: file_body)
+  end
+  let(:file_body) { fixture("dotnet_tools_jsons", "dotnet-tools.json") }
+  let(:parser) { described_class.new(dotnet_tools_json: file) }
+
+  describe "dependency_set" do
+    subject(:dependency_set) { parser.dependency_set }
+
+    it { is_expected.to be_a(Dependabot::FileParsers::Base::DependencySet) }
+
+    describe "the dependencies" do
+      subject(:dependencies) { dependency_set.dependencies }
+
+      its(:length) { is_expected.to eq(2) }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("botsay")
+          expect(dependency.version).to eq("1.0.0")
+          expect(dependency.requirements).to eq(
+            [{
+              requirement: "1.0.0",
+              file: "dotnet-tools.json",
+              groups: ["dependencies"],
+              source: nil
+            }]
+          )
+        end
+      end
+
+      describe "the last dependency" do
+        subject(:dependency) { dependencies.last }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("dotnetsay")
+          expect(dependency.version).to eq("1.0.0")
+          expect(dependency.requirements).to eq(
+            [{
+              requirement: "1.0.0",
+              file: "dotnet-tools.json",
+              groups: ["dependencies"],
+              source: nil
+            }]
+          )
+        end
+      end
+
+      context "with bad JSON" do
+        let(:file_body) { fixture("dotnet_tools_jsons", "invalid_json.json") }
+
+        it "raises a Dependabot::DependencyFileNotParseable error" do
+          expect { parser.dependency_set }.
+            to raise_error(Dependabot::DependencyFileNotParseable) do |error|
+              expect(error.file_name).to eq("dotnet-tools.json")
+            end
+        end
+      end
+    end
+  end
+end

--- a/nuget/spec/dependabot/nuget/file_parser_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_parser_spec.rb
@@ -250,6 +250,42 @@ RSpec.describe Dependabot::Nuget::FileParser do
       end
     end
 
+    context "with a dotnet-tools.json" do
+      let(:files) { [packages_config, dotnet_tools_json] }
+      let(:packages_config) do
+        Dependabot::DependencyFile.new(
+          name: "packages.config",
+          content: fixture("packages_configs", "packages.config")
+        )
+      end
+      let(:dotnet_tools_json) do
+        Dependabot::DependencyFile.new(
+          name: ".config/dotnet-tools.json",
+          content: fixture("dotnet_tools_jsons", "dotnet-tools.json")
+        )
+      end
+
+      its(:length) { is_expected.to eq(11) }
+
+      describe "the last dependency" do
+        subject(:dependency) { dependencies.last }
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("dotnetsay")
+          expect(dependency.version).to eq("1.0.0")
+          expect(dependency.requirements).to eq(
+            [{
+              requirement: "1.0.0",
+              file: ".config/dotnet-tools.json",
+              groups: ["dependencies"],
+              source: nil
+            }]
+          )
+        end
+      end
+    end
+
     context "with an imported properties file" do
       let(:files) { [csproj_file, imported_file] }
       let(:imported_file) do

--- a/nuget/spec/dependabot/nuget/file_updater_spec.rb
+++ b/nuget/spec/dependabot/nuget/file_updater_spec.rb
@@ -361,5 +361,105 @@ RSpec.describe Dependabot::Nuget::FileUpdater do
         end
       end
     end
+
+    context "with a dotnet-tools.json" do
+      let(:dependency_files) { [csproj_file, dotnet_tools_json] }
+      let(:dotnet_tools_json) do
+        Dependabot::DependencyFile.new(
+          content: fixture("dotnet_tools_jsons", "dotnet-tools.json"),
+          name: ".config/dotnet-tools.json"
+        )
+      end
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "dotnetsay",
+          version: "2.1.7",
+          previous_version: "1.0.0",
+          requirements: [{
+            file: ".config/dotnet-tools.json",
+            requirement: "2.1.7",
+            groups: ["dependencies"],
+            source: nil
+          }],
+          previous_requirements: [{
+            file: ".config/dotnet-tools.json",
+            requirement: "1.0.0",
+            groups: ["dependencies"],
+            source: nil
+          }],
+          package_manager: "nuget"
+        )
+      end
+
+      describe "the updated dotnet-tools.json file" do
+        subject(:updated_dotnet_tools_json_file) do
+          updated_files.find { |f| f.name == ".config/dotnet-tools.json" }
+        end
+
+        its(:content) do
+          # botsay is unchanged
+          is_expected.to include '"botsay": {' \
+                                 "\n      \"version\": \"1.0.0\"," \
+                                 "\n      \"commands\": ["
+
+          # dotnetsay is changed
+          is_expected.to include '"dotnetsay": {' \
+                                 "\n      \"version\": \"2.1.7\"," \
+                                 "\n      \"commands\": ["
+        end
+      end
+    end
+
+    context "with a dotnet-tools.json same version edge" do
+      # The RegEx can mistakenly match the an entry and the one following
+      # This guards against such by testing update of the first does not affect the second.
+      # This only happens when two dependencies have the same version but we only need to
+      # update the first, irrespective of different dependency names
+      let(:dependency_files) { [csproj_file, dotnet_tools_json] }
+      let(:dotnet_tools_json) do
+        Dependabot::DependencyFile.new(
+          content: fixture("dotnet_tools_jsons", "dotnet-tools.json"),
+          name: ".config/dotnet-tools.json"
+        )
+      end
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "botsay",
+          version: "1.2.0",
+          previous_version: "1.0.0",
+          requirements: [{
+            file: ".config/dotnet-tools.json",
+            requirement: "1.2.0",
+            groups: ["dependencies"],
+            source: nil
+          }],
+          previous_requirements: [{
+            file: ".config/dotnet-tools.json",
+            requirement: "1.0.0",
+            groups: ["dependencies"],
+            source: nil
+          }],
+          package_manager: "nuget"
+        )
+      end
+
+      describe "the updated dotnet-tools.json file" do
+        subject(:updated_dotnet_tools_json_file) do
+          updated_files.find { |f| f.name == ".config/dotnet-tools.json" }
+        end
+
+        its(:content) do
+          # botsay is changed
+          is_expected.to include '"botsay": {' \
+                                 "\n      \"version\": \"1.2.0\"," \
+                                 "\n      \"commands\": ["
+
+          # dotnetsay is unchanged
+          is_expected.to include '"dotnetsay": {' \
+                                 "\n      \"version\": \"1.0.0\"," \
+                                 "\n      \"commands\": ["
+        end
+      end
+    end
   end
 end

--- a/nuget/spec/fixtures/dotnet_tools_jsons/dotnet-tools.json
+++ b/nuget/spec/fixtures/dotnet_tools_jsons/dotnet-tools.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "botsay": {
+      "version": "1.0.0",
+      "commands": [
+        "botsay"
+      ]
+    },
+    "dotnetsay": {
+      "version": "1.0.0",
+      "commands": [
+        "dotnetsay"
+      ]
+    }
+  }
+}

--- a/nuget/spec/fixtures/dotnet_tools_jsons/invalid_json.json
+++ b/nuget/spec/fixtures/dotnet_tools_jsons/invalid_json.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "botsay": {
+      "version": "1.0.0",
+      "commands": [
+        "botsay"
+      ],
+    },
+    "dotnetsay": {
+      "version": "1.0.0",
+      "commands": [
+        "dotnetsay"
+      ]
+    }
+  }
+}

--- a/nuget/spec/fixtures/github/contents_dotnet_config_directory.json
+++ b/nuget/spec/fixtures/github/contents_dotnet_config_directory.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "dotnet-tools.json",
+    "path": "dotnet-tools.json",
+    "sha": "7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+    "size": 917,
+    "url": "https://api.github.com/repos/gocardless/business/contents/.config/dotnet-tools.json?ref=master",
+    "html_url": "https://github.com/gocardless/business/blob/master/.config/dotnet-tools.json",
+    "git_url": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+    "download_url": "https://raw.githubusercontent.com/gocardless/business/master/.config/dotnet-tools.json",
+    "type": "file",
+    "_links": {
+      "self": "https://api.github.com/repos/gocardless/business/contents/.config/dotnet-tools.json?ref=master",
+      "git": "https://api.github.com/repos/gocardless/business/git/blobs/7ac321e0e1b20c05042f3af419beb322db0e4cc1",
+      "html": "https://github.com/gocardless/business/blob/master/.config/dotnet-tools.json"
+    }
+  }
+]

--- a/nuget/spec/fixtures/github/contents_dotnet_dotnet_tools.json
+++ b/nuget/spec/fixtures/github/contents_dotnet_dotnet_tools.json
@@ -1,0 +1,18 @@
+{
+  "name": ".config/dotnet-tools.json",
+  "path": ".config/dotnet-tools.json",
+  "sha": "b353132ecf9b4ee712f5527319f3c6c59a581578",
+  "size": 1367,
+  "url": "https://api.github.com/repos/fsharp/fsharp/contents/.config/dotnet-tools.json?ref=master",
+  "html_url": "https://github.com/fsharp/fsharp/blob/master/.config/dotnet-tools.json",
+  "git_url": "https://api.github.com/repos/fsharp/fsharp/git/blobs/b353132ecf9b4ee712f5527319f3c6c59a581578",
+  "download_url": "https://raw.githubusercontent.com/fsharp/fsharp/master/.config/dotnet-tools.json",
+  "type": "file",
+  "content": "ewogICJ2ZXJzaW9uIjogMSwKICAiaXNSb290IjogdHJ1ZSwKICAidG9vbHMiOiB7CiAgICAiYm90c2F5IjogewogICAgICAidmVyc2lvbiI6ICIxLjAuMCIsCiAgICAgICJjb21tYW5kcyI6IFsKICAgICAgICAiYm90c2F5IgogICAgICBdCiAgICB9LAogICAgImRvdG5ldHNheSI6IHsKICAgICAgInZlcnNpb24iOiAiMi4xLjMiLAogICAgICAiY29tbWFuZHMiOiBbCiAgICAgICAgImRvdG5ldHNheSIKICAgICAgXQogICAgfQogIH0KfQo=",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/fsharp/fsharp/contents/.config/dotnet-tools.json?ref=master",
+    "git": "https://api.github.com/repos/fsharp/fsharp/git/blobs/b353132ecf9b4ee712f5527319f3c6c59a581578",
+    "html": "https://github.com/fsharp/fsharp/blob/master/.config/dotnet-tools.json"
+  }
+}

--- a/nuget/spec/fixtures/github/contents_dotnet_global.json
+++ b/nuget/spec/fixtures/github/contents_dotnet_global.json
@@ -1,0 +1,18 @@
+{
+  "name": "global.json",
+  "path": "global.json",
+  "sha": "b353132ecf9b4ee712f5527319f3c6c59a581578",
+  "size": 1367,
+  "url": "https://api.github.com/repos/fsharp/fsharp/contents/global.json?ref=master",
+  "html_url": "https://github.com/fsharp/fsharp/blob/master/global.json",
+  "git_url": "https://api.github.com/repos/fsharp/fsharp/git/blobs/b353132ecf9b4ee712f5527319f3c6c59a581578",
+  "download_url": "https://raw.githubusercontent.com/fsharp/fsharp/master/global.json",
+  "type": "file",
+  "content": "ewogICJzZGsiOiB7CiAgICAidmVyc2lvbiI6ICIyLjIuMTA0IgogIH0sCiAgIm1zYnVpbGQtc2RrcyI6IHsKICAgICJNaWNyb3NvZnQuQnVpbGQuVHJhdmVyc2FsIjogIjEuMC40NSIKICB9Cn0K",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/fsharp/fsharp/contents/global.json?ref=master",
+    "git": "https://api.github.com/repos/fsharp/fsharp/git/blobs/b353132ecf9b4ee712f5527319f3c6c59a581578",
+    "html": "https://github.com/fsharp/fsharp/blob/master/global.json"
+  }
+}


### PR DESCRIPTION
Local dotnet tools such as [`dotnet-ef`](https://learn.microsoft.com/en-us/ef/core/cli/dotnet) are distributed [as NuGet packages](https://www.nuget.org/packages/dotnet-ef/). The tools and their versions are stored in `.config/dotnet-tools.json` as decribed in the [docs](https://learn.microsoft.com/en-us/dotnet/core/tools/local-tools-how-to-use).

This PR adds support for updating them using the existing infrastructure for NuGet. Basically similar to the support for `global.json` but works around directory nesting and multiline regex match for the JSON.

Fixes: #1697 