### PR TITLE
Reparse dependencies after each batch when performing grouped updates

### DIFF
--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -28,6 +28,13 @@ module Dependabot
 
         group.dependencies.each do |dependency|
           dependency_files = dependency_file_batch.dependency_files
+          reparsed_dependencies = dependency_file_parser(dependency_files).parse
+          dependency = reparsed_dependencies.find { |d| d.name == dependency.name }
+
+          # If the dependency can not be found in the reparsed files then it was likely removed by a previous
+          # dependency update
+          next if dependency.nil?
+
           updated_dependencies = compile_updates_for(dependency, dependency_files)
 
           next unless updated_dependencies.any?
@@ -65,6 +72,17 @@ module Dependabot
           updated_dependencies: all_updated_dependencies,
           updated_dependency_files: dependency_file_batch.updated_files,
           dependency_group: group
+        )
+      end
+
+      def dependency_file_parser(dependency_files)
+        Dependabot::FileParsers.for_package_manager(job.package_manager).new(
+          dependency_files: dependency_files,
+          repo_contents_path: job.repo_contents_path,
+          source: job.source,
+          credentials: job.credentials,
+          reject_external_code: job.reject_external_code?,
+          options: job.experiments
         )
       end
 


### PR DESCRIPTION
Fixes https://github.com/dependabot/dependabot-core/issues/7238

This PR attempts to address the root cause of npm transitive dependencies generating `NoChangeErrors` during grouped updates.

Here's the error we're seeing:

```
2023/05/05 11:49:01 INFO Checking if @typescript-eslint/typescript-estree 5.27.1 needs updating
2023/05/05 11:49:02 INFO Latest version is 5.59.2
2023/05/05 11:49:03 INFO Requirements to unlock own
2023/05/05 11:49:03 INFO Requirements update strategy widen_ranges
2023/05/05 11:49:03 INFO Updating @typescript-eslint/typescript-estree from 5.27.1 to 5.59.1
2023/05/05 11:49:03 ERROR Error processing @typescript-eslint/typescript-estree (Dependabot::NpmAndYarn::FileUpdater::GroupedSubDependencyUpToDate)
2023/05/05 11:49:03 ERROR Subdependency is already up-to-date
2023/05/05 11:49:03 ERROR /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb:59:in `updated_dependency_files'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:85:in `generate_dependency_files'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:36:in `run'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:25:in `create_from'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/group_update_creation.rb:70:in `create_change_for'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/group_update_creation.rb:33:in `block in compile_all_dependency_changes_for'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/group_update_creation.rb:23:in `each'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/group_update_creation.rb:23:in `compile_all_dependency_changes_for'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:78:in `block in run_grouped_dependency_updates'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:75:in `each'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:75:in `run_grouped_dependency_updates'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:43:in `perform'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:72:in `run'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:38:in `perform_job'
2023/05/05 11:49:03 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:52:in `run'
2023/05/05 11:49:03 ERROR bin/update_files.rb:23:in `<main>'
```

Compare updates for the same groups for when we re-parse dependencies after each update in a grouped update PR:

```
+------------------------------------------------------------------------------------------------------------------------------------+
|                                                Changes to Dependabot Pull Requests                                                 |
+---------+--------------------------------------------------------------------------------------------------------------------------+
| created | fetch-factory ( from 0.0.1 to 0.2.1 )                                                                                    |
| created | babel-jest ( from 28.1.1 to 29.5.0 )                                                                                     |
| created | babel-jest ( from 28.1.1 to 29.5.0 ), diff-sequences ( from 28.1.1 to 29.4.3 ), eslint-plugin-jest ( from 26.5.3 to 2... |
| created | eslint-plugin-jest ( from 26.5.3 to 27.2.1 )                                                                             |
| created | @types/node ( from 18.16.2 to 20.1.0 )                                                                                   |
| created | caniuse-lite ( from 1.0.30001481 to 1.0.30001486 )                                                                       |
| created | core-js-compat ( from 3.30.1 to 3.30.2 )                                                                                 |
| created | electron-to-chromium ( from 1.4.377 to 1.4.385 )                                                                         |
| created | espree ( from 9.5.1 to 9.5.2 )                                                                                           |
+---------+--------------------------------------------------------------------------------------------------------------------------+
```

versus when we don't:

```
+------------------------------------------------------------------------------------------------------------------------------------+
|                                                Changes to Dependabot Pull Requests                                                 |
+---------+--------------------------------------------------------------------------------------------------------------------------+
| created | fetch-factory ( from 0.0.1 to 0.2.1 )                                                                                    |
| created | babel-jest ( from 28.1.1 to 29.5.0 ), @babel/compat-data ( from 7.21.4 to 7.21.7 ), @babel/generator ( from 7.21.4 to... |
| created | babel-jest ( from 28.1.1 to 29.5.0 ), diff-sequences ( from 28.1.1 to 29.4.3 ), eslint-plugin-jest ( from 26.5.3 to 2... |
| created | eslint-plugin-jest ( from 26.5.3 to 27.2.1 )                                                                             |
| created | @types/node ( from 18.16.2 to 18.16.3 )                                                                                  |
| created | caniuse-lite ( from 1.0.30001481 to 1.0.30001482 )                                                                       |
| created | electron-to-chromium ( from 1.4.377 to 1.4.382 )                                                                         |
+---------+--------------------------------------------------------------------------------------------------------------------------+
Dependabot encountered '7' error(s) during execution, please check the logs for more details.
+------------------------------------------------------+
|            Dependencies failed to update             |
+--------------------------------------+---------------+
| babel-plugin-polyfill-corejs3        | unknown_error |
| @typescript-eslint/scope-manager     | unknown_error |
| @typescript-eslint/types             | unknown_error |
| @typescript-eslint/typescript-estree | unknown_error |
| @typescript-eslint/utils             | unknown_error |
| @typescript-eslint/visitor-keys      | unknown_error |
| @typescript-eslint/type-utils        | unknown_error |
+--------------------------------------+---------------+
```

(there are some extra dependencies that show up but that is because they have recent updates)