### PR TITLE
Improve npm package manager instrumentation

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -121,7 +121,7 @@ module Dependabot
         if (package_manager = package.fetch("packageManager", nil))
           get_yarn_version_from_package_json(package_manager)
         elsif yarn_lock
-          1
+          Helpers.yarn_version_numeric(yarn_lock.content)
         end
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -55,6 +55,7 @@ module Dependabot
         package_managers["npm"] = Helpers.npm_version_numeric(package_lock.content) if package_lock
         package_managers["yarn"] = yarn_version if yarn_version
         package_managers["shrinkwrap"] = 1 if shrinkwrap
+        package_managers["unknown"] = 1 if package_managers.empty?
 
         {
           ecosystem: "npm",

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -16,6 +16,14 @@ module Dependabot
         6
       end
 
+      def self.yarn_version_numeric(lockfile_content)
+        if yarn_berry?(lockfile_content)
+          3
+        else
+          1
+        end
+      end
+
       def self.fetch_yarnrc_yml_value(key, default_value)
         if File.exist?(".yarnrc.yml") && (yarnrc = YAML.load_file(".yarnrc.yml"))
           yarnrc.fetch(key, default_value)


### PR DESCRIPTION
This is definitely not perfect, but I think better than what we have.

There's two improvements:

* If given a yarn Berry lockfile, we were still incorrectly instrumenting yarn 1 (unless `packageManager` set in `package.json`).
* If we can't resolve a specific package manager, we'll still run the update job and provide updates. We'll use the npm update checker but we could potentially switch to any other package manager without issues, so I think it's helpful to log separately.