### PR TITLE
buid(deps): bump Yarn from 3.5.0 to 3.6.0

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG PNPM_VERSION=8.6.4
 
 # Check for updates at https://github.com/yarnpkg/berry/releases
-ARG YARN_VERSION=3.5.0
+ARG YARN_VERSION=3.6.0
 
 # See https://github.com/nodesource/distributions#installation-instructions
 ARG NODEJS_VERSION=16.x


### PR DESCRIPTION
Changelog: https://github.com/yarnpkg/berry/compare/@yarnpkg/cli/3.5.0...@yarnpkg/cli/3.6.0