### PR TITLE
docs(npm): explain situations where parsing `resolved` can fail

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -100,6 +100,8 @@ module Dependabot
             uri = URI.parse(resolved)
           rescue URI::InvalidURIError
             # Ignoring non-URIs since they're not registries.
+            # This can happen if resolved is `false`, for instance
+            # npm6 bug https://github.com/npm/cli/issues/1138
             next
           end
 


### PR DESCRIPTION
Follow up for the following discussion https://github.com/dependabot/dependabot-core/pull/7030#discussion_r1164833616