### PR TITLE
[Updater] The Updater always expects job.dependency_groups to be defined

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         suite:
           - { path: bundler, name: bundler, ecosystem: bundler }
-          - { path: bundler, name: bundler-grouped, ecosystem: bundler }
+          - { path: bundler, name: bundler-group-rules, ecosystem: bundler }
           - { path: cargo, name: cargo, ecosystem: cargo }
           - { path: composer, name: composer, ecosystem: composer }
           - { path: docker, name: docker, ecosystem: docker }
@@ -64,7 +64,7 @@ jobs:
             - 'common/**'
             - 'updater/**'
             - 'bundler/**'
-          bundler-grouped:
+          bundler-group-rules:
             - .github/workflows/smoke.yml
             - Dockerfile.updater-core
             - 'common/**'

--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -75,6 +75,9 @@ module Dependabot
     end
 
     def ungrouped_dependencies
+      # If no groups are defined, all dependencies are ungrouped by default.
+      return allowed_dependencies unless groups.any?
+
       Dependabot::DependencyGroupEngine.ungrouped_dependencies(allowed_dependencies)
     end
 

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -38,7 +38,6 @@ module Dependabot
           @error_handler = error_handler
         end
 
-        # rubocop:disable Metrics/AbcSize
         def perform
           if dependency_snapshot.groups.any?
             run_grouped_dependency_updates
@@ -61,7 +60,6 @@ module Dependabot
 
           run_ungrouped_dependency_updates if dependency_snapshot.ungrouped_dependencies.any?
         end
-        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dependabot/updater/operations/update_all_versions"
 require "dependabot/updater/group_update_creation"
 
 # This class implements our strategy for creating Pull Requests for Dependency
@@ -23,7 +24,7 @@ module Dependabot
           return false if job.updating_a_pull_request?
           return false if job.dependencies&.any?
 
-          Dependabot::Experiments.enabled?(:grouped_updates_prototype)
+          job.dependency_groups&.any? && Dependabot::Experiments.enabled?(:grouped_updates_prototype)
         end
 
         def self.tag_name
@@ -39,10 +40,37 @@ module Dependabot
 
         # rubocop:disable Metrics/AbcSize
         def perform
-          # FIXME: This preserves the default behavior of grouping all updates into a single PR
-          # but we should figure out if this is the default behavior we want.
-          register_all_dependencies_group unless job.dependency_groups&.any?
+          if dependency_snapshot.groups.any?
+            run_grouped_dependency_updates
+            run_ungrouped_dependency_updates if dependency_snapshot.ungrouped_dependencies.any?
+          else
+            # We shouldn't have selected this operation if no groups were defined
+            # due to the rules in `::applies_to?`, but if it happens it isn't
+            # enough reasons to fail the job.
+            Dependabot.logger.warn(
+              "No dependency groups defined!"
+            )
 
+            # We should warn our exception tracker...
+            service.capture_exception(
+              error: DependabotError.new("Attempted a grouped update with no groups defined."),
+              job: job
+            )
+
+            # ... and then just delegate everything to UpdateAllVersions
+            run_ungrouped_dependency_updates
+          end
+        end
+        # rubocop:enable Metrics/AbcSize
+
+        private
+
+        attr_reader :job,
+                    :service,
+                    :dependency_snapshot,
+                    :error_handler
+
+        def run_grouped_dependency_updates
           Dependabot.logger.info("Starting grouped update job for #{job.source.repo}")
 
           dependency_snapshot.groups.each do |_group_hash, group|
@@ -67,22 +95,6 @@ module Dependabot
               Dependabot.logger.info("Nothing to update for Dependency Group: '#{group.name}'")
             end
           end
-
-          run_ungrouped_dependency_updates if dependency_snapshot.ungrouped_dependencies.any?
-        end
-        # rubocop:enable Metrics/AbcSize
-
-        private
-
-        attr_reader :job,
-                    :service,
-                    :dependency_snapshot,
-                    :error_handler
-
-        def register_all_dependencies_group
-          all_dependencies_group = { "name" => "all-dependencies", "rules" => { "patterns" => ["*"] } }
-          Dependabot::DependencyGroupEngine.register(all_dependencies_group["name"],
-                                                     all_dependencies_group["rules"]["patterns"])
         end
 
         def run_ungrouped_dependency_updates

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -42,7 +42,6 @@ module Dependabot
         def perform
           if dependency_snapshot.groups.any?
             run_grouped_dependency_updates
-            run_ungrouped_dependency_updates if dependency_snapshot.ungrouped_dependencies.any?
           else
             # We shouldn't have selected this operation if no groups were defined
             # due to the rules in `::applies_to?`, but if it happens it isn't
@@ -51,15 +50,16 @@ module Dependabot
               "No dependency groups defined!"
             )
 
-            # We should warn our exception tracker...
+            # We should warn our exception tracker in case this represents an
+            # unexpected problem hydrating groups we have swallowed and then
+            # delegate everything to run_ungrouped_dependency_updates.
             service.capture_exception(
               error: DependabotError.new("Attempted a grouped update with no groups defined."),
               job: job
             )
-
-            # ... and then just delegate everything to UpdateAllVersions
-            run_ungrouped_dependency_updates
           end
+
+          run_ungrouped_dependency_updates if dependency_snapshot.ungrouped_dependencies.any?
         end
         # rubocop:enable Metrics/AbcSize
 

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -48,16 +48,10 @@ module Dependabot
             return []
           end
 
-          dependencies = if dependency_snapshot.ungrouped_dependencies.any?
-                           dependency_snapshot.ungrouped_dependencies
-                         else
-                           dependency_snapshot.allowed_dependencies
-                         end
-
           if Environment.deterministic_updates?
-            dependencies
+            dependency_snapshot.ungrouped_dependencies
           else
-            dependencies.shuffle
+            dependency_snapshot.ungrouped_dependencies.shuffle
           end
         end
 

--- a/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
@@ -119,9 +119,9 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
       )
 
       expect(Dependabot::Updater::Operations::UpdateAllVersions).to receive(:new) do |args|
-        expect(args[:dependency_snapshot].dependencies.length).to eql(2)
-        expect(args[:dependency_snapshot].dependencies.first.name).to eql("dummy-pkg-a")
-        expect(args[:dependency_snapshot].dependencies.last.name).to eql("dummy-pkg-b")
+        expect(args[:dependency_snapshot].ungrouped_dependencies.length).to eql(2)
+        expect(args[:dependency_snapshot].ungrouped_dependencies.first.name).to eql("dummy-pkg-a")
+        expect(args[:dependency_snapshot].ungrouped_dependencies.last.name).to eql("dummy-pkg-b")
       end.and_return(instance_double(Dependabot::Updater::Operations::UpdateAllVersions, perform: nil))
 
       group_update_all.perform

--- a/updater/spec/dependabot/updater/operations_spec.rb
+++ b/updater/spec/dependabot/updater/operations_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             security_updates_only?: false,
                             updating_a_pull_request?: true,
                             dependencies: [],
+                            dependency_groups: [],
                             is_a?: true)
 
       expect(described_class.class_for(job: job)).to be_nil
@@ -29,6 +30,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             security_updates_only?: false,
                             updating_a_pull_request?: false,
                             dependencies: [],
+                            dependency_groups: [],
                             is_a?: true)
 
       expect(described_class.class_for(job: job)).to be(Dependabot::Updater::Operations::UpdateAllVersions)
@@ -42,6 +44,7 @@ RSpec.describe Dependabot::Updater::Operations do
                               security_updates_only?: false,
                               updating_a_pull_request?: false,
                               dependencies: [],
+                              dependency_groups: [anything],
                               is_a?: true)
 
         expect(described_class.class_for(job: job)).to be(Dependabot::Updater::Operations::GroupUpdateAllVersions)
@@ -57,6 +60,7 @@ RSpec.describe Dependabot::Updater::Operations do
                               updating_a_pull_request?: true,
                               dependencies: [anything],
                               dependency_group_to_refresh: anything,
+                              dependency_groups: [anything],
                               is_a?: true)
 
         expect(described_class.class_for(job: job)).
@@ -72,6 +76,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             updating_a_pull_request?: true,
                             dependencies: [anything],
                             dependency_group_to_refresh: nil,
+                            dependency_groups: [anything],
                             is_a?: true)
 
       expect(described_class.class_for(job: job)).
@@ -83,6 +88,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             security_updates_only?: true,
                             updating_a_pull_request?: false,
                             dependencies: [anything],
+                            dependency_groups: [anything],
                             is_a?: true)
 
       expect(described_class.class_for(job: job)).
@@ -94,6 +100,7 @@ RSpec.describe Dependabot::Updater::Operations do
                             security_updates_only?: true,
                             updating_a_pull_request?: true,
                             dependencies: [anything],
+                            dependency_groups: [anything],
                             is_a?: true)
 
       expect(described_class.class_for(job: job)).

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -2262,27 +2262,6 @@ RSpec.describe Dependabot::Updater do
       updater.run
     end
 
-    it "performs a grouped and ungrouped dependency update when both are present" do
-      job = build_job(experiments: { "grouped-updates-prototype" => true },
-                      dependency_groups: [{ "name" => "group-b", "rules" => { "patterns" => ["dummy-pkg-b"] } }])
-      stub_update_checker
-      service = build_service
-      snapshot = build_dependency_snapshot(job: job)
-      updater = build_updater(
-        service: service,
-        job: job,
-        dependency_snapshot: snapshot
-      )
-
-      allow(service).to receive(:create_pull_request)
-      expect(snapshot).to receive(:groups).at_least(:once).and_call_original
-      expect(snapshot).to receive(:ungrouped_dependencies).at_least(:once).and_call_original
-      expect(service).to receive(:increment_metric).
-        with("updater.started", { tags: { operation: :grouped_updates_prototype } })
-
-      updater.run
-    end
-
     it "does not include ignored dependencies in the group PR" do
       job = build_job(
         ignore_conditions: [

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -2275,7 +2275,7 @@ RSpec.describe Dependabot::Updater do
       )
 
       allow(service).to receive(:create_pull_request)
-      expect(snapshot).to receive(:groups).and_call_original
+      expect(snapshot).to receive(:groups).at_least(:once).and_call_original
       expect(snapshot).to receive(:ungrouped_dependencies).at_least(:once).and_call_original
       expect(service).to receive(:increment_metric).
         with("updater.started", { tags: { operation: :grouped_updates_prototype } })

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_with_ungrouped.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_with_ungrouped.yaml
@@ -1,0 +1,38 @@
+job:
+  package-manager: bundler
+  source:
+    provider: github
+    repo: dependabot/smoke-tests
+    directory: "/bundler"
+    branch:
+    api-endpoint: https://api.github.com/
+    hostname: github.com
+  dependencies:
+  existing-pull-requests: []
+  updating-a-pull-request: false
+  lockfile-only: false
+  update-subdependencies: false
+  ignore-conditions: []
+  requirements-update-strategy:
+  allowed-updates:
+  - dependency-type: direct
+    update-type: all
+  credentials-metadata:
+  - type: git_source
+    host: github.com
+  security-advisories: []
+  max-updater-run-time: 2700
+  vendor-dependencies: false
+  experiments:
+    grouped-updates-prototype: true
+  reject-external-code: false
+  commit-message-options:
+    prefix:
+    prefix-development:
+    include-scope:
+  security-updates-only: false
+  dependency-groups:
+  - name: group-b
+    rules:
+      patterns:
+        - "dummy-pkg-b"


### PR DESCRIPTION
As we start to test configured Dependency Groups, we no longer need to rely on the Updater handling empty dependency groups by failing over to a "group everything in one PR" placeholder rule.

The service is now responsible for injecting this in places where it is required, otherwise we should treat an empty `job.dependency_groups` as a sign the feature is not being invoked since this is the target production behaviour.

Removing it now will avoid any debugging confusion as we start to test more widely.

### Other Changes

As part of making this change I migrated the test that verifies that the `GroupUpdateAllVersions` class handles mixes of grouped and ungrouped dependencies properly from the "legacy" `updater_spec.rb` into the class-specific test.

This lead on to a further change in `DependabotSnapshot#ungrouped_dependencies` as it was surprising to find this set empty where no groups were defined.

I've added a guard clause to return the full list of `allowed_dependencies` when `DependabotSnapshot#groups` are empty so it can be asserted against in tests consistently and `UpdateAllVersions` no longer needs to be aware of whether groups exist or not.