### PR TITLE
Improve naming of a method

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -173,7 +173,7 @@ module Dependabot
       def package_lock
         return @package_lock if defined?(@package_lock)
 
-        @package_lock = fetch_file_if_present("package-lock.json") unless ignore_package_lock?
+        @package_lock = fetch_file_if_present("package-lock.json") unless skip_package_lock?
       end
 
       def yarn_lock
@@ -490,7 +490,7 @@ module Dependabot
         {}
       end
 
-      def ignore_package_lock?
+      def skip_package_lock?
         return false unless npmrc
 
         npmrc.content.match?(/^package-lock\s*=\s*false/)


### PR DESCRIPTION
Since we have `ignore` settings, this may lead code reader into thinking we actually support skipping lockfiles through `dependabot.yml`. This is just trying to respect a package manager specific setting, so let's rename it to reduce confusion.

Suggested by @jeffwidman at https://github.com/dependabot/dependabot-core/pull/7081#discussion_r1176058626.