### PR TITLE
Cargo: handle unsupported toolchain versions (part 2)

### DIFF
--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -237,6 +237,10 @@ module Dependabot
             return nil
           end
 
+          if error.message.include?("usage of sparse registries requires `-Z sparse-registry`")
+            raise Dependabot::DependencyFileNotEvaluatable, "Dependabot only supports toolchain 1.68 and up."
+          end
+
           raise Dependabot::DependencyFileNotResolvable, error.message if resolvability_error?(error.message)
 
           raise error

--- a/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/version_resolver_spec.rb
@@ -163,6 +163,21 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::VersionResolver do
       end
     end
 
+    context "when using a toolchain that is too old" do
+      let(:toolchain_file) do
+        Dependabot::DependencyFile.new(
+          name: "rust-toolchain",
+          content: "[toolchain]\nchannel = \"1.67\"\n"
+        )
+      end
+      let(:unprepared_dependency_files) { [manifest, lockfile, toolchain_file] }
+
+      it "raises a helpful error" do
+        expect { subject }.
+          to raise_error(Dependabot::DependencyFileNotEvaluatable)
+      end
+    end
+
     context "using a feature that is not enabled" do
       let(:manifest_fixture_name) { "disabled_feature" }
       let(:lockfile_fixture_name) { "bare_version_specified" }


### PR DESCRIPTION
This is the same PR as #7122 but against the version resolver. 

It would probably be good in the future to create a native helper that both the version resolver and lockfile updater use since the errors seem like they are the same between the two. 