### PR TITLE
Re-parse dependencies after each group update batch

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -88,7 +88,7 @@ module Dependabot
             ).parse
         end
 
-        def dependency_up_to_date?(dependency)
+        def dependency_up_to_date?(dependency, lockfile_dependencices: lockfile)
           existing_dep = lockfile_dependencies.find { |dep| dep.name == dependency.name }
 
           # If the dependency is missing but top level it should be treated as


### PR DESCRIPTION
This PR attempts to address the root cause of npm transitive dependencies generating `NoChangeErrors` during grouped updates.

Compare updates for the same groups for when we skip non top-level dependencies:

```
+------------------------------------------------------------------------------------------------------------------------------------+
|                                                Changes to Dependabot Pull Requests                                                 |
+---------+--------------------------------------------------------------------------------------------------------------------------+
| created | fetch-factory ( from 0.0.1 to 0.2.1 )                                                                                    |
| created | babel-jest ( from 28.1.1 to 29.5.0 )                                                                                     |
| created | babel-jest ( from 28.1.1 to 29.5.0 ), diff-sequences ( from 28.1.1 to 29.4.3 ), eslint-plugin-jest ( from 26.5.3 to 2... |
| created | eslint-plugin-jest ( from 26.5.3 to 27.2.1 )                                                                             |
| created | @types/node ( from 18.16.2 to 20.1.0 )                                                                                   |
| created | caniuse-lite ( from 1.0.30001481 to 1.0.30001486 )                                                                       |
| created | core-js-compat ( from 3.30.1 to 3.30.2 )                                                                                 |
| created | electron-to-chromium ( from 1.4.377 to 1.4.385 )                                                                         |
| created | espree ( from 9.5.1 to 9.5.2 )                                                                                           |
+---------+--------------------------------------------------------------------------------------------------------------------------+
```

versus when we don't:

```
+------------------------------------------------------------------------------------------------------------------------------------+
|                                                Changes to Dependabot Pull Requests                                                 |
+---------+--------------------------------------------------------------------------------------------------------------------------+
| created | fetch-factory ( from 0.0.1 to 0.2.1 )                                                                                    |
| created | babel-jest ( from 28.1.1 to 29.5.0 ), @babel/compat-data ( from 7.21.4 to 7.21.7 ), @babel/generator ( from 7.21.4 to... |
| created | babel-jest ( from 28.1.1 to 29.5.0 ), diff-sequences ( from 28.1.1 to 29.4.3 ), eslint-plugin-jest ( from 26.5.3 to 2... |
| created | eslint-plugin-jest ( from 26.5.3 to 27.2.1 )                                                                             |
| created | @types/node ( from 18.16.2 to 18.16.3 )                                                                                  |
| created | caniuse-lite ( from 1.0.30001481 to 1.0.30001482 )                                                                       |
| created | electron-to-chromium ( from 1.4.377 to 1.4.382 )                                                                         |
+---------+--------------------------------------------------------------------------------------------------------------------------+
Dependabot encountered '7' error(s) during execution, please check the logs for more details.
+------------------------------------------------------+
|            Dependencies failed to update             |
+--------------------------------------+---------------+
| babel-plugin-polyfill-corejs3        | unknown_error |
| @typescript-eslint/scope-manager     | unknown_error |
| @typescript-eslint/types             | unknown_error |
| @typescript-eslint/typescript-estree | unknown_error |
| @typescript-eslint/utils             | unknown_error |
| @typescript-eslint/visitor-keys      | unknown_error |
| @typescript-eslint/type-utils        | unknown_error |
+--------------------------------------+---------------+
```

(there are some extra dependencies that show up but that is because they have recent updates)