### PR TITLE
Replace ruby-debug-ide with debug gem

### DIFF
--- a/.devcontainer/core-dev/devcontainer.json
+++ b/.devcontainer/core-dev/devcontainer.json
@@ -127,6 +127,7 @@
     "LoranKloeze.ruby-rubocop-revived",
     "groksrc.ruby",
     "hoovercj.ruby-linter",
-    "miguel-savignano.ruby-symbols"
+    "miguel-savignano.ruby-symbols",
+    "koichisasada.vscode-rdbg"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
 	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
 	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
 		"rebornix.ruby",
@@ -10,9 +9,9 @@
 		"groksrc.ruby",
 		"hoovercj.ruby-linter",
 		"miguel-savignano.ruby-symbols",
-		"ms-vscode-remote.remote-containers"
+		"ms-vscode-remote.remote-containers",
+		"koichisasada.vscode-rdbg"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-	"unwantedRecommendations": [
-	]
+	"unwantedRecommendations": []
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,9 +6,9 @@
   "configurations": [
     {
       "name": "Debug dry run",
-      "type": "Ruby",
+      "type": "rdbg",
       "request": "launch",
-      "program": "${workspaceRoot}/bin/dry-run.rb",
+      "script": "${workspaceRoot}/bin/dry-run.rb",
       "cwd": "${workspaceRoot}",
       "useBundler": true,
       "args": [
@@ -18,12 +18,19 @@
     },
     {
       "name": "Debug Tests",
-      "type": "Ruby",
+      "type": "rdbg",
       "request": "launch",
-      "program": "${workspaceRoot}/omnibus/.bundle/bin/rspec",
+      "script": "${workspaceRoot}/omnibus/.bundle/bin/rspec",
       "cwd": "${workspaceRoot}/${input:ecosystem}",
       "useBundler": true,
-      "args": ["${input:test_path}"],
+      "args": [
+        "${input:test_path}"
+      ],
+    },
+    {
+      "type": "rdbg",
+      "name": "Attach with rdbg",
+      "request": "attach"
     },
     {
       "type": "node",

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -21,8 +21,8 @@ gemspec path: "../python"
 gemspec path: "../terraform"
 
 # Visual Studio Code integration
+gem "debug", group: :development
 gem "reek", group: :development
-gem "ruby-debug-ide", group: :development
 gem "solargraph", group: :development
 
 gemspec

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -21,7 +21,6 @@ gemspec path: "../python"
 gemspec path: "../terraform"
 
 # Visual Studio Code integration
-gem "debug", group: :development
 gem "reek", group: :development
 gem "solargraph", group: :development
 


### PR DESCRIPTION
Addresses Issues 7027 and 7017 ( Fixes #7027 )  updates outdated gem ruby-debug-ide and updates .devcontainer/core-dev and .vscode/launch.json

Follow on PRs will address outdated extension for rubocop