### PR TITLE
[Updater] GroupUpdateAllVersions now performs refreshes for existing PRs instead of deferring them to a separate job

### DIFF
--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -46,51 +46,5 @@ module Dependabot
     def grouped_update?
       !!dependency_group
     end
-
-    # This method combines checking the job's `updating_a_pull_request` flag
-    # with verification the dependencies involved remain the same.
-    #
-    # If the dependencies involved have changed, we should close the old PR
-    # rather than supersede it as the new changes don't necessarily follow
-    # from the previous ones; dependencies could have been removed from the
-    # project, or pinned by other changes.
-    def should_replace_existing_pr?
-      return false unless job.updating_a_pull_request?
-
-      # NOTE: Gradle, Maven and Nuget dependency names can be case-insensitive
-      # and the dependency name injected from a security advisory often doesn't
-      # match what users have specified in their manifest.
-      updated_dependencies.map(&:name).map(&:downcase) != job.dependencies.map(&:downcase)
-    end
-
-    def matches_existing_pr?
-      !!existing_pull_request
-    end
-
-    private
-
-    def existing_pull_request
-      if grouped_update?
-        # We only want PRs for the same group that have the same versions
-        job.existing_group_pull_requests.find do |pr|
-          pr["dependency-group-name"] == dependency_group.name &&
-            Set.new(pr["dependencies"]) == updated_dependencies_set
-        end
-      else
-        job.existing_pull_requests.find { |pr| Set.new(pr) == updated_dependencies_set }
-      end
-    end
-
-    def updated_dependencies_set
-      Set.new(
-        updated_dependencies.map do |dep|
-          {
-            "dependency-name" => dep.name,
-            "dependency-version" => dep.version,
-            "dependency-removed" => dep.removed? ? true : nil
-          }.compact
-        end
-      )
-    end
   end
 end

--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -53,14 +53,10 @@ module Dependabot
       end
     end
 
-    def job_group_name
-      job.dependency_group_to_refresh
-    end
-
     # Returns just the group that is specifically requested to be updated by
     # the job definition
     def job_group
-      return nil unless job_group_name
+      return nil unless job.dependency_group_to_refresh
       return @job_group if defined?(@job_group)
 
       @job_group = groups.fetch(job.dependency_group_to_refresh.to_sym, nil)

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -91,8 +91,9 @@ module Dependabot
       # TODO: Make this hash required
       #
       # We will need to do a pass updating the CLI and smoke tests before this is possible,
-      # so let's consider it optional for now.
-      @existing_group_pull_requests   = attributes.fetch(:existing_group_pull_requests, [])
+      # so let's consider it optional for now. If we get a nil value, let's force it to be
+      # an array.
+      @existing_group_pull_requests   = attributes.fetch(:existing_group_pull_requests, []) || []
       @experiments                    = attributes.fetch(:experiments, {})
       @ignore_conditions              = attributes.fetch(:ignore_conditions)
       @package_manager                = attributes.fetch(:package_manager)

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -110,6 +110,8 @@ module Dependabot
           end
         end
 
+        # If a PR exists for a group, we defer to this logic to determine if the existing changes
+        # still apply or if we need to replace the existing PR.
         def run_refresh_for(group, pull_request)
           Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest.new(
             service: service,
@@ -122,6 +124,9 @@ module Dependabot
             operation.previous_dependency_names = pull_request["dependencies"].map do |dependency|
               dependency["dependency-name"]
             end
+            # Unlike a standalone refresh job, we shouldn't rebase the PR - we only care about
+            # replacing it if the target dependencies or versions have changed.
+            operation.defer_rebasing_existing_prs = true
           end.perform
         end
 

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -2301,26 +2301,6 @@ RSpec.describe Dependabot::Updater do
       expect(service).not_to receive(:create_pull_request)
       updater.run
     end
-
-    it "does not create a new pull request for a group if one already exists" do
-      job = build_job(
-        existing_group_pull_requests: [
-          {
-            "dependency-group-name" => "group-b",
-            "dependencies" => [
-              { "dependency-name" => "dummy-pkg-b", "dependency-version" => "1.2.0" }
-            ]
-          }
-        ],
-        dependency_groups: [{ "name" => "group-b", "rules" => { "patterns" => ["dummy-pkg-b"] } }],
-        experiments: { "grouped-updates-prototype" => true }
-      )
-      service = build_service
-      updater = build_updater(service: service, job: job)
-
-      expect(service).not_to receive(:create_pull_request)
-      updater.run
-    end
   end
 
   def build_updater(service: build_service, job: build_job, dependency_files: default_dependency_files,

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_with_existing_pr.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_with_existing_pr.yaml
@@ -1,0 +1,43 @@
+job:
+  package-manager: bundler
+  source:
+    provider: github
+    repo: dependabot/smoke-tests
+    directory: "/bundler"
+    branch:
+    api-endpoint: https://api.github.com/
+    hostname: github.com
+  dependencies:
+  existing-pull-requests: []
+  existing-group-pull-requests:
+    - dependency-group-name: "group-b"
+      dependencies:
+        - dependency-name: "dummy-pkg-b"
+          dependency-version: "1.2.0"
+  updating-a-pull-request: false
+  lockfile-only: false
+  update-subdependencies: false
+  ignore-conditions: []
+  requirements-update-strategy:
+  allowed-updates:
+  - dependency-type: direct
+    update-type: all
+  credentials-metadata:
+  - type: git_source
+    host: github.com
+  security-advisories: []
+  max-updater-run-time: 2700
+  vendor-dependencies: false
+  experiments:
+    grouped-updates-prototype: true
+  reject-external-code: false
+  commit-message-options:
+    prefix:
+    prefix-development:
+    include-scope:
+  security-updates-only: false
+  dependency-groups:
+  - name: group-b
+    rules:
+      patterns:
+        - "dummy-pkg-b"

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_with_existing_stale_pr.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_all_with_existing_stale_pr.yaml
@@ -1,0 +1,45 @@
+job:
+  package-manager: bundler
+  source:
+    provider: github
+    repo: dependabot/smoke-tests
+    directory: "/bundler"
+    branch:
+    api-endpoint: https://api.github.com/
+    hostname: github.com
+  dependencies:
+  existing-pull-requests: []
+  existing-group-pull-requests:
+    - dependency-group-name: "everything-everywhere-all-at-once"
+      dependencies:
+        - dependency-name: "dummy-pkg-b"
+          dependency-version: "1.2.0"
+        - dependency-name: "dummy-pkg-c"
+          dependency-version: "0.99.0"
+  updating-a-pull-request: false
+  lockfile-only: false
+  update-subdependencies: false
+  ignore-conditions: []
+  requirements-update-strategy:
+  allowed-updates:
+  - dependency-type: direct
+    update-type: all
+  credentials-metadata:
+  - type: git_source
+    host: github.com
+  security-advisories: []
+  max-updater-run-time: 2700
+  vendor-dependencies: false
+  experiments:
+    grouped-updates-prototype: true
+  reject-external-code: false
+  commit-message-options:
+    prefix:
+    prefix-development:
+    include-scope:
+  security-updates-only: false
+  dependency-groups:
+  - name: everything-everywhere-all-at-once
+    rules:
+      patterns:
+        - "*"


### PR DESCRIPTION
For our initial iteration of grouped update scheduled jobs we choose the following strategy:
- The scheduled `GroupUpdateAllVersions` job only runs for groups which do not have a pre-existing, open pull request
- Separately, the service elects to enqueue a `RefreshGroupUpdatePullRequest` for these existing open pull requests

This approach optimised for avoiding a single Operation doing too much and prefer to run smaller jobs when we can, **but** a major drawback is it means that the primarily scheduled update job logs do not show these refreshes.

This is a pretty significant drawback as we currently do not do a great job of surfacing refresh/rebase logs in the UI.

### Changes

This branch adds a small interface to allow the `RefreshGroupUpdatePullRequest` to have data about an existing pull request to be injected as an 'overlay' on the `Dependabot::Job` in order to allow `GroupUpdateAllVersions` to delegate to it to perform refresh operations in-line without having to incorporate the refresh logic directly.