### PR TITLE
Create version bump PRs using a custom action

### DIFF
--- a/.github/workflows/gems-bump-version.yml
+++ b/.github/workflows/gems-bump-version.yml
@@ -1,0 +1,71 @@
+name: Gems - Bump Version
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version Type?"
+        required: true
+        type: choice
+        options:
+          - minor
+          - patch
+        default: "minor"
+
+jobs:
+  Create-PR-To-Bump-Dependabot-Gems-Version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1 # bump-version.rb needs bundler
+
+      - name: Bump the version
+        run: |
+          NEW_VERSION=$(bin/bump-version.rb ${{ github.event.inputs.version_type }})
+          echo "New version is: $NEW_VERSION"
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+
+      - name: Configure the git user
+        run: |
+          git config user.name "github-actions[bot]"
+          # Specifying the full email allows the avatar to show up: https://github.com/orgs/community/discussions/26560
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create a branch and commit the changes
+        run: |
+          # Using an idempotent branch name ensures no duplicate PR's are created
+          # if the action is re-run before the previous PR is merged.
+          # The branch name is purposefully different from the release tag to
+          # avoid ambiguity when selecting git refs.
+          git checkout -b "bump-to-v${{ env.NEW_VERSION }}"
+          git add common/lib/dependabot.rb updater/Gemfile.lock
+          echo "Creating commit / PR linking to the releases notes URL."
+          echo "This URL will 404 until the release is actually tagged, which you should do as soon as the PR is merged."
+          git commit -m "v${{ env.NEW_VERSION }}" -m "Release notes: https://github.com/${{ github.repository }}/releases/tag/v${{ env.NEW_VERSION }}"
+
+      - name: Push the branch
+        run: |
+          echo "Pushing branch to remote. If this fails, check if a branch/PR already exists for this version."
+          git config push.autoSetupRemote true
+          git push
+
+      - name: Create a PR from the branch with the commit
+        run: |
+          PR_URL=$(gh pr create --fill) # `fill` re-uses the title / body from the commit
+          echo "PR created at URL: $PR_URL"
+          echo "PR_URL=$PR_URL" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set summary
+        run: |
+          echo ":rocket: PR created at URL: ${{ env.PR_URL }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "After the PR is approved/merged, create a new release tagged as \`v${{ env.NEW_VERSION }}\`, _making sure to point it at the merge commit_:" >> $GITHUB_STEP_SUMMARY
+          echo "* You can do this via the web UI - use the \`Generate release notes\` button and then edit as needed: https://github.com/${{ github.repository }}/releases/new?tag=v${{ env.NEW_VERSION }}&title=v${{ env.NEW_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "* Or via the GitHub CLI:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "    gh release create v${{ env.NEW_VERSION }} --title v${{ env.NEW_VERSION }} --generate-notes --draft" >> $GITHUB_STEP_SUMMARY
+          echo "    > https://github.com/${{ github.repository }}/releases/tag/untagged-XXXXXX" >> $GITHUB_STEP_SUMMARY
+          echo "    # Use the generated URL to review/edit the release notes." >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "Once the release is tagged, another GitHub Action workflow automatically pushes it to RubyGems." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -1,4 +1,4 @@
-name: Release gems
+name: Gems - Release to RubyGems
 on:
   push:
     tags:

--- a/README.md
+++ b/README.md
@@ -535,22 +535,14 @@ recurring payments from Europe, check them out.
 <details><summary>:book: Release guide</summary>
 <p>
 
-Publish a new release to RubyGems using the following steps:
+Publish a new release to RubyGems by running the ["Gems - Bump Version" workflow](https://github.com/dependabot/dependabot-core/actions/workflows/gems-bump-version.yml) and following the instructions on the job summary.
 
-1. Ensure you have the latest merged changes:  `git checkout main` and `git pull`
-2. Run `bin/bump-version.rb` to bump the version.
-3. Create a PR with the change and merge after getting it reviewed.
-4. Tag that commit as a new release using the format `v1.2.3`: https://github.com/dependabot/dependabot-core/releases/new
-   - Use the 'Generate release notes' button and then edit as needed.
-   - Or via the GitHub CLI:
+In a nutshell the process will be:
 
-      ```bash
-      gh release create v1.X.X --generate-notes --draft"
-      > https://github.com/dependabot/fetch-metadata/releases/tag/untagged-XXXXXX"
-      # Use the generated URL to review/edit the release notes, and then publish it."
-      ```
-
-5. Once the release is tagged, it will be automatically pushed to RubyGems.
+1. Run the action to generate a version bump PR.
+2. Merge the PR.
+3. Tag that merge commit as a new release using the format `v1.2.3`. The job summary contains a URL pre-populated with the correct version for the title and tag.
+4. Once the release is tagged, another GitHub Action workflow automatically pushes it to RubyGems.
 
 </p>
 </details>

--- a/bin/bump-version.rb
+++ b/bin/bump-version.rb
@@ -22,33 +22,12 @@ new_version =
   end
 
 new_version_contents = version_contents.gsub(version, new_version)
-
 File.write(version_path, new_version_contents)
-puts "☑️  common/lib/dependabot.rb updated"
 
 # Bump the updater's Gemfile.lock with the new version
 `cd updater/ && bundle lock`
 unless $?.success?
-  puts "Failed to update updater/Gemfile.lock"
+  puts "Failed to update `updater/Gemfile.lock`"
   exit $?.exitstatus
 end
-puts "☑️  updater/Gemfile.lock updated"
-puts
-puts "Now, create the PR"
-puts
-puts "git checkout -b v#{new_version}"
-puts "git add common/lib/dependabot.rb updater/Gemfile.lock"
-puts "git commit -m 'v#{new_version}'"
-puts "git push origin HEAD:v#{new_version}"
-puts "# ... create PR and merge after getting it approved."
-puts
-puts "Once the PR is merged, create a new release tagged with that version using the format `v1.2.3`"
-puts
-puts "* You can do this via the web UI: https://github.com/dependabot/dependabot-core/releases/new"
-puts "  Use the 'Generate release notes' button and then edit as needed."
-puts "* Or via the GitHub CLI:"
-puts "    gh release create v1.X.X --generate-notes --draft"
-puts "    > https://github.com/dependabot/fetch-metadata/releases/tag/untagged-XXXXXX"
-puts "    # Use the generated URL to review/edit the release notes, and then publish it."
-puts
-puts "Once the release is tagged, it will be automatically pushed to RubyGems."
+puts new_version


### PR DESCRIPTION
This continues the process of streamlining our releases by adding a custom GitHub Action workflow to automate creating version bump PR's.

For now, I intentionally left it as manually triggered to keep the review straightforward and let us try it for a week or two.

Once we're sure we're happy with this, then we plan to add a workflow trigger of a regular cron task to ensure we release frequently... probably on a weekly cadence.

Related:
* https://github.com/dependabot/dependabot-core/issues/7132