### PR TITLE
[Updater] Grouped updates will not include ignored dependencies

### DIFF
--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -164,13 +164,13 @@ module Dependabot
         # tooling may find collaborators which need to be updated in lock-step.
         #
         # This method **must** must return an Array when it errors
-        def compile_updates_for(dependency, dependency_files)
+        #
+        def compile_updates_for(dependency, dependency_files) # rubocop:disable Metrics/MethodLength
           checker = update_checker_for(dependency, dependency_files, raise_on_ignored: raise_on_ignored?(dependency))
 
           log_checking_for_update(dependency)
 
-          # FIXME: Grouped updates currently do not interact with ignore rules
-          # return [] if all_versions_ignored?(dependency, checker)
+          return [] if all_versions_ignored?(dependency, checker)
 
           if checker.up_to_date?
             log_up_to_date(dependency)
@@ -228,7 +228,7 @@ module Dependabot
             dependency_files: dependency_files,
             repo_contents_path: job.repo_contents_path,
             credentials: job.credentials,
-            ignored_versions: [], # FIXME: Grouped updates do not honour ignore rules for now
+            ignored_versions: job.ignore_conditions_for(dependency),
             security_advisories: [], # FIXME: Version updates do not use advisory data for now
             raise_on_ignored: raise_on_ignored,
             requirements_update_strategy: job.requirements_update_strategy,
@@ -240,8 +240,7 @@ module Dependabot
           Dependabot.logger.info(
             "Checking if #{dependency.name} #{dependency.version} needs updating"
           )
-          # FIXME: Grouped updates do not honour ignore rules for now
-          # job.log_ignore_conditions_for(dependency)
+          job.log_ignore_conditions_for(dependency)
         end
 
         def all_versions_ignored?(dependency, checker)

--- a/updater/spec/fixtures/rubygems-versions-a.json
+++ b/updater/spec/fixtures/rubygems-versions-a.json
@@ -1,0 +1,59 @@
+[
+  {
+    "authors": "Dependabot",
+    "built_at": "2017-06-08T00:00:00.000Z",
+    "created_at": "2017-06-08T11:17:36.474Z",
+    "description": "",
+    "downloads_count": 3115,
+    "metadata": {},
+    "number": "1.2.0",
+    "summary": "A dummy package for testing Dependabot",
+    "platform": "ruby",
+    "rubygems_version": ">= 0",
+    "ruby_version": ">= 0",
+    "prerelease": false,
+    "licenses": [
+      "MIT"
+    ],
+    "requirements": [],
+    "sha": "51b99c7db0d39924d690e19282f63d1fba9cc002ef55a139d9b6a4b0469399a1"
+  },
+  {
+    "authors": "Dependabot",
+    "built_at": "2017-06-08T00:00:00.000Z",
+    "created_at": "2017-06-08T11:08:53.333Z",
+    "description": "",
+    "downloads_count": 1562,
+    "metadata": {},
+    "number": "1.1.0",
+    "summary": "A dummy package for testing Dependabot",
+    "platform": "ruby",
+    "rubygems_version": ">= 0",
+    "ruby_version": ">= 0",
+    "prerelease": false,
+    "licenses": [
+      "MIT"
+    ],
+    "requirements": [],
+    "sha": "c8725691239b43d5f4c343b64d30afae6dd25ff1a79cca4d80534804c638b113"
+  },
+  {
+    "authors": "Dependabot",
+    "built_at": "2017-06-08T00:00:00.000Z",
+    "created_at": "2017-06-08T11:08:20.605Z",
+    "description": "",
+    "downloads_count": 1569,
+    "metadata": {},
+    "number": "1.0.0",
+    "summary": "A dummy package for testing Dependabot",
+    "platform": "ruby",
+    "rubygems_version": ">= 0",
+    "ruby_version": ">= 0",
+    "prerelease": false,
+    "licenses": [
+      "MIT"
+    ],
+    "requirements": [],
+    "sha": "0147d64042d5ab109d185f54957fcfb88f1ff9158651944ff75c6c82d47ab444"
+  }
+]

--- a/updater/spec/fixtures/rubygems-versions-b.json
+++ b/updater/spec/fixtures/rubygems-versions-b.json
@@ -1,0 +1,59 @@
+[
+  {
+    "authors": "Dependabot",
+    "built_at": "2017-06-08T00:00:00.000Z",
+    "created_at": "2017-06-08T11:17:36.474Z",
+    "description": "",
+    "downloads_count": 3115,
+    "metadata": {},
+    "number": "1.2.0",
+    "summary": "A dummy package for testing Dependabot",
+    "platform": "ruby",
+    "rubygems_version": ">= 0",
+    "ruby_version": ">= 0",
+    "prerelease": false,
+    "licenses": [
+      "MIT"
+    ],
+    "requirements": [],
+    "sha": "51b99c7db0d39924d690e19282f63d1fba9cc002ef55a139d9b6a4b0469399a1"
+  },
+  {
+    "authors": "Dependabot",
+    "built_at": "2017-06-08T00:00:00.000Z",
+    "created_at": "2017-06-08T11:08:53.333Z",
+    "description": "",
+    "downloads_count": 1562,
+    "metadata": {},
+    "number": "1.1.0",
+    "summary": "A dummy package for testing Dependabot",
+    "platform": "ruby",
+    "rubygems_version": ">= 0",
+    "ruby_version": ">= 0",
+    "prerelease": false,
+    "licenses": [
+      "MIT"
+    ],
+    "requirements": [],
+    "sha": "c8725691239b43d5f4c343b64d30afae6dd25ff1a79cca4d80534804c638b113"
+  },
+  {
+    "authors": "Dependabot",
+    "built_at": "2017-06-08T00:00:00.000Z",
+    "created_at": "2017-06-08T11:08:20.605Z",
+    "description": "",
+    "downloads_count": 1569,
+    "metadata": {},
+    "number": "1.0.0",
+    "summary": "A dummy package for testing Dependabot",
+    "platform": "ruby",
+    "rubygems_version": ">= 0",
+    "ruby_version": ">= 0",
+    "prerelease": false,
+    "licenses": [
+      "MIT"
+    ],
+    "requirements": [],
+    "sha": "0147d64042d5ab109d185f54957fcfb88f1ff9158651944ff75c6c82d47ab444"
+  }
+]


### PR DESCRIPTION
We originally bypassed ignore conditions for the grouped updates prototype as we were not sure they would interact predictably at first.

After some further testing, we are good to restore this capability when creating group PRs.