### PR TITLE
cargo: support rust-toolchain with toml extension

### DIFF
--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -287,6 +287,14 @@ module Dependabot
       def rust_toolchain
         @rust_toolchain ||= fetch_file_if_present("rust-toolchain")&.
                             tap { |f| f.support_file = true }
+        return @rust_toolchain if @rust_toolchain
+
+        # Per https://rust-lang.github.io/rustup/overrides.html the file can
+        # have a `.toml` extension, but the non-extension version is preferred.
+        # Renaming here to simplify finding it later in the code.
+        @rust_toolchain ||= fetch_file_if_present("rust-toolchain.toml")&.
+                            tap { |f| f.support_file = true }&.
+                            tap { |f| f.name = "rust-toolchain" }
       end
     end
   end

--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -285,9 +285,10 @@ module Dependabot
       end
 
       def rust_toolchain
-        @rust_toolchain ||= fetch_file_if_present("rust-toolchain")&.
+        return @rust_toolchain if defined?(@rust_toolchain)
+
+        @rust_toolchain = fetch_file_if_present("rust-toolchain")&.
                             tap { |f| f.support_file = true }
-        return @rust_toolchain if @rust_toolchain
 
         # Per https://rust-lang.github.io/rustup/overrides.html the file can
         # have a `.toml` extension, but the non-extension version is preferred.

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -109,6 +109,31 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
     end
   end
 
+  context "with a rust-toolchain.toml file" do
+    before do
+      stub_request(:get, url + "?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "contents_cargo_with_toolchain.json").gsub(/rust-toolchain/, "rust-toolchain.toml"),
+          headers: json_header
+        )
+
+      stub_request(:get, url + "rust-toolchain.toml?ref=sha").
+        with(headers: { "Authorization" => "token token" }).
+        to_return(
+          status: 200,
+          body: fixture("github", "contents_cargo_lockfile.json"),
+          headers: json_header
+        )
+    end
+
+    it "fetches the Cargo.toml and rust-toolchain" do
+      expect(file_fetcher_instance.files.map(&:name)).
+        to match_array(%w(Cargo.toml rust-toolchain))
+    end
+  end
+
   context "with a path dependency" do
     before do
       stub_request(:get, url + "?ref=sha").


### PR DESCRIPTION
Fixes #4915

Per https://rust-lang.github.io/rustup/overrides.html the rust-toolchain file can have a `.toml` extension, but the non-extension version is preferred. So I've added a second lookup for the extensioned file.
