### PR TITLE
Refactor preparing `package.json` files

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -513,16 +513,18 @@ module Dependabot
                 file.content
               end
 
+            package_json_preparer = package_json_preparer(updated_content)
+
             # TODO: Figure out if we need to lock git deps for npm 7 and can
             # start deprecating this hornets nest
             #
             # NOTE: When updating a package-lock.json we have to manually lock
             # all git dependencies, otherwise npm will (unhelpfully) update them
             updated_content = lock_git_deps(updated_content)
-            updated_content = replace_ssh_sources(updated_content)
+            updated_content = package_json_preparer.replace_ssh_sources(updated_content)
             updated_content = lock_deps_with_latest_reqs(updated_content)
 
-            updated_content = sanitized_package_json_content(updated_content)
+            updated_content = package_json_preparer.remove_invalid_characters(updated_content)
 
             File.write(file.name, updated_content)
           end
@@ -614,35 +616,12 @@ module Dependabot
           JSON.pretty_generate(json, indent: indent)
         end
 
-        def replace_ssh_sources(content)
-          updated_content = content
-
-          git_ssh_requirements_to_swap.each do |req|
-            new_req = req.gsub(%r{git\+ssh://git@(.*?)[:/]}, 'https://\1/')
-            updated_content = updated_content.gsub(req, new_req)
-          end
-
-          updated_content
-        end
-
         def git_ssh_requirements_to_swap
           return @git_ssh_requirements_to_swap if @git_ssh_requirements_to_swap
 
-          @git_ssh_requirements_to_swap = []
-
-          package_files.each do |file|
-            NpmAndYarn::FileParser::DEPENDENCY_TYPES.each do |t|
-              JSON.parse(file.content).fetch(t, {}).each do |_, requirement|
-                next unless requirement.is_a?(String)
-                next unless requirement.start_with?("git+ssh:")
-
-                req = requirement.split("#").first
-                @git_ssh_requirements_to_swap << req
-              end
-            end
+          @git_ssh_requirements_to_swap = package_files.flat_map do |file|
+            package_json_preparer(file.content).swapped_ssh_requirements
           end
-
-          @git_ssh_requirements_to_swap
         end
 
         def post_process_npm_lockfile(updated_lockfile_content)
@@ -841,6 +820,14 @@ module Dependabot
             ).updated_package_json.content
         end
 
+        def package_json_preparer(content)
+          @package_json_preparer ||= {}
+          @package_json_preparer[content] ||=
+            PackageJsonPreparer.new(
+              package_json_content: content
+            )
+        end
+
         def npmrc_disables_lockfile?
           npmrc_content.match?(/^package-lock\s*=\s*false/)
         end
@@ -849,13 +836,6 @@ module Dependabot
           return @npm8 if defined?(@npm8)
 
           @npm8 = Dependabot::NpmAndYarn::Helpers.npm_version(lockfile.content) == "npm8"
-        end
-
-        def sanitized_package_json_content(content)
-          content.
-            gsub(/\{\{[^\}]*?\}\}/, "something"). # {{ nm }} syntax not allowed
-            gsub(/(?<!\\)\\ /, " ").          # escaped whitespace not allowed
-            gsub(%r{^\s*//.*}, " ")           # comments are not allowed
         end
 
         def sanitize_package_name(package_name)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_preparer.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_preparer.rb
@@ -48,7 +48,7 @@ module Dependabot
 
           paths_array.each { |path| path.gsub!(%r{^\./}, "") }
 
-          json.to_json
+          JSON.pretty_generate(json)
         end
 
         def remove_invalid_characters(content)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -538,12 +538,10 @@ module Dependabot
         end
 
         def updated_package_json_content(file)
-          @updated_package_json_content ||= {}
-          @updated_package_json_content[file.name] ||=
-            PackageJsonUpdater.new(
-              package_json: file,
-              dependencies: top_level_dependencies
-            ).updated_package_json.content
+          PackageJsonUpdater.new(
+            package_json: file,
+            dependencies: top_level_dependencies
+          ).updated_package_json.content
         end
 
         def npmrc_disables_lockfile?


### PR DESCRIPTION
I found a fair bit of duplicated logic when updating NPM and Yarn lockfiles that's already implemented in `PackageJsonPreparer`. So I'm refactoring things to reuse it.