### PR TITLE
Allow updating gemspecs loaded from a Gemfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,6 @@ updates:
     schedule:
       interval: "weekly"
 
-  # No ecosystem folders are watched because they roll up to the omnibus watcher
-  - package-ecosystem: "bundler"
-    directory: "/omnibus"
-    schedule:
-      interval: "weekly"
-
   # Watch the per-ecosystem native helpers
   - package-ecosystem: "composer"
     directory: "/composer/helpers/v1"

--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -142,7 +142,7 @@ module Dependabot
 
         raise Dependabot::PathDependenciesNotReachable, unfetchable_gems if unfetchable_gems.any?
 
-        gemspec_files.tap { |ar| ar.each { |f| f.support_file = true } }
+        gemspec_files
       end
 
       def path_gemspec_paths

--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -297,8 +297,7 @@ module Dependabot
       def gemspecs
         # Path gemspecs are excluded (they're supporting files)
         @gemspecs ||= prepared_dependency_files.
-                      select { |file| file.name.end_with?(".gemspec") }.
-                      reject(&:support_file?)
+                      select { |file| file.name.end_with?(".gemspec") }
       end
 
       def imported_ruby_files

--- a/bundler/lib/dependabot/bundler/file_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater.rb
@@ -159,8 +159,7 @@ module Dependabot
 
       def top_level_gemspecs
         dependency_files.
-          select { |file| file.name.end_with?(".gemspec") }.
-          reject(&:support_file?)
+          select { |file| file.name.end_with?(".gemspec") }
       end
 
       def bundler_version

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -146,8 +146,7 @@ module Dependabot
 
         def top_level_gemspecs
           dependency_files.
-            select { |file| file.name.end_with?(".gemspec") }.
-            reject(&:support_file?)
+            select { |file| file.name.end_with?(".gemspec") }
         end
 
         def ruby_version_file

--- a/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
@@ -143,8 +143,7 @@ module Dependabot
 
         def top_level_gemspecs
           dependency_files.
-            select { |f| f.name.end_with?(".gemspec") }.
-            reject(&:support_file?)
+            select { |f| f.name.end_with?(".gemspec") }
         end
 
         def ruby_version_file

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -377,10 +377,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
 
     context "with a path-based dependency" do
       let(:dependency_files) do
-        bundler_project_dependency_files("path_source").tap do |files|
-          gemspec = files.find { |f| f.name == "plugins/example/example.gemspec" }
-          gemspec.support_file = true
-        end
+        bundler_project_dependency_files("path_source")
       end
 
       let(:expected_requirements) do
@@ -392,7 +389,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
         }]
       end
 
-      its(:length) { is_expected.to eq(4) }
+      its(:length) { is_expected.to eq(15) }
 
       it "does not include the path dependency" do
         expect(dependencies.map(&:name)).to_not include("example")

--- a/bundler/spec/dependabot/bundler/update_checker/file_preparer_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/file_preparer_spec.rb
@@ -287,15 +287,12 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::FilePreparer do
 
     describe "the updated path gemspec" do
       let(:dependency_files) do
-        bundler_project_dependency_files("nested_gemspec").tap do |files|
-          file = files.find { |f| f.name == "some/example.gemspec" }
-          file.support_file = true
-        end
+        bundler_project_dependency_files("nested_gemspec")
       end
       subject { prepared_dependency_files.find { |f| f.name == "some/example.gemspec" } }
       let(:version) { "1.4.3" }
 
-      its(:content) { is_expected.to include(%("business", "~> 1.0")) }
+      its(:content) { is_expected.to include(%("business", ">= 1.4.3")) }
 
       context "when the file requires sanitizing" do
         subject { prepared_dependency_files.find { |f| f.name == "example.gemspec" } }


### PR DESCRIPTION
This patch would need careful consideration since I guess there was a reason to forbid this in the first place.

But it makes Dependabot generate correct PRs for our development dependencies in /common.

Without this PR:

```
$ bin/dry-run.rb bundler dependabot/dependabot-core --dir /updater --dep rubocop-performance 
=> fetching dependency files
=> dumping fetched dependency files: ./dry-run/dependabot/dependabot-core/updater
=> parsing dependency files
=> updating 1 dependencies: rubocop-performance

=== rubocop-performance (1.16.0)
 => checking for updates 1/1
🌍 --> GET https://rubygems.org/api/v1/versions/rubocop-performance.json
🌍 <-- 200 https://rubygems.org/api/v1/versions/rubocop-performance.json
 => latest available version is 1.17.1
 => latest allowed version is 1.16.0
 => requirements to unlock: update_not_possible
 => requirements update strategy: bump_versions
    (no update possible 🙅‍♀️)
🌍 Total requests made: '1'
🎈 Package manager version log: {:ecosystem=>"bundler", :package_managers=>{"bundler"=>"2"}}
```

With this PR:

```
$ bin/dry-run.rb bundler dependabot/dependabot-core --dir /updater --dep rubocop-performance 
=> fetching dependency files
=> dumping fetched dependency files: ./dry-run/dependabot/dependabot-core/updater
=> parsing dependency files
=> updating 1 dependencies: rubocop-performance

=== rubocop-performance (1.16.0)
 => checking for updates 1/1
🌍 --> GET https://rubygems.org/api/v1/versions/rubocop-performance.json
🌍 <-- 200 https://rubygems.org/api/v1/versions/rubocop-performance.json
 => latest available version is 1.17.1
 => latest allowed version is 1.17.1
 => requirements to unlock: own
 => requirements update strategy: bump_versions
🌍 --> GET https://rubygems.org/api/v1/gems/rubocop-performance.json
🌍 <-- 200 https://rubygems.org/api/v1/gems/rubocop-performance.json
🌍 --> GET https://github.com/rubocop/rubocop-performance.git/info/refs?service=git-upload-pack
🌍 <-- 200 https://github.com/rubocop/rubocop-performance.git/info/refs?service=git-upload-pack
 => bump rubocop-performance from 1.16.0 to 1.17.1 in /updater

    ± Gemfile.lock
    ~~~
    --- /tmp/original20230411-111-w7po7c	2023-04-11 13:13:21.064695014 +0000
    +++ /tmp/updated20230411-111-h7mc7	2023-04-11 13:13:21.064695014 +0000
    @@ -213,7 +213,7 @@
           sawyer (~> 0.9)
         parallel (1.22.1)
         parseconfig (1.0.8)
    -    parser (3.2.1.0)
    +    parser (3.2.2.0)
           ast (~> 2.4.1)
         pathname-common_prefix (0.0.1)
         public_suffix (5.0.1)
    @@ -254,9 +254,9 @@
           rubocop-ast (>= 1.26.0, < 2.0)
           ruby-progressbar (~> 1.7)
           unicode-display_width (>= 2.4.0, < 3.0)
    -    rubocop-ast (1.27.0)
    +    rubocop-ast (1.28.0)
           parser (>= 3.2.1.0)
    -    rubocop-performance (1.16.0)
    +    rubocop-performance (1.17.1)
           rubocop (>= 1.7.0, < 2.0)
           rubocop-ast (>= 0.4.0)
         ruby-progressbar (1.13.0)
    @@ -311,7 +311,7 @@
       octokit (= 6.1.1)
       rspec (~> 3.12)
       rubocop (~> 1.48.0)
    -  rubocop-performance (~> 1.16.0)
    +  rubocop-performance (~> 1.17.1)
       sentry-raven (~> 3.1)
       terminal-table (~> 3.0.2)
       vcr (~> 6.1)
    ~~~
    5 insertions (+), 5 deletions (-)

    ± ../common/dependabot-common.gemspec
    ~~~
    --- /tmp/original20230411-111-ap6icn	2023-04-11 13:13:21.066695014 +0000
    +++ /tmp/updated20230411-111-hn873o	2023-04-11 13:13:21.067695014 +0000
    @@ -47,7 +47,7 @@
       spec.add_development_dependency "rspec", "~> 3.12"
       spec.add_development_dependency "rspec-its", "~> 1.3"
       spec.add_development_dependency "rubocop", "~> 1.48.0"
    -  spec.add_development_dependency "rubocop-performance", "~> 1.16.0"
    +  spec.add_development_dependency "rubocop-performance", "~> 1.17.1"
       spec.add_development_dependency "simplecov", "~> 0.22.0"
       spec.add_development_dependency "simplecov-console", "~> 0.9.1"
       spec.add_development_dependency "stackprof", "~> 0.2.16"
    ~~~
    2 insertions (+), 2 deletions (-)
🌍 Total requests made: '3'
🎈 Package manager version log: {:ecosystem=>"bundler", :package_managers=>{"bundler"=>"2"}}
```

Note that we currently run these updates [in `/omnibus`](https://github.com/dependabot/dependabot-core/pull/7037) but they don't include updates to the lockfile in `updater/`