### PR TITLE
Fix an issue where vendored gems are mistakenly parsed as Gemfiles

### DIFF
--- a/updater/lib/dependabot/updater/group_dependency_file_batch.rb
+++ b/updater/lib/dependabot/updater/group_dependency_file_batch.rb
@@ -10,6 +10,8 @@ module Dependabot
           hash[file.path] = { file: file, changed: false, changes: 0 }
         end
 
+        @other_updated_files = {}
+
         Dependabot.logger.debug("Starting with '#{@dependency_file_batch.count}' dependency files:")
         debug_current_state
       end
@@ -22,39 +24,48 @@ module Dependabot
       end
 
       # Returns an array of DependencyFile objects that have changed at least once
-      def updated_files
-        @dependency_file_batch.filter_map do |_path, data|
-          data[:file] if data[:changed]
-        end
+      def changed_files
+        @dependency_file_batch.filter_map { |_path, data| data[:file] if data[:changed] } +
+          @other_updated_files.map { |_path, data| data[:file] }
       end
 
       # Replaces the existing files
       def merge(updated_files)
         updated_files.each do |updated_file|
-          existing_file = @dependency_file_batch[updated_file.path]
-
-          change_count = if existing_file
-                           existing_file.fetch(:change_count, 0)
-                         else
-                           verb = updated_file.deleted? ? "removed" : "added"
-                           Dependabot.logger.debug("File #{verb}: '#{updated_file.path}'")
-                           0
-                         end
-
-          @dependency_file_batch[updated_file.path] = { file: updated_file, changed: true, changes: change_count + 1 }
+          if (existing_file = @dependency_file_batch[updated_file.path])
+            # The file is a dependency file we started with, let's replace the old version
+            change_count = existing_file.fetch(:change_count, 0)
+            @dependency_file_batch[updated_file.path] = { file: updated_file, changed: true, changes: change_count + 1 }
+          elsif (existing_file = @other_updated_files[updated_file.path])
+            # The file is a non-dependency file we previous modified, let's replace the old version
+            change_count = existing_file.fetch(:change_count, 0)
+            @other_updated_files[updated_file.path] = { file: updated_file, changed: true, changes: change_count + 1 }
+          else
+            # The file is new, let's add it
+            verb = updated_file.deleted? ? "removed" : "added"
+            Dependabot.logger.debug("File #{verb}: '#{updated_file.path}'")
+            @other_updated_files[updated_file.path] = { file: updated_file, changed: true, changes: 1 }
+          end
         end
 
-        Dependabot.logger.debug("Dependency files updated:")
         debug_current_state
       end
 
       def debug_current_state
         return unless Dependabot.logger.debug?
 
-        @dependency_file_batch.each do |path, data|
-          changed_string = data[:changed] ? "( Changed #{data[:changes]} times )" : ""
-          Dependabot.logger.debug("  - #{path} #{changed_string}")
+        Dependabot.logger.debug("Dependency files updated:")
+        @dependency_file_batch.each{ |path, data| debug_file_hash(path, data) }
+
+        if @other_updated_files.any?
+          Dependabot.logger.debug("Other files updated:")
+          @other_updated_files.each{ |path, data| debug_file_hash(path, data) }
         end
+      end
+
+      def debug_file_hash(path, data)
+        changed_string = data[:changed] ? "( Changed #{data[:changes]} times )" : ""
+        Dependabot.logger.debug("  - #{path} #{changed_string}")
       end
     end
   end

--- a/updater/lib/dependabot/updater/group_dependency_file_batch.rb
+++ b/updater/lib/dependabot/updater/group_dependency_file_batch.rb
@@ -36,7 +36,8 @@ module Dependabot
           change_count = if existing_file
                            existing_file.fetch(:change_count, 0)
                          else
-                           Dependabot.logger.debug("New file added: '#{updated_file.path}'")
+                           verb = updated_file.deleted? ? "removed" : "added"
+                           Dependabot.logger.debug("File #{verb}: '#{updated_file.path}'")
                            0
                          end
 

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -70,7 +70,7 @@ module Dependabot
         Dependabot::DependencyChange.new(
           job: job,
           updated_dependencies: all_updated_dependencies,
-          updated_dependency_files: dependency_file_batch.updated_files,
+          updated_dependency_files: dependency_file_batch.changed_files,
           dependency_group: group
         )
       end


### PR DESCRIPTION
Potential fix for https://github.com/dependabot/dependabot-core/issues/7319

When updating using groups and vendored gems, we saw the following issue in the logs:

```
updater | 
updater |       string = string.dup.force_encoding(encoding)
updater |                          ^^^^^^^^^^^^^^^
updater | 2023/05/14 08:00:20 ERROR <job_662289885> /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/parser-3.2.2.0/lib/parser/base.rb:98:in `setup_source_buffer'
updater | 2023/05/14 08:00:20 ERROR <job_662289885> /home/dependabot/dependabot-updater/vendor/ruby/3.1.0/gems/parser-3.2.2.0/lib/parser/base.rb:32:in `parse'
updater | 2023/05/14 08:00:20 ERROR <job_662289885> /home/dependabot/bundler/lib/dependabot/bundler/file_parser/gemfile_declaration_finder.rb:45:in `parsed_gemfile'
up
```

The issue was that a `DependencyFile` with a `nil` value for `content` was passed into the `gemfile_declaration_finder` unexpectedly **after** we made the first change to the dependency files which debug showed us was:

```
2023/05/25 17:40:34 DEBUG Dependency files updated:
2023/05/25 17:40:34 DEBUG   - /Gemfile 
2023/05/25 17:40:34 DEBUG   - /Gemfile.lock ( Changed 1 times )
2023/05/25 17:40:34 DEBUG   - /vendor/cache/[redacted]-old-version ( Changed 1 times )
2023/05/25 17:40:34 DEBUG   - /vendor/cache/[redacted]-new-version ( Changed 1 times )
```

Upon investigating further, I realised that we currently handle all `DependencyFile` objects passed back from the updater in all ecosystems as being dependency **manifests**, but this isn't true when vendoring is involved and in this case by including the vendored file change in the subsequent step it was causing the Bundler implementation to try to parse it as if it was a Gemfile.

I was able to fix the problem using this change by removing the vendored files from being passed to subsequent steps **but I'm not sure this is the right approach** - it seems like something else is wrong inside the bundler library that we are finding a vendored file instead of the Gemfile as we should be looking through the set rather than using an arbitrary file, e.g. first or last in array.

I need to add a simple test case that captures the problem to iterate on this a little more.

### Tasks

- [ ] Add a test case for Gemfile.lock-only changes with vendored files
- [ ] Verify it is red with existing behaviour due to the nil content error
- [ ] Determine _why_ the wrong file is being used as a Gemfile
- [ ] Figure out if we should partition file changes like this or drop that part of the change
