### PR TITLE
Stub registry request that's not captured by a VCR

### DIFF
--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -901,6 +901,13 @@ RSpec.describe Dependabot::Terraform::FileParser do
     end
 
     context "with a private module proxy that can't be reached", vcr: true do
+      before do
+        artifactory_repo_url = "http://artifactory.dependabot.com/artifactory/tf-modules/azurerm"
+
+        stub_request(:get, "#{artifactory_repo_url}/terraform-azurerm-nsg-rules.v1.1.0.tar.gz?terraform-get=1").
+          and_return(status: 401)
+      end
+
       let(:files) { project_dependency_files("private_module_proxy") }
 
       it "raises an error" do


### PR DESCRIPTION
Stubs out a registry request that's not captured by a VCR. The test fails when the VCR mode is set to `:none` as part of https://github.com/dependabot/dependabot-core/pull/4822

See https://github.com/dependabot/dependabot-core/actions/runs/4957979462/jobs/8870303817?pr=4822#step:5:223 for the error