### PR TITLE
Add a placeholder `dependabot-core.gemspec`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,8 @@ require "bundler"
 require "./common/lib/dependabot"
 require "yaml"
 
+# ./dependabot-core.gemspec is purposefully excluded from this list
+# because it's an empty gem as a placeholder to prevent namesquatting.
 GEMSPECS = %w(
   common/dependabot-common.gemspec
   go_modules/dependabot-go_modules.gemspec

--- a/dependabot-core.gemspec
+++ b/dependabot-core.gemspec
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# This is a placeholder gem to prevent namesquatting on https://rubygems.org/gems/dependabot-core
+# Any updates must be manually published to RubyGems.
+# It's excluded from the normal release process because it's not expected to change.
+
+Gem::Specification.new do |spec|
+  spec.name = "dependabot-core"
+  spec.summary      = "This is a placeholder gem to prevent namesquatting. " \
+                      "You probably want the gem 'dependabot-omnibus'."
+  spec.description  = "This is a placeholder gem to prevent namesquatting. " \
+                      "You probably want the gem 'dependabot-omnibus'."
+  spec.authors     = "Dependabot"
+  spec.email       = "opensource@github.com"
+  spec.files       = [] # intentionally empty, this is a placeholder gem to prevent namesquatting
+  spec.homepage    = "https://github.com/dependabot/dependabot-core"
+  spec.license = "Nonstandard" # License Zero Prosperity Public License
+
+  spec.metadata = {
+    "bug_tracker_uri" => "https://github.com/dependabot/dependabot-core/issues"
+  }
+
+  spec.version = "0.95.1"
+  # Since a placeholder gem, no need to keep `required_ruby_version` up to date with `.ruby-version`
+  spec.required_ruby_version = ">= 3" # rubocop:disable Gemspec/RequiredRubyVersion
+end


### PR DESCRIPTION
While auditing [our gems](https://rubygems.org/profiles/dependabot), I noticed there was a `dependabot-core` gem that hadn't been updated in years: https://rubygems.org/gems/dependabot-core/versions/0.94.13

This was probably the original gem before it was all split apart into the meta gem `dependabot-omnibus` and the subgems.

This creates confusion because the name matches the `dependabot-core` repo.

At first I planned to delete it, but then I saw the note on Rubygems that deleting a gem frees up the namespace. We would much rather own this namespace to prevent namesquatting, so I've created a placeholder gemspec that has no associated source code.

I wasn't sure if `gem` would allow building/publishing with no source code, so tested, and it all worked:

```shell
$ gem build dependabot-core.gemspec
WARNING:  no files specified
WARNING:  description and summary are identical
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: dependabot-core
  Version: 0.95.1
  File: dependabot-core-0.95.1.gem
$ gem push dependabot-core-0.95.1.gem
Pushing gem to https://rubygems.org...
Successfully registered gem: dependabot-core (0.95.1)
```

You can see the updated gem here: https://rubygems.org/gems/dependabot-core/versions/0.95.1

Which is much less confusing than it used to be.

I think we should keep the gemspec around in case anyone needs to make small changes at some point, no need for them to recreate the whole file.

This repo seemed like the best fit, I wasn't sure whether to float it in `./common`, so I stuck it in the root dir... seems harmless enough.

Fix https://github.com/dependabot/dependabot-core/issues/6993