### PR TITLE
Switch to watching releases rather than tags

### DIFF
--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -1,8 +1,7 @@
 name: Gems - Release to RubyGems
 on:
-  push:
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+  release:
+    types: [published]
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Watching for tags works, but introduces the risk that an unexpected tag name that happens to match the regex will trigger a push.

Additionally, a tag on a branch other than `main` could trigger the workflow as well.

By limiting only to actual releases, we ensure that we only push to RubyGems when we actually publish a release.

Related:
* https://github.com/dependabot/dependabot-core/issues/7132