### PR TITLE
Prevent links in PR description that link to redirect.redirect.github.com

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -134,6 +134,8 @@ module Dependabot
         end
 
         def replace_github_host(text)
+          return text if !github_redirection_service.nil? && text.include?(github_redirection_service)
+
           text.gsub(
             /(www\.)?github.com/, github_redirection_service || "github.com"
           )

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1209,6 +1209,43 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
         end
 
+        context "from Bitbucket" do
+          let(:source) do
+            Dependabot::Source.new(provider: "bitbucket", repo: "gocardless/bump")
+          end
+
+          it "sanitizes github links" do
+            expect(pr_message).to eq(
+              "Bumps [business](https://github.com/gocardless/business) from `2468a02` to `cff701b`.\n" \
+              "\\#Commits\n\n" \
+              "  - [`26f4887`](https://github.com/gocardless/business/commit/" \
+              "26f4887ec647493f044836363537e329d9d213aa) Bump version to\n" \
+              "    v1.4.0\n" \
+              "  - [`7abe4c2`](https://github.com/gocardless/business/commit/" \
+              "7abe4c2dc0161904c40c221a48999d12995fbea7) \\[Fix\n" \
+              "    [\\#9](https://redirect.github.com/gocardless/business/issues/9)\\] Allow custom calendars\n" \
+              "  - [`1c72c35`](https://github.com/gocardless/business/commit/" \
+              "1c72c35ff2aa9d7ce0403d7fd4aa010d94723076) Allow custom\n" \
+              "    calendars\n" \
+              "  - [`5555535`](https://github.com/gocardless/business/commit/" \
+              "5555535ff2aa9d7ce0403d7fd4aa010d94723076)\n" \
+              "  - [`0bfb8c3`](https://github.com/gocardless/business/commit/" \
+              "0bfb8c3f0d2701abf9248185beeb8adf643374f6) Spacing:\n" \
+              "    [my/repo\\#5](https://redirect.github.com/my/repo/pull/5)\n" \
+              "  - [`a5970da`](https://github.com/gocardless/business/commit/" \
+              "a5970daf0b824e4c3974e57474b6cf9e39a11d0f) Merge pull\n" \
+              "    request [\\#8](https://redirect.github.com/gocardless/business/issues/8) from" \
+              " gocardless/rename-sepa-to-ecb\n" \
+              "  - [`d2eb29b`](https://github.com/gocardless/business/commit/" \
+              "d2eb29beda934c14220146c82f830de2edd63a25)\n" \
+              "    [12](https://redirect.github.com/gocardless/business/issues/12) Remove *SEPA* calendar" \
+              " (replaced by TARGET)\n" \
+              "  - See full diff in [compare\n" \
+              "    view](https://github.com/gocardless/business/compare/2468a02a6230e59ed1232d95d1ad3ef157195b03...cff701b3bfb182afc99a85657d7c9f3d6c1ccce2)\n"
+            )
+          end
+        end
+
         context "from codecommit" do
           let(:source) do
             Dependabot::Source.new(


### PR DESCRIPTION
The different sections of the metadata go through the LinkAndMentionSanitizer twice.

Once per sub section and once as the complete message.

In case of source providers that support HTML that is not a problem. The Markdown is converted to HTML and after that left alone.

In case of a source provider that does not support HTML (like bitbucket) there is a problem.
The links in the markdown are converted from github.com to redirect.github.com. And in the second pass the links are converted from redirect.github.com to redirect.redirect.github.com.

This PR contains a fix so only the second pass will convert the links in case the source provider does not support HTML.