### PR TITLE
Replace skipping workflow flags on PR description

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -41,6 +41,7 @@ module Dependabot
           msg += commits_cascade
           msg += maintainer_changes_cascade
           msg += break_tag unless msg == ""
+          msg = sanitize_skipping_workflow_tags(msg)
           "\n" + sanitize_links_and_mentions(msg, unsafe: true)
         end
 
@@ -131,6 +132,7 @@ module Dependabot
             end
           msg = link_issues(text: msg)
           msg = sanitize_links_and_mentions(msg)
+          msg = sanitize_skipping_workflow_tags(msg)
 
           build_details_tag(summary: "Commits", body: msg)
         end
@@ -248,6 +250,10 @@ module Dependabot
           LinkAndMentionSanitizer.
             new(github_redirection_service: github_redirection_service).
             sanitize_links_and_mentions(text: text, unsafe: unsafe, format_html: source_provider_supports_html?)
+        end
+
+        def sanitize_skipping_workflow_tags(text)
+          text.gsub(/\[skip ci|ci skip|skip actions|actions skip|no ci\]/, "[REMOVED SKIPPING WORKFLOW FLAG]")
         end
 
         def sanitize_template_tags(text)

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -132,7 +132,6 @@ module Dependabot
             end
           msg = link_issues(text: msg)
           msg = sanitize_links_and_mentions(msg)
-          msg = sanitize_skipping_workflow_tags(msg)
 
           build_details_tag(summary: "Commits", body: msg)
         end
@@ -253,7 +252,7 @@ module Dependabot
         end
 
         def sanitize_skipping_workflow_tags(text)
-          text.gsub(/\[skip ci|ci skip|skip actions|actions skip|no ci\]/, "[REMOVED SKIPPING WORKFLOW FLAG]")
+          text.gsub(/\[(skip ci|ci skip|skip actions|actions skip|no ci)\]/, "[REMOVED SKIPPING WORKFLOW FLAG]")
         end
 
         def sanitize_template_tags(text)

--- a/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
@@ -874,7 +874,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
                           "5555535ff2aa9d7ce0403d7fd4aa010d94723076"
               },
               {
-                message: "Allow custom calendars",
+                message: "Allow custom calendars [skip ci]",
                 sha: "1c72c35ff2aa9d7ce0403d7fd4aa010d94723076",
                 html_url: "https://github.com/gocardless/business/commit/" \
                           "1c72c35ff2aa9d7ce0403d7fd4aa010d94723076"

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       "business/issues/9\">#9</a>] Allow custom calendars</li>\n" \
       "<li><a href=\"https://github.com/gocardless/business/commit/" \
       "1c72c35ff2aa9d7ce0403d7fd4aa010d94723076\"><code>1c72c35</code></a> " \
-      "Allow custom calendars</li>\n" \
+      "Allow custom calendars [skip ci]</li>\n" \
       "<li><a href=\"https://github.com/gocardless/business/commit/" \
       "5555535ff2aa9d7ce0403d7fd4aa010d94723076\"><code>5555535</code>" \
       "</a></li>\n" \

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       "business/issues/9\">#9</a>] Allow custom calendars</li>\n" \
       "<li><a href=\"https://github.com/gocardless/business/commit/" \
       "1c72c35ff2aa9d7ce0403d7fd4aa010d94723076\"><code>1c72c35</code></a> " \
-      "Allow custom calendars [skip ci]</li>\n" \
+      "Allow custom calendars [REMOVED SKIPPING WORKFLOW FLAG]</li>\n" \
       "<li><a href=\"https://github.com/gocardless/business/commit/" \
       "5555535ff2aa9d7ce0403d7fd4aa010d94723076\"><code>5555535</code>" \
       "</a></li>\n" \

--- a/common/spec/fixtures/github/commits-business-1.4.0.json
+++ b/common/spec/fixtures/github/commits-business-1.4.0.json
@@ -176,7 +176,7 @@
         "email": "greysteil@gmail.com",
         "date": "2014-12-24T16:16:55Z"
       },
-      "message": "Allow custom calendars",
+      "message": "Allow custom calendars [skip ci]",
       "tree": {
         "sha": "23d7441279d87e155f45347e7c484c56ed4c6afa",
         "url": "https://api.github.com/repos/gocardless/business/git/trees/23d7441279d87e155f45347e7c484c56ed4c6afa"

--- a/common/spec/fixtures/raw/changelog.md
+++ b/common/spec/fixtures/raw/changelog.md
@@ -26,7 +26,7 @@
 
 ## 1.5.0 - June 2, 2015
 
-- Add 2016 holiday definitions
+- Add 2016 holiday definitions [skip ci]
 
 ## 1.4.0 - December 24, 2014
 

--- a/common/spec/fixtures/raw/reverse_changelog.md
+++ b/common/spec/fixtures/raw/reverse_changelog.md
@@ -21,7 +21,7 @@
 
 ## 1.5.0 - June 2, 2015
 
-- Add 2016 holiday definitions
+- Add 2016 holiday definitions [skip ci]
 
 ## 1.6.0 - December 23, 2016
 


### PR DESCRIPTION
Adds a process to replace the flags used to skip workflows, described in this [article](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs), to `[REMOVED SKIPPING WORKFLOW FLAG]`.

When using the `Squash and merge` option in PRs on Github with the configuration to use the title and description of the PR as the merge commit information, when doing the merge, if there is a skipping workflow flag in the commit description, the repository actions are skipped, as happened [here](https://github.com/RafaelWerner/dependabot_test/commit/8b041a33c1e91d11dcfca828d28cde51ae0a452c).