### PR TITLE
[Grouped Updates] Remove prototype from branch names

### DIFF
--- a/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
@@ -21,7 +21,7 @@ module Dependabot
         # fixed-length name, so we can punt on handling truncation until
         # we determine the strict validation rules for names
         def new_branch_name
-          File.join(prefixes, dependency_group.name, prototype_suffix).gsub("/", separator)
+          File.join(prefixes, timestamped_group_name).gsub("/", separator)
         end
 
         private
@@ -37,9 +37,11 @@ module Dependabot
           ].compact
         end
 
-        # FIXME: Remove once grouped PRs can supersede each other
-        def prototype_suffix
-          "prototype-#{Time.now.utc.to_i}"
+        # When superseding a grouped update pull request, we will have a period
+        # of time when there are two branches for the group so we use a timestamp
+        # to avoid collisions.
+        def timestamped_group_name
+          "#{dependency_group.name}-#{Time.now.utc.to_i}"
         end
 
         def package_manager

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe Dependabot::PullRequestCreator do
           to receive(:new).
           with(
             source: source,
-            branch_name: start_with("dependabot/bundler/all-the-things/prototype-"),
+            branch_name: start_with("dependabot/bundler/all-the-things-"),
             base_commit: base_commit,
             credentials: credentials,
             files: files,


### PR DESCRIPTION
As described, changes the branch naming from:

> dependabot/ecosystem/group-name/prototype-1683734594

to

> dependabot/ecosystem/group-name-1683734594

We maintain the timestamp to avoid jobs recreating group PRs colliding but drop the word 'prototype' as we've got enough working we're moving towards beta