### PR TITLE
Revert "Allow updating gemspecs loaded from a Gemfile"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@ updates:
     schedule:
       interval: "weekly"
 
+  # No ecosystem folders are watched because they roll up to the omnibus watcher
+  - package-ecosystem: "bundler"
+    directory: "/omnibus"
+    schedule:
+      interval: "weekly"
+
   # Watch the per-ecosystem native helpers
   - package-ecosystem: "composer"
     directory: "/composer/helpers/v1"

--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -142,7 +142,7 @@ module Dependabot
 
         raise Dependabot::PathDependenciesNotReachable, unfetchable_gems if unfetchable_gems.any?
 
-        gemspec_files
+        gemspec_files.tap { |ar| ar.each { |f| f.support_file = true } }
       end
 
       def path_gemspec_paths

--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -297,7 +297,8 @@ module Dependabot
       def gemspecs
         # Path gemspecs are excluded (they're supporting files)
         @gemspecs ||= prepared_dependency_files.
-                      select { |file| file.name.end_with?(".gemspec") }
+                      select { |file| file.name.end_with?(".gemspec") }.
+                      reject(&:support_file?)
       end
 
       def imported_ruby_files

--- a/bundler/lib/dependabot/bundler/file_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater.rb
@@ -159,7 +159,8 @@ module Dependabot
 
       def top_level_gemspecs
         dependency_files.
-          select { |file| file.name.end_with?(".gemspec") }
+          select { |file| file.name.end_with?(".gemspec") }.
+          reject(&:support_file?)
       end
 
       def bundler_version

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -148,7 +148,8 @@ module Dependabot
 
         def top_level_gemspecs
           dependency_files.
-            select { |file| file.name.end_with?(".gemspec") && Pathname.new(file.name).dirname.to_s == "." }
+            select { |file| file.name.end_with?(".gemspec") && Pathname.new(file.name).dirname.to_s == "." }.
+            reject(&:support_file?)
         end
 
         def ruby_version_file

--- a/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
@@ -143,7 +143,8 @@ module Dependabot
 
         def top_level_gemspecs
           dependency_files.
-            select { |f| f.name.end_with?(".gemspec") }
+            select { |f| f.name.end_with?(".gemspec") }.
+            reject(&:support_file?)
         end
 
         def ruby_version_file

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -377,7 +377,10 @@ RSpec.describe Dependabot::Bundler::FileParser do
 
     context "with a path-based dependency" do
       let(:dependency_files) do
-        bundler_project_dependency_files("path_source")
+        bundler_project_dependency_files("path_source").tap do |files|
+          gemspec = files.find { |f| f.name == "plugins/example/example.gemspec" }
+          gemspec.support_file = true
+        end
       end
 
       let(:expected_requirements) do
@@ -389,7 +392,7 @@ RSpec.describe Dependabot::Bundler::FileParser do
         }]
       end
 
-      its(:length) { is_expected.to eq(15) }
+      its(:length) { is_expected.to eq(4) }
 
       it "does not include the path dependency" do
         expect(dependencies.map(&:name)).to_not include("example")

--- a/bundler/spec/dependabot/bundler/update_checker/file_preparer_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/file_preparer_spec.rb
@@ -287,12 +287,15 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::FilePreparer do
 
     describe "the updated path gemspec" do
       let(:dependency_files) do
-        bundler_project_dependency_files("nested_gemspec")
+        bundler_project_dependency_files("nested_gemspec").tap do |files|
+          file = files.find { |f| f.name == "some/example.gemspec" }
+          file.support_file = true
+        end
       end
       subject { prepared_dependency_files.find { |f| f.name == "some/example.gemspec" } }
       let(:version) { "1.4.3" }
 
-      its(:content) { is_expected.to include(%("business", ">= 1.4.3")) }
+      its(:content) { is_expected.to include(%("business", "~> 1.0")) }
 
       context "when the file requires sanitizing" do
         subject { prepared_dependency_files.find { |f| f.name == "example.gemspec" } }


### PR DESCRIPTION
### Issue
- https://github.com/dependabot/dependabot-core/issues/7071

### Description
When there is a Gem installed via a symlink, Dependabot removes the symlink.
I have created a repository that reproduces this issue: https://github.com/laboone/monorepo-for-dependabot
In this repository, Dependabot creates a PR that removes the symlink, as shown in https://github.com/laboone/monorepo-for-dependabot/pull/1.

This functionality seems to have been introduced in https://github.com/dependabot/dependabot-core/pull/7051.
This PR is a revert of that change.