### PR TITLE
Pull Request names are Dependency Group aware

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -226,7 +226,8 @@ module Dependabot
           pr_message_header: pr_message_header,
           pr_message_footer: pr_message_footer,
           vulnerabilities_fixed: vulnerabilities_fixed,
-          github_redirection_service: github_redirection_service
+          github_redirection_service: github_redirection_service,
+          dependency_group: dependency_group
         )
     end
 

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -3,6 +3,7 @@
 require "pathname"
 require "dependabot/clients/github_with_retries"
 require "dependabot/clients/gitlab_with_retries"
+require "dependabot/dependency_group"
 require "dependabot/logger"
 require "dependabot/metadata_finders"
 require "dependabot/pull_request_creator"
@@ -21,12 +22,13 @@ module Dependabot
       attr_reader :source, :dependencies, :files, :credentials,
                   :pr_message_header, :pr_message_footer,
                   :commit_message_options, :vulnerabilities_fixed,
-                  :github_redirection_service
+                  :github_redirection_service, :dependency_group
 
       def initialize(source:, dependencies:, files:, credentials:,
                      pr_message_header: nil, pr_message_footer: nil,
                      commit_message_options: {}, vulnerabilities_fixed: {},
-                     github_redirection_service: DEFAULT_GITHUB_REDIRECTION_SERVICE)
+                     github_redirection_service: DEFAULT_GITHUB_REDIRECTION_SERVICE,
+                     dependency_group: nil)
         @dependencies               = dependencies
         @files                      = files
         @source                     = source
@@ -36,6 +38,7 @@ module Dependabot
         @commit_message_options     = commit_message_options
         @vulnerabilities_fixed      = vulnerabilities_fixed
         @github_redirection_service = github_redirection_service
+        @dependency_group           = dependency_group
       end
 
       def pr_name

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       pr_message_footer: pr_message_footer,
       commit_message_options: commit_message_options,
       vulnerabilities_fixed: vulnerabilities_fixed,
-      github_redirection_service: github_redirection_service
+      github_redirection_service: github_redirection_service,
+      dependency_group: dependency_group
     )
   end
 
@@ -46,6 +47,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
   let(:trailers) { nil }
   let(:vulnerabilities_fixed) { { "business" => [] } }
   let(:github_redirection_service) { "redirect.github.com" }
+  let(:dependency_group) { nil }
 
   let(:gemfile) do
     Dependabot::DependencyFile.new(

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -819,6 +819,97 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
       end
     end
+
+    context "for a dependency group" do
+      let(:dependency_group) do
+        Dependabot::DependencyGroup.new(name: "all-the-things", rules: anything)
+      end
+
+      before do
+        stub_request(:get, watched_repo_url + "/commits?per_page=100").
+          to_return(
+            status: 200,
+            body: commits_response,
+            headers: json_header
+          )
+      end
+      let(:commits_response) { fixture("github", "commits.json") }
+
+      it { is_expected.to eq("Bump the all-the-things group with 1 update") }
+
+      context "with two dependencies" do
+        let(:dependency2) do
+          Dependabot::Dependency.new(
+            name: "business2",
+            version: "1.5.0",
+            previous_version: "1.4.0",
+            package_manager: "dummy",
+            requirements: [],
+            previous_requirements: []
+          )
+        end
+        let(:dependencies) { [dependency, dependency2] }
+
+        it { is_expected.to eq("Bump the all-the-things group with 2 updates") }
+      end
+
+      context "with two dependencies with the same name" do
+        let(:dependency2) do
+          Dependabot::Dependency.new(
+            name: "business",
+            version: "1.5.0",
+            previous_version: "1.4.0",
+            package_manager: "dummy",
+            requirements: [],
+            previous_requirements: []
+          )
+        end
+        let(:dependencies) { [dependency, dependency2] }
+
+        it { is_expected.to eq("Bump the all-the-things group with 1 update") }
+      end
+
+      context "with three dependencies" do
+        let(:dependency2) do
+          Dependabot::Dependency.new(
+            name: "business2",
+            version: "1.5.0",
+            previous_version: "1.4.0",
+            package_manager: "dummy",
+            requirements: [],
+            previous_requirements: []
+          )
+        end
+        let(:dependency3) do
+          Dependabot::Dependency.new(
+            name: "business3",
+            version: "1.5.0",
+            previous_version: "1.4.0",
+            package_manager: "dummy",
+            requirements: [],
+            previous_requirements: []
+          )
+        end
+        let(:dependencies) { [dependency, dependency2, dependency3] }
+
+        it { is_expected.to eq("Bump the all-the-things group with 3 updates") }
+      end
+
+      context "with a directory specified" do
+        let(:gemfile) do
+          Dependabot::DependencyFile.new(
+            name: "Gemfile",
+            content: fixture("ruby", "gemfiles", "Gemfile"),
+            directory: "directory"
+          )
+        end
+
+        it "includes the directory" do
+          expect(pr_name).
+            to eq("Bump the all-the-things group in /directory with 1 update")
+        end
+      end
+    end
   end
 
   describe "#pr_message" do

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -403,6 +403,17 @@ RSpec.describe Dependabot::PullRequestCreator do
         expect(dummy_creator).to receive(:create)
         creator_with_group.create
       end
+
+      it "passes the dependency_group to the PullRequestCreator::MessageBuilder" do
+        allow(described_class::Github).to receive(:new).and_return(dummy_creator)
+        allow(dummy_creator).to receive(:create)
+
+        expect(described_class::MessageBuilder).
+          to receive(:new).
+          with(hash_including(dependency_group: dependency_group))
+
+        creator_with_group.create
+      end
     end
   end
 end


### PR DESCRIPTION
Currently any PRs we generate for Dependency Groups use existing logic to make a best effort to summarise all the dependencies that have changed.

This is adequate for some cases where only 1-3 dependencies have changed, but in testing we've found groups of ~10 which break the PR layout badly and are generally not terribly friendly to encounter.

This change introduces a new naming strategy specifically for PRs created by Dependency Groups where they use the **name of the group** being updated instead of the Dependencies involved, leaving this for the PR body to communicate, e.g.

> Bump the all-the-things group in myproject/ with 3 updates

This achieves two things:
- It builds awareness when a PR has been created from a group configuration rather than a single dependency upgrade for the reviewer/merger
- It avoids any potential edgecases were we could generate breaking branch names.

This approach should be considered a beta approach for now and we may refine the UX later, for example to have a breakpoint where we show the dependencies that have changed up to a certain breakpoint before we employ this strategy.