### PR TITLE
Switch from `Changelog.md` to GitHub releases

### DIFF
--- a/CHANGELOG_ARCHIVE_2019_TO_SWITCH_TO_GITHUB_RELEASES.md
+++ b/CHANGELOG_ARCHIVE_2019_TO_SWITCH_TO_GITHUB_RELEASES.md
@@ -1,3 +1,12 @@
+## Deprecated in favor of GitHub releases April 24th, 2023
+
+The Dependabot-core [Changelog is now available through GitHub Releases](https://github.com/dependabot/dependabot-core/releases).
+
+We switched to GitHub Releases to avoid the race condition between the version bump pull request and another pull
+request. If the other PR is merged between the time the version bump pull request was created and when it was merged,
+then the other pull request wasn't getting pulled into our changelog. This also allows a lot more flexibility around
+automation the creation of the version bump PR.
+
 ## v0.217.0, 24 April 2023
 
 - Run UpdateAllVersions with ungrouped dependencies [#7110](https://github.com/dependabot/dependabot-core/pull/7110)

--- a/bin/bump-version.rb
+++ b/bin/bump-version.rb
@@ -8,50 +8,6 @@ end
 component = ARGV[0].to_sym
 dry_run = ARGV[1] == "--dry-run"
 
-# rubocop:disable Lint/LiteralAsCondition
-unless `which gh` && $?.success?
-  puts "Please install the gh cli: brew install gh"
-  exit 1
-end
-
-unless `gh auth status -h github.com > /dev/null 2>&1` && $?.success?
-  puts "Please login to GitHub first: gh auth login"
-  exit 1
-end
-# rubocop:enable Lint/LiteralAsCondition
-
-CHANGELOG_PATH = File.join(__dir__, "..", "CHANGELOG.md")
-CHANGELOG_CONTENTS = File.read(CHANGELOG_PATH)
-
-def proposed_changes(version, _new_version)
-  dependabot_team = `gh api -X GET 'orgs/dependabot/teams/maintainers/members' --jq '.[].login'`
-  dependabot_team = dependabot_team.split("\n").map(&:strip) + ["dependabot"]
-
-  commit_subjects = `git log --pretty="%s" v#{version}..HEAD`.lines
-  merge_subjects = commit_subjects.select do |s|
-    s.downcase.start_with?("merge pull request #") && !s.match?(/release[-_\s]notes/i)
-  end
-  pr_numbers = merge_subjects.map { |s| s.match(/#(\d+)/)[1].to_i }
-  puts "⏳ fetching pull request details"
-  pr_details = pr_numbers.map do |pr_number|
-    pr_details = `gh pr view #{pr_number} --json title,author --jq ".title,.author.login"`
-    title, author = pr_details.split("\n").map(&:strip)
-    {
-      title: title,
-      author: author,
-      number: pr_number,
-      link: "https://github.com/dependabot/dependabot-core/pull/#{pr_number}"
-    }
-  end
-
-  pr_details.map do |details|
-    line = "- #{details[:title]}"
-    line += " (@#{details[:author]})" unless dependabot_team.include?(details[:author])
-    line += " [##{details[:number]}](#{details[:link]})"
-    line
-  end
-end
-
 # Update version file
 version_path = File.join(__dir__, "..", "common", "lib", "dependabot.rb")
 version_contents = File.read(version_path)
@@ -80,37 +36,23 @@ else
   puts "☑️  updater/Gemfile.lock updated"
 end
 
-proposed_changes = proposed_changes(version, new_version)
-
-# Update CHANGELOG
-if dry_run
-  puts "Would update CHANGELOG:"
-  puts proposed_changes
-else
-  new_changelog_contents = [
-    "## v#{new_version}, #{Time.now.strftime('%e %B %Y').strip}\n",
-    proposed_changes.join("\n") + "\n",
-    CHANGELOG_CONTENTS
-  ].join("\n")
-
-  File.write(CHANGELOG_PATH, new_changelog_contents)
-  puts "☑️  CHANGELOG.md updated"
-end
-
 unless dry_run
+  puts "Now, create the PR"
   puts
-  puts "Double check the changes (editing CHANGELOG.md where necessary), then"
-  puts "commit, tag, and push the release:"
-  puts
-  puts "git checkout -b v#{new_version}-release-notes"
-  puts "git add CHANGELOG.md common/lib/dependabot.rb updater/Gemfile.lock"
+  puts "git checkout -b v#{new_version}"
+  puts "git add common/lib/dependabot.rb updater/Gemfile.lock"
   puts "git commit -m 'v#{new_version}'"
-  puts "git push origin HEAD:v#{new_version}-release-notes"
-  puts "# ... create PR, verify, merge, for example:"
-  puts "gh pr create"
-  puts "# tag the approved release notes:"
-  puts "git fetch"
-  puts "git tag 'v#{new_version}' 'origin/v#{new_version}-release-notes'"
-  puts "git push origin v#{new_version}"
+  puts "git push origin HEAD:v#{new_version}"
+  puts "# ... create PR and merge after getting it approved."
   puts
+  puts "Once the PR is merged, create a new release tagged with that version using the format `v1.2.3"
+  puts
+  puts "* You can do this via the web UI: https://github.com/dependabot/dependabot-core/releases/new"
+  puts "  Use the 'Generate release notes' button and then edit as needed."
+  puts "* Or via the GitHub CLI:"
+  puts "    gh release create v1.X.X --generate-notes --draft"
+  puts "    > https://github.com/dependabot/fetch-metadata/releases/tag/untagged-XXXXXX"
+  puts "    # Use the generated URL to review/edit the release notes, and then publish it."
+  puts
+  puts "Once the release is tagged, it will be automatically pushed to RubyGems."
 end

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/dependabot/dependabot-core/issues",
-    "changelog_uri" => "https://github.com/dependabot/dependabot-core/blob/main/CHANGELOG.md"
+    "changelog_uri" => "https://github.com/dependabot/dependabot-core/releases/tag/v#{Dependabot::VERSION}"
   }
 
   spec.version = Dependabot::VERSION


### PR DESCRIPTION
We'd like to publish release more often, and part of that is making the release process more streamlined so that the maintainers don't dread the busywork of cutting a release.

Part of that is automating creating PR's that bump the version... but there's a race condition because we don't keep the changelog routinely updated with every PR... so if the version bump PR is opened, and then another PR is merged, that other PR won't be mentioning in the release notes.

The easiest way to sidestep that is to switch to managing the release notes via GitHub releases and stop using a Changelog text file.

We've had this discussion of "flat file vs git tags / GitHub releases" on a number of open source projects that I help maintain, and the pros/cons typically boil down to GitHub releases are more convenient, but they are more difficult to grep offline and less portable for projects that are concerned about lock-in to GitHub.

:dependabot: is already tightly connected to GitHub so I don't think that's a concern. :joy:

And :dependabot: is built around the concept of internet access, so I don't foresee much need to be grep'ing the changelog while offline... Searching for a release right from the releases page ([example](https://github.com/vishvananda/netns/releases?q=watch+github&expanded=true)) will generally be good enough, and advanced use cases can still grep the git tags content.

There's more streamlining to come, but this is a good incremental step to move us forward.

Related:
* https://github.com/dependabot/dependabot-core/issues/7132