### PR TITLE
v0.217.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.217.0, 24 April 2023
+
+- Run UpdateAllVersions with ungrouped dependencies [#7110](https://github.com/dependabot/dependabot-core/pull/7110)
+- [Updater] Ensure we no longer test the legacy code path [#7136](https://github.com/dependabot/dependabot-core/pull/7136)
+- [Updater] Extract RefreshSecurityUpdatePullRequest into an Operation class [#7128](https://github.com/dependabot/dependabot-core/pull/7128)
+- [Updater] DependencyChange passes any group to the PR message builder [#7137](https://github.com/dependabot/dependabot-core/pull/7137)
+
 ## v0.216.2, 20 April 2023
 
 - Pull Request names are Dependency Group aware [#7115](https://github.com/dependabot/dependabot-core/pull/7115)

--- a/common/lib/dependabot.rb
+++ b/common/lib/dependabot.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dependabot
-  VERSION = "0.216.2"
+  VERSION = "0.217.0"
 end

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -322,4 +322,4 @@ DEPENDENCIES
   webmock (~> 3.18)
 
 BUNDLED WITH
-   2.3.26
+   2.4.11

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       rake (~> 13.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0218.1)
+    mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     multi_xml (0.6.0)

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -1,19 +1,19 @@
 PATH
   remote: ../bundler
   specs:
-    dependabot-bundler (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-bundler (0.217.0)
+      dependabot-common (= 0.217.0)
 
 PATH
   remote: ../cargo
   specs:
-    dependabot-cargo (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-cargo (0.217.0)
+      dependabot-common (= 0.217.0)
 
 PATH
   remote: ../common
   specs:
-    dependabot-common (0.216.2)
+    dependabot-common (0.217.0)
       aws-sdk-codecommit (~> 1.28)
       aws-sdk-ecr (~> 1.5)
       bundler (>= 1.16, < 3.0.0)
@@ -32,88 +32,88 @@ PATH
 PATH
   remote: ../composer
   specs:
-    dependabot-composer (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-composer (0.217.0)
+      dependabot-common (= 0.217.0)
 
 PATH
   remote: ../docker
   specs:
-    dependabot-docker (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-docker (0.217.0)
+      dependabot-common (= 0.217.0)
 
 PATH
   remote: ../elm
   specs:
-    dependabot-elm (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-elm (0.217.0)
+      dependabot-common (= 0.217.0)
 
 PATH
   remote: ../git_submodules
   specs:
-    dependabot-git_submodules (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-git_submodules (0.217.0)
+      dependabot-common (= 0.217.0)
       parseconfig (~> 1.0, < 1.1.0)
 
 PATH
   remote: ../github_actions
   specs:
-    dependabot-github_actions (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-github_actions (0.217.0)
+      dependabot-common (= 0.217.0)
 
 PATH
   remote: ../go_modules
   specs:
-    dependabot-go_modules (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-go_modules (0.217.0)
+      dependabot-common (= 0.217.0)
 
 PATH
   remote: ../gradle
   specs:
-    dependabot-gradle (0.216.2)
-      dependabot-common (= 0.216.2)
-      dependabot-maven (= 0.216.2)
+    dependabot-gradle (0.217.0)
+      dependabot-common (= 0.217.0)
+      dependabot-maven (= 0.217.0)
 
 PATH
   remote: ../hex
   specs:
-    dependabot-hex (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-hex (0.217.0)
+      dependabot-common (= 0.217.0)
 
 PATH
   remote: ../maven
   specs:
-    dependabot-maven (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-maven (0.217.0)
+      dependabot-common (= 0.217.0)
 
 PATH
   remote: ../npm_and_yarn
   specs:
-    dependabot-npm_and_yarn (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-npm_and_yarn (0.217.0)
+      dependabot-common (= 0.217.0)
 
 PATH
   remote: ../nuget
   specs:
-    dependabot-nuget (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-nuget (0.217.0)
+      dependabot-common (= 0.217.0)
 
 PATH
   remote: ../pub
   specs:
-    dependabot-pub (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-pub (0.217.0)
+      dependabot-common (= 0.217.0)
 
 PATH
   remote: ../python
   specs:
-    dependabot-python (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-python (0.217.0)
+      dependabot-common (= 0.217.0)
 
 PATH
   remote: ../terraform
   specs:
-    dependabot-terraform (0.216.2)
-      dependabot-common (= 0.216.2)
+    dependabot-terraform (0.217.0)
+      dependabot-common (= 0.217.0)
 
 GEM
   remote: https://rubygems.org/
@@ -201,7 +201,7 @@ GEM
       rake (~> 13.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     multi_xml (0.6.0)
@@ -322,4 +322,4 @@ DEPENDENCIES
   webmock (~> 3.18)
 
 BUNDLED WITH
-   2.4.11
+   2.3.26


### PR DESCRIPTION
## v0.217.0, 24 April 2023

- Run UpdateAllVersions with ungrouped dependencies [#7110](https://github.com/dependabot/dependabot-core/pull/7110)
- [Updater] Ensure we no longer test the legacy code path [#7136](https://github.com/dependabot/dependabot-core/pull/7136)
- [Updater] Extract RefreshSecurityUpdatePullRequest into an Operation class [#7128](https://github.com/dependabot/dependabot-core/pull/7128)
- [Updater] DependencyChange passes any group to the PR message builder [#7137](https://github.com/dependabot/dependabot-core/pull/7137)