### PR TITLE
Do not catch the `0` exit code

### DIFF
--- a/bin/bump-version.rb
+++ b/bin/bump-version.rb
@@ -28,7 +28,7 @@ puts "☑️  common/lib/dependabot.rb updated"
 
 # Bump the updater's Gemfile.lock with the new version
 `cd updater/ && bundle lock`
-if $?.exitstatus
+unless $?.success?
   puts "Failed to update updater/Gemfile.lock"
   exit $?.exitstatus
 end


### PR DESCRIPTION
In https://github.com/dependabot/dependabot-core/pull/7208 I added this error checking, but I discovered through further testing that `$?.exitstatus` is always "truthy" in ruby, even for a `0` exit code!

I double-checked this variant, and it works as expected for both the success/failure cases.