### PR TITLE
Upgrade Node.js to active LTS version (18.x)

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -7,11 +7,11 @@ ARG PNPM_VERSION=8.6.4
 ARG YARN_VERSION=3.6.0
 
 # See https://github.com/nodesource/distributions#installation-instructions
-ARG NODEJS_VERSION=16.x
+ARG NODEJS_VERSION=18.x
 
 # Check for updates at https://github.com/npm/cli/releases
 # This version should be compatible with the Node.js version declared above. See https://nodejs.org/en/download/releases as well
-ARG NPM_VERSION=8.19.4
+ARG NPM_VERSION=9.5.1
 
 # Install Node and npm
 RUN curl -sL https://deb.nodesource.com/setup_$NODEJS_VERSION | bash - \

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -2522,7 +2522,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
                 to eq("git+ssh://git@github.com/jonschlinkert/is-number.git#" \
                       "0c6b15a88bc10cd47f67a09506399dfc9ddc075d")
               expect(parsed_package_lock["dependencies"]["is-number"]["from"]).
-                to eq("is-number@jonschlinkert/is-number#semver:^4.0.0")
+                to eq("is-number@github:jonschlinkert/is-number#semver:^4.0.0")
             end
           end
         end


### PR DESCRIPTION
# Changes

Upgrades the Node.js version that dependabot uses to the latest active LTS (Long Term Support) version which is 18.x. https://nodejs.org/en
![image](https://github.com/dependabot/dependabot-core/assets/127199/1b48187c-4c3f-416d-9eca-aa9a5c8d6897)

# Why

* Dependabot currently uses a `Maintenance LTS` version of Node.js instead of a `Active LTS` version. https://nodejs.dev/en/about/releases/
![image](https://github.com/dependabot/dependabot-core/assets/127199/f79602c6-7473-4575-99d9-8bb58218b265)
* We run into the following issue since we have `engine-strict` enabled and want to avoid 
```
Dependabot uses Node.js v16.20.0
 and NPM 8.19.4
. Due to the engine-strict setting, the update will not succeed.
```

# Related issues / threads

* https://github.com/dependabot/dependabot-core/issues/4072#issuecomment-1413222679
* https://github.com/dependabot/dependabot-core/pull/7194 
* https://zenn.dev/risu729/articles/dependabot-engine-strict
