### PR TITLE
prebuild Python image for faster Codespace startup

### DIFF
--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
-# This pull takes a while, adding it to the prebuild
-docker pull ghcr.io/dependabot/dependabot-updater:latest
+# Prebuilding Python since it takes a long time. This also gets us a pre-built update-core image
+# which will make building all of the other images faster too. If another image is taking a long
+# time to build, consider adding it here.
+script/build python
 docker pull ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest


### PR DESCRIPTION
When we launch a fresh Codespace and run `script/build` or `docker-dev-shell` the images tend to miss the cache for some reason and have to build from scratch. I have tried to figure out why the Docker cache is missing, and am officially giving up for now. 

By adding the Python image build to the pre-build we'll be able to build all images MUCH faster since the updater-core is what tends to take the most time for most ecosystems, other than Python.

I considered adding a prebuild of all the images, but decided not to so the prebuild process is shorter for testing it.