### PR TITLE
[Updater] DependencyChange passes any group to the PR message builder

### DIFF
--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -11,7 +11,7 @@
 # by adapters to create a Pull Request, apply the changes on disk, etc.
 module Dependabot
   class DependencyChange
-    attr_reader :job, :updated_dependencies, :updated_dependency_files
+    attr_reader :job, :updated_dependencies, :updated_dependency_files, :dependency_group
 
     def initialize(job:, updated_dependencies:, updated_dependency_files:, dependency_group: nil)
       @job = job
@@ -28,7 +28,8 @@ module Dependabot
         dependencies: updated_dependencies,
         files: updated_dependency_files,
         credentials: job.credentials,
-        commit_message_options: job.commit_message_options
+        commit_message_options: job.commit_message_options,
+        dependency_group: dependency_group
       ).message
     end
 
@@ -42,11 +43,8 @@ module Dependabot
       updated_dependency_files.map(&:to_h)
     end
 
-    # FIXME: This is a placeholder for using a concrete DependencyGroup object to create
-    # as grouped rule hash to pass to the Dependabot API client. For now, we just
-    # use a flag on whether a rule has been assigned to the change.
     def grouped_update?
-      !!@dependency_group
+      !!dependency_group
     end
   end
 end

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -93,7 +93,7 @@ module Dependabot
                     :error_handler
 
         def register_all_dependencies_group
-          all_dependencies_group = { "name" => "group-all", "rules" => { "patterns" => ["*"] } }
+          all_dependencies_group = { "name" => "all-dependencies", "rules" => { "patterns" => ["*"] } }
           Dependabot::DependencyGroupEngine.register(all_dependencies_group["name"],
                                                      all_dependencies_group["rules"]["patterns"])
         end

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -99,10 +99,36 @@ RSpec.describe Dependabot::DependencyChange do
           files: updated_dependency_files,
           dependencies: updated_dependencies,
           credentials: job_credentials,
-          commit_message_options: commit_message_options
+          commit_message_options: commit_message_options,
+          dependency_group: nil
         )
 
       expect(dependency_change.pr_message).to eql("Hello World!")
+    end
+
+    context "when a dependency group is assigned" do
+      it "delegates to the Dependabot::PullRequestCreator::MessageBuilder with the group included" do
+        group = Dependabot::DependencyGroup.new(name: "foo", rules: anything)
+
+        dependency_change = described_class.new(
+          job: job,
+          updated_dependencies: updated_dependencies,
+          updated_dependency_files: updated_dependency_files,
+          dependency_group: group
+        )
+
+        expect(Dependabot::PullRequestCreator::MessageBuilder).
+          to receive(:new).with(
+            source: github_source,
+            files: updated_dependency_files,
+            dependencies: updated_dependencies,
+            credentials: job_credentials,
+            commit_message_options: commit_message_options,
+            dependency_group: group
+          )
+
+        expect(dependency_change.pr_message).to eql("Hello World!")
+      end
     end
   end
 
@@ -113,15 +139,14 @@ RSpec.describe Dependabot::DependencyChange do
 
     context "when a dependency group is assigned" do
       it "is true" do
-        rule = described_class.new(
+        dependency_change = described_class.new(
           job: job,
           updated_dependencies: updated_dependencies,
           updated_dependency_files: updated_dependency_files,
-          # For now the dependency_group parameter is treated permissively as any non-nil value
-          dependency_group: anything
+          dependency_group: Dependabot::DependencyGroup.new(name: "foo", rules: anything)
         )
 
-        expect(rule.grouped_update?).to be true
+        expect(dependency_change.grouped_update?).to be true
       end
     end
   end


### PR DESCRIPTION
In order to ensure the PR title and message body are built using the right strategy, we need to pass any group assigned to the `Dependabot::DependencyChange` on to the `Dependabot::PullRequestCreator::MessageBuilder` class.

I've also made a small agreement change to the name of the placeholder group we use if no configuration is supplied to use the same placeholder name we use elsewhere.