### PR TITLE
Remove unused `GH_TOKEN` env var

### DIFF
--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -1,6 +1,5 @@
 name: Latest images
 env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   UPDATER_IMAGE: "ghcr.io/dependabot/dependabot-updater-"
 on:
   push:


### PR DESCRIPTION
`GH_TOKEN` is necessary when using the `gh` CLI.

We use `gh` over in `images-branch.yml` when doing some stuff around forks, but not here in `images-latest.yml`.

I considered leaving it for consistency, and in case we ever add back `gh`. But the consistency arg doesn't make sense since `images-updater-core.yml` doesn't have this. And if we add back `gh`, we'll get an obvious error message about the problem per https://github.com/github/docs/issues/21930#issuecomment-1310122605.