### PR TITLE
Add tag to indicate if repo is private in sentry reports

### DIFF
--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -41,6 +41,7 @@ module Dependabot
       vendor_dependencies
       dependency_groups
       dependency_group_to_refresh
+      repo_private
     )
 
     attr_reader :allowed_updates,
@@ -80,7 +81,7 @@ module Dependabot
 
     # NOTE: "attributes" are fetched and injected at run time from
     # dependabot-api using the UpdateJobPrivateSerializer
-    def initialize(attributes)
+    def initialize(attributes) # rubocop:disable Metrics/AbcSize
       @id                             = attributes.fetch(:id)
       @allowed_updates                = attributes.fetch(:allowed_updates)
       @commit_message_options         = attributes.fetch(:commit_message_options, {})
@@ -111,6 +112,7 @@ module Dependabot
       @vendor_dependencies            = attributes.fetch(:vendor_dependencies, false)
       @dependency_groups              = attributes.fetch(:dependency_groups, [])
       @dependency_group_to_refresh    = attributes.fetch(:dependency_group_to_refresh, nil)
+      @repo_private                   = attributes.fetch(:repo_private, nil)
 
       register_experiments
       register_dependency_groups
@@ -128,6 +130,10 @@ module Dependabot
       return nil unless clone?
 
       @repo_contents_path
+    end
+
+    def repo_private?
+      @repo_private
     end
 
     def updating_a_pull_request?

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -72,7 +72,8 @@ module Dependabot
         {
           tags: tags.merge({
             update_job_id: job&.id,
-            package_manager: job&.package_manager
+            package_manager: job&.package_manager,
+            repo_private: job&.repo_private?
           }.compact),
           extra: extra.merge({
             dependency_name: dependency&.name

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe Dependabot::Job do
       experiments: experiments,
       commit_message_options: commit_message_options,
       security_updates_only: security_updates_only,
-      dependency_groups: dependency_groups
+      dependency_groups: dependency_groups,
+      repo_private: repo_private
     }
   end
 
@@ -65,6 +66,7 @@ RSpec.describe Dependabot::Job do
   let(:commit_message_options) { nil }
   let(:vendor_dependencies) { false }
   let(:dependency_groups) { [] }
+  let(:repo_private) { false }
 
   describe "::new_update_job" do
     let(:job_json) { fixture("jobs/job_with_credentials.json") }


### PR DESCRIPTION
Currently finding a way to reproduce issues found in Sentry can be challenging, usually the easiest way is to find a public project that we can run our code against. Today this is hard, because we need to manually comb the errors in sentry until we find one that's public.

With this change, that should no longer be an issue.