### PR TITLE
Remove Updater#legacy_run

### DIFF
--- a/updater/lib/dependabot/environment.rb
+++ b/updater/lib/dependabot/environment.rb
@@ -46,14 +46,6 @@ module Dependabot
       @job_definition ||= JSON.parse(File.read(job_path))
     end
 
-    # TODO: Remove
-    #
-    # This is purely to provide a stubbable method for tests to start disabling
-    # this codeline and it can be removed before merging this branch
-    def self.legacy_run_enabled?
-      true
-    end
-
     private_class_method def self.environment_variable(variable_name, default = :_undefined)
       return ENV.fetch(variable_name, default) unless default == :_undefined
 

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
+# Dependabot components
 require "dependabot/dependency_change"
 require "dependabot/dependency_change_builder"
 require "dependabot/environment"
 require "dependabot/experiments"
 require "dependabot/file_fetchers"
 require "dependabot/logger"
+require "dependabot/security_advisory"
+require "dependabot/update_checkers"
+
+# Ecosystems
 require "dependabot/python"
 require "dependabot/terraform"
 require "dependabot/elm"
@@ -23,17 +28,15 @@ require "dependabot/npm_and_yarn"
 require "dependabot/bundler"
 require "dependabot/pub"
 
+# Updater components
 require "dependabot/updater/error_handler"
 require "dependabot/updater/operations"
 require "dependabot/updater/security_update_helpers"
-require "dependabot/security_advisory"
-require "dependabot/update_checkers"
+
 require "wildcard_matcher"
 
 module Dependabot
   class Updater
-    # FIXME: Remove this once we deprecate the legacy_run code path
-    include SecurityUpdateHelpers
     class SubprocessFailed < StandardError
       attr_reader :raven_context
 
@@ -53,13 +56,11 @@ module Dependabot
       @job = job
       @dependency_snapshot = dependency_snapshot
       @error_handler = ErrorHandler.new(service: service, job: job)
-      # TODO: Collect @created_pull_requests on the Job object?
-      @created_pull_requests = []
     end
 
     def run
       return unless job
-      return legacy_run unless (operation_class = Operations.class_for(job: job))
+      raise Dependabot::NotImplemented unless (operation_class = Operations.class_for(job: job))
 
       Dependabot.logger.debug("Performing job with #{operation_class}")
       service.increment_metric("updater.started", tags: { operation: operation_class.tag_name })
@@ -89,403 +90,6 @@ module Dependabot
 
     private
 
-    attr_accessor :created_pull_requests
     attr_reader :service, :job, :dependency_snapshot, :error_handler
-
-    # This is the original logic within run, we currently fail over to this if
-    # no Operation class exists for the given job.
-    def legacy_run
-      raise Dependabot::NotImplemented unless Environment.legacy_run_enabled?
-
-      service.increment_metric("updater.started", tags: { operation: "Legacy" })
-      if job.updating_a_pull_request?
-        Dependabot.logger.info("Starting PR update job for #{job.source.repo}")
-        check_and_update_existing_pr_with_error_handling(dependencies)
-      else
-        Dependabot.logger.info("Starting update job for #{job.source.repo}")
-        dependencies.each { |dep| check_and_create_pr_with_error_handling(dep) }
-      end
-    end
-
-    def check_and_create_pr_with_error_handling(dependency)
-      check_and_create_pull_request(dependency)
-    rescue Dependabot::InconsistentRegistryResponse => e
-      error_handler.log_error(
-        dependency: dependency,
-        error: e,
-        error_type: "inconsistent_registry_response",
-        error_detail: e.message
-      )
-    rescue StandardError => e
-      error_handler.handle_dependabot_error(error: e, dependency: dependency)
-    end
-
-    def check_and_update_existing_pr_with_error_handling(dependencies)
-      dependency = dependencies.last
-      check_and_update_pull_request(dependencies)
-    rescue StandardError => e
-      error_handler.handle_dependabot_error(error: e, dependency: dependency)
-    end
-
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/PerceivedComplexity
-    # rubocop:disable Metrics/MethodLength
-    def check_and_update_pull_request(dependencies)
-      if dependencies.count != job.dependencies.count
-        # If the job dependencies mismatch the parsed dependencies, then
-        # we should close the PR as at least one thing we changed has been
-        # removed from the project.
-        close_pull_request(reason: :dependency_removed)
-        return
-      end
-
-      # NOTE: Prevent security only updates from turning into latest version
-      # updates if the current version is no longer vulnerable. This happens
-      # when a security update is applied by the user directly and the existing
-      # pull request is rebased.
-      if job.security_updates_only? &&
-         dependencies.none? { |d| job.allowed_update?(d) }
-        lead_dependency = dependencies.first
-        if job.vulnerable?(lead_dependency)
-          Dependabot.logger.info(
-            "Dependency no longer allowed to update #{lead_dependency.name} #{lead_dependency.version}"
-          )
-        else
-          Dependabot.logger.info("No longer vulnerable #{lead_dependency.name} #{lead_dependency.version}")
-        end
-        close_pull_request(reason: :up_to_date)
-        return
-      end
-
-      # The first dependency is the "lead" dependency in a multi-dependency
-      # update - i.e., the one we're trying to update.
-      #
-      # Note: Gradle, Maven and Nuget dependency names can be case-insensitive
-      # and the dependency name in the security advisory often doesn't match
-      # what users have specified in their manifest.
-      lead_dep_name = job.dependencies.first.downcase
-      lead_dependency = dependencies.find do |dep|
-        dep.name.downcase == lead_dep_name
-      end
-      checker = update_checker_for(lead_dependency, raise_on_ignored: raise_on_ignored?(lead_dependency))
-      log_checking_for_update(lead_dependency)
-
-      return if all_versions_ignored?(lead_dependency, checker)
-
-      return close_pull_request(reason: :up_to_date) if checker.up_to_date?
-
-      requirements_to_unlock = requirements_to_unlock(checker)
-      log_requirements_for_update(requirements_to_unlock, checker)
-
-      return close_pull_request(reason: :update_no_longer_possible) if requirements_to_unlock == :update_not_possible
-
-      updated_deps = checker.updated_dependencies(
-        requirements_to_unlock: requirements_to_unlock
-      )
-
-      dependency_change = Dependabot::DependencyChangeBuilder.create_from(
-        job: job,
-        dependency_files: dependency_snapshot.dependency_files,
-        updated_dependencies: updated_deps,
-        change_source: checker.dependency
-      )
-
-      # NOTE: Gradle, Maven and Nuget dependency names can be case-insensitive
-      # and the dependency name in the security advisory often doesn't match
-      # what users have specified in their manifest.
-      job_dependencies = job.dependencies.map(&:downcase)
-      if dependency_change.updated_dependencies.map(&:name).map(&:downcase) != job_dependencies
-        # The dependencies being updated have changed. Close the existing
-        # multi-dependency PR and try creating a new one.
-        close_pull_request(reason: :dependencies_changed)
-        create_pull_request(dependency_change)
-      elsif existing_pull_request(dependency_change.updated_dependencies)
-        # The existing PR is for this version. Update it.
-        update_pull_request(dependency_change)
-      else
-        # The existing PR is for a previous version. Supersede it.
-        create_pull_request(dependency_change)
-      end
-    end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/PerceivedComplexity
-    # rubocop:enable Metrics/MethodLength
-
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
-    # rubocop:disable Metrics/MethodLength
-    def check_and_create_pull_request(dependency)
-      checker = update_checker_for(dependency, raise_on_ignored: raise_on_ignored?(dependency))
-
-      log_checking_for_update(dependency)
-
-      return if all_versions_ignored?(dependency, checker)
-
-      # If the dependency isn't vulnerable or we can't know for sure we won't be
-      # able to know if the updated dependency fixes any advisories
-      if job.security_updates_only?
-        unless checker.vulnerable?
-          # The current dependency isn't vulnerable if the version is correct and
-          # can be matched against the advisories affected versions
-          if checker.version_class.correct?(checker.dependency.version)
-            return record_security_update_not_needed_error(checker)
-          end
-
-          return record_dependency_file_not_supported_error(checker)
-        end
-        return record_security_update_ignored(checker) unless job.allowed_update?(dependency)
-      end
-
-      if checker.up_to_date?
-        # The current version is still vulnerable and  Dependabot can't find a
-        # published or compatible non-vulnerable version, this can happen if the
-        # fixed version hasn't been published yet or the published version isn't
-        # compatible with the current enviroment (e.g. python version) or
-        # version (uses a different version suffix for gradle/maven)
-        return record_security_update_not_found(checker) if job.security_updates_only?
-
-        return log_up_to_date(dependency)
-      end
-
-      if pr_exists_for_latest_version?(checker)
-        record_pull_request_exists_for_latest_version(checker) if job.security_updates_only?
-        return Dependabot.logger.info(
-          "Pull request already exists for #{checker.dependency.name} " \
-          "with latest version #{checker.latest_version}"
-        )
-      end
-
-      requirements_to_unlock = requirements_to_unlock(checker)
-      log_requirements_for_update(requirements_to_unlock, checker)
-
-      if requirements_to_unlock == :update_not_possible
-        return record_security_update_not_possible_error(checker) if job.security_updates_only? && job.dependencies
-
-        return Dependabot.logger.info(
-          "No update possible for #{dependency.name} #{dependency.version}"
-        )
-      end
-
-      updated_deps = checker.updated_dependencies(
-        requirements_to_unlock: requirements_to_unlock
-      )
-
-      # Prevent updates that don't end up fixing any security advisories,
-      # blocking any updates where dependabot-core updates to a vulnerable
-      # version. This happens for npm/yarn subdendencies where Dependabot has no
-      # control over the target version. Related issue:
-      # https://github.com/github/dependabot-api/issues/905
-      if job.security_updates_only? &&
-         updated_deps.none? { |d| job.security_fix?(d) }
-        return record_security_update_not_possible_error(checker)
-      end
-
-      if (existing_pr = existing_pull_request(updated_deps))
-        # Create a update job error to prevent dependabot-api from creating a
-        # update_not_possible error, this is likely caused by a update job retry
-        # so should be invisible to users (as the first job completed with a pull
-        # request)
-        record_pull_request_exists_for_security_update(existing_pr) if job.security_updates_only?
-
-        deps = existing_pr.map do |dep|
-          if dep.fetch("dependency-removed", false)
-            "#{dep.fetch('dependency-name')}@removed"
-          else
-            "#{dep.fetch('dependency-name')}@#{dep.fetch('dependency-version')}"
-          end
-        end
-
-        return Dependabot.logger.info(
-          "Pull request already exists for #{deps.join(', ')}"
-        )
-      end
-
-      if peer_dependency_should_update_instead?(checker.dependency.name, updated_deps)
-        return Dependabot.logger.info(
-          "No update possible for #{dependency.name} #{dependency.version} " \
-          "(peer dependency can be updated)"
-        )
-      end
-
-      dependency_change = Dependabot::DependencyChangeBuilder.create_from(
-        job: job,
-        dependency_files: dependency_snapshot.dependency_files,
-        updated_dependencies: updated_deps,
-        change_source: checker.dependency
-      )
-      create_pull_request(dependency_change)
-    end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
-
-    def raise_on_ignored?(dependency)
-      job.security_updates_only? || job.ignore_conditions_for(dependency).any?
-    end
-
-    def requirements_to_unlock(checker)
-      if job.lockfile_only? || !checker.requirements_unlocked_or_can_be?
-        if checker.can_update?(requirements_to_unlock: :none) then :none
-        else
-          :update_not_possible
-        end
-      elsif checker.can_update?(requirements_to_unlock: :own) then :own
-      elsif checker.can_update?(requirements_to_unlock: :all) then :all
-      else
-        :update_not_possible
-      end
-    end
-
-    # If a version update for a peer dependency is possible we should
-    # defer to the PR that will be created for it to avoid duplicate PRs.
-    def peer_dependency_should_update_instead?(dependency_name, updated_deps)
-      # This doesn't apply to security updates as we can't rely on the
-      # peer dependency getting updated.
-      return false if job.security_updates_only?
-
-      updated_deps.
-        reject { |dep| dep.name == dependency_name }.
-        any? do |dep|
-          next true if existing_pull_request([dep])
-
-          original_peer_dep = ::Dependabot::Dependency.new(
-            name: dep.name,
-            version: dep.previous_version,
-            requirements: dep.previous_requirements,
-            package_manager: dep.package_manager
-          )
-          update_checker_for(original_peer_dep, raise_on_ignored: false).
-            can_update?(requirements_to_unlock: :own)
-        end
-    end
-
-    def log_checking_for_update(dependency)
-      Dependabot.logger.info(
-        "Checking if #{dependency.name} #{dependency.version} needs updating"
-      )
-      job.log_ignore_conditions_for(dependency)
-    end
-
-    def all_versions_ignored?(dependency, checker)
-      Dependabot.logger.info("Latest version is #{checker.latest_version}")
-      false
-    rescue Dependabot::AllVersionsIgnored
-      Dependabot.logger.info("All updates for #{dependency.name} were ignored")
-
-      # Report this error to the backend to create an update job error
-      raise if job.security_updates_only?
-
-      true
-    end
-
-    def log_up_to_date(dependency)
-      Dependabot.logger.info(
-        "No update needed for #{dependency.name} #{dependency.version}"
-      )
-    end
-
-    def log_requirements_for_update(requirements_to_unlock, checker)
-      Dependabot.logger.info("Requirements to unlock #{requirements_to_unlock}")
-
-      return unless checker.respond_to?(:requirements_update_strategy)
-
-      Dependabot.logger.info(
-        "Requirements update strategy #{checker.requirements_update_strategy}"
-      )
-    end
-
-    def pr_exists_for_latest_version?(checker)
-      latest_version = checker.latest_version&.to_s
-      return false if latest_version.nil?
-
-      job.existing_pull_requests.
-        select { |pr| pr.count == 1 }.
-        map(&:first).
-        select { |pr| pr.fetch("dependency-name") == checker.dependency.name }.
-        any? { |pr| pr.fetch("dependency-version", nil) == latest_version }
-    end
-
-    def existing_pull_request(updated_dependencies)
-      new_pr_set = Set.new(
-        updated_dependencies.map do |dep|
-          {
-            "dependency-name" => dep.name,
-            "dependency-version" => dep.version,
-            "dependency-removed" => dep.removed? ? true : nil
-          }.compact
-        end
-      )
-
-      job.existing_pull_requests.find { |pr| Set.new(pr) == new_pr_set } ||
-        created_pull_requests.find { |pr| Set.new(pr) == new_pr_set }
-    end
-
-    def dependencies
-      # Rebases and security updates have dependencies, version updates don't
-      return dependency_snapshot.job_dependencies if job.dependencies
-
-      if dependency_snapshot.dependencies.any? && dependency_snapshot.allowed_dependencies.none?
-        Dependabot.logger.info("Found no dependencies to update after filtering allowed updates")
-        return []
-      end
-
-      allowed_deps = dependency_snapshot.allowed_dependencies
-      # Return dependencies in a random order, with top-level dependencies
-      # considered first so that dependency runs which time out don't always hit
-      # the same dependencies
-      allowed_deps = allowed_deps.shuffle unless Environment.deterministic_updates?
-
-      # Consider updating vulnerable deps first. Only consider the first 10,
-      # though, to ensure they don't take up the entire update run
-      deps = allowed_deps.select { |d| job.vulnerable?(d) }.sample(10) +
-             allowed_deps.reject { |d| job.vulnerable?(d) }
-
-      deps
-    end
-
-    def update_checker_for(dependency, raise_on_ignored:)
-      Dependabot::UpdateCheckers.for_package_manager(job.package_manager).new(
-        dependency: dependency,
-        dependency_files: dependency_snapshot.dependency_files,
-        repo_contents_path: job.repo_contents_path,
-        credentials: job.credentials,
-        ignored_versions: job.ignore_conditions_for(dependency),
-        security_advisories: job.security_advisories_for(dependency),
-        raise_on_ignored: raise_on_ignored,
-        requirements_update_strategy: job.requirements_update_strategy,
-        options: job.experiments
-      )
-    end
-
-    def create_pull_request(dependency_change)
-      Dependabot.logger.info("Submitting #{dependency_change.updated_dependencies.map(&:name).join(', ')} " \
-                             "pull request for creation")
-
-      service.create_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
-
-      created_pull_requests << dependency_change.updated_dependencies.map do |dep|
-        {
-          "dependency-name" => dep.name,
-          "dependency-version" => dep.version,
-          "dependency-removed" => dep.removed? ? true : nil
-        }.compact
-      end
-    end
-
-    def update_pull_request(dependency_change)
-      Dependabot.logger.info("Submitting #{dependency_change.updated_dependencies.map(&:name).join(', ')} " \
-                             "pull request for update")
-
-      service.update_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
-    end
-
-    def close_pull_request(reason:)
-      reason_string = reason.to_s.tr("_", " ")
-      Dependabot.logger.info("Telling backend to close pull request for " \
-                             "#{job.dependencies.join(', ')} - #{reason_string}")
-      service.close_pull_request(job.dependencies, reason)
-    end
   end
 end

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -10,6 +10,35 @@ require "dependabot/file_fetchers"
 require "dependabot/updater"
 require "dependabot/service"
 
+### DO NOT ADD NEW TESTS TO THIS FILE
+#
+# This file tests all of our specific Dependabot::Updater::Operations via the
+# top-level Dependabot::Updater interface as it predates us breaking the class
+# up.
+#
+# Any tests should be added to the relevant file in spec/dependabot/operations,
+# if it does not exist it should be created, for an example see:
+#   updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
+#
+### Migration Path
+#
+# This file mixes tests that are specific to a single Operation with standard
+# behaviours that should be tested against several Operations.
+#
+# To migrate this file, follow this pattern:
+# - Remove all but the target class from Updater::OPERATIONS to 'brown-out'
+#   the code paths you aren't focused on
+# - Run this spec
+# - Copy any _passing_ tests to your new spec/dependabot/operations file
+# - Check which of the failing tests should apply to the target Operation
+# - Copy them and adjust their setup so they pass
+# - Repeat for the next Operation
+# - Consider breaking out shared_example groups for any tests which are the same
+#   for each Operation
+#
+# Once this process has been completed, this test should be repurposed to ensure
+# that the Updater delegates to the right Operation class and handles halting
+# errors in an expected way.
 RSpec.describe Dependabot::Updater do
   before do
     allow(Dependabot.logger).to receive(:info)

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -12,8 +12,6 @@ require "dependabot/service"
 
 RSpec.describe Dependabot::Updater do
   before do
-    # TODO: Remove
-    allow(Dependabot::Environment).to receive(:legacy_run_enabled?) { false }
     allow(Dependabot.logger).to receive(:info)
 
     stub_request(:get, "https://index.rubygems.org/versions").
@@ -1373,38 +1371,6 @@ RSpec.describe Dependabot::Updater do
 
             updater.run
           end
-        end
-      end
-
-      # This scenario is not currently used in production, it only exists
-      # implicity due to the legacy code mode-switching within methods.
-      #
-      # This will be deprecated when `legacy_run` is removed but should be
-      # fairly trivial to bring back if required.
-      context "and the job is create a version PR" do
-        before do
-          # Permit the legacy_run method to be used
-          allow(Dependabot::Environment).to receive(:legacy_run_enabled?) { true }
-        end
-
-        it "only attempts to update dependencies on the specified list" do
-          stub_update_checker
-
-          job = build_job(
-            requested_dependencies: ["dummy-pkg-b"],
-            updating_a_pull_request: false
-          )
-          service = build_service
-          updater = build_updater(service: service, job: job)
-
-          expect(updater).
-            to receive(:check_and_create_pr_with_error_handling).
-            and_call_original
-          expect(updater).
-            to_not receive(:check_and_update_existing_pr_with_error_handling)
-          expect(service).to receive(:create_pull_request).once
-
-          updater.run
         end
       end
 

--- a/updater/spec/spec_helper.rb
+++ b/updater/spec/spec_helper.rb
@@ -60,13 +60,6 @@ RSpec.configure do |config|
       fixture(File.join("job_definitions", "#{path}.yaml"))
     )
   end
-
-  # TODO: Remove once Updater#legacy_run is gone
-  config.before do
-    require "dependabot/environment"
-
-    allow(Dependabot::Environment).to receive(:legacy_run_enabled?) { false }
-  end
 end
 
 VCR.configure do |config|


### PR DESCRIPTION
We haven't seen any jobs hit this code path in over one week of observation, so let's complete the migration and remove this code.

This PR does not address refactoring the specs into per-operation files since that is off the critical path and we've generally been treating gaps tests as no-harm, no-foul.

It does however remove a test for one "operation" that doesn't actually exist in production: creating a brand new PR for one or more specific Dependencies.

If we need this behaviour in future, it'll be relatively trivial to compose a new Operation class and test to bring it back so let's remove it for clarity for now.

Finally, I've added some notes on the plan to split and migrate the tests as well as a warning to avoid adding new tests to the old interface. I've added an issue to the backlog to circle back to do this as we get time.