### PR TITLE
Fix outdated reference to DockerHub

### DIFF
--- a/.github/workflows/images-updater-core.yml
+++ b/.github/workflows/images-updater-core.yml
@@ -9,7 +9,7 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
 jobs:
   push-updater-core-image:
-    name: Push dependabot-updater-core image to docker hub
+    name: Push dependabot-updater-core image to GHCR
     runs-on: ubuntu-latest
     if: github.repository == 'dependabot/dependabot-core'
     permissions:


### PR DESCRIPTION
When the images were split, this was updated to push to GHCR rather than Dockerhub.

In fact, you can see here the last image was pushed 3 months ago: https://hub.docker.com/r/dependabot/dependabot-core/tags

But this reference to dockerhub wasn't updated.

Note:
This pushes the `dependabot-updater-core` image to GHCR, but not the ecosystem-specific images... that was likely an oversight. Correcting that is outside the scope of this PR though.