### PR TITLE
fix(gradle): update dependencies only if group and artifact ids are the same

### DIFF
--- a/gradle/lib/dependabot/gradle/file_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater.rb
@@ -139,15 +139,27 @@ module Dependabot
           line = evaluate_properties(line, buildfile)
           line = line.gsub(%r{(?<=^|\s)//.*$}, "")
 
-          if dependency.name.include?(":")
-            next false unless line.include?(dependency.name.split(":").first)
-            next false unless line.include?(dependency.name.split(":").last)
-          elsif requirement.fetch(:file).end_with?(".toml")
-            next false unless line.include?(dependency.name)
+          line_matches_dependency?(line, dependency, requirement)
+        end
+      end
+
+      def line_matches_dependency?(line, dependency, requirement)
+        if dependency.name.include?(":")
+          group, name = dependency.name.split(":")
+          version = requirement.fetch(:requirement)
+
+          line.include?("#{group}:#{name}:#{version}") || (
+            /group\s*[=:]\s*['"]#{group}['"]/.match?(line) &&
+              /name\s*[=:]\s*['"]#{name}['"]/.match?(line) &&
+              /version\s*[=:]\s*['"]#{version}['"]/.match?(line)
+          )
+        else
+          if requirement.fetch(:file).end_with?(".toml")
+            return false unless line.include?(dependency.name)
           else
             name_regex_value = /['"]#{Regexp.quote(dependency.name)}['"]/
             name_regex = /(id|kotlin)(\s+#{name_regex_value}|\(#{name_regex_value}\))/
-            next false unless line.match?(name_regex)
+            return false unless line.match?(name_regex)
           end
 
           line.include?(requirement.fetch(:requirement))

--- a/gradle/spec/dependabot/gradle/file_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater_spec.rb
@@ -702,6 +702,62 @@ RSpec.describe Dependabot::Gradle::FileUpdater do
           )
         end
       end
+      context "build_same_groupId_different_artifactId.gradle" do
+        let(:buildfile) do
+          Dependabot::DependencyFile.new(
+            name: "buildfiles/build_same_groupId_different_artifactId.gradle",
+            content: fixture("buildfiles", "build_same_groupId_different_artifactId.gradle")
+          )
+        end
+        let(:dependencies) do
+          [
+            Dependabot::Dependency.new(
+              name: "com.graphql-java:graphql-java",
+              version: "21",
+              previous_version: "20.0",
+              requirements: [{
+                file: "buildfiles/build_same_groupId_different_artifactId.gradle",
+                requirement: "21.0",
+                groups: [],
+                source: nil,
+                metadata: nil
+              }],
+              previous_requirements: [{
+                file: "buildfiles/build_same_groupId_different_artifactId.gradle",
+                requirement: "20.0",
+                groups: [],
+                source: nil,
+                metadata: nil
+              }],
+              package_manager: "gradle"
+            )
+          ]
+        end
+
+        subject(:updated_buildfile) do
+          updated_files.find { |f| f.name == "buildfiles/build_same_groupId_different_artifactId.gradle" }
+        end
+        its(:content) do
+          is_expected.
+            to include("com.graphql-java:graphql-java-extended-scalars:20.0")
+          is_expected.
+            to include("com.graphql-java:graphql-java:21.0")
+          is_expected.
+            to include("group: 'com.graphql-java', name: 'graphql-java', version: '21.0'")
+          is_expected.
+            to include("group: 'com.graphql-java', version: '21.0', name: 'graphql-java'")
+          is_expected.
+            to include("version: '21.0', group: 'com.graphql-java', name: 'graphql-java'")
+          is_expected.
+            to include("version: '21.0', name: 'graphql-java', group: 'com.graphql-java'")
+          is_expected.
+            to include("name: 'graphql-java', version: '21.0', group: 'com.graphql-java'")
+          is_expected.
+            to include("name: 'graphql-java', group: 'com.graphql-java',version: '21.0'")
+          is_expected.
+            to include("group: 'com.graphql-java', name: 'graphql-java-extended-scalars', version: '20.0'")
+        end
+      end
     end
   end
 end

--- a/gradle/spec/fixtures/buildfiles/build_same_groupId_different_artifactId.gradle
+++ b/gradle/spec/fixtures/buildfiles/build_same_groupId_different_artifactId.gradle
@@ -1,0 +1,18 @@
+# See https://github.com/dependabot/dependabot-core/issues/7002
+
+dependencies {
+implementation 'com.graphql-java:graphql-java-extended-scalars:20.0'
+implementation 'com.graphql-java:graphql-java:20.0'
+implementation group: 'com.graphql-java', name: 'graphql-java-extended-scalars', version: '20.0'
+
+implementation group: 'com.graphql-java', name: 'graphql-java', version: '20.0'
+implementation group: 'com.graphql-java', version: '20.0', name: 'graphql-java'
+
+implementation version: '20.0', group: 'com.graphql-java', name: 'graphql-java'
+implementation version: '20.0', name: 'graphql-java', group: 'com.graphql-java'
+
+implementation name: 'graphql-java', version: '20.0', group: 'com.graphql-java'
+implementation name: 'graphql-java', group: 'com.graphql-java',version: '20.0'
+
+
+}


### PR DESCRIPTION
With the current implementation, any line matching the requirement is upgraded. That leads to undesired side effects as described in the issue

Fixes #7002