### PR TITLE
feat(maven): use `groupId` and `artifactId` for the dependency name

### DIFF
--- a/maven/lib/dependabot/maven.rb
+++ b/maven/lib/dependabot/maven.rb
@@ -23,6 +23,6 @@ Dependabot::Dependency.
     "maven",
     lambda { |name|
       _group_id, artifact_id, _classifier = name.split(":")
-      %w(bom library).include?(artifact_id) ? name : artifact_id
+      name.length <= 100 ? name : artifact_id
     }
   )

--- a/maven/spec/dependabot/maven_spec.rb
+++ b/maven/spec/dependabot/maven_spec.rb
@@ -17,21 +17,26 @@ RSpec.describe Dependabot::Maven do
     end
 
     context "normal dependency" do
-      let(:name) { "group.com:dep" }
+      let(:name) { "group.com:dep:mule-plugin" }
 
-      it { is_expected.to eq("dep") }
+      it { is_expected.to eq("group.com:dep:mule-plugin") }
     end
 
     context "dependency with classifier" do
       let(:name) { "group.com:dep:mule-plugin" }
 
-      it { is_expected.to eq("dep") }
+      it { is_expected.to eq("group.com:dep:mule-plugin") }
     end
 
     context "with a special-cased name" do
       let(:name) { "group.com:bom" }
 
       it { is_expected.to eq("group.com:bom") }
+    end
+
+    context "with a 100+ character name" do
+      let(:name) { "com.long-domain-name-that-should-be-replaced-by-ellipsis.this-is-longer-group-id:the-longest-artifact-id" } # rubocop:disable Layout/LineLength
+      it { is_expected.to eq("the-longest-artifact-id") }
     end
   end
 end


### PR DESCRIPTION
Fixes #3845

Depends on https://github.com/dependabot/smoke-tests/pull/59/files

Implemented just like #6526 as suggested