### PR TITLE
[Updater] Ensure we no longer test the legacy code path

### DIFF
--- a/updater/lib/dependabot/environment.rb
+++ b/updater/lib/dependabot/environment.rb
@@ -46,6 +46,14 @@ module Dependabot
       @job_definition ||= JSON.parse(File.read(job_path))
     end
 
+    # TODO: Remove
+    #
+    # This is purely to provide a stubbable method for tests to start disabling
+    # this codeline and it can be removed before merging this branch
+    def self.legacy_run_enabled?
+      true
+    end
+
     private_class_method def self.environment_variable(variable_name, default = :_undefined)
       return ENV.fetch(variable_name, default) unless default == :_undefined
 

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -95,6 +95,8 @@ module Dependabot
     # This is the original logic within run, we currently fail over to this if
     # no Operation class exists for the given job.
     def legacy_run
+      raise Dependabot::NotImplemented unless Environment.legacy_run_enabled?
+
       service.increment_metric("updater.started", tags: { operation: "Legacy" })
       if job.updating_a_pull_request?
         Dependabot.logger.info("Starting PR update job for #{job.source.repo}")

--- a/updater/lib/dependabot/updater/operations.rb
+++ b/updater/lib/dependabot/updater/operations.rb
@@ -36,6 +36,17 @@ module Dependabot
       ]
 
       def self.class_for(job:)
+        # Let's not bother generating the string if debug is disabled
+        if Dependabot.logger.debug?
+          update_type = job.security_updates_only? ? "security" : "version"
+          update_verb = job.updating_a_pull_request? ? "refresh" : "create"
+          update_deps = job.dependencies&.any? ? job.dependencies.count : "all"
+
+          Dependabot.logger.debug(
+            "Finding operation for a #{update_type} to #{update_verb} a Pull Request for #{update_deps} dependencies"
+          )
+        end
+
         raise ArgumentError, "Expected Dependabot::Job, got #{job.class}" unless job.is_a?(Dependabot::Job)
 
         OPERATIONS.find { |op| op.applies_to?(job: job) }

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1383,6 +1383,11 @@ RSpec.describe Dependabot::Updater do
       # This will be deprecated when `legacy_run` is removed but should be
       # fairly trivial to bring back if required.
       context "and the job is create a version PR" do
+        before do
+          # Permit the legacy_run method to be used
+          allow(Dependabot::Environment).to receive(:legacy_run_enabled?) { true }
+        end
+
         it "only attempts to update dependencies on the specified list" do
           stub_update_checker
 

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1165,7 +1165,6 @@ RSpec.describe Dependabot::Updater do
           updater.run
         end
 
-
         context "when the dependency is a sub-dependency" do
           it "still attempts to update the dependency" do
             stub_update_checker(vulnerable?: true)

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -12,6 +12,8 @@ require "dependabot/service"
 
 RSpec.describe Dependabot::Updater do
   before do
+    # TODO: Remove
+    allow(Dependabot::Environment).to receive(:legacy_run_enabled?) { false }
     allow(Dependabot.logger).to receive(:info)
 
     stub_request(:get, "https://index.rubygems.org/versions").

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -449,9 +449,9 @@ RSpec.describe Dependabot::Updater do
     end
 
     context "when ignore conditions are set" do
-      def expect_update_checker_with_ignored_versions(versions)
+      def expect_update_checker_with_ignored_versions(versions, dependency_matcher: anything)
         expect(Dependabot::Bundler::UpdateChecker).to have_received(:new).with(
-          dependency: anything,
+          dependency: dependency_matcher,
           dependency_files: anything,
           repo_contents_path: anything,
           credentials: anything,
@@ -463,12 +463,11 @@ RSpec.describe Dependabot::Updater do
         ).once
       end
 
-      describe "when ignores match the dependency name" do
+      describe "when ignores match the a dependency being checked" do
         it "passes ignored_versions to the update checker" do
           stub_update_checker
 
           job = build_job(
-            requested_dependencies: ["dummy-pkg-b"],
             ignore_conditions: [
               {
                 "dependency-name" => "dummy-pkg-b",
@@ -531,14 +530,14 @@ RSpec.describe Dependabot::Updater do
         it "doesn't enable raised_on_ignore for ignore logging" do
           stub_update_checker
 
-          job = build_job(requested_dependencies: ["dummy-pkg-b"])
+          job = build_job
           service = build_service
           updater = build_updater(service: service, job: job)
 
           updater.run
 
           expect(Dependabot::Bundler::UpdateChecker).to have_received(:new).with(
-            dependency: anything,
+            dependency: having_attributes(name: "dummy-pkg-b"),
             dependency_files: anything,
             repo_contents_path: anything,
             credentials: anything,
@@ -556,7 +555,6 @@ RSpec.describe Dependabot::Updater do
           stub_update_checker
 
           job = build_job(
-            requested_dependencies: ["dummy-pkg-b"],
             ignore_conditions: [
               {
                 "dependency-name" => "dummy-pkg-b",
@@ -570,7 +568,7 @@ RSpec.describe Dependabot::Updater do
           updater.run
 
           expect(Dependabot::Bundler::UpdateChecker).to have_received(:new).with(
-            dependency: anything,
+            dependency: having_attributes(name: "dummy-pkg-b"),
             dependency_files: anything,
             repo_contents_path: anything,
             credentials: anything,
@@ -588,7 +586,6 @@ RSpec.describe Dependabot::Updater do
           stub_update_checker
 
           job = build_job(
-            requested_dependencies: ["dummy-pkg-b"],
             ignore_conditions: [
               {
                 "dependency-name" => "dummy-pkg-b",
@@ -602,7 +599,7 @@ RSpec.describe Dependabot::Updater do
           updater.run
 
           expect(Dependabot::Bundler::UpdateChecker).to have_received(:new).with(
-            dependency: anything,
+            dependency: having_attributes(name: "dummy-pkg-b"),
             dependency_files: anything,
             repo_contents_path: anything,
             credentials: anything,
@@ -620,7 +617,6 @@ RSpec.describe Dependabot::Updater do
           stub_update_checker
 
           job = build_job(
-            requested_dependencies: ["dummy-pkg-a"],
             ignore_conditions: [
               {
                 "dependency-name" => "dummy-pkg-b",
@@ -633,7 +629,7 @@ RSpec.describe Dependabot::Updater do
 
           updater.run
 
-          expect_update_checker_with_ignored_versions([])
+          expect_update_checker_with_ignored_versions([], dependency_matcher: having_attributes(name: "dummy-pkg-a"))
         end
       end
 
@@ -642,7 +638,6 @@ RSpec.describe Dependabot::Updater do
           stub_update_checker
 
           job = build_job(
-            requested_dependencies: ["dummy-pkg-a"],
             ignore_conditions: [
               {
                 "dependency-name" => "dummy-pkg-*",
@@ -655,7 +650,10 @@ RSpec.describe Dependabot::Updater do
 
           updater.run
 
-          expect_update_checker_with_ignored_versions([">= 0"])
+          expect_update_checker_with_ignored_versions(
+            [">= 0"],
+            dependency_matcher: having_attributes(name: "dummy-pkg-a")
+          )
         end
       end
 
@@ -664,7 +662,6 @@ RSpec.describe Dependabot::Updater do
           stub_update_checker
 
           job = build_job(
-            requested_dependencies: ["dummy-pkg-b"],
             ignore_conditions: [
               {
                 "dependency-name" => "dummy-pkg-a",
@@ -685,7 +682,10 @@ RSpec.describe Dependabot::Updater do
 
           updater.run
 
-          expect_update_checker_with_ignored_versions([">= 2.0.0, < 3", "> 1.1.0, < 1.2", ">= 1.2.a, < 2"])
+          expect_update_checker_with_ignored_versions(
+            [">= 2.0.0, < 3", "> 1.1.0, < 1.2", ">= 1.2.a, < 2"],
+            dependency_matcher: having_attributes(name: "dummy-pkg-b")
+          )
         end
       end
     end

--- a/updater/spec/spec_helper.rb
+++ b/updater/spec/spec_helper.rb
@@ -53,6 +53,13 @@ RSpec.configure do |config|
   def fixture(path)
     File.read(File.join("spec", "fixtures", path))
   end
+
+  # TODO: Remove once Updater#legacy_run is gone
+  config.before do
+    require "dependabot/environment"
+
+    allow(Dependabot::Environment).to receive(:legacy_run_enabled?) { false }
+  end
 end
 
 VCR.configure do |config|


### PR DESCRIPTION
Follows on from https://github.com/dependabot/dependabot-core/pull/7128

Now that all well-formed job definitions are routed to an Operation class, the only jobs that can possibly hit the `Updater#legacy_run` path are those where the attributes **do not match real-world configurations**.

This PR makes a change to disable the `Updater#legacy_run` method in our test suite so any existing or new tests which hit the legacy code line will fail.

Having done this, it then addresses two cohorts of failing tests:
- A set of ignore condition tests which are creating new Version PRs but are using `job.dependencies` as a convenience in their test setup to avoid having to account for N dependencies
  - This fix for these is to adjust the expectations so they only examine the target dependency without using this hook
- A set of tests which target creating a new PR for a _specific_ dependency that were not security updates
  - For this group the tests were mostly checking the same behaviour for updating as for grouping, so I updated them to be security updates to reflect real world conditions and they continue to pass
  - In one case, testing that a nominated subdependency would still result in an update, I moved this into the "Updating a PR" test as this is the scenario we are most likely to encounter and handle this problem
  - Finally, one test outright checks we can create a fresh PR for a nominated single Dependency, which is behaviour we do not actually use in the real world. I've allowed this to continue passing by enabling the legacy code, but it will be removed when we clean up.

### Rationale

The overall goal of the Operation classes is to only have concrete code lines for the job configurations we run in the real world, this ultimately means removing a single capability expressed in our tests at present which is to create a fresh Version Update PR for a set of specific dependencies.

This capability definitely seems like something we might want in future, but in keeping with our intent to make the code paths as explicit as possible I think it makes sense to remove it until we need it rather than leave ambiguity.

As a follow-on from the grouped update introduction and as part of the cleanup from this task the `updater_spec` should be broken up to more thoroughly test the concrete classes which will make it much easier to bring this back with _exhaustive_ testing rather than having one example in the file currently touch this path.