### PR TITLE
cargo: Fix sparse registry error on update

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -32,7 +32,7 @@ module Dependabot
             SharedHelpers.with_git_configured(credentials: credentials) do
               # Shell out to Cargo, which handles everything for us, and does
               # so without doing an install (so it's fast).
-              run_shell_command("cargo update -p #{dependency_spec}", fingerprint: "cargo update -p <dependency_spec>")
+              run_shell_command("cargo -Z sparse-registry update -p #{dependency_spec}", fingerprint: "cargo update -p <dependency_spec>")
             end
 
             updated_lockfile = File.read("Cargo.lock")

--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -6,6 +6,7 @@ require "dependabot/git_commit_checker"
 require "dependabot/cargo/file_updater"
 require "dependabot/cargo/file_updater/manifest_updater"
 require "dependabot/cargo/file_parser"
+require "dependabot/cargo/toolchain_parser"
 require "dependabot/shared_helpers"
 module Dependabot
   module Cargo
@@ -32,7 +33,7 @@ module Dependabot
             SharedHelpers.with_git_configured(credentials: credentials) do
               # Shell out to Cargo, which handles everything for us, and does
               # so without doing an install (so it's fast).
-              run_shell_command("cargo -Z sparse-registry update -p #{dependency_spec}", fingerprint: "cargo update -p <dependency_spec>")
+              run_shell_command("cargo #{toolchain_parser.sparse_flag} update -p #{dependency_spec}", fingerprint: "cargo update -p <dependency_spec>")
             end
 
             updated_lockfile = File.read("Cargo.lock")
@@ -367,6 +368,10 @@ module Dependabot
         def toolchain
           @toolchain ||=
             dependency_files.find { |f| f.name == "rust-toolchain" }
+        end
+
+        def toolchain_parser
+          @toolchain_parser ||= Cargo::ToolchainParser.new(toolchain)
         end
 
         def virtual_manifest?(file)

--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -33,7 +33,8 @@ module Dependabot
             SharedHelpers.with_git_configured(credentials: credentials) do
               # Shell out to Cargo, which handles everything for us, and does
               # so without doing an install (so it's fast).
-              run_shell_command("cargo #{toolchain_parser.sparse_flag} update -p #{dependency_spec}", fingerprint: "cargo update -p <dependency_spec>")
+              run_shell_command("cargo #{toolchain_parser.sparse_flag} update -p #{dependency_spec}",
+                                fingerprint: "cargo update -p <dependency_spec>")
             end
 
             updated_lockfile = File.read("Cargo.lock")

--- a/cargo/lib/dependabot/cargo/toolchain_parser.rb
+++ b/cargo/lib/dependabot/cargo/toolchain_parser.rb
@@ -1,0 +1,33 @@
+require "toml-rb"
+
+module Dependabot
+  module Cargo
+    class ToolchainParser
+      def initialize(toolchain)
+        @toolchain = toolchain
+      end
+
+      def sparse_flag
+        return @sparse_flag if defined?(@sparse_flag)
+
+        @sparse_flag = needs_sparse_flag ? "-Z sparse-registry" : ""
+      end
+
+      private
+
+      attr_reader :toolchain
+
+      def needs_sparse_flag
+        return false unless toolchain
+
+        channel = TomlRB.parse(toolchain.content).fetch("toolchain", nil)&.fetch("channel", nil)
+        return false unless channel
+
+        date = channel.match(/nightly-(\d{4}-\d{2}-\d{2})/)&.captures&.first
+        return false unless date
+
+        Date.parse(date) < Date.parse("2023-01-20")
+      end
+    end
+  end
+end

--- a/cargo/lib/dependabot/cargo/toolchain_parser.rb
+++ b/cargo/lib/dependabot/cargo/toolchain_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "toml-rb"
 
 module Dependabot
@@ -17,6 +19,7 @@ module Dependabot
 
       attr_reader :toolchain
 
+      # We only need to set the -Z sparse-registry flag for nightly toolchains between 2023-01-20 and
       def needs_sparse_flag
         return false unless toolchain
 
@@ -26,7 +29,7 @@ module Dependabot
         date = channel.match(/nightly-(\d{4}-\d{2}-\d{2})/)&.captures&.first
         return false unless date
 
-        Date.parse(date) < Date.parse("2023-01-20")
+        Date.parse(date).between?(Date.parse("2022-07-10"), Date.parse("2023-01-20"))
       end
     end
   end

--- a/cargo/lib/dependabot/cargo/toolchain_parser.rb
+++ b/cargo/lib/dependabot/cargo/toolchain_parser.rb
@@ -19,7 +19,8 @@ module Dependabot
 
       attr_reader :toolchain
 
-      # We only need to set the -Z sparse-registry flag for nightly toolchains between 2023-01-20 and
+      # We only need to set the -Z sparse-registry flag for nightly and unstable toolchains
+      # during which the feature exists and is reading the environment variable CARGO_REGISTRIES_CRATES_IO_PROTOCOL.
       def needs_sparse_flag
         return false unless toolchain
 

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -134,7 +134,7 @@ module Dependabot
         # so without doing an install (so it's fast).
         def run_cargo_update_command
           run_cargo_command(
-            "cargo update -p #{dependency_spec} --verbose",
+            "cargo -Z sparse-registry update -p #{dependency_spec} --verbose",
             fingerprint: "cargo update -p <dependency_spec> --verbose"
           )
         end

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -6,7 +6,9 @@ require "dependabot/shared_helpers"
 require "dependabot/cargo/update_checker"
 require "dependabot/cargo/file_parser"
 require "dependabot/cargo/version"
+require "dependabot/cargo/toolchain_parser"
 require "dependabot/errors"
+
 module Dependabot
   module Cargo
     class UpdateChecker
@@ -134,7 +136,7 @@ module Dependabot
         # so without doing an install (so it's fast).
         def run_cargo_update_command
           run_cargo_command(
-            "cargo -Z sparse-registry update -p #{dependency_spec} --verbose",
+            "cargo #{toolchain_parser.sparse_flag} update -p #{dependency_spec} --verbose",
             fingerprint: "cargo update -p <dependency_spec> --verbose"
           )
         end
@@ -405,6 +407,10 @@ module Dependabot
         def toolchain
           @toolchain ||= prepared_dependency_files.
                          find { |f| f.name == "rust-toolchain" }
+        end
+
+        def toolchain_parser
+          @toolchain_parser ||= Cargo::ToolchainParser.new(toolchain)
         end
 
         def git_dependency?

--- a/cargo/spec/dependabot/cargo/toolchain_parser_spec.rb
+++ b/cargo/spec/dependabot/cargo/toolchain_parser_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "dependabot/dependency_file"
+require "dependabot/cargo/toolchain_parser"
+
+RSpec.describe Dependabot::Cargo::ToolchainParser do
+  it "returns sparse-registry for nightlies in a certain range" do
+    toolchain = Dependabot::DependencyFile.new(
+      name: "rust-toolchain",
+      content: "[toolchain]\nchannel = \"nightly-2022-07-10\""
+    )
+    expect(described_class.new(toolchain).sparse_flag).to eq("-Z sparse-registry")
+  end
+
+  it "doesn't return sparse-registry for stable" do
+    toolchain = Dependabot::DependencyFile.new(
+      name: "rust-toolchain",
+      content: "[toolchain]\nchannel = \"stable\""
+    )
+    expect(described_class.new(toolchain).sparse_flag).to eq("")
+  end
+
+  it "doesn't return sparse-registry when no toolchain file" do
+    expect(described_class.new(nil).sparse_flag).to eq("")
+  end
+
+  it "doesn't return sparse-registry for nightlies outside the range" do
+    toolchain = Dependabot::DependencyFile.new(
+      name: "rust-toolchain",
+      content: "[toolchain]\nchannel = \"nightly-2023-01-21\""
+    )
+    expect(described_class.new(toolchain).sparse_flag).to eq("")
+  end
+
+  it "doesn't return sparse-registry when the channel isn't specified" do
+    toolchain = Dependabot::DependencyFile.new(
+      name: "rust-toolchain",
+      content: "[toolchain]"
+    )
+    expect(described_class.new(toolchain).sparse_flag).to eq("")
+  end
+end


### PR DESCRIPTION
We're seeing some errors like this:

```
error: failed to get `arrow` as a dependency of package `geoengine-datatypes v0.7.0 (/home/dependabot/dependabot-updater/dependabot_tmp_dir/datatypes)`
 
Caused by: 
 failed to load source for dependency `arrow`
 
Caused by:
 Unable to update registry `crates-io`
 
Caused by:
  usage of sparse registries requires `-Z sparse-registry`
```

This is due to the sparse registry we enabled in https://github.com/dependabot/dependabot-core/pull/6995. It seems this setting is required for the update to work as well as the environment variable.