### PR TITLE
avoid rebuilding native code on common/updater code changes

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -103,10 +103,7 @@ RUN gem install bundler -v $BUNDLER_V2_VERSION --no-document && \
  bundle install && \
  rm -rf ~/.bundle
 
-# Add project after bundle install to avoid re-installing gems when only the project code changes
 COPY --chown=dependabot:dependabot LICENSE $DEPENDABOT_HOME
-COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
-COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 
 ENV PATH="$DEPENDABOT_HOME/bin:$PATH"
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"

--- a/bundler/Dockerfile
+++ b/bundler/Dockerfile
@@ -6,4 +6,6 @@ COPY --chown=dependabot:dependabot bundler/helpers /opt/bundler/helpers
 RUN bash /opt/bundler/helpers/v1/build \
   && bash /opt/bundler/helpers/v2/build
 
-COPY --chown=dependabot:dependabot bundler /home/dependabot/bundler
+COPY --chown=dependabot:dependabot bundler $DEPENDABOT_HOME/bundler
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/cargo/Dockerfile
+++ b/cargo/Dockerfile
@@ -15,4 +15,6 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.68.2 --pr
 # Configure cargo to use Git CLI so the Git shim works
 RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo/config.toml
 
-COPY --chown=dependabot:dependabot cargo /home/dependabot/cargo
+COPY --chown=dependabot:dependabot cargo $DEPENDABOT_HOME/cargo
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -3,3 +3,6 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 # This isn't a real ecosystem, adding it to make CI work easily.
 # If you don't like this, it might be a good idea to move
 # Dockerfile.updater-core in here instead, or refactor CI.
+
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/composer/Dockerfile
+++ b/composer/Dockerfile
@@ -54,5 +54,8 @@ RUN mkdir /tmp/composer-cache \
 
 COPY --chown=dependabot:dependabot composer/helpers /opt/composer/helpers
 RUN bash /opt/composer/helpers/v1/build \
-  && bash /opt/composer/helpers/v2/build
-COPY --chown=dependabot:dependabot composer /home/dependabot/composer
+  && bash /opt/composer/helpers/v2/build \
+
+COPY --chown=dependabot:dependabot composer $DEPENDABOT_HOME/composer
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,4 +17,6 @@ RUN cd /tmp \
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot docker /home/dependabot/docker
+COPY --chown=dependabot:dependabot docker $DEPENDABOT_HOME/docker
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/elm/Dockerfile
+++ b/elm/Dockerfile
@@ -13,4 +13,6 @@ RUN [ "$TARGETARCH" != "amd64" ] \
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot elm /home/dependabot/elm
+COPY --chown=dependabot:dependabot elm $DEPENDABOT_HOME/elm
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/git_submodules/Dockerfile
+++ b/git_submodules/Dockerfile
@@ -2,4 +2,6 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot git_submodules /home/dependabot/git_submodules
+COPY --chown=dependabot:dependabot git_submodules $DEPENDABOT_HOME/git_submodules
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/github_actions/Dockerfile
+++ b/github_actions/Dockerfile
@@ -2,4 +2,6 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot github_actions /home/dependabot/github_actions
+COPY --chown=dependabot:dependabot github_actions $DEPENDABOT_HOME/github_actions
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/go_modules/Dockerfile
+++ b/go_modules/Dockerfile
@@ -23,4 +23,6 @@ COPY go_modules/helpers /opt/go_modules/helpers
 RUN bash /opt/go_modules/helpers/build
 
 USER dependabot
-COPY --chown=dependabot:dependabot go_modules /home/dependabot/go_modules
+COPY --chown=dependabot:dependabot go_modules $DEPENDABOT_HOME/go_modules
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -2,5 +2,7 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot maven /home/dependabot/maven
-COPY --chown=dependabot:dependabot gradle /home/dependabot/gradle
+COPY --chown=dependabot:dependabot maven $DEPENDABOT_HOME/maven
+COPY --chown=dependabot:dependabot gradle $DEPENDABOT_HOME/gradle
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -28,4 +28,6 @@ ENV MIX_HOME="/opt/hex/mix"
 ENV HEX_VERSION="1.0.1"
 RUN bash /opt/hex/helpers/build
 
-COPY --chown=dependabot:dependabot hex /home/dependabot/hex
+COPY --chown=dependabot:dependabot hex $DEPENDABOT_HOME/hex
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -1,4 +1,6 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER dependabot
-COPY --chown=dependabot:dependabot maven /home/dependabot/maven
+COPY --chown=dependabot:dependabot maven $DEPENDABOT_HOME/maven
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -38,4 +38,6 @@ ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 # Our native helpers pull in yarn 1, so we need to reset the version globally
 RUN corepack prepare yarn@$YARN_VERSION --activate
 
-COPY --chown=dependabot:dependabot npm_and_yarn ${DEPENDABOT_HOME}/npm_and_yarn
+COPY --chown=dependabot:dependabot npm_and_yarn $DEPENDABOT_HOME/npm_and_yarn
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -2,4 +2,6 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 
 USER dependabot
 
-COPY --chown=dependabot:dependabot nuget /home/dependabot/nuget
+COPY --chown=dependabot:dependabot nuget $DEPENDABOT_HOME/nuget
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -131,4 +131,7 @@ COPY --from=python-3.10 /usr/local/.pyenv/3.10.tar.gz /usr/local/.pyenv/3.10.tar
 COPY --from=python-3.9 /usr/local/.pyenv/3.9.tar.gz /usr/local/.pyenv/3.9.tar.gz
 COPY --from=python-3.8 /usr/local/.pyenv/3.8.tar.gz /usr/local/.pyenv/3.8.tar.gz
 COPY --from=python-3.7 /usr/local/.pyenv/3.7.tar.gz /usr/local/.pyenv/3.7.tar.gz
-COPY --chown=dependabot:dependabot python /home/dependabot/python
+
+COPY --chown=dependabot:dependabot python $DEPENDABOT_HOME/python
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -13,4 +13,6 @@ USER dependabot
 COPY --chown=dependabot:dependabot terraform/helpers /opt/terraform/helpers
 RUN bash /opt/terraform/helpers/build
 
-COPY --chown=dependabot:dependabot terraform /home/dependabot/terraform
+COPY --chown=dependabot:dependabot terraform $DEPENDABOT_HOME/terraform
+COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common
+COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater


### PR DESCRIPTION
When we modify code in common/ or updater/ it would rebuild all of the native code too, including Python which takes a long time. 

This change moves the copying of the code into each of the ecosystem-specific Dockerfiles, so it should avoid those rebuilds more often. 

The downside is a bit of duplication. 