### PR TITLE
Cargo: handle TOML parsing errors

### DIFF
--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -34,8 +34,10 @@ module Dependabot
           }
         }
       rescue TomlRB::ParseError
-        raise Dependabot::DependencyFileNotParseable.new(rust_toolchain.path,
-                                                         "only rust-toolchain files formatted as TOML are supported, the non-TOML format was deprecated by Rust")
+        raise Dependabot::DependencyFileNotParseable.new(
+          rust_toolchain.path,
+          "only rust-toolchain files formatted as TOML are supported, the non-TOML format was deprecated by Rust"
+        )
       end
 
       private

--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -33,6 +33,8 @@ module Dependabot
             "channel" => channel
           }
         }
+      rescue TomlRB::ParseError
+        raise Dependabot::DependencyFileNotParseable, rust_toolchain.path
       end
 
       private

--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -35,7 +35,7 @@ module Dependabot
         }
       rescue TomlRB::ParseError
         raise Dependabot::DependencyFileNotParseable.new(rust_toolchain.path,
-                                                         "only rust-toolchain files with TOML syntax are supported")
+                                                         "only rust-toolchain files formatted as TOML are supported, the non-TOML format was deprecated by Rust")
       end
 
       private

--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -34,7 +34,8 @@ module Dependabot
           }
         }
       rescue TomlRB::ParseError
-        raise Dependabot::DependencyFileNotParseable, rust_toolchain.path
+        raise Dependabot::DependencyFileNotParseable.new(rust_toolchain.path,
+                                                         "only rust-toolchain files with TOML syntax are supported")
       end
 
       private

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
         with(headers: { "Authorization" => "token token" }).
         to_return(
           status: 200,
-          body: JSON.dump({ content: Base64.encode64("[toolchain]\nchannel = \"nightly-2019-01-01\"") }),
+          body: JSON.dump({ content: Base64.encode64("nightly-2019-01-01") }),
           headers: json_header
         )
     end
@@ -115,11 +115,8 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
         to match_array(%w(Cargo.toml rust-toolchain))
     end
 
-    it "provides the Rust channel" do
-      expect(file_fetcher_instance.package_manager_version).to eq({
-        ecosystem: "cargo",
-        package_managers: { "channel" => "nightly-2019-01-01" }
-      })
+    it "raises a DependencyFileNotParseable error" do
+      expect { file_fetcher_instance.package_manager_version }.to raise_error(Dependabot::DependencyFileNotParseable)
     end
   end
 


### PR DESCRIPTION
Per the [docs](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file), the toolchain files should be TOML since rustup 1.23. We're seeing a fair amount of projects using the old style, which won't work with what version we're on, so going to turn that unknown error into a DependencyFileNotParseable error. 