### PR TITLE
fix NilClass error on credential-less runs

### DIFF
--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -70,7 +70,7 @@ module Dependabot
     def self.new_update_job(job_id:, job_definition:, repo_contents_path: nil)
       job_hash = standardise_keys(job_definition["job"])
       attrs = job_hash.slice(*PERMITTED_KEYS)
-      attrs[:credentials] = job_hash[:credentials_metadata]
+      attrs[:credentials] = job_hash[:credentials_metadata] || []
 
       new(attrs.merge(id: job_id, repo_contents_path: repo_contents_path))
     end


### PR DESCRIPTION
Noticed in https://github.com/dependabot/dependabot-core/issues/7223, when running a CLI job without credentials can result in a NilClass error due to `credentials_metadata` not existing.

Defaulting the value to `[]` fixes it. 

This isn't something that can happen in production, more of a user-friendly feature for folks who haven't set up a LOCAL_GITHUB_ACCESS_TOKEN. 