### PR TITLE
CodeQL: ignore purposefully invalid ruby files

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,6 +51,10 @@ jobs:
         languages: ${{ matrix.language }}
         # TODO: Unpin when https://github.com/github/codeql/issues/13103 fixed.
         tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-20230418/codeql-bundle.tar.gz
+        config: |
+          paths-ignore:
+            - 'bundler/spec/fixtures/projects/bundler1/invalid_ruby/Gemfile'
+            - 'bundler/spec/fixtures/projects/bundler2/invalid_ruby/Gemfile'
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
CodeQL is complaining that these two files are unparsable Ruby:
```
[2023-04-20 07:34:33] [build-stdout] [2023-04-20 07:34:33] [build-stdout]  WARN /home/runner/work/dependabot-core/dependabot-core/bundler/spec/fixtures/projects/bundler1/invalid_ruby/Gemfile:2: A parse error occurred. Check the syntax of the file. If the file is invalid, correct the error or exclude the file from analysis.
[2023-04-20 07:34:33] [build-stdout] [2023-04-20 07:34:33] [build-stdout]  WARN /home/runner/work/dependabot-core/dependabot-core/bundler/spec/fixtures/projects/bundler2/invalid_ruby/Gemfile:2: A parse error occurred. Check the syntax of the file. If the file is invalid, correct the error or exclude the file from analysis.
```

These two files are test specs and intentionally unparsable, so ignoring them.

Docs on configuring ignores are here:
* https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning#specifying-directories-to-scan
* https://github.com/github/codeql-action#configuration-via-config-input