### PR TITLE
[Updater] Fix a crash in Grouped Updates when vendoring files

### DIFF
--- a/updater/lib/dependabot/updater/group_dependency_file_batch.rb
+++ b/updater/lib/dependabot/updater/group_dependency_file_batch.rb
@@ -36,7 +36,6 @@ module Dependabot
           change_count = if existing_file
                            existing_file.fetch(:change_count, 0)
                          else
-                           # Let's warn about this in debug mode, but otherwise tolerate this.
                            Dependabot.logger.debug("New file added: '#{updated_file.path}'")
                            0
                          end

--- a/updater/lib/dependabot/updater/group_dependency_file_batch.rb
+++ b/updater/lib/dependabot/updater/group_dependency_file_batch.rb
@@ -37,7 +37,7 @@ module Dependabot
                            existing_file.fetch(:change_count, 0)
                          else
                            # Let's warn about this in debug mode, but otherwise tolerate this.
-                           Dependabot.logger.debug("Updated an unexpected file at '#{existing_file.path}'")
+                           Dependabot.logger.debug("New file added: '#{updated_file.path}'")
                            0
                          end
 


### PR DESCRIPTION
As title, this currently results in a `NotImplementedError` being raised as we are trying to log the path of the wrong object 🤦🏻 