### PR TITLE
Fix flaky cargo spec

### DIFF
--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -91,6 +91,11 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
       end
 
       context "because an existing requirement is no good" do
+        let(:dependency_version) { "0.1.38" }
+        let(:requirements) do
+          [{ file: "Cargo.toml", requirement: "0.3.20", groups: [], source: nil }]
+        end
+
         let(:manifest_fixture_name) { "missing_version" }
         let(:lockfile_fixture_name) { "missing_version" }
 


### PR DESCRIPTION
The `cargo update` command tested here can fail because of two reasons:

* The version of the dependency we're updating to does not exist (time 99.0.0).
* The version of an unrelated dependency we're locked to does not exist (regex 99.0.0).

This spec is checking for the latter, but `cargo update` may throw either error inconsistently.

Let's force a valid version of time to update to, so that the second error is always raised.

Example of the error: https://github.com/dependabot/dependabot-core/actions/runs/4892537905/jobs/8734412290?pr=7222#step:5:176

```
Failures:

  1) Dependabot::Cargo::FileUpdater::LockfileUpdater#updated_lockfile_content when updating the lockfile fails because an existing requirement is no good raises a helpful error
     Failure/Error:
       expect { updater.updated_lockfile_content }.
         to raise_error do |error|
           expect(error).to be_a(Dependabot::DependencyFileNotResolvable)
           expect(error.message).
             to include("version for the requirement `regex = \"^99.0.0\"`")
         end

       expected #<Dependabot::SharedHelpers::HelperSubprocessFailed: Updating crates.io index
       error: failed to select.../dependabot/cargo/dependabot_tmp_dir)`
       perhaps a crate was updated and forgotten to be re-vendored?> to be a kind of Dependabot::DependencyFileNotResolvable
     # ./spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb:98:in `block (5 levels) in <top (required)>'
     # /home/dependabot/common/spec/spec_helper.rb:63:in `block (2 levels) in <top (required)>'

Finished in 42.36 seconds (files took 1.04 seconds to load)
356 examples, 1 failure

Failed examples:

rspec ./spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb:97 # Dependabot::Cargo::FileUpdater::LockfileUpdater#updated_lockfile_content when updating the lockfile fails because an existing requirement is no good raises a helpful error
```