### PR TITLE
Ensure we start from `main` even if workflow run from a branch

### DIFF
--- a/.github/workflows/gems-bump-version.yml
+++ b/.github/workflows/gems-bump-version.yml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Ensure we start from main in case the workflow is run from a branch
+          ref: "main"
+
       - uses: ruby/setup-ruby@v1 # bump-version.rb needs bundler
         with:
           # Use the version of bundler specified in `updater/Gemfile.lock`.


### PR DESCRIPTION
I kept having problems while testing https://github.com/dependabot/dependabot-core/pull/7324/ until I realized that because I was doing my testing on a branch, `actions/checkout` was starting from the branch and then opening a PR against `main`, so it included not only the commit generated within this workflow, but also whatever other commits I'd made during my testing.

For this particular workflow, we always want to start from `main` as we're building a PR that should only contain the version bump commit.