### PR TITLE
build(deps): bump Yarn from 3.4.1 to 3.5.0

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 ENV DEPENDABOT_HOME /home/dependabot
 ### JAVASCRIPT
-ARG YARN_VERSION=3.4.1
+ARG YARN_VERSION=3.5.0
 
 # Install Node and npm
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \


### PR DESCRIPTION
We never heard back from Yarn regarding the [release notes for this version](https://github.com/yarnpkg/berry/issues/5369)

But @deivid-rodriguez [confirmed that we are using `3.5.0` ](https://github.com/dependabot/dependabot-core/pull/7001#issuecomment-1517845943)



