### PR TITLE
🛑 Stop clobbering Octokit middleware

### DIFF
--- a/common/lib/dependabot/clients/github_with_retries.rb
+++ b/common/lib/dependabot/clients/github_with_retries.rb
@@ -95,7 +95,7 @@ module Dependabot
           c.proxy = ENV["HTTPS_PROXY"] if ENV["HTTPS_PROXY"]
         end
 
-        Octokit.middleware = Faraday::RackBuilder.new do |builder|
+        args[:middleware] = Faraday::RackBuilder.new do |builder|
           builder.use Faraday::Retry::Middleware, exceptions: RETRYABLE_ERRORS, max: max_retries || 3
 
           Octokit::Default::MIDDLEWARE.handlers.each do |handler|


### PR DESCRIPTION
If `dependabot-core` is used in another application which has a separate dependency on Octokit, requests made through `dependabot-core` will rewrite the middleware stack. This is an attempt to prevent that behavior and make the setting of middleware specific to the client being built.