### PR TITLE
Pass the serialized group name when creating a PR for grouped updates

### DIFF
--- a/common/lib/dependabot/dependency_group.rb
+++ b/common/lib/dependabot/dependency_group.rb
@@ -4,17 +4,28 @@ require "wildcard_matcher"
 
 module Dependabot
   class DependencyGroup
-    attr_reader :name, :rules, :dependencies
+    attr_reader :name, :rules, :dependencies, :id
 
     def initialize(name:, rules:)
       @name = name
       @rules = rules
       @dependencies = []
+      @id = id_hash
     end
 
     def contains?(dependency)
       @dependencies.include?(dependency) if @dependencies.any?
       rules.any? { |rule| WildcardMatcher.match?(rule, dependency.name) }
+    end
+
+    private
+
+    def id_hash
+      { "name" => serialized_group_name }
+    end
+
+    def serialized_group_name
+      name.downcase.gsub("-", "_").to_sym
     end
   end
 end

--- a/common/lib/dependabot/dependency_group.rb
+++ b/common/lib/dependabot/dependency_group.rb
@@ -4,13 +4,12 @@ require "wildcard_matcher"
 
 module Dependabot
   class DependencyGroup
-    attr_reader :name, :rules, :dependencies, :id
+    attr_reader :name, :rules, :dependencies
 
     def initialize(name:, rules:)
       @name = name
       @rules = rules
       @dependencies = []
-      @id = id_hash
     end
 
     def contains?(dependency)
@@ -18,11 +17,11 @@ module Dependabot
       rules.any? { |rule| WildcardMatcher.match?(rule, dependency.name) }
     end
 
-    private
-
-    def id_hash
+    def to_h
       { "name" => serialized_group_name }
     end
+    
+    private
 
     def serialized_group_name
       name.downcase.gsub("-", "_").to_sym

--- a/common/lib/dependabot/dependency_group.rb
+++ b/common/lib/dependabot/dependency_group.rb
@@ -18,13 +18,7 @@ module Dependabot
     end
 
     def to_h
-      { "name" => serialized_group_name }
-    end
-    
-    private
-
-    def serialized_group_name
-      name.downcase.gsub("-", "_").to_sym
+      { "name" => name }
     end
   end
 end

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -166,6 +166,15 @@ module Dependabot
       client
     end
 
+    def dependency_group_hash(dependency_change)
+      return {} unless dependency_change.grouped_update?
+
+      # FIXME: We currently assumpt that _an attempt_ to send a DependencyGroup#id should
+      # result in the `grouped-update` flag being set, regardless of whether the
+      # DependencyGroup actually exists.
+      { "dependency-group": dependency_change.dependency_group.id }.compact
+    end
+
     def create_pull_request_data(dependency_change, base_commit_sha)
       data = {
         dependencies: dependency_change.updated_dependencies.map do |dep|
@@ -181,17 +190,8 @@ module Dependabot
         end,
         "updated-dependency-files": dependency_change.updated_dependency_files_hash,
         "base-commit-sha": base_commit_sha
-      }.merge({
-        # TODO: Replace this flag with a dependency-group object
-        #
-        # In future this should be something like:
-        #    "dependency-group": dependency_change.dependency_group_hash
-        #
-        # This will allow us to pass back the rule id and other parameters
-        # to allow Dependabot API to augment PR creation and associate it
-        # with the rule for rebasing, etc.
-        "grouped-update": dependency_change.grouped_update? ? true : nil
-      }.compact)
+      }.merge(dependency_group_hash(dependency_change))
+
       return data unless dependency_change.pr_message
 
       data["commit-message"] = dependency_change.pr_message.commit_message

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -172,7 +172,7 @@ module Dependabot
       # FIXME: We currently assumpt that _an attempt_ to send a DependencyGroup#id should
       # result in the `grouped-update` flag being set, regardless of whether the
       # DependencyGroup actually exists.
-      { "dependency-group": dependency_change.dependency_group.id }.compact
+      { "dependency-group": dependency_change.dependency_group.to_h }.compact
     end
 
     def create_pull_request_data(dependency_change, base_commit_sha)

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Dependabot::ApiClient do
           to(have_requested(:post, create_pull_request_url).
              with do |req|
                data = JSON.parse(req.body)["data"]
-               expect(data["dependency-group"]).to eq({ "name" => "dummy_group_name" })
+               expect(data["dependency-group"]).to eq({ "name" => "dummy-group-name" })
              end)
       end
     end

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -175,22 +175,25 @@ RSpec.describe Dependabot::ApiClient do
     end
 
     context "grouped updates" do
-      it "does not include the grouped_update key by default" do
+      it "does not include the grouped-update or dependency-group keys by default" do
         client.create_pull_request(dependency_change, base_commit)
 
         expect(WebMock).
           to(have_requested(:post, create_pull_request_url).
              with do |req|
                expect(req.body).not_to include("grouped-update")
+               expect(req.body).not_to include("dependency-group")
              end)
       end
 
-      it "flags the PR as a grouped-update if the dependency change has a dependency group assigned" do
+      it "flags the PR as having dependency-groups if the dependency change has a dependency group assigned" do
+        group = Dependabot::DependencyGroup.new(name: "dummy-group-name", rules: ["*"])
+
         grouped_dependency_change = Dependabot::DependencyChange.new(
           job: job,
           updated_dependencies: dependencies,
           updated_dependency_files: dependency_files,
-          dependency_group: anything
+          dependency_group: group
         )
 
         client.create_pull_request(grouped_dependency_change, base_commit)
@@ -199,7 +202,11 @@ RSpec.describe Dependabot::ApiClient do
           to(have_requested(:post, create_pull_request_url).
              with do |req|
                data = JSON.parse(req.body)["data"]
-               expect(data["grouped-update"]).to be true
+               # FIXME: Once we fully remove the `group-all` prototype behavior, we can also remove the
+               # `grouped-update` expectation since dependency-groups will require rules and only
+               # return the `dependency-group` key
+               expect(data["grouped-update"]).to be nil
+               expect(data["dependency-group"]).to eq({ "name" => "dummy_group_name" })
              end)
       end
     end

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -175,13 +175,12 @@ RSpec.describe Dependabot::ApiClient do
     end
 
     context "grouped updates" do
-      it "does not include the grouped-update or dependency-group keys by default" do
+      it "does not include the dependency-group key by default" do
         client.create_pull_request(dependency_change, base_commit)
 
         expect(WebMock).
           to(have_requested(:post, create_pull_request_url).
              with do |req|
-               expect(req.body).not_to include("grouped-update")
                expect(req.body).not_to include("dependency-group")
              end)
       end
@@ -202,10 +201,6 @@ RSpec.describe Dependabot::ApiClient do
           to(have_requested(:post, create_pull_request_url).
              with do |req|
                data = JSON.parse(req.body)["data"]
-               # FIXME: Once we fully remove the `group-all` prototype behavior, we can also remove the
-               # `grouped-update` expectation since dependency-groups will require rules and only
-               # return the `dependency-group` key
-               expect(data["grouped-update"]).to be nil
                expect(data["dependency-group"]).to eq({ "name" => "dummy_group_name" })
              end)
       end


### PR DESCRIPTION
Pass the serialized group name to PR creator (and the API client) when creating a PR for grouped updates.

We no longer pass the `grouped-update` key to the PR creator and instead pass in the `dependency-group` name

For now we are transforming the group name to downcase, snake_case, and to a symbol (although the test checks the name after it's been serialized to JSON, so the DependencyChange#id is converted to a string)