### PR TITLE
Don't run update checker unnecessarily on all javascript packages in a monorepo

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -320,8 +320,7 @@ module Dependabot
           SharedHelpers.in_a_temporary_repo_directory(base_dir, repo_contents_path) do
             dependency_files_builder.write_temporary_dependency_files
 
-            filtered_package_files.flat_map do |file|
-              path = Pathname.new(file.name).dirname
+            paths_requiring_update_check.flat_map do |path|
               run_checker(path: path, version: version)
             end.compact
           end
@@ -612,12 +611,12 @@ module Dependabot
           ).parse.select(&:top_level?)
         end
 
-        def filtered_package_files
-          @filtered_package_files ||=
+        def paths_requiring_update_check
+          @paths_requiring_update_check ||=
             DependencyFilesFilterer.new(
               dependency_files: dependency_files,
               updated_dependencies: [dependency]
-            ).package_files_requiring_update
+            ).paths_requiring_update_check
         end
 
         def dependency_files_builder

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_files_filterer_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_files_filterer_spec.rb
@@ -187,17 +187,17 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyFilesFilterer do
     end
   end
 
-  describe ".package_files_requiring_update" do
-    subject(:package_files_requiring_update) do
+  describe ".paths_requiring_update_check" do
+    subject(:paths_requiring_update_check) do
       described_class.new(
         dependency_files: dependency_files,
         updated_dependencies: updated_dependencies
-      ).package_files_requiring_update
+      ).paths_requiring_update_check
     end
 
     it do
       is_expected.to contain_exactly(
-        project_dependency_file("package.json")
+        "."
       )
     end
 
@@ -220,7 +220,7 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyFilesFilterer do
 
       it do
         is_expected.to contain_exactly(
-          project_dependency_file("packages/package2/package.json")
+          "packages/package2"
         )
       end
     end


### PR DESCRIPTION
If a monorepo provides multiple packages, but a single root lockfile, we just need to run the update checker in the root lockfile, since that one should be managing all dependencies.

We were running the update checker once per package, making things painfully slow.

Also, we were running the commands to check for the update inside each folder, and I'm not sure that actually works as expected in presence of a root lockfile.