### PR TITLE
Make `gem-bump-version` inherit `ruby`/`bundler` versions

### DIFF
--- a/.github/workflows/gems-bump-version.yml
+++ b/.github/workflows/gems-bump-version.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1 # bump-version.rb needs bundler
+        with:
+          # Use the version of bundler specified in `updater/Gemfile.lock`.
+          # Otherwise the generated PR will change `BUNDLED WITH` in
+          # `updater/Gemfile.lock`, which in prod will silently change the
+          # version of bundler used by the bundler native helper.
+          working-directory: updater
 
       - name: Bump the version
         run: |

--- a/updater/.ruby-version
+++ b/updater/.ruby-version
@@ -1,0 +1,1 @@
+../.ruby-version


### PR DESCRIPTION
We need to inherit the bundler version used in `updater/Gemfile.lock` when running the `gem-bump-version` GitHub action.

Otherwise when the action runs, `ruby/setup-ruby` will use a default `bundler` version, which will change `BUNDLED WITH` to this default version.

Normally that wouldn't matter, but we also pin the version of `bundler` used in the native helper for the `bundler` ecosystem. And when we run the Updater in production at GitHub, since `BUNLDED WITH` is the last time we run `bundle install`, it'll change the bundler version not only for the `updater` app, but also for the native helper. So we'd be silently getting a different version of `bundler`, but _only_ when running the `updater`, which means local debugging would see the pinned bundler version.

Instead, let's avoid all that by ensuring we respect the version of `bundler` pinned in `Gemfile.lock`.

By default, `setup/setup-ruby` looks for `Gemfile.lock` in the root directory, so the way to do that is set the working directory to `updater` so it looks for `updater/Gemfile.lock`.

Unfortunately, that creates a new problem... `ruby/setup-ruby` looks for `.ruby-version` to find the Ruby version to run. Since we set the working directory to `updater`, it looks for `updater/.ruby-version`. And we don't want to move `.ruby-version` out of the root directory because that's where `rubocop` and other tooling such as IDE's look for it.

Deivid pointed out that in the context of running this action, the version of Ruby really doesn't matter, since it's only used for the `bump-version.rb` script, which is very simple/generic. However, when I tried running the action, `ruby/setup-ruby` complained that it required a version of ruby to be specified. We don't want to have _yet-another-place_ to maintain the ruby version, so the way around that was to add a symlink: `cd updater && ln -s ../.ruby-version .ruby-version`.

I tested this in another repo, and it worked successfully... the resulting PR used the version of `ruby` pinned in the root `.ruby-version` and the version of `bundler` pinned in `updater/Gemfile.lock`'s `BUNDLED WITH`.