### PR TITLE
Catch `bundle lock` failures

### DIFF
--- a/bin/bump-version.rb
+++ b/bin/bump-version.rb
@@ -28,6 +28,10 @@ puts "☑️  common/lib/dependabot.rb updated"
 
 # Bump the updater's Gemfile.lock with the new version
 `cd updater/ && bundle lock`
+if $?.exitstatus
+  puts "Failed to update updater/Gemfile.lock"
+  exit $?.exitstatus
+end
 puts "☑️  updater/Gemfile.lock updated"
 puts
 puts "Now, create the PR"


### PR DESCRIPTION
If `bundle lock` failed for some reason, then the exit code wasn't preserved and the message about the gemfile being updated successfully was incorrectly printed.