### PR TITLE
cargo: gather toolchain statistics

### DIFF
--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -20,6 +20,21 @@ module Dependabot
         "Repo must contain a Cargo.toml."
       end
 
+      def package_manager_version
+        channel = if rust_toolchain
+                    TomlRB.parse(rust_toolchain.content).fetch("toolchain", nil)&.fetch("channel", nil)
+                  else
+                    "default"
+                  end
+
+        {
+          ecosystem: "cargo",
+          package_managers: {
+            "channel" => channel
+          }
+        }
+      end
+
       private
 
       def fetch_files

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -82,6 +82,13 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
       expect(file_fetcher_instance.files.map(&:name)).
         to eq(["Cargo.toml"])
     end
+
+    it "provides the Rust channel" do
+      expect(file_fetcher_instance.package_manager_version).to eq({
+        ecosystem: "cargo",
+        package_managers: { "channel" => "default" }
+      })
+    end
   end
 
   context "with a rust-toolchain file" do
@@ -98,7 +105,7 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
         with(headers: { "Authorization" => "token token" }).
         to_return(
           status: 200,
-          body: fixture("github", "contents_cargo_lockfile.json"),
+          body: JSON.dump({ content: Base64.encode64("[toolchain]\nchannel = \"nightly-2019-01-01\"") }),
           headers: json_header
         )
     end
@@ -106,6 +113,13 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
     it "fetches the Cargo.toml and rust-toolchain" do
       expect(file_fetcher_instance.files.map(&:name)).
         to match_array(%w(Cargo.toml rust-toolchain))
+    end
+
+    it "provides the Rust channel" do
+      expect(file_fetcher_instance.package_manager_version).to eq({
+        ecosystem: "cargo",
+        package_managers: { "channel" => "nightly-2019-01-01" }
+      })
     end
   end
 
@@ -123,7 +137,7 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
         with(headers: { "Authorization" => "token token" }).
         to_return(
           status: 200,
-          body: fixture("github", "contents_cargo_lockfile.json"),
+          body: JSON.dump({ content: Base64.encode64("[toolchain]\nchannel = \"1.2.3\"") }),
           headers: json_header
         )
     end
@@ -131,6 +145,13 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
     it "fetches the Cargo.toml and rust-toolchain" do
       expect(file_fetcher_instance.files.map(&:name)).
         to match_array(%w(Cargo.toml rust-toolchain))
+    end
+
+    it "provides the Rust channel" do
+      expect(file_fetcher_instance.package_manager_version).to eq({
+        ecosystem: "cargo",
+        package_managers: { "channel" => "1.2.3" }
+      })
     end
   end
 


### PR DESCRIPTION
We want to gather info on the optional Cargo overrides file to find out how many people are using them, and what versions are commonly pinned. That will help us make decisions about what versions of the toolchain we should continue to support. 