### PR TITLE
Update abandoned misogi ruby-rubocop

### DIFF
--- a/.devcontainer/core-dev/devcontainer.json
+++ b/.devcontainer/core-dev/devcontainer.json
@@ -124,7 +124,7 @@
   "extensions": [
     "rebornix.ruby",
     "castwide.solargraph",
-    "misogi.ruby-rubocop",
+    "LoranKloeze.ruby-rubocop-revived",
     "groksrc.ruby",
     "hoovercj.ruby-linter",
     "miguel-savignano.ruby-symbols"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,7 @@
 	"recommendations": [
 		"rebornix.ruby",
 		"castwide.solargraph",
-		"misogi.ruby-rubocop",
+		"LoranKloeze.ruby-rubocop-revived",
 		"groksrc.ruby",
 		"hoovercj.ruby-linter",
 		"miguel-savignano.ruby-symbols",


### PR DESCRIPTION
Fixes #7017 by replacing "misgogi-ruby-rubcop" with "LoranKloeze.ruby-rubocop-revived"