### PR TITLE
Cargo: handle dependencies that are not in the index

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -149,6 +149,11 @@ module Dependabot
             raise Dependabot::DependencyFileNotEvaluatable, "Dependabot only supports toolchain 1.68 and up."
           end
 
+          # package doesn't exist in the index
+          if (match = stdout.match(/no matching package named `([^`]+)` found/))
+            raise Dependabot::DependencyFileNotResolvable, match[1]
+          end
+
           raise SharedHelpers::HelperSubprocessFailed.new(
             message: stdout,
             error_context: {

--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -105,6 +105,31 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
       end
     end
 
+    context "when the dependency doesn't exist" do
+      random_unlikely_package_name = (0...255).map { ("a".."z").to_a[rand(26)] }.join
+      content = <<~CONTENT
+        [package]
+        name = "foo"
+        version = "0.1.0"
+        authors = ["me"]
+
+        [dependencies]
+        #{random_unlikely_package_name} = "99.99.99"
+      CONTENT
+
+      let(:manifest) do
+        Dependabot::DependencyFile.new(name: "Cargo.toml", content: content)
+      end
+
+      it "raises a helpful error" do
+        expect { updated_lockfile_content }.
+          to raise_error do |error|
+            expect(error).to be_a(Dependabot::DependencyFileNotResolvable)
+            expect(error.message).to include(random_unlikely_package_name)
+          end
+      end
+    end
+
     describe "the updated lockfile" do
       it "updates the dependency version in the lockfile" do
         expect(updated_lockfile_content).


### PR DESCRIPTION
Currently when Dependabot encounters an error from Cargo when it can't find a dependency it raises a HelperSubprocessFailed error. 

This recategorizes that case to a DependencyFileNotResolvable error which shows a better error including the dependency that was not found.

I randomly generated the dependency name in the test so no one can register the name and break our tests 😄 