### PR TITLE
Update Bundler to 2.4.13

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -93,7 +93,7 @@ COPY --from=ruby:3.1.4 --chown=dependabot:dependabot /usr/local /usr/local
 # When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
 # Generally simplest to match the bundler version to the one that comes by default with whatever Ruby version we install.
 # This way other projects that import this library don't have to futz around with installing new / unexpected bundler versions.
-ARG BUNDLER_V2_VERSION=2.4.11
+ARG BUNDLER_V2_VERSION=2.4.13
 
 # We had to explicitly bump this as the bundled version `0.2.2` in ubuntu 20.04 has a bug.
 # Once Ubuntu base image pulls in a new enough yaml version, we may not need to

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -322,4 +322,4 @@ DEPENDENCIES
   webmock (~> 3.18)
 
 BUNDLED WITH
-   2.4.11
+   2.4.13


### PR DESCRIPTION
We've seen reports of [this error](https://github.com/rubygems/rubygems/issues/6614), and Bundler 2.4.13 should fix it!