### PR TITLE
Fix incorrect detection of top level gemspecs

### DIFF
--- a/bundler/lib/dependabot/bundler/file_parser/file_preparer.rb
+++ b/bundler/lib/dependabot/bundler/file_parser/file_preparer.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 require "dependabot/dependency_file"
-require "dependabot/bundler/file_parser"
+require "dependabot/file_parsers/base"
 require "dependabot/bundler/file_updater/gemspec_sanitizer"
 
 module Dependabot
   module Bundler
-    class FileParser
+    class FileParser < Dependabot::FileParsers::Base
       class FilePreparer
         def initialize(dependency_files:)
           @dependency_files = dependency_files

--- a/bundler/lib/dependabot/bundler/file_parser/gemfile_declaration_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_parser/gemfile_declaration_finder.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 require "parser/current"
-require "dependabot/bundler/file_parser"
+require "dependabot/file_parsers/base"
 
 module Dependabot
   module Bundler
-    class FileParser
+    class FileParser < Dependabot::FileParsers::Base
       # Checks whether a dependency is declared in a Gemfile
       class GemfileDeclarationFinder
         def initialize(gemfile:)

--- a/bundler/lib/dependabot/bundler/file_parser/gemspec_declaration_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_parser/gemspec_declaration_finder.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 require "parser/current"
+require "dependabot/file_parsers/base"
 
 module Dependabot
   module Bundler
-    class FileParser
+    class FileParser < Dependabot::FileParsers::Base
       # Checks whether a dependency is declared in a gemspec file
       class GemspecDeclarationFinder
         def initialize(gemspec:)

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -146,7 +146,7 @@ module Dependabot
 
         def top_level_gemspecs
           dependency_files.
-            select { |file| file.name.end_with?(".gemspec") }
+            select { |file| file.name.end_with?(".gemspec") && Pathname.new(file.name).dirname.to_s == "." }
         end
 
         def ruby_version_file

--- a/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
@@ -11,36 +11,39 @@ RSpec.describe Dependabot::Bundler::FileUpdater::LockfileUpdater do
   let(:updater) do
     described_class.new(
       dependencies: [dependency],
-      dependency_files: [gemspec, other_gemspec, gemfile, lockfile],
+      dependency_files: files,
       options: {},
       credentials: []
     )
   end
-  let(:gemspec) do
-    bundler_project_dependency_file("multiple_path_gems", filename: "vendor/net-imap/net-imap.gemspec")
-  end
-  let(:other_gemspec) do
-    bundler_project_dependency_file("multiple_path_gems", filename: "vendor/couchrb/couchrb.gemspec")
-  end
-  let(:gemfile) do
-    bundler_project_dependency_file("multiple_path_gems", filename: "Gemfile")
-  end
-  let(:lockfile) do
-    bundler_project_dependency_file("multiple_path_gems", filename: "Gemfile.lock")
-  end
-  let(:dependency) do
-    Dependabot::Dependency.new(
-      name: "ice_nine",
-      version: "0.11.2",
-      previous_version: "0.11.1",
-      requirements: [],
-      previous_requirements: [],
-      package_manager: "bundler"
-    )
-  end
 
-  describe "#updated_lockfile_content" do
-    let(:updated_lockfile_content) { updater.updated_lockfile_content }
+  let(:updated_lockfile_content) { updater.updated_lockfile_content }
+
+  describe "with multiple path gems" do
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "ice_nine",
+        version: "0.11.2",
+        previous_version: "0.11.1",
+        requirements: [],
+        previous_requirements: [],
+        package_manager: "bundler"
+      )
+    end
+
+    let(:files) { [gemspec, other_gemspec, gemfile, lockfile] }
+    let(:gemspec) do
+      bundler_project_dependency_file("multiple_path_gems", filename: "vendor/net-imap/net-imap.gemspec")
+    end
+    let(:other_gemspec) do
+      bundler_project_dependency_file("multiple_path_gems", filename: "vendor/couchrb/couchrb.gemspec")
+    end
+    let(:gemfile) do
+      bundler_project_dependency_file("multiple_path_gems", filename: "Gemfile")
+    end
+    let(:lockfile) do
+      bundler_project_dependency_file("multiple_path_gems", filename: "Gemfile.lock")
+    end
 
     it "upgrades dependency" do
       expect(updated_lockfile_content).to  include("ice_nine (0.11.2)")
@@ -49,6 +52,34 @@ RSpec.describe Dependabot::Bundler::FileUpdater::LockfileUpdater do
     it "keeps correct versions of path dependencies" do
       expect(updated_lockfile_content).to  include("couchrb (0.9.0)")
       expect(updated_lockfile_content).to  include("net-imap (0.3.3)")
+    end
+  end
+
+  context "when having vendored gemspecs with ruby version requirements" do
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "activesupport",
+        version: "6.0.3",
+        previous_version: "6.0.2",
+        requirements: [],
+        previous_requirements: [],
+        package_manager: "bundler"
+      )
+    end
+
+    let(:files) { [gemspec, gemfile, lockfile] }
+    let(:gemspec) do
+      bundler_project_dependency_file("path_gem_with_ruby_requirement", filename: "vendor/couchrb/couchrb.gemspec")
+    end
+    let(:gemfile) do
+      bundler_project_dependency_file("path_gem_with_ruby_requirement", filename: "Gemfile")
+    end
+    let(:lockfile) do
+      bundler_project_dependency_file("path_gem_with_ruby_requirement", filename: "Gemfile.lock")
+    end
+
+    it "upgrades dependency" do
+      expect(updated_lockfile_content).to include("activesupport (6.0.3)")
     end
   end
 end

--- a/bundler/spec/fixtures/projects/bundler1/path_gem_with_ruby_requirement/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler1/path_gem_with_ruby_requirement/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "activesupport", ">= 6.0.2" # needs ruby >= 2.5
+gem "couchrb", path: "vendor/couchrb" # needs ruby >= 1.9.3

--- a/bundler/spec/fixtures/projects/bundler1/path_gem_with_ruby_requirement/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler1/path_gem_with_ruby_requirement/Gemfile.lock
@@ -1,0 +1,34 @@
+PATH
+  remote: vendor/couchrb
+  specs:
+    couchrb (0.9.0)
+      ice_nine
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.0.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
+    concurrent-ruby (1.2.2)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    ice_nine (0.11.1)
+    minitest (5.18.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.11)
+      thread_safe (~> 0.1)
+    zeitwerk (2.6.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport (>= 6.0.2)
+  couchrb!
+
+BUNDLED WITH
+   1.17.3

--- a/bundler/spec/fixtures/projects/bundler1/path_gem_with_ruby_requirement/vendor/couchrb/couchrb.gemspec
+++ b/bundler/spec/fixtures/projects/bundler1/path_gem_with_ruby_requirement/vendor/couchrb/couchrb.gemspec
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name          = "couchrb"
+  spec.version       = "0.9.0"
+  spec.authors       = ["nicholas a. evans"]
+  spec.email         = ["<nevans@410labs.com>"]
+
+  spec.summary       = %q{CouchDB client library.}
+  spec.description   = %q{CouchRb provides a ruby-flavored interface to CouchDB.  The basic resources try to follow the CouchDB API as closely as possible, but many additional features are available.}
+  spec.homepage      = "https://github.com/410labs/couchrb"
+
+  spec.required_ruby_version = ">= 1.9.3"
+
+  spec.add_dependency "ice_nine"
+end

--- a/bundler/spec/fixtures/projects/bundler2/path_gem_with_ruby_requirement/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/path_gem_with_ruby_requirement/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "activesupport", ">= 6.0.2" # needs ruby >= 2.5
+gem "couchrb", path: "vendor/couchrb" # needs ruby >= 1.9.3

--- a/bundler/spec/fixtures/projects/bundler2/path_gem_with_ruby_requirement/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler2/path_gem_with_ruby_requirement/Gemfile.lock
@@ -1,0 +1,34 @@
+PATH
+  remote: vendor/couchrb
+  specs:
+    couchrb (0.9.0)
+      ice_nine
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.0.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
+    concurrent-ruby (1.2.2)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    ice_nine (0.11.1)
+    minitest (5.18.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.11)
+      thread_safe (~> 0.1)
+    zeitwerk (2.6.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport (>= 6.0.2)
+  couchrb!
+
+BUNDLED WITH
+   2.4.12

--- a/bundler/spec/fixtures/projects/bundler2/path_gem_with_ruby_requirement/vendor/couchrb/couchrb.gemspec
+++ b/bundler/spec/fixtures/projects/bundler2/path_gem_with_ruby_requirement/vendor/couchrb/couchrb.gemspec
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name          = "couchrb"
+  spec.version       = "0.9.0"
+  spec.authors       = ["nicholas a. evans"]
+  spec.email         = ["<nevans@410labs.com>"]
+
+  spec.summary       = %q{CouchDB client library.}
+  spec.description   = %q{CouchRb provides a ruby-flavored interface to CouchDB.  The basic resources try to follow the CouchDB API as closely as possible, but many additional features are available.}
+  spec.homepage      = "https://github.com/410labs/couchrb"
+
+  spec.required_ruby_version = ">= 1.9.3"
+
+  spec.add_dependency "ice_nine"
+end


### PR DESCRIPTION
When dealing with libraries, Dependabot sets an extra requirement on Ruby to be the lowest version supported by the gem.

However, it was also incorrectly doing so when dealing with vendored path gems, because all gemspecs were being considered when adding this extra requirement, not just the one in the top level.