### PR TITLE
Go: fix grouped updates missing updated dependencies in manifests

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater.rb
@@ -117,6 +117,7 @@ module Dependabot
         @file_updater ||=
           GoModUpdater.new(
             dependencies: dependencies,
+            dependency_files: dependency_files,
             credentials: credentials,
             repo_contents_path: repo_contents_path,
             directory: directory,

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -92,13 +92,12 @@ module Dependabot
           @updated_files ||= update_files
         end
 
-        def update_files # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/MethodLength
+        def update_files # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
           in_repo_path do
             # During grouped updates, the dependency_files are from a previous dependency
             # update, so we need to update them on disk after the git reset in in_repo_path.
             dependency_files.each do |file|
-              path = File.join(file.name)
-              path = Pathname.new(path).expand_path
+              path = Pathname.new(file.name).expand_path
               FileUtils.mkdir_p(path.dirname)
               File.write(path, file.content)
             end

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -63,9 +63,10 @@ module Dependabot
 
         GO_MOD_VERSION = /^go 1\.[\d]+$/
 
-        def initialize(dependencies:, credentials:, repo_contents_path:,
+        def initialize(dependencies:, dependency_files:, credentials:, repo_contents_path:,
                        directory:, options:)
           @dependencies = dependencies
+          @dependency_files = dependency_files
           @credentials = credentials
           @repo_contents_path = repo_contents_path
           @directory = directory
@@ -84,15 +85,24 @@ module Dependabot
 
         private
 
-        attr_reader :dependencies, :credentials, :repo_contents_path,
+        attr_reader :dependencies, :dependency_files, :credentials, :repo_contents_path,
                     :directory
 
         def updated_files
           @updated_files ||= update_files
         end
 
-        def update_files # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+        def update_files # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/MethodLength
           in_repo_path do
+            # During grouped updates, the dependency_files are from a previous dependency
+            # update, so we need to update them on disk after the git reset in in_repo_path.
+            dependency_files.each do |file|
+              path = File.join(file.name)
+              path = Pathname.new(path).expand_path
+              FileUtils.mkdir_p(path.dirname)
+              File.write(path, file.content)
+            end
+
             # Map paths in local replace directives to path hashes
             original_go_mod = File.read("go.mod")
             original_manifest = parse_manifest

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -41,6 +41,38 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
   describe "#updated_go_mod_content" do
     subject(:updated_go_mod_content) { updater.updated_go_mod_content }
 
+    context "for a grouped update" do
+      let(:dependency_name) { "rsc.io/quote" }
+      let(:dependency_version) { "v1.5.2" }
+      let(:dependency_previous_version) { "v1.4.0" }
+      let(:requirements) { previous_requirements }
+      let(:previous_requirements) do
+        [{
+           file: "go.mod",
+           requirement: "v1.4.0",
+           groups: [],
+           source: {
+             type: "default",
+             source: "rsc.io/quote"
+           }
+         }]
+      end
+      let(:dependency_files) { [
+        Dependabot::DependencyFile.new(
+          name: "go.mod",
+          # simulate a previous update from a grouped update
+          content: go_mod_content.gsub("rsc.io/qr v0.1.0", "rsc.io/qr v0.1.1")
+        )
+      ] }
+
+      it "updated the dependency" do
+        is_expected.to include(%(rsc.io/quote v1.5.2\n))
+      end
+      it "retained the previous change" do
+        is_expected.to include(%(rsc.io/qr v0.1.1\n))
+      end
+    end
+
     context "for a top level dependency" do
       let(:dependency_name) { "rsc.io/quote" }
       let(:dependency_version) { "v1.4.0" }

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
   let(:updater) do
     described_class.new(
       dependencies: [dependency],
+      dependency_files: dependency_files,
       credentials: credentials,
       repo_contents_path: repo_contents_path,
       directory: directory,
@@ -22,6 +23,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
   let(:tidy) { true }
   let(:directory) { "/" }
   let(:goprivate) { "*" }
+  let(:dependency_files) { [] }
 
   let(:credentials) { [] }
 

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -48,22 +48,24 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
       let(:requirements) { previous_requirements }
       let(:previous_requirements) do
         [{
-           file: "go.mod",
-           requirement: "v1.4.0",
-           groups: [],
-           source: {
-             type: "default",
-             source: "rsc.io/quote"
-           }
-         }]
+          file: "go.mod",
+          requirement: "v1.4.0",
+          groups: [],
+          source: {
+            type: "default",
+            source: "rsc.io/quote"
+          }
+        }]
       end
-      let(:dependency_files) { [
-        Dependabot::DependencyFile.new(
-          name: "go.mod",
-          # simulate a previous update from a grouped update
-          content: go_mod_content.gsub("rsc.io/qr v0.1.0", "rsc.io/qr v0.1.1")
-        )
-      ] }
+      let(:dependency_files) do
+        [
+          Dependabot::DependencyFile.new(
+            name: "go.mod",
+            # simulate a previous update from a grouped update
+            content: go_mod_content.gsub("rsc.io/qr v0.1.0", "rsc.io/qr v0.1.1")
+          )
+        ]
+      end
 
       it "updated the dependency" do
         is_expected.to include(%(rsc.io/quote v1.5.2\n))

--- a/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater_spec.rb
@@ -182,6 +182,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater do
           to receive(:new).
           with(
             dependencies: anything,
+            dependency_files: anything,
             credentials: anything,
             repo_contents_path: anything,
             directory: anything,


### PR DESCRIPTION
The Go updater code has two code paths. The more common one is it uses the cloned repo to do updates, first doing a `git reset`, not using the manifests that were fetched.

The other path only happens when a clone fails and there's no vendoring (and other specific conditions) where it will write out a dummy project that imports all dependencies so that the update can proceed with imperfect information.

The problem is when Grouped Updates comes along, the Go code needs to write the manifests to disk each time since they get wiped out between updates of the dependencies with that `git reset`.

So this PR passes in the dependency_files to the GoModUpdater so it can overwrite what is on disk each time, and make the Grouped Update successful. 