### PR TITLE
Improve corepack setup

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -487,6 +487,9 @@ fetcher = Dependabot::FileFetchers.for_package_manager($package_manager).new(**f
 $files = fetch_files(fetcher)
 return if $files.empty?
 
+ecosystem_versions = fetcher.ecosystem_versions
+puts "🎈 Ecosystem Versions log: #{ecosystem_versions}" unless ecosystem_versions.nil?
+
 # Parse the dependency files
 puts "=> parsing dependency files"
 parser = Dependabot::FileParsers.for_package_manager($package_manager).new(
@@ -750,8 +753,6 @@ StackProf.stop if $options[:profile]
 StackProf.results("tmp/stackprof-#{Time.now.strftime('%Y-%m-%d-%H:%M')}.dump") if $options[:profile]
 
 puts "🌍 Total requests made: '#{$network_trace_count}'"
-ecosystem_versions = fetcher.ecosystem_versions
-puts "🎈 Ecosystem Versions log: #{ecosystem_versions}" unless ecosystem_versions.nil?
 
 # rubocop:enable Metrics/BlockLength
 

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -1,5 +1,8 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
+# Check for updates at https://github.com/nodejs/corepack/releases
+ARG COREPACK_VERSION=0.24.0
+
 # Check for updates at https://github.com/pnpm/pnpm/releases
 ARG PNPM_VERSION=8.11.0
 
@@ -22,6 +25,7 @@ RUN mkdir -p /etc/apt/keyrings \
   && apt-get install -y --no-install-recommends \
   nodejs \
   && rm -rf /var/lib/apt/lists/* \
+  && npm install -g corepack@$COREPACK_VERSION \
   && npm install -g npm@$NPM_VERSION \
   && rm -rf ~/.npm
 

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -32,10 +32,10 @@ RUN mkdir -p /etc/apt/keyrings \
 USER dependabot
 
 # Install pnpm and set it to a stable version
-RUN corepack prepare pnpm@$PNPM_VERSION --activate
+RUN corepack install pnpm@$PNPM_VERSION --global
 
 # Install yarn berry and set it to a stable version
-RUN corepack prepare yarn@$YARN_VERSION --activate
+RUN corepack install yarn@$YARN_VERSION --global
 
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 COPY --chown=dependabot:dependabot npm_and_yarn/helpers /opt/npm_and_yarn/helpers

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -26,7 +26,6 @@ RUN mkdir -p /etc/apt/keyrings \
   nodejs \
   && rm -rf /var/lib/apt/lists/* \
   && npm install -g corepack@$COREPACK_VERSION \
-  && npm install -g npm@$NPM_VERSION \
   && rm -rf ~/.npm
 
 USER dependabot
@@ -36,6 +35,9 @@ RUN corepack install pnpm@$PNPM_VERSION --global
 
 # Install yarn berry and set it to a stable version
 RUN corepack install yarn@$YARN_VERSION --global
+
+# Install npm and set it to a stable version
+RUN corepack install npm@$NPM_VERSION --global
 
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 COPY --chown=dependabot:dependabot npm_and_yarn/helpers /opt/npm_and_yarn/helpers

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -29,8 +29,6 @@ RUN mkdir -p /etc/apt/keyrings \
   && npm install -g npm@$NPM_VERSION \
   && rm -rf ~/.npm
 
-RUN corepack enable
-
 USER dependabot
 
 # Install pnpm and set it to a stable version

--- a/npm_and_yarn/helpers/test/npm6/conflicting-dependency-parser.test.js
+++ b/npm_and_yarn/helpers/test/npm6/conflicting-dependency-parser.test.js
@@ -11,7 +11,7 @@ describe("findConflictingDependencies", () => {
   beforeEach(() => {
     tempDir = fs.mkdtempSync(os.tmpdir() + path.sep);
   });
-  afterEach(() => fs.rmdir(tempDir, { recursive: true }, () => {}));
+  afterEach(() => fs.rm(tempDir, { recursive: true }, () => {}));
 
   it("finds conflicting dependencies", async () => {
     helpers.copyDependencies("conflicting-dependency-parser/simple", tempDir);

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -60,7 +60,7 @@ module Dependabot
       def ecosystem_versions
         package_managers = {}
 
-        package_managers["npm"] = npm_version if package_lock
+        package_managers["npm"] = npm_version if npm_version
         package_managers["yarn"] = yarn_version if yarn_version
         package_managers["pnpm"] = pnpm_version if pnpm_version
         package_managers["shrinkwrap"] = 1 if shrinkwrap
@@ -171,7 +171,9 @@ module Dependabot
       end
 
       def npm_version
-        Helpers.npm_version_numeric(package_lock.content)
+        return @npm_version if defined?(@npm_version)
+
+        @npm_version = package_manager.setup("npm")
       end
 
       def yarn_version
@@ -187,7 +189,10 @@ module Dependabot
       end
 
       def package_manager
-        @package_manager ||= PackageManager.new(parsed_package_json, lockfiles: { yarn: yarn_lock, pnpm: pnpm_lock })
+        @package_manager ||= PackageManager.new(
+          parsed_package_json,
+          lockfiles: { npm: package_lock, yarn: yarn_lock, pnpm: pnpm_lock }
+        )
       end
 
       def package_json

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -75,9 +75,9 @@ module Dependabot
         fetched_files = []
         fetched_files << package_json
         fetched_files << npmrc if npmrc
-        fetched_files += npm_files
-        fetched_files += yarn_files
-        fetched_files += pnpm_files
+        fetched_files += npm_files if npm_version
+        fetched_files += yarn_files if yarn_version
+        fetched_files += pnpm_files if pnpm_version
         fetched_files += lerna_files
         fetched_files += workspace_package_jsons
         fetched_files += path_dependencies(fetched_files)
@@ -190,7 +190,7 @@ module Dependabot
       def package_manager
         @package_manager ||= PackageManager.new(
           parsed_package_json,
-          lockfiles: { npm: package_lock, yarn: yarn_lock, pnpm: pnpm_lock }
+          lockfiles: { npm: package_lock || shrinkwrap, yarn: yarn_lock, pnpm: pnpm_lock }
         )
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -177,19 +177,13 @@ module Dependabot
       def yarn_version
         return @yarn_version if defined?(@yarn_version)
 
-        @yarn_version = package_manager.requested_version("yarn") || guess_yarn_version
-      end
-
-      def guess_yarn_version
-        return unless yarn_lock
-
-        Helpers.yarn_version_numeric(yarn_lock)
+        @yarn_version = package_manager.version("yarn")
       end
 
       def pnpm_version
         return @pnpm_version if defined?(@pnpm_version)
 
-        version = package_manager.requested_version("pnpm") || guess_pnpm_version
+        version = package_manager.version("pnpm")
 
         if version && Version.new(version.to_s) < Version.new("7")
           raise ToolVersionNotSupported.new("PNPM", version.to_s, "7.*, 8.*")
@@ -198,14 +192,8 @@ module Dependabot
         @pnpm_version = version
       end
 
-      def guess_pnpm_version
-        return unless pnpm_lock
-
-        Helpers.pnpm_version_numeric(pnpm_lock)
-      end
-
       def package_manager
-        @package_manager ||= PackageManager.new(parsed_package_json)
+        @package_manager ||= PackageManager.new(parsed_package_json, lockfiles: { yarn: yarn_lock, pnpm: pnpm_lock })
       end
 
       def package_json

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -93,7 +93,7 @@ module Dependabot
 
       def npm_files
         fetched_npm_files = []
-        fetched_npm_files << package_lock if package_lock
+        fetched_npm_files << package_lock if package_lock && !skip_package_lock?
         fetched_npm_files << shrinkwrap if shrinkwrap
         fetched_npm_files << inferred_npmrc if inferred_npmrc
         fetched_npm_files
@@ -109,7 +109,7 @@ module Dependabot
 
       def pnpm_files
         fetched_pnpm_files = []
-        fetched_pnpm_files << pnpm_lock if pnpm_lock
+        fetched_pnpm_files << pnpm_lock if pnpm_lock && !skip_pnpm_lock?
         fetched_pnpm_files << pnpm_workspace_yaml if pnpm_workspace_yaml
         fetched_pnpm_files += pnpm_workspace_package_jsons
         fetched_pnpm_files
@@ -201,7 +201,7 @@ module Dependabot
       def package_lock
         return @package_lock if defined?(@package_lock)
 
-        @package_lock = fetch_file_if_present("package-lock.json") unless skip_package_lock?
+        @package_lock = fetch_file_if_present("package-lock.json")
       end
 
       def yarn_lock
@@ -213,7 +213,7 @@ module Dependabot
       def pnpm_lock
         return @pnpm_lock if defined?(@pnpm_lock)
 
-        @pnpm_lock = fetch_file_if_present("pnpm-lock.yaml") unless skip_pnpm_lock?
+        @pnpm_lock = fetch_file_if_present("pnpm-lock.yaml")
       end
 
       def shrinkwrap

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -63,7 +63,6 @@ module Dependabot
         package_managers["npm"] = npm_version if npm_version
         package_managers["yarn"] = yarn_version if yarn_version
         package_managers["pnpm"] = pnpm_version if pnpm_version
-        package_managers["shrinkwrap"] = 1 if shrinkwrap
         package_managers["unknown"] = 1 if package_managers.empty?
 
         {

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -177,19 +177,13 @@ module Dependabot
       def yarn_version
         return @yarn_version if defined?(@yarn_version)
 
-        @yarn_version = package_manager.version("yarn")
+        @yarn_version = package_manager.setup("yarn")
       end
 
       def pnpm_version
         return @pnpm_version if defined?(@pnpm_version)
 
-        version = package_manager.version("pnpm")
-
-        if version && Version.new(version.to_s) < Version.new("7")
-          raise ToolVersionNotSupported.new("PNPM", version.to_s, "7.*, 8.*")
-        end
-
-        @pnpm_version = version
+        @pnpm_version = package_manager.setup("pnpm")
       end
 
       def package_manager

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -74,6 +74,7 @@ module Dependabot
       def fetch_files
         fetched_files = []
         fetched_files << package_json
+        fetched_files << npmrc if npmrc
         fetched_files += npm_files
         fetched_files += yarn_files
         fetched_files += pnpm_files
@@ -94,7 +95,6 @@ module Dependabot
         fetched_npm_files = []
         fetched_npm_files << package_lock if package_lock
         fetched_npm_files << shrinkwrap if shrinkwrap
-        fetched_npm_files << npmrc if npmrc
         fetched_npm_files << inferred_npmrc if inferred_npmrc
         fetched_npm_files
       end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
@@ -24,7 +24,7 @@ module Dependabot
         end
 
         def details(dependency_name, _requirement, manifest_name)
-          if Helpers.npm_version(@dependency_file.content) == "npm8"
+          if Helpers.npm8?(@dependency_file)
             # NOTE: npm 8 sometimes doesn't install workspace dependencies in the
             # workspace folder so we need to fallback to checking top-level
             nested_details = parsed.dig("packages", node_modules_path(manifest_name, dependency_name))

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -830,7 +830,7 @@ module Dependabot
         def npm8?
           return @npm8 if defined?(@npm8)
 
-          @npm8 = Dependabot::NpmAndYarn::Helpers.npm_version(lockfile.content) == "npm8"
+          @npm8 = Dependabot::NpmAndYarn::Helpers.npm8?(lockfile)
         end
 
         def sanitize_package_name(package_name)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -248,7 +248,6 @@ module Dependabot
         #   run when installing git dependencies
         def run_npm_install_lockfile_only(*install_args)
           command = [
-            "npm",
             "install",
             *install_args,
             "--force",
@@ -259,7 +258,6 @@ module Dependabot
           ].join(" ")
 
           fingerprint = [
-            "npm",
             "install",
             install_args.empty? ? "" : "<install_args>",
             "--force",
@@ -269,7 +267,7 @@ module Dependabot
             "--package-lock-only"
           ].join(" ")
 
-          SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
+          Helpers.run_npm_command(command, fingerprint: fingerprint)
         end
 
         def npm_install_args(dependency)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -62,15 +62,15 @@ module Dependabot
             "#{d.name}@#{d.version}"
           end.join(" ")
 
-          SharedHelpers.run_shell_command(
-            "pnpm install #{dependency_updates} --lockfile-only --ignore-workspace-root-check",
-            fingerprint: "pnpm install <dependency_updates> --lockfile-only --ignore-workspace-root-check"
+          Helpers.run_pnpm_command(
+            "install #{dependency_updates} --lockfile-only --ignore-workspace-root-check",
+            fingerprint: "install <dependency_updates> --lockfile-only --ignore-workspace-root-check"
           )
         end
 
         def run_pnpm_install
-          SharedHelpers.run_shell_command(
-            "pnpm install --lockfile-only"
+          Helpers.run_pnpm_command(
+            "install --lockfile-only"
           )
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -152,15 +152,15 @@ module Dependabot
           # the lockfile.
 
           if top_level_dependency_updates.all? { |dep| requirements_changed?(dep[:name]) }
-            Helpers.run_yarn_command("yarn install #{yarn_berry_args}".strip)
+            Helpers.run_yarn_command("install #{yarn_berry_args}".strip)
           else
             updates = top_level_dependency_updates.collect do |dep|
               dep[:name]
             end
 
             Helpers.run_yarn_command(
-              "yarn up -R #{updates.join(' ')} #{yarn_berry_args}".strip,
-              fingerprint: "yarn up -R <dependency_names> #{yarn_berry_args}".strip
+              "up -R #{updates.join(' ')} #{yarn_berry_args}".strip,
+              fingerprint: "up -R <dependency_names> #{yarn_berry_args}".strip
             )
           end
           { yarn_lock.name => File.read(yarn_lock.name) }
@@ -176,9 +176,9 @@ module Dependabot
           update = "#{dep.name}@#{dep.version}"
 
           commands = [
-            ["yarn add #{update} #{yarn_berry_args}".strip, "yarn add <update> #{yarn_berry_args}".strip],
-            ["yarn dedupe #{dep.name} #{yarn_berry_args}".strip, "yarn dedupe <dep_name> #{yarn_berry_args}".strip],
-            ["yarn remove #{dep.name} #{yarn_berry_args}".strip, "yarn remove <dep_name> #{yarn_berry_args}".strip]
+            ["add #{update} #{yarn_berry_args}".strip, "add <update> #{yarn_berry_args}".strip],
+            ["dedupe #{dep.name} #{yarn_berry_args}".strip, "dedupe <dep_name> #{yarn_berry_args}".strip],
+            ["remove #{dep.name} #{yarn_berry_args}".strip, "remove <dep_name> #{yarn_berry_args}".strip]
           ]
 
           Helpers.run_yarn_commands(*commands)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -152,8 +152,12 @@ module Dependabot
       end
 
       # Run single npm command returning stdout/stderr.
+      #
+      # NOTE: Needs to be explicitly run through corepack to respect the
+      # `packageManager` setting in `package.json`, because corepack does not
+      # add shims for NPM.
       def self.run_npm_command(command, fingerprint: command)
-        SharedHelpers.run_shell_command("npm #{command}", fingerprint: "npm #{fingerprint}")
+        SharedHelpers.run_shell_command("corepack npm #{command}", fingerprint: "corepack npm #{fingerprint}")
       end
 
       # Setup yarn and run a single yarn command returning stdout/stderr

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -59,7 +59,7 @@ module Dependabot
 
       def self.yarn_major_version
         retries = 0
-        output = SharedHelpers.run_shell_command("yarn --version")
+        output = run_single_yarn_command("--version")
         Version.new(output).major
       rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
         # Should never happen, can probably be removed once this settles
@@ -122,23 +122,23 @@ module Dependabot
 
       def self.setup_yarn_berry
         # Always disable immutable installs so yarn's CI detection doesn't prevent updates.
-        SharedHelpers.run_shell_command("yarn config set enableImmutableInstalls false")
+        run_single_yarn_command("config set enableImmutableInstalls false")
         # Do not generate a cache if offline cache disabled. Otherwise side effects may confuse further checks
-        SharedHelpers.run_shell_command("yarn config set enableGlobalCache true") unless yarn_berry_skip_build?
+        run_single_yarn_command("config set enableGlobalCache true") unless yarn_berry_skip_build?
         # We never want to execute postinstall scripts, either set this config or mode=skip-build must be set
-        SharedHelpers.run_shell_command("yarn config set enableScripts false") if yarn_berry_disable_scripts?
+        run_single_yarn_command("config set enableScripts false") if yarn_berry_disable_scripts?
         if (http_proxy = ENV.fetch("HTTP_PROXY", false))
-          SharedHelpers.run_shell_command("yarn config set httpProxy #{http_proxy}")
+          run_single_yarn_command("config set httpProxy #{http_proxy}", fingerprint: "config set httpProxy <proxy>")
         end
         if (https_proxy = ENV.fetch("HTTPS_PROXY", false))
-          SharedHelpers.run_shell_command("yarn config set httpsProxy #{https_proxy}")
+          run_single_yarn_command("config set httpsProxy #{https_proxy}", fingerprint: "config set httpsProxy <proxy>")
         end
         return unless (ca_file_path = ENV.fetch("NODE_EXTRA_CA_CERTS", false))
 
         if yarn_4_or_higher?
-          SharedHelpers.run_shell_command("yarn config set httpsCaFilePath #{ca_file_path}")
+          run_single_yarn_command("config set httpsCaFilePath #{ca_file_path}")
         else
-          SharedHelpers.run_shell_command("yarn config set caFilePath #{ca_file_path}")
+          run_single_yarn_command("config set caFilePath #{ca_file_path}")
         end
       end
 
@@ -148,14 +148,20 @@ module Dependabot
       # contain malicious code.
       def self.run_yarn_commands(*commands)
         setup_yarn_berry
-        commands.each { |cmd, fingerprint| SharedHelpers.run_shell_command(cmd, fingerprint: fingerprint) }
+        commands.each { |cmd, fingerprint| run_single_yarn_command(cmd, fingerprint: fingerprint) }
       end
 
-      # Run a single yarn command returning stdout/stderr
+      # Setup yarn and run a single yarn command returning stdout/stderr
       def self.run_yarn_command(command, fingerprint: nil)
         setup_yarn_berry
-        SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
+        run_single_yarn_command(command, fingerprint: fingerprint)
       end
+
+      # Run single yarn command returning stdout/stderr
+      def self.run_single_yarn_command(command, fingerprint: nil)
+        SharedHelpers.run_shell_command("yarn #{command}", fingerprint: "yarn #{fingerprint || command}")
+      end
+      private_class_method :run_single_yarn_command
 
       def self.pnpm_lockfile_version(pnpm_lock)
         pnpm_lock.content.match(/^lockfileVersion: ['"]?(?<version>[\d.]+)/)[:version]

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -31,8 +31,10 @@ module Dependabot
       # Mapping from lockfile versions to PNPM versions is at
       # https://github.com/pnpm/spec/tree/274ff02de23376ad59773a9f25ecfedd03a41f64/lockfile, but simplify it for now.
       def self.pnpm_version_numeric(pnpm_lock)
-        if pnpm_lockfile_version(pnpm_lock).to_f >= 5.4
+        if pnpm_lockfile_version(pnpm_lock).to_f >= 6.0
           8
+        elsif pnpm_lockfile_version(pnpm_lock).to_f >= 5.4
+          7
         else
           6
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -151,6 +151,11 @@ module Dependabot
         commands.each { |cmd, fingerprint| run_single_yarn_command(cmd, fingerprint: fingerprint) }
       end
 
+      # Run single npm command returning stdout/stderr.
+      def self.run_npm_command(command, fingerprint: command)
+        SharedHelpers.run_shell_command("npm #{command}", fingerprint: "npm #{fingerprint}")
+      end
+
       # Setup yarn and run a single yarn command returning stdout/stderr
       def self.run_yarn_command(command, fingerprint: nil)
         setup_yarn_berry

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -7,10 +7,6 @@ module Dependabot
       YARN_PATH_NOT_FOUND =
         /^.*(?<error>The "yarn-path" option has been set \(in [^)]+\), but the specified location doesn't exist)/
 
-      def self.npm_version(lockfile_content)
-        "npm#{npm_version_numeric(lockfile_content)}"
-      end
-
       def self.npm_version_numeric(lockfile_content)
         return 8 unless lockfile_content
         return 8 if JSON.parse(lockfile_content)["lockfileVersion"] >= 2
@@ -46,6 +42,12 @@ module Dependabot
         else
           default_value
         end
+      end
+
+      def self.npm8?(package_lock)
+        return true unless package_lock
+
+        npm_version_numeric(package_lock.content) == 8
       end
 
       def self.yarn_berry?(yarn_lock)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -157,6 +157,11 @@ module Dependabot
         run_single_yarn_command(command, fingerprint: fingerprint)
       end
 
+      # Run single pnpm command returning stdout/stderr
+      def self.run_pnpm_command(command, fingerprint: nil)
+        SharedHelpers.run_shell_command("pnpm #{command}", fingerprint: "pnpm #{fingerprint || command}")
+      end
+
       # Run single yarn command returning stdout/stderr
       def self.run_single_yarn_command(command, fingerprint: nil)
         SharedHelpers.run_shell_command("yarn #{command}", fingerprint: "yarn #{fingerprint || command}")

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -7,8 +7,8 @@ module Dependabot
       YARN_PATH_NOT_FOUND =
         /^.*(?<error>The "yarn-path" option has been set \(in [^)]+\), but the specified location doesn't exist)/
 
-      def self.npm_version_numeric(lockfile_content)
-        return 8 unless lockfile_content
+      def self.npm_version_numeric(lockfile)
+        lockfile_content = lockfile.content
         return 8 if JSON.parse(lockfile_content)["lockfileVersion"] >= 2
 
         6
@@ -47,7 +47,7 @@ module Dependabot
       def self.npm8?(package_lock)
         return true unless package_lock
 
-        npm_version_numeric(package_lock.content) == 8
+        npm_version_numeric(package_lock) == 8
       end
 
       def self.yarn_berry?(yarn_lock)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
@@ -23,7 +23,6 @@ module Dependabot
         # - `--ignore-scripts` disables prepare and prepack scripts which are run
         #   when installing git dependencies
         command = [
-          "npm",
           "update",
           *dependency_names,
           "--force",
@@ -34,7 +33,6 @@ module Dependabot
         ].join(" ")
 
         fingerprint = [
-          "npm",
           "update",
           "<dependency_names>",
           "--force",
@@ -44,7 +42,7 @@ module Dependabot
           "--package-lock-only"
         ].join(" ")
 
-        SharedHelpers.run_shell_command(command, fingerprint: fingerprint)
+        Helpers.run_npm_command(command, fingerprint: fingerprint)
       end
     end
   end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -56,19 +56,10 @@ module Dependabot
       end
 
       def guessed_version(name)
-        send(:"guess_#{name}_version", @lockfiles[name.to_sym])
-      end
+        lockfile = @lockfiles[name.to_sym]
+        return unless lockfile
 
-      def guess_yarn_version(yarn_lock)
-        return unless yarn_lock
-
-        Helpers.yarn_version_numeric(yarn_lock)
-      end
-
-      def guess_pnpm_version(pnpm_lock)
-        return unless pnpm_lock
-
-        Helpers.pnpm_version_numeric(pnpm_lock)
+        Helpers.send(:"#{name}_version_numeric", lockfile)
       end
     end
   end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -4,9 +4,16 @@
 module Dependabot
   module NpmAndYarn
     class PackageManager
-      def initialize(package_json)
+      def initialize(package_json, lockfiles:)
         @package_json = package_json
+        @lockfiles = lockfiles
       end
+
+      def version(name)
+        requested_version(name) || guessed_version(name)
+      end
+
+      private
 
       def requested_version(name)
         version = @package_json.fetch("packageManager", nil)
@@ -14,6 +21,22 @@ module Dependabot
 
         version_match = version.match(/#{name}@(?<version>\d+.\d+.\d+)/)
         version_match&.named_captures&.fetch("version", nil)
+      end
+
+      def guessed_version(name)
+        send(:"guess_#{name}_version", @lockfiles[name.to_sym])
+      end
+
+      def guess_yarn_version(yarn_lock)
+        return unless yarn_lock
+
+        Helpers.yarn_version_numeric(yarn_lock)
+      end
+
+      def guess_pnpm_version(pnpm_lock)
+        return unless pnpm_lock
+
+        Helpers.pnpm_version_numeric(pnpm_lock)
       end
     end
   end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -9,9 +9,12 @@ module Dependabot
       def initialize(package_json, lockfiles:)
         @package_json = package_json
         @lockfiles = lockfiles
+        @package_manager = package_json.fetch("packageManager", nil)
       end
 
       def setup(name)
+        return unless @package_manager.nil? || @package_manager.start_with?("#{name}@")
+
         version = requested_version(name)
 
         if version
@@ -48,11 +51,9 @@ module Dependabot
       end
 
       def requested_version(name)
-        version = @package_json.fetch("packageManager", nil)
-        return unless version
+        return unless @package_manager
 
-        version_match = version.match(/#{name}@(?<version>\d+.\d+.\d+)/)
-        version_match&.named_captures&.fetch("version", nil)
+        @package_manager.match(/#{name}@(?<version>\d+.\d+.\d+)/)["version"]
       end
 
       def guessed_version(name)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -66,8 +66,10 @@ module Dependabot
                             run_yarn_updater(path, lockfile_name)
                           elsif lockfile.name.end_with?("pnpm-lock.yaml")
                             run_pnpm_updater(path, lockfile_name)
+                          elsif Helpers.npm8?(lockfile)
+                            run_npm8_updater(path, lockfile_name)
                           else
-                            run_npm_updater(path, lockfile_name, lockfile.content)
+                            run_npm_updater(path, lockfile_name)
                           end
 
           updated_files.fetch(lockfile_name)
@@ -136,21 +138,24 @@ module Dependabot
           end
         end
 
-        def run_npm_updater(path, lockfile_name, lockfile_content)
+        def run_npm8_updater(path, lockfile_name)
           SharedHelpers.with_git_configured(credentials: credentials) do
             Dir.chdir(path) do
-              npm_version = Dependabot::NpmAndYarn::Helpers.npm_version(lockfile_content)
+              NativeHelpers.run_npm8_subdependency_update_command([dependency.name])
 
-              if npm_version == "npm8"
-                NativeHelpers.run_npm8_subdependency_update_command([dependency.name])
-                { lockfile_name => File.read(lockfile_name) }
-              else
-                SharedHelpers.run_helper_subprocess(
-                  command: NativeHelpers.helper_path,
-                  function: "npm6:updateSubdependency",
-                  args: [Dir.pwd, lockfile_name, [dependency.to_h]]
-                )
-              end
+              { lockfile_name => File.read(lockfile_name) }
+            end
+          end
+        end
+
+        def run_npm_updater(path, lockfile_name)
+          SharedHelpers.with_git_configured(credentials: credentials) do
+            Dir.chdir(path) do
+              SharedHelpers.run_helper_subprocess(
+                command: NativeHelpers.helper_path,
+                function: "npm6:updateSubdependency",
+                args: [Dir.pwd, lockfile_name, [dependency.to_h]]
+              )
             end
           end
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -129,9 +129,9 @@ module Dependabot
         def run_pnpm_updater(path, lockfile_name)
           SharedHelpers.with_git_configured(credentials: credentials) do
             Dir.chdir(path) do
-              SharedHelpers.run_shell_command(
-                "pnpm update #{dependency.name} --lockfile-only",
-                fingerprint: "pnpm update <dependency_name> --lockfile-only"
+              Helpers.run_pnpm_command(
+                "update #{dependency.name} --lockfile-only",
+                fingerprint: "update <dependency_name> --lockfile-only"
               )
               { lockfile_name => File.read(lockfile_name) }
             end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -118,8 +118,8 @@ module Dependabot
           SharedHelpers.with_git_configured(credentials: credentials) do
             Dir.chdir(path) do
               Helpers.run_yarn_command(
-                "yarn up -R #{dependency.name} #{Helpers.yarn_berry_args}".strip,
-                fingerprint: "yarn up -R <dependency_name> #{Helpers.yarn_berry_args}".strip
+                "up -R #{dependency.name} #{Helpers.yarn_berry_args}".strip,
+                fingerprint: "up -R <dependency_name> #{Helpers.yarn_berry_args}".strip
               )
               { lockfile_name => File.read(lockfile_name) }
             end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -618,8 +618,8 @@ module Dependabot
 
         def run_npm8_checker(version:)
           cmd =
-            "npm install #{version_install_arg(version: version)} --package-lock-only --dry-run=true --ignore-scripts"
-          output = SharedHelpers.run_shell_command(cmd)
+            "install #{version_install_arg(version: version)} --package-lock-only --dry-run=true --ignore-scripts"
+          output = Helpers.run_npm_command(cmd)
           if output.match?(NPM8_PEER_DEP_ERROR_REGEX)
             error_context = { command: cmd, process_exit_value: 1 }
             raise SharedHelpers::HelperSubprocessFailed.new(message: output, error_context: error_context)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -598,9 +598,8 @@ module Dependabot
                 # Find the lockfile that's in the current directory
                 f.name == [path, "package-lock.json"].join("/").sub(%r{\A.?\/}, "")
               end
-              npm_version = Dependabot::NpmAndYarn::Helpers.npm_version(package_lock&.content)
 
-              return run_npm8_checker(version: version) if npm_version == "npm8"
+              return run_npm8_checker(version: version) if Dependabot::NpmAndYarn::Helpers.npm8?(package_lock)
 
               SharedHelpers.run_helper_subprocess(
                 command: NativeHelpers.helper_path,

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -562,7 +562,7 @@ module Dependabot
           SharedHelpers.with_git_configured(credentials: credentials) do
             Dir.chdir(path) do
               output = Helpers.run_yarn_command(
-                "yarn add #{dependency.name}@#{version} #{Helpers.yarn_berry_args}".strip
+                "add #{dependency.name}@#{version} #{Helpers.yarn_berry_args}".strip
               )
               if output.include?("YN0060")
                 raise SharedHelpers::HelperSubprocessFailed.new(

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -539,9 +539,9 @@ module Dependabot
         def run_pnpm_checker(path:, version:)
           SharedHelpers.with_git_configured(credentials: credentials) do
             Dir.chdir(path) do
-              output = SharedHelpers.run_shell_command(
-                "pnpm update #{dependency.name}@#{version} --lockfile-only",
-                fingerprint: "pnpm update <dependency_name>@<version> --lockfile-only"
+              output = Helpers.run_pnpm_command(
+                "update #{dependency.name}@#{version} --lockfile-only",
+                fingerprint: "update <dependency_name>@<version> --lockfile-only"
               )
               if PNPM_PEER_DEP_ERROR_REGEX.match?(output)
                 raise SharedHelpers::HelperSubprocessFailed.new(

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -366,9 +366,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
           .to match_array(%w(package.json pnpm-lock.yaml))
       end
 
-      it "parses the version as 8" do
+      it "parses the version as 7" do
         expect(file_fetcher_instance.ecosystem_versions).to eq(
-          { package_managers: { "pnpm" => 8 } }
+          { package_managers: { "pnpm" => 7 } }
         )
       end
     end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -339,9 +339,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
           )
       end
 
-      it "fetches the package.json and pnpm-lock.yaml" do
-        expect(file_fetcher_instance.files.map(&:name))
-          .to match_array(%w(package.json pnpm-lock.yaml))
+      it "raises tool version not supported error" do
+        expect { file_fetcher_instance.files }
+          .to raise_error(Dependabot::ToolVersionNotSupported)
       end
 
       it "raises tool version not supported error" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -440,12 +440,6 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
       expect(file_fetcher_instance.files.map(&:name))
         .to match_array(%w(package.json npm-shrinkwrap.json))
     end
-
-    it "parses the shrinkwrap file" do
-      expect(file_fetcher_instance.ecosystem_versions).to eq(
-        { package_managers: { "shrinkwrap" => 1 } }
-      )
-    end
   end
 
   context "with a package-lock.json file but no yarn.lock" do


### PR DESCRIPTION

~We're already using corepack to activate the version of Yarn used by each project through the `packageManager` field in their `package.json` file.~

~However, downloading and activating the project's version on the fly could fail sometimes, for example, in some firewalled environments.~

~This PR takes a more explicit approach of explicitly activating the project's version with `corepack`, but if that fails, proceed with the global version.~

~NOTE: I included a few other refactorings and improvements with the PR.~

This PR has been repurposed. Its original purpose was 👆, however, we have never heard any reports of corepack failing to activate versions, so I don't want to complicate our implementation fixing a non issue.

However, the other corepack improvements I made here seemed nice, so I kept them and iterated on them. This is a summary of what's in here right now:

* Improve our corepack setup, and make corepack be used consistently by all package managers.
* Make Dependabot use PNPM 7 for lockfile 5.4 format, since that will result in better diffs. We use corepack to activate that version when necessary.
* Whenever a package manager is explicitly configured through `packageManager` setting in the `package.json` file, we only consider dependency files for that package manager and ignore the others if present. This fixes errors like `bin/dry-run.rb npm_and_yarn "internet-identity-labs/nfid"`, which results in `Usage Error: This project is configured to use npm` when trying to run `pnpm` on it.