### PR TITLE
Minor cleanup on the publish RubyGems action

### DIFF
--- a/.github/workflows/gems-release-to-rubygems.yml
+++ b/.github/workflows/gems-release-to-rubygems.yml
@@ -1,20 +1,25 @@
 name: Gems - Release to RubyGems
 on:
   release:
+    # It's fine to trigger on every release because if we tag a release w/o
+    # bumping the Gem version, RubyGems will reject it with an error that the
+    # version is already live.
     types: [published]
-permissions:
-  contents: read
+
 jobs:
   release-gems:
     name: Release gems to rubygems.org
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
       - run: |
           [ -d ~/.gem ] || mkdir ~/.gem
           echo "---" > ~/.gem/credentials
-          echo ":rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}" > ~/.gem/credentials
+          echo ":rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY_WITH_SCOPE_LIMITED_TO_PUSH }}" > ~/.gem/credentials
           chmod 0600 ~/.gem/credentials
           gem install rake && rake gems:release


### PR DESCRIPTION
Clarify that we're safe to run on every release.

Also clarify the expected scope of the API key so that if someone rotates it, they remember to limit the scope of it.

Related:
* https://github.com/dependabot/dependabot-core/issues/7132