### PR TITLE
build(deps): bump Rust from 1.68.2 to 1.69.0

### DIFF
--- a/cargo/Dockerfile
+++ b/cargo/Dockerfile
@@ -10,7 +10,8 @@ ENV RUSTUP_HOME=/opt/rust \
 RUN mkdir -p "$RUSTUP_HOME" && chown dependabot:dependabot "$RUSTUP_HOME"
 
 USER dependabot
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.68.2 --profile minimal
+# Look for updates at https://github.com/rust-lang/rust/releases
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.69.0 --profile minimal
 
 # Configure cargo to use Git CLI so the Git shim works
 RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo/config.toml


### PR DESCRIPTION
See https://github.com/rust-lang/rust/releases/tag/1.69.0

And https://blog.rust-lang.org/2023/04/20/Rust-1.69.0.html