### PR TITLE
[Updater] Add missing log lines to job startup

### DIFF
--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -61,6 +61,9 @@ module Dependabot
             return
           end
 
+          Dependabot.logger.info("Starting PR update job for #{job.source.repo}")
+          Dependabot.logger.info("Updating the '#{dependency_snapshot.job_group.name}' group")
+
           dependency_change = compile_all_dependency_changes_for(dependency_snapshot.job_group)
 
           begin


### PR DESCRIPTION
Noticed while debugging something else, we don't have our usual markers in the logs when we start a rebase job for a group, so let's add them.

I've also split out the `perform` method to avoid a long method warning and push the error handling around update/close calls into its own method.