### PR TITLE
Improve some exception error messages

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -98,7 +98,7 @@ module Dependabot
 
     def initialize(file_path, msg = nil)
       @file_path = file_path
-      super(msg)
+      super(msg || "#{file_path} not parseable")
     end
 
     def file_name

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -80,7 +80,7 @@ module Dependabot
 
     def initialize(file_path, msg = nil)
       @file_path = file_path
-      super("#{file_path} not found" || msg)
+      super(msg || "#{file_path} not found")
     end
 
     def file_name


### PR DESCRIPTION
Amends 086274e3a4d8f476a1b95a96de2ce9d10515a590, which did not really fix the problem for `Dependabot::DependencyFileNotFound`, and applies the same improvement for `Dependabot::DependencyFileNotParseable`.