### PR TITLE
[Grouped Updates] Generate deterministic branch names based on content

### DIFF
--- a/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
@@ -50,7 +50,7 @@ module Dependabot
         def dependency_digest
           @dependency_digest ||= Digest::MD5.hexdigest(dependencies.map do |dependency|
             "#{dependency.name}-#{dependency.removed? ? 'removed' : dependency.version}"
-          end.join(",")).slice(0, 10)
+          end.sort.join(",")).slice(0, 10)
         end
 
         def package_manager

--- a/common/spec/dependabot/pull_request_creator/branch_namer/dependency_group_strategy_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer/dependency_group_strategy_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::DependencyGroupStrat
         expect(new_namer.new_branch_name).to eql(branch_name)
       end
 
-      it "generates a different branch name for a diffset set of dependencies for the same group" do
+      it "generates a different branch name for a different set of dependencies for the same group" do
         removed_dependency = Dependabot::Dependency.new(
           name: "old_business",
           version: "1.4.0",
@@ -83,6 +83,36 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer::DependencyGroupStrat
           dependency_group: dependency_group
         )
         expect(new_namer.new_branch_name).not_to eql(namer.new_branch_name)
+      end
+
+      it "generates the same branch name regardless of the order of dependencies" do
+        removed_dependency = Dependabot::Dependency.new(
+          name: "old_business",
+          version: "1.4.0",
+          previous_version: "1.4.0",
+          package_manager: "bundler",
+          requirements: {},
+          previous_requirements: {},
+          removed: true
+        )
+
+        forward_namer = described_class.new(
+          dependencies: [dependency, removed_dependency],
+          files: [gemfile],
+          target_branch: target_branch,
+          separator: separator,
+          dependency_group: dependency_group
+        )
+
+        backward_namer = described_class.new(
+          dependencies: [removed_dependency, dependency],
+          files: [gemfile],
+          target_branch: target_branch,
+          separator: separator,
+          dependency_group: dependency_group
+        )
+
+        expect(forward_namer.new_branch_name).to eql(backward_namer.new_branch_name)
       end
     end
 


### PR DESCRIPTION
Grouped update Pull Requests will generally have more dependencies that we can tolerate in the branch name compared to solo dependency PRs, but we rely on deterministic branch names to avoid race conditions where we retry pushing a branch that has already been successfully pushed.

The current behaviour of appending a timestamp is resulting in us opening the odd duplicate when something causes us to backoff and partially retry opening the PR, see:
- https://github.com/github/dependabot-action/pull/949
- https://github.com/github/dependabot-action/pull/950

This fixes the bug by updating the branch naming strategy for groups to use a short ( 10 character ) digest hash of the dependency changes.

This will ensure that if we open a new PR for the same group with different versions or dependencies, it will still avoid clashing with any lingering old PRs that haven't been cleaned up while giving us back the guarantee of at-most-once pushes.