### PR TITLE
Fetching GitLab repo contents correctly uses the ref argument

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -375,7 +375,7 @@ module Dependabot
 
       def _gitlab_repo_contents(repo, path, commit)
         gitlab_client.
-          repo_tree(repo, path: path, ref_name: commit, per_page: 100).
+          repo_tree(repo, path: path, ref: commit, per_page: 100).
           map do |file|
             # GitLab API essentially returns the output from `git ls-tree`
             type = case file.type


### PR DESCRIPTION
Dependabot can properly list GitLab repo contents on a given branch/commit.

This is problematic when you are, for example, testing dependabot config and the requirements files are not present on the main repository branch, but on the changed branch only. In such case, dependabot won't see expected requirements, resulting in `Dependabot::DependencyFileNotFound`.

# Context
According to the GitLab API (https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree), you have to use the `ref` argument to list the repository at a given commit/branch.

The GitLab client blindly passes all the arguments to the API itself, including the `ref_name` argument. GitLab ignores extra GET parameters, thus it wasn't erroring out.