### PR TITLE
Prepare yarn berry just once

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -12,11 +12,13 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
   && npm install -g npm@8.19.4 \
   && rm -rf ~/.npm
 
-# Install yarn berry and set it to a stable version
-RUN corepack enable \
-  && corepack prepare yarn@$YARN_VERSION --activate
+RUN corepack enable
 
 USER dependabot
+
+# Install yarn berry and set it to a stable version
+RUN corepack prepare yarn@$YARN_VERSION --activate
+
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 COPY --chown=dependabot:dependabot npm_and_yarn/helpers /opt/npm_and_yarn/helpers
 RUN bash /opt/npm_and_yarn/helpers/build
@@ -34,9 +36,6 @@ COPY --chown=dependabot:dependabot updater/config/.yarnrc updater/config/.npmrc 
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
 # END: HACKY WORKAROUND FOR NPM GIT INSTALLS SPAWNING CHILD PROCESS
-
-# Our native helpers pull in yarn 1, so we need to reset the version globally
-RUN corepack prepare yarn@$YARN_VERSION --activate
 
 COPY --chown=dependabot:dependabot npm_and_yarn $DEPENDABOT_HOME/npm_and_yarn
 COPY --chown=dependabot:dependabot common $DEPENDABOT_HOME/common


### PR DESCRIPTION
I think the problem was not that native helpers pull Yarn 1, but that the version was being activated for the root user, not for the dependabot user. I don't think we need it for root.

(Extracted from #7134)