### PR TITLE
Fix flaky specs in updater

### DIFF
--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
   end
 
   describe "#register" do
-    before do
+    after do
       dependency_group_engine.reset!
     end
 
@@ -92,7 +92,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
   end
 
   describe "#groups_for" do
-    before do
+    after do
       dependency_group_engine.reset!
     end
 
@@ -106,7 +106,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
   end
 
   describe "#dependency_groups" do
-    before do
+    after do
       dependency_group_engine.reset!
     end
 
@@ -142,7 +142,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
   end
 
   describe "#ungrouped_dependencies" do
-    before do
+    after do
       dependency_group_engine.reset!
     end
 
@@ -176,7 +176,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
   end
 
   describe "#reset!" do
-    before do
+    after do
       dependency_group_engine.reset!
     end
 
@@ -199,7 +199,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
   end
 
   describe "#calculate_dependency_groups!" do
-    before do
+    after do
       dependency_group_engine.reset!
     end
 

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -2207,6 +2207,7 @@ RSpec.describe Dependabot::Updater do
   describe "#run with the grouped experiment enabled" do
     after do
       Dependabot::Experiments.reset!
+      Dependabot::DependencyGroupEngine.reset!
     end
 
     it "updates multiple dependencies in a single PR correctly" do


### PR DESCRIPTION
Reproducer:

```
$ script/ci-test-updater './spec/dependabot/dependency_group_engine_spec.rb[1:4:1]' './spec/dependabot/updater_spec.rb[1:2:1]' --seed 24926
```

There was one spec causing side effects that was missing cleanup.

Also I changed cleaning up side effects to be done after the specs that create them, not before.