### PR TITLE
NPM: handle EBADENGINE better

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -418,6 +418,12 @@ module Dependabot
             raise Dependabot::DependencyFileNotParseable, msg
           end
 
+          if error_message.include?("EBADENGINE")
+            msg = "Dependabot uses Node.js #{`node --version`} and NPM #{`npm --version`}. " \
+                  "Due to the engine-strict setting, the update will not succeed."
+            raise Dependabot::DependencyFileNotResolvable, msg
+          end
+
           raise error
         end
         # rubocop:enable Metrics/AbcSize

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -180,6 +180,15 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
       end
     end
 
+    context "with engines-strict and a version that won't work with Dependabot" do
+      let(:files) { project_dependency_files("npm8/engines") }
+
+      it "raises a helpful error" do
+        expect { updated_npm_lock_content }.
+          to raise_error(Dependabot::DependencyFileNotResolvable)
+      end
+    end
+
     context "when the lockfile does not have indentation" do
       let(:files) { project_dependency_files("npm8/simple_no_indentation") }
 

--- a/npm_and_yarn/spec/fixtures/projects/npm8/engines/.npmrc
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/engines/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/npm_and_yarn/spec/fixtures/projects/npm8/engines/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/engines/package-lock.json
@@ -1,0 +1,164 @@
+{
+    "name": "project-name",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "project-name",
+            "version": "1.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "fetch-factory": "^0.0.1"
+            },
+            "devDependencies": {
+                "etag": "^1.0.0"
+            }
+        },
+        "node_modules/encoding": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+            "dependencies": {
+                "iconv-lite": "0.4.19"
+            }
+        },
+        "node_modules/es6-promise": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+            "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+        },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fetch-factory": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.1.tgz",
+            "integrity": "sha1-4AdgWb2zHjFHx1s7jAQTO6jH4HE=",
+            "dependencies": {
+                "es6-promise": "3.3.1",
+                "isomorphic-fetch": "2.2.1",
+                "lodash": "3.10.1"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/isomorphic-fetch": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+            "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+            "dependencies": {
+                "node-fetch": "1.7.3",
+                "whatwg-fetch": "2.0.3"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+            "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "node_modules/node-fetch": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+            "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+            "dependencies": {
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
+            }
+        },
+        "node_modules/whatwg-fetch": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+            "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        }
+    },
+    "dependencies": {
+        "encoding": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+            "requires": {
+                "iconv-lite": "0.4.19"
+            }
+        },
+        "es6-promise": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+            "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+        },
+        "etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "dev": true
+        },
+        "fetch-factory": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.1.tgz",
+            "integrity": "sha1-4AdgWb2zHjFHx1s7jAQTO6jH4HE=",
+            "requires": {
+                "es6-promise": "3.3.1",
+                "isomorphic-fetch": "2.2.1",
+                "lodash": "3.10.1"
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "isomorphic-fetch": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+            "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+            "requires": {
+                "node-fetch": "1.7.3",
+                "whatwg-fetch": "2.0.3"
+            }
+        },
+        "lodash": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+            "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "node-fetch": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+            "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+            "requires": {
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
+            }
+        },
+        "whatwg-fetch": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+            "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        }
+    }
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm8/engines/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm8/engines/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "{{ name }}",
+    "engines": {
+      "node": "512",
+      "npm": "256"
+    },
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no\\ test\ specified\" && exit 1",
+        "prettify": "prettier --write \"{{packages/*/src,examples,cypress,scripts}/**/,}*.{js,jsx,ts,tsx,css,md}\""
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/waltfy/PROTO_TEST.git"
+    },
+    "author": "",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/waltfy/PROTO_TEST/issues"
+    },
+    "homepage": "https://github.com/waltfy/PROTO_TEST#readme",
+    "dependencies": {
+      "fetch-factory": "^0.0.1"
+    },
+    "devDependencies": {
+      "etag" : "^1.0.0"
+    }}


### PR DESCRIPTION
For additional context see https://github.com/dependabot/dependabot-core/issues/4072#issuecomment-1413222679

When `engine-strict` is set to true, Dependabot can error if the currently installed version doesn't match the range set in package.json. 

This gives the error in the UI more substance to help the customer figure out why it happened and solve the problem if they choose. Also helps clean up our error reporting!
