### PR TITLE
Update Bundler to 2.4.11

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -93,7 +93,7 @@ COPY --from=ruby:3.1.4 --chown=dependabot:dependabot /usr/local /usr/local
 # When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
 # Generally simplest to match the bundler version to the one that comes by default with whatever Ruby version we install.
 # This way other projects that import this library don't have to futz around with installing new / unexpected bundler versions.
-ARG BUNDLER_V2_VERSION=2.4.10
+ARG BUNDLER_V2_VERSION=2.4.11
 
 RUN gem install bundler -v $BUNDLER_V2_VERSION --no-document && \
  rm -rf /var/lib/gems/*/cache/* && \

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -318,4 +318,4 @@ DEPENDENCIES
   webmock (~> 3.18)
 
 BUNDLED WITH
-   2.4.10
+   2.4.11


### PR DESCRIPTION
There's [a change](https://github.com/rubygems/rubygems/pull/6578) in 2.4.11 that may prevent Dependabot from timing out when trying to update big Gemfiles.