### PR TITLE
Use `latest` `bundler` for generating `updater/Gemfile.Lock`

### DIFF
--- a/.github/workflows/gems-bump-version.yml
+++ b/.github/workflows/gems-bump-version.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1 # bump-version.rb needs bundler
+        with:
+          # We pin bundler version in Dockerfile.updater-core BUNDLER_V2_VERSION
+          # which also ends up in `updater/Gemfile.lock`. To avoid having to
+          # keep the pin in-sync here, assume that core is generally on 'latest'.
+          bundler: 'latest'
 
       - name: Bump the version
         run: |


### PR DESCRIPTION
Previously, the version of bundler defaults to the one shipped with Ruby.

However, we custom pin to newer versions in `Dockerfile.updater-core`, so when we then run `bundle lock`, within the context of `docker-dev-shell`, it bumps the `BUNDLED WITH` version: https://github.com/dependabot/dependabot-core/pull/7229#discussion_r1184064978

The `ruby/setup-ruby` action does support reading the bundler version from `Gemfile.lock`: https://github.com/ruby/setup-ruby/blob/d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c/action.yml#L20

But our lockfile is in a subdirectory. They do support specifying the working directory to look into: https://github.com/ruby/setup-ruby/blob/d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c/action.yml#L27-L28

But if we do that, then the action doesn't pickup the `.ruby-version` file, since that's located in the root directory.

I really _didn't_ want to manage yet another pin, so defaulted this to `latest` with the assumption that generally in `dependabot-core` we'll be on the latest version of `bundler`.

This is an alternative to:
* https://github.com/dependabot/dependabot-core/pull/7231