### PR TITLE
[Updater] Avoid mis-representing a Dependency Group as a Dependency in error handling

### DIFF
--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -66,7 +66,7 @@ module Dependabot
     #
     # This should be called as an alternative/in addition to record_update_job_error
     # for cases where an error could indicate a problem with the service.
-    def capture_exception(error:, job: nil, dependency: nil, tags: {}, extra: {})
+    def capture_exception(error:, job: nil, dependency: nil, dependency_group: nil, tags: {}, extra: {})
       Raven.capture_exception(
         error,
         {
@@ -76,7 +76,8 @@ module Dependabot
             repo_private: job&.repo_private?
           }.compact),
           extra: extra.merge({
-            dependency_name: dependency&.name
+            dependency_name: dependency&.name,
+            dependency_group: dependency_group&.name
           }.compact)
         }
       )

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -37,16 +37,6 @@ require "wildcard_matcher"
 
 module Dependabot
   class Updater
-    class SubprocessFailed < StandardError
-      attr_reader :raven_context
-
-      def initialize(message, raven_context:)
-        super(message)
-
-        @raven_context = raven_context
-      end
-    end
-
     # To do work, this class needs three arguments:
     # - The Dependabot::Service to send events and outcomes to
     # - The Dependabot::Job that describes the work to be done

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -33,123 +33,33 @@ module Dependabot
         @job = job
       end
 
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
-      def handle_dependabot_error(error:, dependency:)
+      # This method handles errors where there is a dependency in the current
+      # context. This should be used by preference where possible.
+      def handle_dependency_error(error:, dependency:)
         # If the error is fatal for the run, we should re-raise it rather than
         # pass it back to the service.
         raise error if RUN_HALTING_ERRORS.keys.any? { |err| error.is_a?(err) }
 
-        error_details =
-          case error
-          when Dependabot::DependencyFileNotResolvable
-            {
-              "error-type": "dependency_file_not_resolvable",
-              "error-detail": { message: error.message }
-            }
-          when Dependabot::DependencyFileNotEvaluatable
-            {
-              "error-type": "dependency_file_not_evaluatable",
-              "error-detail": { message: error.message }
-            }
-          when Dependabot::GitDependenciesNotReachable
-            {
-              "error-type": "git_dependencies_not_reachable",
-              "error-detail": { "dependency-urls": error.dependency_urls }
-            }
-          when Dependabot::GitDependencyReferenceNotFound
-            {
-              "error-type": "git_dependency_reference_not_found",
-              "error-detail": { dependency: error.dependency }
-            }
-          when Dependabot::PrivateSourceAuthenticationFailure
-            {
-              "error-type": "private_source_authentication_failure",
-              "error-detail": { source: error.source }
-            }
-          when Dependabot::PrivateSourceTimedOut
-            {
-              "error-type": "private_source_timed_out",
-              "error-detail": { source: error.source }
-            }
-          when Dependabot::PrivateSourceCertificateFailure
-            {
-              "error-type": "private_source_certificate_failure",
-              "error-detail": { source: error.source }
-            }
-          when Dependabot::MissingEnvironmentVariable
-            {
-              "error-type": "missing_environment_variable",
-              "error-detail": {
-                "environment-variable": error.environment_variable
-              }
-            }
-          when Dependabot::GoModulePathMismatch
-            {
-              "error-type": "go_module_path_mismatch",
-              "error-detail": {
-                "declared-path": error.declared_path,
-                "discovered-path": error.discovered_path,
-                "go-mod": error.go_mod
-              }
-            }
-          when Dependabot::NotImplemented
-            {
-              "error-type": "not_implemented",
-              "error-detail": {
-                message: error.message
-              }
-            }
-          when Dependabot::SharedHelpers::HelperSubprocessFailed
-            # If a helper subprocess has failed the error may include sensitive
-            # info such as file contents or paths. This information is already
-            # in the job logs, so we send a breadcrumb to Sentry to retrieve those
-            # instead.
-            msg = "Subprocess #{error.raven_context[:fingerprint]} failed to run. Check the job logs for error messages"
-            sanitized_error = SubprocessFailed.new(msg, raven_context: error.raven_context)
-            sanitized_error.set_backtrace(error.backtrace)
-            service.capture_exception(error: sanitized_error, job: job)
-
-            { "error-type": "unknown_error" }
-          when *Octokit::RATE_LIMITED_ERRORS
-            # If we get a rate-limited error we let dependabot-api handle the
-            # retry by re-enqueing the update job after the reset
-            {
-              "error-type": "octokit_rate_limited",
-              "error-detail": {
-                "rate-limit-reset": error.response_headers["X-RateLimit-Reset"]
-              }
-            }
-          else
-            service.capture_exception(
-              error: error,
-              job: job,
-              dependency: dependency
-            )
-            { "error-type": "unknown_error" }
-          end
-
+        error_details = error_details_for(error, dependency: dependency)
         service.record_update_job_error(
           error_type: error_details.fetch(:"error-type"),
           error_details: error_details[:"error-detail"],
           dependency: dependency
         )
 
-        log_error(
+        log_dependency_error(
           dependency: dependency,
           error: error,
           error_type: error_details.fetch(:"error-type"),
           error_detail: error_details.fetch(:"error-detail", nil)
         )
       end
-      # rubocop:enable Metrics/MethodLength
-      # rubocop:enable Metrics/AbcSize
 
-      def log_error(dependency:, error:, error_type:, error_detail: nil)
+      # Provides logging for errors that occur when processing a dependency
+      def log_dependency_error(dependency:, error:, error_type:, error_detail: nil)
         if error_type == "unknown_error"
           Dependabot.logger.error "Error processing #{dependency.name} (#{error.class.name})"
-          Dependabot.logger.error error.message
-          error.backtrace.each { |line| Dependabot.logger.error line }
+          log_unknown_error_with_backtrace(error)
         else
           Dependabot.logger.info(
             "Handled error whilst updating #{dependency.name}: #{error_type} #{error_detail}"
@@ -157,9 +67,137 @@ module Dependabot
         end
       end
 
+      # This method handles errors where there is no dependency in the current
+      # context.
+      def handle_job_error(error:)
+        # If the error is fatal for the run, we should re-raise it rather than
+        # pass it back to the service.
+        raise error if RUN_HALTING_ERRORS.keys.any? { |err| error.is_a?(err) }
+
+        error_details = error_details_for(error)
+        service.record_update_job_error(
+          error_type: error_details.fetch(:"error-type"),
+          error_details: error_details[:"error-detail"]
+        )
+        log_job_error(
+          error: error,
+          error_type: error_details.fetch(:"error-type"),
+          error_detail: error_details.fetch(:"error-detail", nil)
+        )
+      end
+
+      # Provides logging for errors that occur outside of a dependency context
+      def log_job_error(error:, error_type:, error_detail: nil)
+        if error_type == "unknown_error"
+          Dependabot.logger.error "Error processing job (#{error.class.name})"
+          log_unknown_error_with_backtrace(error)
+        else
+          Dependabot.logger.info(
+            "Handled error whilst processing job: #{error_type} #{error_detail}"
+          )
+        end
+      end
+
       private
 
       attr_reader :service, :job
+
+      # This method accepts an error class and returns an appropriate `error_details` hash
+      # to be reported to the backend service.
+      def error_details_for(error, dependency: nil) # rubocop:disable Metrics/MethodLength
+        case error
+        when Dependabot::DependencyFileNotResolvable
+          {
+            "error-type": "dependency_file_not_resolvable",
+            "error-detail": { message: error.message }
+          }
+        when Dependabot::DependencyFileNotEvaluatable
+          {
+            "error-type": "dependency_file_not_evaluatable",
+            "error-detail": { message: error.message }
+          }
+        when Dependabot::GitDependenciesNotReachable
+          {
+            "error-type": "git_dependencies_not_reachable",
+            "error-detail": { "dependency-urls": error.dependency_urls }
+          }
+        when Dependabot::GitDependencyReferenceNotFound
+          {
+            "error-type": "git_dependency_reference_not_found",
+            "error-detail": { dependency: error.dependency }
+          }
+        when Dependabot::PrivateSourceAuthenticationFailure
+          {
+            "error-type": "private_source_authentication_failure",
+            "error-detail": { source: error.source }
+          }
+        when Dependabot::PrivateSourceTimedOut
+          {
+            "error-type": "private_source_timed_out",
+            "error-detail": { source: error.source }
+          }
+        when Dependabot::PrivateSourceCertificateFailure
+          {
+            "error-type": "private_source_certificate_failure",
+            "error-detail": { source: error.source }
+          }
+        when Dependabot::MissingEnvironmentVariable
+          {
+            "error-type": "missing_environment_variable",
+            "error-detail": {
+              "environment-variable": error.environment_variable
+            }
+          }
+        when Dependabot::GoModulePathMismatch
+          {
+            "error-type": "go_module_path_mismatch",
+            "error-detail": {
+              "declared-path": error.declared_path,
+              "discovered-path": error.discovered_path,
+              "go-mod": error.go_mod
+            }
+          }
+        when Dependabot::NotImplemented
+          {
+            "error-type": "not_implemented",
+            "error-detail": {
+              message: error.message
+            }
+          }
+        when Dependabot::SharedHelpers::HelperSubprocessFailed
+          # If a helper subprocess has failed the error may include sensitive
+          # info such as file contents or paths. This information is already
+          # in the job logs, so we send a breadcrumb to Sentry to retrieve those
+          # instead.
+          msg = "Subprocess #{error.raven_context[:fingerprint]} failed to run. Check the job logs for error messages"
+          sanitized_error = SubprocessFailed.new(msg, raven_context: error.raven_context)
+          sanitized_error.set_backtrace(error.backtrace)
+          service.capture_exception(error: sanitized_error, job: job)
+
+          { "error-type": "unknown_error" }
+        when *Octokit::RATE_LIMITED_ERRORS
+          # If we get a rate-limited error we let dependabot-api handle the
+          # retry by re-enqueing the update job after the reset
+          {
+            "error-type": "octokit_rate_limited",
+            "error-detail": {
+              "rate-limit-reset": error.response_headers["X-RateLimit-Reset"]
+            }
+          }
+        else
+          service.capture_exception(
+            error: error,
+            job: job,
+            dependency: dependency
+          )
+          { "error-type": "unknown_error" }
+        end
+      end
+
+      def log_unknown_error_with_backtrace(error)
+        Dependabot.logger.error error.message
+        error.backtrace.each { |line| Dependabot.logger.error line }
+      end
     end
   end
 end

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "dependabot/updater/errors"
+
 # This class is responsible for determining how to present a Dependabot::Error
 # to the Service and Logger.
 #

--- a/updater/lib/dependabot/updater/errors.rb
+++ b/updater/lib/dependabot/updater/errors.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Dependabot
+  class Updater
+    class SubprocessFailed < StandardError
+      attr_reader :raven_context
+
+      def initialize(message, raven_context:)
+        super(message)
+
+        @raven_context = raven_context
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -34,7 +34,7 @@ module Dependabot
           # dependency update
           next if dependency.nil?
 
-          updated_dependencies = compile_updates_for(dependency, dependency_files)
+          updated_dependencies = compile_updates_for(dependency, dependency_files, group)
 
           next unless updated_dependencies.any?
 
@@ -94,7 +94,7 @@ module Dependabot
 
         false
       rescue StandardError => e
-        error_handler.handle_dependency_error(error: e, dependency: lead_dependency)
+        error_handler.handle_dependency_error(error: e, dependency: lead_dependency, dependency_group: dependency_group)
 
         false
       end
@@ -107,7 +107,7 @@ module Dependabot
       #
       # This method **must** must return an Array when it errors
       #
-      def compile_updates_for(dependency, dependency_files) # rubocop:disable Metrics/MethodLength
+      def compile_updates_for(dependency, dependency_files, group) # rubocop:disable Metrics/MethodLength
         checker = update_checker_for(dependency, dependency_files, raise_on_ignored: raise_on_ignored?(dependency))
 
         log_checking_for_update(dependency)
@@ -150,7 +150,7 @@ module Dependabot
         )
         [] # return an empty set
       rescue StandardError => e
-        error_handler.handle_dependency_error(error: e, dependency: dependency)
+        error_handler.handle_dependency_error(error: e, dependency: dependency, dependency_group: group)
         [] # return an empty set
       end
 

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -85,7 +85,7 @@ module Dependabot
           change_source: dependency_group
         )
       rescue Dependabot::InconsistentRegistryResponse => e
-        error_handler.log_error(
+        error_handler.log_dependency_error(
           dependency: lead_dependency,
           error: e,
           error_type: "inconsistent_registry_response",
@@ -94,9 +94,7 @@ module Dependabot
 
         false
       rescue StandardError => e
-        raise if ErrorHandler::RUN_HALTING_ERRORS.keys.any? { |err| e.is_a?(err) }
-
-        error_handler.handle_dependabot_error(error: e, dependency: lead_dependency)
+        error_handler.handle_dependency_error(error: e, dependency: lead_dependency)
 
         false
       end
@@ -144,7 +142,7 @@ module Dependabot
 
         updated_deps
       rescue Dependabot::InconsistentRegistryResponse => e
-        error_handler.log_error(
+        error_handler.log_dependency_error(
           dependency: dependency,
           error: e,
           error_type: "inconsistent_registry_response",
@@ -152,7 +150,7 @@ module Dependabot
         )
         [] # return an empty set
       rescue StandardError => e
-        error_handler.handle_dependabot_error(error: e, dependency: dependency)
+        error_handler.handle_dependency_error(error: e, dependency: dependency)
         [] # return an empty set
       end
 

--- a/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
@@ -45,13 +45,7 @@ module Dependabot
             begin
               service.create_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
             rescue StandardError => e
-              raise if ErrorHandler::RUN_HALTING_ERRORS.keys.any? { |err| e.is_a?(err) }
-
-              # FIXME: This will result in us reporting a the group name as a dependency name
-              #
-              # In future we should modify this method to accept both dependency and group
-              # so the downstream error handling can tag things appropriately.
-              error_handler.handle_dependabot_error(error: e, dependency: group)
+              error_handler.handle_job_error(error: e)
             end
           else
             Dependabot.logger.info("Nothing to update for Dependency Group: '#{group.name}'")

--- a/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
@@ -45,7 +45,7 @@ module Dependabot
             begin
               service.create_pull_request(dependency_change, dependency_snapshot.base_commit_sha)
             rescue StandardError => e
-              error_handler.handle_job_error(error: e)
+              error_handler.handle_job_error(error: e, dependency_group: group)
             end
           else
             Dependabot.logger.info("Nothing to update for Dependency Group: '#{group.name}'")

--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -55,14 +55,14 @@ module Dependabot
         def check_and_create_pr_with_error_handling(dependency)
           check_and_create_pull_request(dependency)
         rescue Dependabot::InconsistentRegistryResponse => e
-          error_handler.log_error(
+          error_handler.log_dependency_error(
             dependency: dependency,
             error: e,
             error_type: "inconsistent_registry_response",
             error_detail: e.message
           )
         rescue StandardError => e
-          error_handler.handle_dependabot_error(error: e, dependency: dependency)
+          error_handler.handle_dependency_error(error: e, dependency: dependency)
         end
 
         # rubocop:disable Metrics/AbcSize

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -84,7 +84,7 @@ module Dependabot
             close_pull_request(reason: :up_to_date)
           end
         rescue StandardError => e
-          error_handler.handle_job_error(error: e)
+          error_handler.handle_job_error(error: e, group: job_group)
         end
 
         # Having created the dependency_change, we need to determine the right strategy to apply it to the project:

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -84,13 +84,7 @@ module Dependabot
             close_pull_request(reason: :up_to_date)
           end
         rescue StandardError => e
-          raise if ErrorHandler::RUN_HALTING_ERRORS.keys.any? { |err| e.is_a?(err) }
-
-          # FIXME: This will result in us reporting a the group name as a dependency name
-          #
-          # In future we should modify this method to accept both dependency and group
-          # so the downstream error handling can tag things appropriately.
-          error_handler.handle_dependabot_error(error: e, dependency: dependency_change.dependency_group)
+          error_handler.handle_job_error(error: e)
         end
 
         # Having created the dependency_change, we need to determine the right strategy to apply it to the project:

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -39,7 +39,7 @@ module Dependabot
           dependency = dependencies.last
           check_and_update_pull_request(dependencies)
         rescue StandardError => e
-          error_handler.handle_dependabot_error(error: e, dependency: dependency)
+          error_handler.handle_dependency_error(error: e, dependency: dependency)
         end
 
         private

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -36,7 +36,7 @@ module Dependabot
           dependency = dependencies.last
           check_and_update_pull_request(dependencies)
         rescue StandardError => e
-          error_handler.handle_dependabot_error(error: e, dependency: dependency)
+          error_handler.handle_dependency_error(error: e, dependency: dependency)
         end
 
         private

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -58,14 +58,14 @@ module Dependabot
         def check_and_create_pr_with_error_handling(dependency)
           check_and_create_pull_request(dependency)
         rescue Dependabot::InconsistentRegistryResponse => e
-          error_handler.log_error(
+          error_handler.log_dependency_error(
             dependency: dependency,
             error: e,
             error_type: "inconsistent_registry_response",
             error_detail: e.message
           )
         rescue StandardError => e
-          error_handler.handle_dependabot_error(error: e, dependency: dependency)
+          error_handler.handle_dependency_error(error: e, dependency: dependency)
         end
 
         # rubocop:disable Metrics/AbcSize

--- a/updater/spec/dependabot/updater/error_handler_spec.rb
+++ b/updater/spec/dependabot/updater/error_handler_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "dependabot/dependency"
+require "dependabot/job"
+require "dependabot/service"
+require "dependabot/updater/error_handler"
+
+RSpec.describe Dependabot::Updater::ErrorHandler do
+  subject(:error_handler) do
+    described_class.new(
+      service: mock_service,
+      job: mock_job
+    )
+  end
+
+  let(:mock_service) do
+    instance_double(Dependabot::Service)
+  end
+
+  let(:mock_job) do
+    instance_double(Dependabot::Job)
+  end
+
+  describe "#handle_dependency_error" do
+    let(:dependency) do
+      instance_double(Dependabot::Dependency, name: "broken-biscuits")
+    end
+
+    let(:handle_dependency_error) do
+      error_handler.handle_dependency_error(error: error, dependency: dependency)
+    end
+
+    context "with a handled known error" do
+      let(:error) do
+        Dependabot::DependencyFileNotResolvable.new("The file is full of bees")
+      end
+
+      it "records the error with the service and logs it out" do
+        expect(mock_service).to receive(:record_update_job_error).with(
+          error_type: "dependency_file_not_resolvable",
+          error_details: { message: "The file is full of bees" },
+          dependency: dependency
+        )
+
+        expect(Dependabot.logger).to receive(:info).with(
+          a_string_starting_with("Handled error whilst updating broken-biscuits:")
+        )
+
+        handle_dependency_error
+      end
+    end
+
+    context "with a handled unknown error" do
+      let(:error) do
+        StandardError.new("There are bees everywhere").tap do |err|
+          err.set_backtrace ["bees.rb:5:in `buzz`"]
+        end
+      end
+
+      it "records the error with the service, logs the backtrace and captures the exception" do
+        expect(mock_service).to receive(:record_update_job_error).with(
+          error_type: "unknown_error",
+          error_details: nil,
+          dependency: dependency
+        )
+
+        expect(mock_service).to receive(:capture_exception).with(
+          error: error,
+          job: mock_job,
+          dependency: dependency
+        )
+
+        expect(Dependabot.logger).to receive(:error).with(
+          "Error processing broken-biscuits (StandardError)"
+        )
+        expect(Dependabot.logger).to receive(:error).with(
+          "There are bees everywhere"
+        )
+        expect(Dependabot.logger).to receive(:error).with(
+          "bees.rb:5:in `buzz`"
+        )
+
+        handle_dependency_error
+      end
+    end
+
+    context "with a job-halting error" do
+      let(:error) do
+        Dependabot::OutOfDisk.new("The disk is full of bees")
+      end
+
+      it "re-raises the error" do
+        expect { handle_dependency_error }.to raise_error(error)
+      end
+    end
+
+    context "with a subprocess failure error" do
+      let(:error_context) do
+        { bumblebees: "many", honeybees: "few", wasps: "none", fingerprint: "123456789" }
+      end
+
+      let(:error) do
+        Dependabot::SharedHelpers::HelperSubprocessFailed.new(message: "the kernal is full of bees",
+                                                              error_context: error_context).tap do |err|
+          err.set_backtrace ["****** ERROR 8335 -- 101"]
+        end
+      end
+
+      it "records the error with the service and logs the backtrace" do
+        expect(mock_service).to receive(:record_update_job_error).with(
+          error_type: "unknown_error",
+          error_details: nil,
+          dependency: dependency
+        )
+
+        expect(mock_service).to receive(:capture_exception)
+
+        expect(Dependabot.logger).to receive(:error).with(
+          "Error processing broken-biscuits (Dependabot::SharedHelpers::HelperSubprocessFailed)"
+        )
+        expect(Dependabot.logger).to receive(:error).with(
+          "the kernal is full of bees"
+        )
+        expect(Dependabot.logger).to receive(:error).with(
+          "****** ERROR 8335 -- 101"
+        )
+
+        handle_dependency_error
+      end
+
+      it "sanitizes the error and captures it" do
+        allow(Dependabot.logger).to receive(:error)
+        allow(mock_service).to receive(:record_update_job_error)
+        expect(mock_service).to receive(:capture_exception).with(
+          error: an_instance_of(Dependabot::Updater::SubprocessFailed), job: mock_job
+        ) do |args|
+          expect(args[:error].message).
+            to eq('Subprocess ["123456789"] failed to run. Check the job logs for error messages')
+          expect(args[:error].raven_context).
+            to eq(fingerprint: ["123456789"],
+                  extra: {
+                    bumblebees: "many", honeybees: "few", wasps: "none"
+                  })
+        end
+
+        handle_dependency_error
+      end
+    end
+  end
+
+  describe "handle_job_error" do
+    let(:handle_job_error) do
+      error_handler.handle_job_error(error: error)
+    end
+
+    context "with a handled known error" do
+      let(:error) do
+        Dependabot::DependencyFileNotResolvable.new("The file is full of bees")
+      end
+
+      it "records the error with the service and logs it out" do
+        expect(mock_service).to receive(:record_update_job_error).with(
+          error_type: "dependency_file_not_resolvable",
+          error_details: { message: "The file is full of bees" }
+        )
+
+        expect(Dependabot.logger).to receive(:info).with(
+          a_string_starting_with("Handled error whilst processing job:")
+        )
+
+        handle_job_error
+      end
+    end
+
+    context "with a handled unknown error" do
+      let(:error) do
+        StandardError.new("There are bees everywhere").tap do |err|
+          err.set_backtrace ["bees.rb:5:in `buzz`"]
+        end
+      end
+
+      it "records the error with the service, logs the backtrace and captures the exception" do
+        expect(mock_service).to receive(:record_update_job_error).with(
+          error_type: "unknown_error",
+          error_details: nil
+        )
+
+        expect(mock_service).to receive(:capture_exception).with(
+          error: error,
+          job: mock_job,
+          dependency: nil
+        )
+
+        expect(Dependabot.logger).to receive(:error).with(
+          "Error processing job (StandardError)"
+        )
+        expect(Dependabot.logger).to receive(:error).with(
+          "There are bees everywhere"
+        )
+        expect(Dependabot.logger).to receive(:error).with(
+          "bees.rb:5:in `buzz`"
+        )
+
+        handle_job_error
+      end
+    end
+
+    context "with a job-halting error" do
+      let(:error) do
+        Dependabot::OutOfDisk.new("The disk is full of bees")
+      end
+
+      it "re-raises the error" do
+        expect { handle_job_error }.to raise_error(error)
+      end
+    end
+  end
+end

--- a/updater/spec/dependabot/updater/error_handler_spec.rb
+++ b/updater/spec/dependabot/updater/error_handler_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 
 require "dependabot/dependency"
+require "dependabot/dependency_group"
 require "dependabot/job"
 require "dependabot/service"
 require "dependabot/updater/error_handler"
@@ -69,7 +70,8 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
         expect(mock_service).to receive(:capture_exception).with(
           error: error,
           job: mock_job,
-          dependency: dependency
+          dependency: dependency,
+          dependency_group: nil
         )
 
         expect(Dependabot.logger).to receive(:error).with(
@@ -190,7 +192,8 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
         expect(mock_service).to receive(:capture_exception).with(
           error: error,
           job: mock_job,
-          dependency: nil
+          dependency: nil,
+          dependency_group: nil
         )
 
         expect(Dependabot.logger).to receive(:error).with(

--- a/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
@@ -72,8 +72,6 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
     end
 
     it "performs a grouped and ungrouped dependency update when both are present" do
-      expect(mock_error_handler).not_to receive(:handle_dependabot_error)
-
       expect(mock_service).to receive(:create_pull_request) do |dependency_change|
         expect(dependency_change.dependency_group.name).to eql("group-b")
 
@@ -109,9 +107,7 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
     end
 
     it "logs a warning, reports an error but defers everything to individual updates" do
-      expect(mock_error_handler).not_to receive(:handle_dependabot_error)
-      expect(mock_service).not_to receive(:create_pull_request)
-
+      # Our mocks will fail due to unexpected messages if any errors or PRs are dispatched
       expect(Dependabot.logger).to receive(:warn).with("No dependency groups defined!")
 
       expect(mock_service).to receive(:capture_exception).with(
@@ -148,7 +144,6 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
         "Found 2 group(s)."
       )
 
-      expect(mock_error_handler).not_to receive(:handle_dependabot_error)
       expect(mock_service).to receive(:create_pull_request) do |dependency_change|
         expect(dependency_change.dependency_group.name).to eql("my-group")
         expect(dependency_change.updated_dependency_files_hash).to eql(updated_bundler_files_hash)
@@ -177,9 +172,6 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
     end
 
     it "does not create a new pull request for a group if one already exists" do
-      expect(mock_error_handler).not_to receive(:handle_dependabot_error)
-      expect(mock_service).not_to receive(:create_pull_request)
-
       allow(Dependabot.logger).to receive(:info)
       expect(Dependabot.logger).to receive(:info).with(
         "Detected existing pull request for 'group-b'."
@@ -204,9 +196,7 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
     end
 
     it "raises no errors and creates no pull requests" do
-      expect(mock_error_handler).not_to receive(:handle_dependabot_error)
-      expect(mock_service).not_to receive(:create_pull_request)
-
+      # Our mocks will fail due to unexpected messages if any errors or PRs are dispatched
       group_update_all.perform
     end
   end
@@ -237,7 +227,6 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
     end
 
     it "creates a DependencyChange for just the modified files without reporting errors" do
-      expect(mock_error_handler).not_to receive(:handle_dependabot_error)
       expect(mock_service).to receive(:create_pull_request) do |dependency_change|
         expect(dependency_change.dependency_group.name).to eql("everything-everywhere-all-at-once")
 
@@ -283,7 +272,6 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
     end
 
     it "creates a DependencyChange for both of the manifests without reporting errors" do
-      expect(mock_error_handler).not_to receive(:handle_dependabot_error)
       expect(mock_service).to receive(:create_pull_request) do |dependency_change|
         expect(dependency_change.dependency_group.name).to eql("dependabot-core-images")
 

--- a/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
     end
 
     it "updates the existing pull request without errors" do
-      expect(mock_error_handler).not_to receive(:handle_dependabot_error)
       expect(mock_service).to receive(:update_pull_request) do |dependency_change|
         expect(dependency_change.dependency_group.name).to eql("everything-everywhere-all-at-once")
         expect(dependency_change.updated_dependency_files_hash).to eql(updated_bundler_files_hash)
@@ -95,7 +94,6 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
     end
 
     it "closes the pull request" do
-      expect(mock_error_handler).not_to receive(:handle_dependabot_error)
       expect(mock_service).to receive(:close_pull_request).with(["dummy-pkg-b"], :up_to_date)
 
       group_update_all.perform
@@ -116,7 +114,6 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
     end
 
     it "closes the existing pull request and creates a new one" do
-      expect(mock_error_handler).not_to receive(:handle_dependabot_error)
       expect(mock_service).to receive(:close_pull_request).with(%w(dummy-pkg-b dummy-pkg-c), :dependencies_changed)
 
       expect(mock_service).to receive(:create_pull_request) do |dependency_change|
@@ -142,7 +139,6 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
     end
 
     it "creates a new pull request to supersede the existing one" do
-      expect(mock_error_handler).not_to receive(:handle_dependabot_error)
       expect(mock_service).to receive(:create_pull_request) do |dependency_change|
         expect(dependency_change.dependency_group.name).to eql("everything-everywhere-all-at-once")
         expect(dependency_change.updated_dependency_files_hash).to eql(updated_bundler_files_hash)
@@ -166,7 +162,6 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
     end
 
     it "does not attempt to update the other group's pull request" do
-      expect(mock_error_handler).not_to receive(:handle_dependabot_error)
       expect(mock_service).to receive(:create_pull_request) do |dependency_change|
         expect(dependency_change.dependency_group.name).to eql("everything-everywhere-all-at-once")
         expect(dependency_change.updated_dependency_files_hash).to eql(updated_bundler_files_hash)
@@ -190,10 +185,7 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
     end
 
     it "does nothing, logs a warning and notices an error" do
-      expect(mock_error_handler).not_to receive(:handle_dependabot_error)
-      expect(mock_service).not_to receive(:create_pull_request)
-      expect(mock_service).not_to receive(:close_pull_request)
-      expect(mock_service).not_to receive(:update_pull_request)
+      # Our mocks will fail due to unexpected messages if any errors or PRs are dispatched
 
       expect(Dependabot.logger).to receive(:warn).with(
         "The 'everything-everywhere-all-at-once' group has been removed from the update config."


### PR DESCRIPTION
This resolves some `FIXME` statements where we were silently substituting the `DependencyGroup#name` for `Dependency#name` as a 'good enough' workaround for the `handle_dependabot_error` method requiring a dependency to be passed.

This PR splits the `handle_dependabot_error` into two flavours:
- handle_dependency_error - this is effectively the same as the existing `handle_dependabot_error` method
- handle_job_error - this is a separate signature for cases where the context does not include a specific Dependency which can be used in places where the `FIXME` was noted

As part of this I've also split the `log_error` method into `log_dependency_error` and `log_job_error` flavours for the same reason.

### Scope

For now, I've settled for sending the `dependency_group` as part of the information we sent to Sentry for unknown errors, omitting it if no group is involved. In a follow-up PR we will revise how the job summary is built up to make sure we explain which errors relate to groups as well as improve the PR summary.