### PR TITLE
Pin docker_registry2 to 1.14.0 to fix CI

### DIFF
--- a/common/dependabot-common.gemspec
+++ b/common/dependabot-common.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-ecr", "~> 1.5"
   spec.add_dependency "bundler", ">= 1.16", "< 3.0.0"
   spec.add_dependency "commonmarker", ">= 0.20.1", "< 0.24.0"
-  spec.add_dependency "docker_registry2", "~> 1.14"
+  spec.add_dependency "docker_registry2", "~> 1.14.0"
   spec.add_dependency "excon", "~> 0.96", "< 0.100"
   spec.add_dependency "faraday", "2.7.4"
   spec.add_dependency "faraday-retry", "2.1.0"

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       aws-sdk-ecr (~> 1.5)
       bundler (>= 1.16, < 3.0.0)
       commonmarker (>= 0.20.1, < 0.24.0)
-      docker_registry2 (~> 1.14)
+      docker_registry2 (~> 1.14.0)
       excon (~> 0.96, < 0.100)
       faraday (= 2.7.4)
       faraday-retry (= 2.1.0)


### PR DESCRIPTION
I think we may need some changes to adapt to version 1.15.0, in particular, to https://github.com/deitch/docker_registry2/pull/85.

In tests we stub a HEAD request which 1.15.0 no longer performs, so hopefully we just need to adapt the specs, but the new version means no behavioral changes for us.

For now I'll pin it to get CI green.