### PR TITLE
Schedule the release PR to arrive weekly

### DIFF
--- a/.github/workflows/gems-bump-version.yml
+++ b/.github/workflows/gems-bump-version.yml
@@ -1,5 +1,7 @@
 name: Gems - Bump Version
 on:
+  schedule:
+    - cron: '25 1 * * THU'
   workflow_dispatch:
     inputs:
       version_type:
@@ -37,8 +39,9 @@ jobs:
           working-directory: updater
 
       - name: Bump the version
+        # Cron runs with no inputs, so version_type will default to 'minor'
         run: |
-          NEW_VERSION=$(bin/bump-version.rb ${{ github.event.inputs.version_type }})
+          NEW_VERSION=$(bin/bump-version.rb ${{ github.event.inputs.version_type || 'minor' }})
           echo "New version is: $NEW_VERSION"
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
This adds a workflow trigger that goes off every Thursday. This way we are reminded to release weekly.

If the version bump PR is already open because it hasn't yet been merged from the previous week, then this workflow will bomb out when it tries to push the branch, since the branch name is idempotent.

Fix: https://github.com/dependabot/dependabot-core/issues/7132