### PR TITLE
No need to specify read perms

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,8 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'schedule' || github.repository == 'dependabot/dependabot-core' }}
     permissions:
-      actions: read
-      contents: read
       security-events: write
 
     strategy:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,9 +1,6 @@
 name: Dependency Review
 on: [pull_request]
 
-permissions:
-  contents: read
-
 jobs:
   dependency-review:
     name: Dependency Review

--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -2,8 +2,6 @@ name: Gems - Release to RubyGems
 on:
   release:
     types: [published]
-permissions:
-  contents: read
 jobs:
   release-gems:
     name: Release gems to rubygems.org


### PR DESCRIPTION
I've changed the default perms of the `GITHUB_TOKEN` to read-only to match the [new
default](https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/).

As a result, there's no need to explicitly downgrade the permissions to `read`, and it creates confusion/visual distraction.

For the CodeQL change, they explicitly document that for public repos only the `security-events` scope needs to be explicitly specified for _public_ repos, such as this one.