### PR TITLE
Bundler: handle SolveFailures as expected errors

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -79,6 +79,10 @@ module Dependabot
               )
             end
           post_process_lockfile(lockfile_body)
+        rescue SharedHelpers::HelperSubprocessFailed => e
+          raise Dependabot::DependencyFileNotResolvable, e.message if e.error_class == "Bundler::SolveFailure"
+
+          raise
         end
 
         def write_temporary_dependency_files

--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -52,7 +52,6 @@ module Dependabot
         rescue SharedHelpers::HelperSubprocessFailed => e
           # TODO: Remove once we stop stubbing out the V2 native helper
           raise Dependabot::NotImplemented, e.message if e.error_class == "Functions::NotImplementedError"
-          raise Dependabot::DependencyFileNotResolvable, e.message if e.error_class == "Bundler::SolveFailure"
 
           raise
         end

--- a/bundler/lib/dependabot/bundler/native_helpers.rb
+++ b/bundler/lib/dependabot/bundler/native_helpers.rb
@@ -52,6 +52,7 @@ module Dependabot
         rescue SharedHelpers::HelperSubprocessFailed => e
           # TODO: Remove once we stop stubbing out the V2 native helper
           raise Dependabot::NotImplemented, e.message if e.error_class == "Functions::NotImplementedError"
+          raise Dependabot::DependencyFileNotResolvable, e.message if e.error_class == "Bundler::SolveFailure"
 
           raise
         end


### PR DESCRIPTION
This should give the user a nice message on why Dependabot couldn't solve the dependencies given, and stop showing as "unknown errors" for our reporting. 