### PR TITLE
Update dependencies where the requirement has not changed for grouped updates

### DIFF
--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -38,7 +38,7 @@ module Dependabot
       updated_deps = updated_dependencies.reject do |d|
         # Avoid rejecting the source dependency
         next false if source_dependency_name && d.name == source_dependency_name
-        next true if d.top_level? && d.requirements == d.previous_requirements
+        next true if d.top_level? && d.requirements == d.previous_requirements && source_dependency_name
 
         d.version == d.previous_version
       end


### PR DESCRIPTION
fixes https://github.com/github/dependabot-updates/issues/4052

WIP

Here's the pull request summary with a993e4bc6dad054b345ada7b9c4407dd549ab7aa applied. Some additional dependencies are updated + shown in the pull request summary even when the requirements have not changed.

a993e4bc6dad054b345ada7b9c4407dd549ab7aa achieves this by ignoring the following guard for grouped updates:
```ruby
next true if d.top_level? && d.requirements == d.previous_requirements
``` 

---

There is likely a more exact way to achieve this result, but this is a PoC that shows our grouped updates are flawed.

Here's an update with the patch:

```
2023/05/12 13:05:57 INFO Starting update group for 'runtime'
2023/05/12 13:05:57 INFO Checking if fetch-factory 0.0.1 needs updating
2023/05/12 13:05:57 INFO Ignored versions:
2023/05/12 13:05:57 INFO   >0.2.1 - from tests/smoke-npm-grouped.yaml
2023/05/12 13:05:57 INFO Latest version is 0.2.1
2023/05/12 13:06:02 INFO Requirements to unlock own
2023/05/12 13:06:02 INFO Requirements update strategy widen_ranges
2023/05/12 13:06:02 INFO Updating fetch-factory from 0.0.1 to 0.2.1
[#<Dependabot::Dependency:0x00007fc3f40ed110
  @metadata={},
  @name="fetch-factory",
  @package_manager="npm_and_yarn",
  @previous_requirements=[{:requirement=>"^0.0.1", :file=>"package.json", :groups=>["dependencies"], :source=>{:type=>"registry", :url=>"https://registry.npmjs.org"}}],
  @previous_version="0.0.1",
  @removed=false,
  @requirements=[{:requirement=>"^0.2.1", :file=>"package.json", :groups=>["dependencies"], :source=>{:type=>"registry", :url=>"https://registry.npmjs.org"}}],
  @version="0.2.1">]
2023/05/12 13:06:03 INFO Checking if lodash 4.17.15 needs updating
2023/05/12 13:06:03 INFO Ignored versions:
2023/05/12 13:06:03 INFO   >4.17.21 - from tests/smoke-npm-grouped.yaml
2023/05/12 13:06:03 INFO Latest version is 4.17.21
2023/05/12 13:06:04 INFO Requirements to unlock all
2023/05/12 13:06:04 INFO Requirements update strategy widen_ranges
2023/05/12 13:06:05 INFO Updating lodash, @types/lodash
[#<Dependabot::Dependency:0x00007fc3f3cb1df8
  @metadata={},
  @name="lodash",
  @package_manager="npm_and_yarn",
  @previous_requirements=[{:requirement=>"^4.17.15", :file=>"package.json", :groups=>["dependencies"], :source=>{:type=>"registry", :url=>"https://registry.npmjs.org"}}],
  @previous_version="4.17.15",
  @removed=false,
  @requirements=[{:requirement=>"^4.17.15", :file=>"package.json", :groups=>["dependencies"], :source=>{:type=>"registry", :url=>"https://registry.npmjs.org"}}],
  @version="4.17.21">,
 #<Dependabot::Dependency:0x00007fc3f3cb1a10
  @metadata={},
  @name="@types/lodash",
  @package_manager="npm_and_yarn",
  @previous_requirements=[{:requirement=>"^4.14.181", :file=>"package.json", :groups=>["devDependencies"], :source=>{:type=>"registry", :url=>"https://registry.npmjs.org"}}],
  @previous_version="4.14.181",
  @removed=false,
  @requirements=[{:requirement=>"^4.14.181", :file=>"package.json", :groups=>["devDependencies"], :source=>{:type=>"registry", :url=>"https://registry.npmjs.org"}}],
  @version="4.14.194">]
2023/05/12 13:06:06 INFO Creating a pull request for 'runtime'
2023/05/12 13:06:06 ERROR Error while generating PR message: no implicit conversion of nil into Array
2023/05/12 13:06:07 ERROR Error while generating commit message: no implicit conversion of nil into Array
``` 

```
+------------------------------------------------------------------------------------------------------------------------------------+
|                                                Changes to Dependabot Pull Requests                                                 |
+---------+--------------------------------------------------------------------------------------------------------------------------+
| created | fetch-factory ( from 0.0.1 to 0.2.1 ), lodash ( from 4.17.15 to 4.17.21 ), @types/lodash ( from 4.14.181 to 4.14.194 )   |
| created | @babel/cli ( from 7.16.0 to 7.21.0 ), @babel/core ( from 7.16.0 to 7.21.4 ), @babel/eslint-parser ( from 7.16.0 to 7.... |
| created | babel-jest ( from 28.1.1 to 29.5.0 ), diff-sequences ( from 28.1.1 to 29.4.3 ), eslint-plugin-jest ( from 26.5.3 to 2... |
| created | @typescript-eslint/eslint-plugin ( from 5.27.1 to 5.59.1 ), @typescript-eslint/parser ( from 5.27.1 to 5.59.1 ), esli... |
| created | @types/node ( from 18.16.2 to 20.1.3 )                                                                                   |
| created | @types/semver ( from 7.3.13 to 7.5.0 )                                                                                   |
| created | caniuse-lite ( from 1.0.30001481 to 1.0.30001486 )                                                                       |
| created | core-js-compat ( from 3.30.1 to 3.30.2 )                                                                                 |
| created | electron-to-chromium ( from 1.4.377 to 1.4.392 )                                                                         |
| created | espree ( from 9.5.1 to 9.5.2 )                                                                                           |
+---------+--------------------------------------------------------------------------------------------------------------------------+
Dependabot encountered '1' error(s) during execution, please check the logs for more details.
+--------------------------------------------------------------------------+
|                      Dependencies failed to update                       |
+----------------------------------------------------------+---------------+
| @babel/helper-builder-binary-assignment-operator-visitor | unknown_error |
+----------------------------------------------------------+---------------+
```

compare this to without the patch when we don't skip the guard clause:

```
2023/05/10 09:00:14 INFO Starting update group for 'runtime'
2023/05/10 09:00:15 INFO Checking if fetch-factory 0.0.1 needs updating
2023/05/10 09:00:15 INFO Ignored versions:
2023/05/10 09:00:15 INFO   >0.2.1 - from tests/smoke-npm-grouped.yaml
2023/05/10 09:00:16 INFO Latest version is 0.2.1
2023/05/10 09:00:21 INFO Requirements to unlock own
2023/05/10 09:00:21 INFO Requirements update strategy widen_ranges
2023/05/10 09:00:21 INFO Updating fetch-factory from 0.0.1 to 0.2.1
2023/05/10 09:00:22 INFO Checking if lodash 4.17.15 needs updating
2023/05/10 09:00:22 INFO Ignored versions:
2023/05/10 09:00:22 INFO   >4.17.21 - from tests/smoke-npm-grouped.yaml
2023/05/10 09:00:23 INFO Latest version is 4.17.21
2023/05/10 09:00:24 INFO Requirements to unlock all
2023/05/10 09:00:24 INFO Requirements update strategy widen_ranges
2023/05/10 09:00:25 INFO Updating lodash, @types/lodash
2023/05/10 09:00:26 INFO Creating a pull request for 'runtime'
```

```
2023/05/10 10:07:18 INFO Updating fetch-factory from 0.0.1 to 0.2.1
[#<Dependabot::Dependency:0x00007f8b58d4b940
  @metadata={},
  @name="fetch-factory",
  @package_manager="npm_and_yarn",
  @previous_requirements=[{:requirement=>"^0.0.1", :file=>"package.json", :groups=>["dependencies"], :source=>{:type=>"registry", :url=>"https://registry.npmjs.org/"}}],
  @previous_version="0.0.1",
  @removed=false,
  @requirements=[{:requirement=>"^0.2.1", :file=>"package.json", :groups=>["dependencies"], :source=>{:type=>"registry", :url=>"https://registry.npmjs.org/"}}],
  @version="0.2.1">]
2023/05/10 10:07:20 INFO Checking if lodash 4.17.15 needs updating
2023/05/10 10:07:20 INFO Ignored versions:
2023/05/10 10:07:20 INFO   >4.17.21 - from tests/smoke-npm-grouped.yaml
2023/05/10 10:07:20 INFO Latest version is 4.17.21
2023/05/10 10:07:21 INFO Requirements to unlock all
2023/05/10 10:07:21 INFO Requirements update strategy widen_ranges
2023/05/10 10:07:21 INFO Updating lodash, @types/lodash
[]
```