### PR TITLE
Ensure updated dependencies are correctly included when building dependency change instance

### DIFF
--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -38,7 +38,8 @@ module Dependabot
       updated_deps = updated_dependencies.reject do |d|
         # Avoid rejecting the source dependency
         next false if source_dependency_name && d.name == source_dependency_name
-        next true if d.top_level? && d.requirements == d.previous_requirements
+
+        next false if d.top_level? && d.requirements != d.previous_requirements
 
         d.version == d.previous_version
       end


### PR DESCRIPTION
Ensures that (a) a dependency whose version has changed but whose requirements have not changed is still included in the generated dependency change instance, and (b) a dependency whose requirements have changed but whose version has not changed is still included in the generated dependency change instance.

Should unblock https://github.com/dependabot/smoke-tests/pull/72