### PR TITLE
Unimplemented `package_manager_version` should raise

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -103,7 +103,7 @@ module Dependabot
       end
 
       def package_manager_version
-        nil
+        raise NotImplementedError
       end
 
       private


### PR DESCRIPTION
Rather than returning `nil` by default, let's raise a `NotImplementedError` to signal that the concrete class hasn't implemented this.

This way we can differentiate between "concrete class didn't implement" vs "concrete class implemented but the result is still `nil`.

It also gives us a hook that we can later test within our `shared_examples` to enforce that concrete implementations implemented this. I'm a little torn on whether we'd actually want to do that though... here at GitHub this observability is crucial for us to plan deprecation policies, but for outside folks using `dependabot-core` as a library for their one-off custom gem, they wouldn't need this... so it feels a bit heavy-handed to require implementing it... although OTOH, tis trivial for them to implement a no-op in the concrete class... anyway, we can figure that out later.

Note that this solution is _not_ idiomatic ruby:

1. http://chrisstump.online/2016/03/23/stop-abusing-notimplementederror/
2. https://oleg0potapov.medium.com/ruby-notimplementederror-dont-use-it-dff1fd7228e5
3. https://stackoverflow.com/questions/13668068/how-to-signal-not-implemented-yet#comment40295636_13668085

In particular the quote that caught my eye:
>  Note that `NotImplementedError` does not subclass `StandardError`, so it won't get caught in bare `rescue` or `rescue => e` blocks

However, this is internally consistent with what we've already done within our abstract base class: https://github.com/dependabot/dependabot-core/blob/79e5758cd455e20256f610c76d36798aa6e28a45/common/lib/dependabot/file_fetchers/base.rb#L35-L41

And it doesn't make things worse because the "fix" is probably to use a new custom error that inherits from `StandardError`, so this is one more line that would get applied.