### PR TITLE
Fix Yarn Berry detection during package manager instrumentation

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -139,7 +139,7 @@ module Dependabot
         if (package_manager = package.fetch("packageManager", nil))
           get_yarn_version_from_package_json(package_manager)
         elsif yarn_lock
-          Helpers.yarn_version_numeric(yarn_lock.content)
+          Helpers.yarn_version_numeric(yarn_lock)
         end
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -16,8 +16,8 @@ module Dependabot
         6
       end
 
-      def self.yarn_version_numeric(lockfile_content)
-        if yarn_berry?(lockfile_content)
+      def self.yarn_version_numeric(yarn_lock)
+        if yarn_berry?(yarn_lock)
           3
         else
           1


### PR DESCRIPTION
The `yarn_berry?` helper receives a `DependencyFile`, not the actual content.