### PR TITLE
use tags in error reporting

### DIFF
--- a/updater/bin/fetch_files.rb
+++ b/updater/bin/fetch_files.rb
@@ -14,8 +14,8 @@ class UpdaterKilledError < StandardError; end
 trap("TERM") do
   puts "Received SIGTERM"
   error = UpdaterKilledError.new("Updater process killed with SIGTERM")
-  extra = { update_job_id: ENV.fetch("DEPENDABOT_JOB_ID", nil) }
-  Raven.capture_exception(error, extra: extra)
+  tags = { update_job_id: ENV.fetch("DEPENDABOT_JOB_ID", nil) }
+  Raven.capture_exception(error, tags: tags)
   exit
 end
 

--- a/updater/bin/update_files.rb
+++ b/updater/bin/update_files.rb
@@ -14,8 +14,8 @@ class UpdaterKilledError < StandardError; end
 trap("TERM") do
   puts "Received SIGTERM"
   error = UpdaterKilledError.new("Updater process killed with SIGTERM")
-  extra = { update_job_id: ENV.fetch("DEPENDABOT_JOB_ID", nil) }
-  Raven.capture_exception(error, extra: extra)
+  tags = { update_job_id: ENV.fetch("DEPENDABOT_JOB_ID", nil) }
+  Raven.capture_exception(error, tags: tags)
   exit
 end
 

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -70,10 +70,10 @@ module Dependabot
         error,
         {
           tags: tags.merge({
+            update_job_id: job&.id,
             package_manager: job&.package_manager
           }.compact),
           extra: extra.merge({
-            update_job_id: job&.id,
             dependency_name: dependency&.name
           }.compact)
         }


### PR DESCRIPTION
Tags are searchable, extra is not. This improves our ability to figure out what is going wrong with a job ID.