### PR TITLE
It's `bug_tracker_uri` not `issue_tracker_uri`

### DIFF
--- a/bundler/dependabot-bundler.gemspec
+++ b/bundler/dependabot-bundler.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/cargo/dependabot-cargo.gemspec
+++ b/cargo/dependabot-cargo.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license      = "Nonstandard" # License Zero Prosperity Public License
 
   spec.metadata = {
-    "issue_tracker_uri" => "https://github.com/dependabot/dependabot-core/issues",
+    "bug_tracker_uri" => "https://github.com/dependabot/dependabot-core/issues",
     "changelog_uri" => "https://github.com/dependabot/dependabot-core/blob/main/CHANGELOG.md"
   }
 

--- a/composer/dependabot-composer.gemspec
+++ b/composer/dependabot-composer.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/docker/dependabot-docker.gemspec
+++ b/docker/dependabot-docker.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/elm/dependabot-elm.gemspec
+++ b/elm/dependabot-elm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/git_submodules/dependabot-git_submodules.gemspec
+++ b/git_submodules/dependabot-git_submodules.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/github_actions/dependabot-github_actions.gemspec
+++ b/github_actions/dependabot-github_actions.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/go_modules/dependabot-go_modules.gemspec
+++ b/go_modules/dependabot-go_modules.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/gradle/dependabot-gradle.gemspec
+++ b/gradle/dependabot-gradle.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/hex/dependabot-hex.gemspec
+++ b/hex/dependabot-hex.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/maven/dependabot-maven.gemspec
+++ b/maven/dependabot-maven.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/npm_and_yarn/dependabot-npm_and_yarn.gemspec
+++ b/npm_and_yarn/dependabot-npm_and_yarn.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/nuget/dependabot-nuget.gemspec
+++ b/nuget/dependabot-nuget.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
   spec.version = common_gemspec.version

--- a/omnibus/dependabot-omnibus.gemspec
+++ b/omnibus/dependabot-omnibus.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/pub/dependabot-pub.gemspec
+++ b/pub/dependabot-pub.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/python/dependabot-python.gemspec
+++ b/python/dependabot-python.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 

--- a/terraform/dependabot-terraform.gemspec
+++ b/terraform/dependabot-terraform.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license      = common_gemspec.license
 
   spec.metadata = {
-    "issue_tracker_uri" => common_gemspec.metadata["issue_tracker_uri"],
+    "bug_tracker_uri" => common_gemspec.metadata["bug_tracker_uri"],
     "changelog_uri" => common_gemspec.metadata["changelog_uri"]
   }
 


### PR DESCRIPTION
I noticed we specify a `issue_tracker_uri` in our RubyGems metadata, but it's not showing up on RubyGems: https://rubygems.org/gems/dependabot-omnibus

A little digging showed [this is supposed to be `bug_tracker_uri`](https://guides.rubygems.org/specification-reference/#metadata).

Compare `rails` where it shows up:
1. https://github.com/rails/rails/blob/744b6715a5d07a2ddffceea8283f7b787541bc60/rails.gemspec#L24
2. https://rubygems.org/gems/rails