### PR TITLE
Fix PNPM issues when updating some manifests

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -35,6 +35,7 @@ jobs:
           - { path: maven, name: maven, ecosystem: maven }
           - { path: npm_and_yarn, name: npm, ecosystem: npm}
           - { path: npm_and_yarn, name: npm-remove-transitive, ecosystem: npm}
+          - { path: npm_and_yarn, name: pnpm, ecosystem: npm}
           - { path: npm_and_yarn, name: yarn, ecosystem: npm}
           - { path: npm_and_yarn, name: yarn-berry, ecosystem: npm}
           - { path: npm_and_yarn, name: yarn-berry-workspaces, ecosystem: npm}
@@ -172,6 +173,12 @@ jobs:
             - 'common/**'
             - 'updater/**'
             - 'python/**'
+          pnpm:
+            - .github/workflows/smoke.yml
+            - Dockerfile.updater-core
+            - 'common/**'
+            - 'updater/**'
+            - 'npm_and_yarn/**'
           poetry:
             - .github/workflows/smoke.yml
             - Dockerfile.updater-core

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -274,6 +274,10 @@ module Dependabot
         "git config --global --add url.https://#{host}/." \
         "insteadOf git://#{host}/"
       )
+      run_shell_command(
+        "git config --global --add url.https://#{host}/." \
+        "insteadOf git+ssh://git@#{host}/"
+      )
     end
 
     def self.reset_git_repo(path)


### PR DESCRIPTION
If some dependency is pinned to a git repo, sometimes PNPM would use ssh through git+ssh protocol, which we were not handling.

Fixes #7258.