### PR TITLE
chore(ee): ignore `.idea` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ coverage/
 .tool-versions
 .rspec_status
 .rdbg_history
+# Ignore Jetbrains IntelliJ project-config directory
+.idea/


### PR DESCRIPTION
I use [IDEA products ](https://www.jetbrains.com/products/) , and I would appreciate if this is merged as currently I need to ensure that I don't commit it accidentally with each pull request

Creating a separate pull request for this as suggested by this comment: 

https://github.com/dependabot/dependabot-core/pull/7029#discussion_r1163093575

Thanks! 