### PR TITLE
Fix Python CI

### DIFF
--- a/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pipfile_file_updater_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PipfileFileUpdater do
           expect(updated_files.map(&:name)).to eq(%w(Pipfile Pipfile.lock))
 
           expect(json_lockfile["default"]["raven"]["version"]).to eq("==6.7.0")
-          expect(json_lockfile["default"]["blinker"]["version"]).to eq("==1.6")
+          expect(json_lockfile["default"]["blinker"]).to have_key("version")
         end
       end
 


### PR DESCRIPTION
We've need to update this spec twice so far, and will have to keep doing this every time blinker releases new versions.

I fixed the spec permanently this time by only checking for presence of the dependency. 