### PR TITLE
[Updater] Add a test for two overlapping groups

### DIFF
--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -71,6 +71,8 @@ module Dependabot
         def run_grouped_dependency_updates
           Dependabot.logger.info("Starting grouped update job for #{job.source.repo}")
 
+          Dependabot.logger.info("Found #{dependency_snapshot.groups.count} group(s).")
+
           dependency_snapshot.groups.each do |_group_hash, group|
             Dependabot.logger.info("Starting update group for '#{group.name}'")
 

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -68,9 +68,8 @@ module Dependabot
                     :dependency_snapshot,
                     :error_handler
 
-        def run_grouped_dependency_updates
+        def run_grouped_dependency_updates # rubocop:disable Metrics/AbcSize
           Dependabot.logger.info("Starting grouped update job for #{job.source.repo}")
-
           Dependabot.logger.info("Found #{dependency_snapshot.groups.count} group(s).")
 
           dependency_snapshot.groups.each do |_group_hash, group|

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_overlapping_groups.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_overlapping_groups.yaml
@@ -1,0 +1,42 @@
+job:
+  package-manager: bundler
+  source:
+    provider: github
+    repo: dependabot/smoke-tests
+    directory: "/bundler"
+    branch:
+    api-endpoint: https://api.github.com/
+    hostname: github.com
+  dependencies:
+  existing-pull-requests: []
+  updating-a-pull-request: false
+  lockfile-only: false
+  update-subdependencies: false
+  ignore-conditions: []
+  requirements-update-strategy:
+  allowed-updates:
+  - dependency-type: direct
+    update-type: all
+  credentials-metadata:
+  - type: git_source
+    host: github.com
+  security-advisories: []
+  max-updater-run-time: 2700
+  vendor-dependencies: false
+  experiments:
+    grouped-updates-prototype: true
+  reject-external-code: false
+  commit-message-options:
+    prefix:
+    prefix-development:
+    include-scope:
+  security-updates-only: false
+  dependency-groups:
+  - name: my-group
+    rules:
+      patterns:
+        - "dummy-pkg-*"
+  - name: my-overlapping-group
+    rules:
+      patterns:
+        - "dummy-pkg-*"


### PR DESCRIPTION
This is a quick unit test that verifies two things:
- That we correctly parse N `dependency_groups` to perform two group update attempts
- That if two groups overlap, we will PR the same dependencies in both by design