### PR TITLE
No need for `--dry-run`

### DIFF
--- a/bin/bump-version.rb
+++ b/bin/bump-version.rb
@@ -2,11 +2,10 @@
 # frozen_string_literal: true
 
 unless %w(minor patch).include?(ARGV[0])
-  puts "usage: bin/bump-version.rb minor|patch [--dry-run]"
+  puts "usage: bin/bump-version.rb minor|patch"
   exit 1
 end
 component = ARGV[0].to_sym
-dry_run = ARGV[1] == "--dry-run"
 
 # Update version file
 version_path = File.join(__dir__, "..", "common", "lib", "dependabot.rb")
@@ -24,35 +23,28 @@ new_version =
 
 new_version_contents = version_contents.gsub(version, new_version)
 
-if dry_run
-  puts "Would update version file:"
-  puts new_version_contents
-else
-  File.write(version_path, new_version_contents)
-  puts "☑️  common/lib/dependabot.rb updated"
+File.write(version_path, new_version_contents)
+puts "☑️  common/lib/dependabot.rb updated"
 
-  # Bump the updater's Gemfile.lock with the new version
-  `cd updater/ && bundle lock`
-  puts "☑️  updater/Gemfile.lock updated"
-end
-
-unless dry_run
-  puts "Now, create the PR"
-  puts
-  puts "git checkout -b v#{new_version}"
-  puts "git add common/lib/dependabot.rb updater/Gemfile.lock"
-  puts "git commit -m 'v#{new_version}'"
-  puts "git push origin HEAD:v#{new_version}"
-  puts "# ... create PR and merge after getting it approved."
-  puts
-  puts "Once the PR is merged, create a new release tagged with that version using the format `v1.2.3"
-  puts
-  puts "* You can do this via the web UI: https://github.com/dependabot/dependabot-core/releases/new"
-  puts "  Use the 'Generate release notes' button and then edit as needed."
-  puts "* Or via the GitHub CLI:"
-  puts "    gh release create v1.X.X --generate-notes --draft"
-  puts "    > https://github.com/dependabot/fetch-metadata/releases/tag/untagged-XXXXXX"
-  puts "    # Use the generated URL to review/edit the release notes, and then publish it."
-  puts
-  puts "Once the release is tagged, it will be automatically pushed to RubyGems."
-end
+# Bump the updater's Gemfile.lock with the new version
+`cd updater/ && bundle lock`
+puts "☑️  updater/Gemfile.lock updated"
+puts
+puts "Now, create the PR"
+puts
+puts "git checkout -b v#{new_version}"
+puts "git add common/lib/dependabot.rb updater/Gemfile.lock"
+puts "git commit -m 'v#{new_version}'"
+puts "git push origin HEAD:v#{new_version}"
+puts "# ... create PR and merge after getting it approved."
+puts
+puts "Once the PR is merged, create a new release tagged with that version using the format `v1.2.3"
+puts
+puts "* You can do this via the web UI: https://github.com/dependabot/dependabot-core/releases/new"
+puts "  Use the 'Generate release notes' button and then edit as needed."
+puts "* Or via the GitHub CLI:"
+puts "    gh release create v1.X.X --generate-notes --draft"
+puts "    > https://github.com/dependabot/fetch-metadata/releases/tag/untagged-XXXXXX"
+puts "    # Use the generated URL to review/edit the release notes, and then publish it."
+puts
+puts "Once the release is tagged, it will be automatically pushed to RubyGems."


### PR DESCRIPTION
Now that this script no longer generates the changelog, it's so simple that there's no need for `--dry-run`. Any file changes can be reverted using `git restore`.

I thought about leaving it in for development purposes, but anyone working on this can hack what they need by commenting code out.

So might as well simplify it, esp since this will be used within a GitHub action workflow soon, simpler is better.