### PR TITLE
Clarify the `images-latest` workflow

### DIFF
--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -51,34 +51,32 @@ jobs:
           - { name: python, ecosystem: pip }
           - { name: terraform, ecosystem: terraform }
     env:
-      TAG: ${{ github.sha }}
+      COMMIT_SHA: ${{ github.sha }}
       NAME: ${{ matrix.suite.name }}
       ECOSYSTEM: ${{ matrix.suite.ecosystem }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Build dependabot-updater image
+      - name: Build the dependabot-updater-<ecosystem> image
+        # despite the script input being $NAME, the resulting image is dependabot-updater-${ECOSYSTEM}
         run: script/build ${NAME}
 
+      - name: Tag the images with the SHA, `latest`, and the date version
+        run: |
+          docker tag "${UPDATER_IMAGE}${ECOSYSTEM}" "${UPDATER_IMAGE}${ECOSYSTEM}:$COMMIT_SHA"
+          docker tag "${UPDATER_IMAGE}${ECOSYSTEM}" "${UPDATER_IMAGE}${ECOSYSTEM}:latest"
+          docker tag "${UPDATER_IMAGE}${ECOSYSTEM}" "${UPDATER_IMAGE}${ECOSYSTEM}:${{ needs.date-version.outputs.date }}"
+
       - name: Log in to GHCR
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Push branch image
-        run: |
-          docker tag "${UPDATER_IMAGE}${ECOSYSTEM}" "${UPDATER_IMAGE}${ECOSYSTEM}:$TAG"
-          docker push "${UPDATER_IMAGE}${ECOSYSTEM}:$TAG"
-
-      - name: Push latest on main
-        run: |
-          docker tag "${UPDATER_IMAGE}${ECOSYSTEM}:$TAG" "${UPDATER_IMAGE}${ECOSYSTEM}:latest"
-          docker tag "${UPDATER_IMAGE}${ECOSYSTEM}:$TAG" "${UPDATER_IMAGE}${ECOSYSTEM}:${{ needs.date-version.outputs.date }}"
-          docker push --all-tags "${UPDATER_IMAGE}${ECOSYSTEM}"
+      - name: Push the images to GHCR
+        run: docker push --all-tags "${UPDATER_IMAGE}${ECOSYSTEM}"
 
       - name: Set summary
         run: |
-          echo "updater uploaded with tag \`$TAG\`" >> $GITHUB_STEP_SUMMARY
+          echo "updater uploaded with tag \`$COMMIT_SHA\`" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${UPDATER_IMAGE}${ECOSYSTEM}:$TAG" >> $GITHUB_STEP_SUMMARY
+          echo "${UPDATER_IMAGE}${ECOSYSTEM}:$COMMIT_SHA" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This took me a little longer than it should have to understand what was going on, so here's a few cleanups that would have helped me grok things faster:
1. Rename `TAG` to `COMMIT_SHA` because tag is a bit ambiguous because the image is actually getting tagged with multiple things.
2. Organize all the tagging steps together.
3. Move the login step right next to publish... total nit, but typical workflows are build, tag, publish, and login is really part of publishing.
4. Clarify that we're _only_ building the ecosystem images, as `dependabot-updater` is ambiguous since there's both the base core image and the ecosystem images.