### PR TITLE
Fix gradle file fetcher when included build is in submodule

### DIFF
--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -41,7 +41,13 @@ module Dependabot
         files += subproject_buildfiles(root_dir)
         files += dependency_script_plugins(root_dir)
         files + included_builds(root_dir).
-                flat_map { |dir| all_buildfiles_in_build(dir) }
+                flat_map do |dir|
+                  all_buildfiles_in_build(dir)
+                rescue Dependabot::DependencyFileNotFound
+                  # included build can be in a submodule
+                  nil
+                end.
+                compact
       end
 
       def included_builds(root_dir)

--- a/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_fetcher_spec.rb
@@ -274,6 +274,22 @@ RSpec.describe Dependabot::Gradle::FileFetcher do
             ))
         end
       end
+
+      context "when the included build can't be found" do
+        before do
+          stub_content_request("?ref=sha", "contents_java_with_settings.json")
+          stub_content_request("settings.gradle?ref=sha", "contents_java_settings_1_included_build.json")
+          stub_content_request("build.gradle?ref=sha", "contents_java_basic_buildfile.json")
+          stub_content_request("app/build.gradle?ref=sha", "contents_java_basic_buildfile.json")
+          stub_no_content_request("included?ref=sha")
+        end
+
+        it "fetches the main buildfile" do
+          expect(file_fetcher_instance.files.count).to eq(3)
+          expect(file_fetcher_instance.files.map(&:name)).
+            to match_array(%w(build.gradle settings.gradle app/build.gradle))
+        end
+      end
     end
 
     context "only a settings.gradle" do


### PR DESCRIPTION
If gradle included build is in submodule, dependabot gives error `dependency_file_not_found` from request to `https://api.github.com:443/repos/<owner>/<repo>/contents/<submodule_path>?ref=<ref>`.

This fixes it by ignoring 404 errors from included build files (gradle subprojects already has similar ignore).