### PR TITLE
Fix parsing some YAMLs due to outdated libyaml

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -95,13 +95,24 @@ COPY --from=ruby:3.1.4 --chown=dependabot:dependabot /usr/local /usr/local
 # This way other projects that import this library don't have to futz around with installing new / unexpected bundler versions.
 ARG BUNDLER_V2_VERSION=2.4.11
 
+# We had to explicitly bump this as the bundled version `0.2.2` in ubuntu 20.04 has a bug.
+# Once Ubuntu base image pulls in a new enough yaml version, we may not need to
+# explicitly manage this. However, if we do opt to pull it back out, see all changes
+# required in https://github.com/dependabot/dependabot-core/pull/7112
+ARG LIBYAML_VERSION=0.2.5
+RUN curl -sL https://pyyaml.org/download/libyaml/yaml-$LIBYAML_VERSION.tar.gz -o libyaml.tar.gz && \
+  mkdir -p $DEPENDABOT_HOME/src/libyaml && \
+  tar -xvf libyaml.tar.gz -C $DEPENDABOT_HOME/src/libyaml && \
+  rm libyaml.tar.gz
+
 RUN gem install bundler -v $BUNDLER_V2_VERSION --no-document && \
  rm -rf /var/lib/gems/*/cache/* && \
+ bundle config set --global build.psych --with-libyaml-source-dir=$DEPENDABOT_HOME/src/libyaml/yaml-$LIBYAML_VERSION && \
  bundle config set --local path 'vendor' && \
  bundle config set --local frozen 'true' && \
  bundle config set --local without 'development' && \
  bundle install && \
- rm -rf ~/.bundle
+ rm -rf ~/.bundle/cache
 
 COPY --chown=dependabot:dependabot LICENSE $DEPENDABOT_HOME
 

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri", "~> 1.8"
   spec.add_dependency "octokit", ">= 4.6", "< 7.0"
   spec.add_dependency "parser", ">= 2.5", "< 4.0"
+  spec.add_dependency "psych", "~> 5.0"
   spec.add_dependency "toml-rb", ">= 1.1.2", "< 3.0"
 
   spec.add_development_dependency "debug", "~> 1.7.1"

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -26,6 +26,7 @@ PATH
       nokogiri (~> 1.8)
       octokit (>= 4.6, < 7.0)
       parser (>= 2.5, < 4.0)
+      psych (~> 5.0)
       toml-rb (>= 1.1.2, < 3.0)
 
 PATH
@@ -216,6 +217,8 @@ GEM
     parser (3.2.2.0)
       ast (~> 2.4.1)
     pathname-common_prefix (0.0.1)
+    psych (5.1.0)
+      stringio
     public_suffix (5.0.1)
     racc (1.6.2)
     rainbow (3.1.1)
@@ -268,6 +271,7 @@ GEM
       faraday (>= 0.17.3, < 3)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
+    stringio (3.0.6)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)


### PR DESCRIPTION
While working on PNPM, I was going crazy because Dependabot could not parse the following YAML file:

https://github.com/ice-lab/icestark/blob/ec2d44244a2b4ebd7af0e0ff0a10f528b33b8a64/pnpm-lock.yaml

However, it would be parsed just fine on my dev machine.

On my dev machine:

```
$ ruby -rpsych -e 'Psych.load_file("tmp/ice-lab/icestark/pnpm-lock.yaml")'
# ok
```

On the development container:

```
$ ruby -rpsych -e 'Psych.load_file("tmp/ice-lab/icestark/pnpm-lock.yaml")'
/usr/local/lib/ruby/gems/3.1.0/gems/psych-4.0.4/lib/psych.rb:455:in `parse': (tmp/ice-lab/icestark/pnpm-lock.yaml): did not find expected ',' or '}' while parsing a flow mapping at line 1308 column 17 (Psych::SyntaxError)
	from /usr/local/lib/ruby/gems/3.1.0/gems/psych-4.0.4/lib/psych.rb:455:in `parse_stream'
	from /usr/local/lib/ruby/gems/3.1.0/gems/psych-4.0.4/lib/psych.rb:399:in `parse'
	from /usr/local/lib/ruby/gems/3.1.0/gems/psych-4.0.4/lib/psych.rb:323:in `safe_load'
	from /usr/local/lib/ruby/gems/3.1.0/gems/psych-4.0.4/lib/psych.rb:369:in `load'
	from /usr/local/lib/ruby/gems/3.1.0/gems/psych-4.0.4/lib/psych.rb:671:in `block in load_file'
	from /usr/local/lib/ruby/gems/3.1.0/gems/psych-4.0.4/lib/psych.rb:670:in `open'
	from /usr/local/lib/ruby/gems/3.1.0/gems/psych-4.0.4/lib/psych.rb:670:in `load_file'
	from -e:1:in `<main>'

```

After investigating, turns out I was using a newer version of libyaml locally, which must've corrected some bugs.

Unfortunately, updating the underlying libyaml is painful, but I think it can be done, so this is my take at it.

An alternative approach would be to avoid parsing YAML. For my purposes is doable, since I just wanted to detect the version used by the PNPM lockfile and that can be figured out pretty reliably without parsing YAML. But I was worried that this could be biting us in other places so I'm trying to upgrade libyaml.