### PR TITLE
Don't hang when metadata source is not accessible

### DIFF
--- a/common/lib/dependabot/git_metadata_fetcher.rb
+++ b/common/lib/dependabot/git_metadata_fetcher.rb
@@ -108,7 +108,7 @@ module Dependabot
       service_pack_uri = uri
       service_pack_uri += ".git" unless service_pack_uri.end_with?(".git") || skip_git_suffix(uri)
 
-      env = { "PATH" => ENV.fetch("PATH", nil) }
+      env = { "PATH" => ENV.fetch("PATH", nil), "GIT_TERMINAL_PROMPT" => "0" }
       command = "git ls-remote #{service_pack_uri}"
       command = SharedHelpers.escape_command(command)
 


### PR DESCRIPTION
When metadata source configured for a release is not accessible by Dependabot, the `git ls-remote` command to find release tags will hang with a prompt asking for user credentials.

I don't think this is a problem in production, or CI, probably because `git` detects automatically that it's being run in a non interactive environment. However, when running specs manually, it shows a prompt. This can be reproduced for example by running the following from the cargo folder:

```
$ rspec spec/dependabot/cargo/update_checker/version_resolver_spec.rb -e "raises a GitDependenciesNotReachable error"
Run options: include {:full_description=>/raises\ a\ GitDependenciesNotReachable\ error/}

Randomized with seed 30240
Username for 'https://github.com':
```

Dependabot is not supposed to be run interactively, so force that behavior for git.

The behavior can be forced by using the [`GIT_TERMINAML_PROMPT`](https://git-scm.com/docs/git#Documentation/git.txt-codeGITTERMINALPROMPTcode) environment variable.