### PR TITLE
Set file encoding in GitLab commits

### DIFF
--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -109,7 +109,7 @@ module Dependabot
             action: file_action(file),
             file_path: file.type == "symlink" ? file.symlink_target : file.path,
             content: file.content,
-            **file_encoding(file)
+            encoding: file.content_encoding
           }
         end
       end
@@ -122,15 +122,6 @@ module Dependabot
           "create"
         else
           "update"
-        end
-      end
-
-      # @param [DependencyFile] file
-      def file_encoding(file)
-        if file.content_encoding == Dependabot::DependencyFile::ContentEncoding::BASE64
-          { encoding: "base64" }
-        else
-          {}
         end
       end
 

--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -128,7 +128,7 @@ module Dependabot
       # @param [DependencyFile] file
       def file_encoding(file)
         if file.content_encoding == Dependabot::DependencyFile::ContentEncoding::BASE64
-          {encoding: "base64"}
+          { encoding: "base64" }
         else
           {}
         end

--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -108,7 +108,8 @@ module Dependabot
           {
             action: file_action(file),
             file_path: file.type == "symlink" ? file.symlink_target : file.path,
-            content: file.content
+            content: file.content,
+            **file_encoding(file)
           }
         end
       end
@@ -121,6 +122,15 @@ module Dependabot
           "create"
         else
           "update"
+        end
+      end
+
+      # @param [DependencyFile] file
+      def file_encoding(file)
+        if file.content_encoding == Dependabot::DependencyFile::ContentEncoding::BASE64
+          {encoding: "base64"}
+        else
+          {}
         end
       end
 

--- a/common/lib/dependabot/pull_request_updater/gitlab.rb
+++ b/common/lib/dependabot/pull_request_updater/gitlab.rb
@@ -99,7 +99,7 @@ module Dependabot
       # @param [DependencyFile] file
       def file_encoding(file)
         if file.content_encoding == Dependabot::DependencyFile::ContentEncoding::BASE64
-          {encoding: "base64"}
+          { encoding: "base64" }
         else
           {}
         end

--- a/common/lib/dependabot/pull_request_updater/gitlab.rb
+++ b/common/lib/dependabot/pull_request_updater/gitlab.rb
@@ -79,7 +79,8 @@ module Dependabot
           {
             action: file_action(file),
             file_path: file.type == "symlink" ? file.symlink_target : file.path,
-            content: file.content
+            content: file.content,
+            **file_encoding(file)
           }
         end
       end
@@ -92,6 +93,15 @@ module Dependabot
           "create"
         else
           "update"
+        end
+      end
+
+      # @param [DependencyFile] file
+      def file_encoding(file)
+        if file.content_encoding == Dependabot::DependencyFile::ContentEncoding::BASE64
+          {encoding: "base64"}
+        else
+          {}
         end
       end
     end

--- a/common/lib/dependabot/pull_request_updater/gitlab.rb
+++ b/common/lib/dependabot/pull_request_updater/gitlab.rb
@@ -95,7 +95,6 @@ module Dependabot
           "update"
         end
       end
-
     end
   end
 end

--- a/common/lib/dependabot/pull_request_updater/gitlab.rb
+++ b/common/lib/dependabot/pull_request_updater/gitlab.rb
@@ -80,7 +80,7 @@ module Dependabot
             action: file_action(file),
             file_path: file.type == "symlink" ? file.symlink_target : file.path,
             content: file.content,
-            **file_encoding(file)
+            encoding: file.content_encoding
           }
         end
       end
@@ -96,14 +96,6 @@ module Dependabot
         end
       end
 
-      # @param [DependencyFile] file
-      def file_encoding(file)
-        if file.content_encoding == Dependabot::DependencyFile::ContentEncoding::BASE64
-          { encoding: "base64" }
-        else
-          {}
-        end
-      end
     end
   end
 end

--- a/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
@@ -148,22 +148,26 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
               {
                 action: "update",
                 file_path: gemfile.path,
-                content: gemfile.content
+                content: gemfile.content,
+                encoding: "utf-8"
               },
               {
                 action: "update",
                 file_path: gemfile_lock.path,
-                content: gemfile_lock.content
+                content: gemfile_lock.content,
+                encoding: "utf-8"
               },
               {
                 action: "create",
                 file_path: created_file.path,
-                content: created_file.content
+                content: created_file.content,
+                encoding: "utf-8"
               },
               {
                 action: "delete",
                 file_path: deleted_file.path,
-                content: ""
+                content: "",
+                encoding: "utf-8"
               }
             ]
           }
@@ -304,7 +308,8 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
                 {
                   action: "update",
                   file_path: files[0].symlink_target,
-                  content: files[0].content
+                  content: files[0].content,
+                  encoding: "utf-8"
                 }
               ]
             }

--- a/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
@@ -237,6 +237,48 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
       end
     end
 
+    context "with a binary file" do
+      let(:gem_content) do
+        Base64.encode64(fixture("ruby", "gems", "addressable-2.7.0.gem"))
+      end
+
+      let(:files) do
+        [
+          Dependabot::DependencyFile.new(
+            name: "addressable-2.7.0.gem",
+            directory: "vendor/cache",
+            content: gem_content,
+            content_encoding:
+              Dependabot::DependencyFile::ContentEncoding::BASE64
+          )
+        ]
+      end
+
+      it "pushes a commit to GitLab and creates a merge request" do
+        creator.create
+
+        expect(WebMock).
+          to have_requested(:post, "#{repo_api_url}/repository/commits").
+          with(
+            body: {
+              branch: branch_name,
+              commit_message: commit_message,
+              actions: [
+                {
+                  action: "update",
+                  file_path: files[0].directory + "/" + files[0].name,
+                  content: files[0].content,
+                  encoding: "base64"
+                }
+              ]
+            }
+          )
+
+        expect(WebMock).
+          to have_requested(:post, "#{repo_api_url}/merge_requests")
+      end
+    end
+
     context "with a symlink" do
       let(:files) do
         [

--- a/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
@@ -183,6 +183,51 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
         )
     end
 
+    context "with a binary file" do
+      let(:gem_content) do
+        Base64.encode64(fixture("ruby", "gems", "addressable-2.7.0.gem"))
+      end
+
+      let(:files) do
+        [
+          Dependabot::DependencyFile.new(
+            name: "addressable-2.7.0.gem",
+            directory: "vendor/cache",
+            content: gem_content,
+            content_encoding:
+              Dependabot::DependencyFile::ContentEncoding::BASE64
+          )
+        ]
+      end
+
+      it "pushes a commit to GitLab" do
+        updater.update
+
+        expect(WebMock).
+          to have_requested(:post, commit_url).
+          with(
+            body: {
+              branch: branch_name,
+              commit_message: JSON.parse(
+                fixture("gitlab", "create_commit.json")
+              )["title"],
+              actions: [
+                {
+                  action: "update",
+                  file_path: files[0].directory + "/" + files[0].name,
+                  content: files[0].content,
+                  encoding: "base64"
+                }
+              ],
+              force: true,
+              start_branch: JSON.parse(
+                fixture("gitlab", "merge_request.json")
+              )["target_branch"]
+            }
+          )
+      end
+    end
+
     context "with a symlink" do
       let(:files) do
         [

--- a/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
@@ -157,22 +157,26 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
               {
                 action: "update",
                 file_path: gemfile.path,
-                content: gemfile.content
+                content: gemfile.content,
+                encoding: "utf-8"
               },
               {
                 action: "update",
                 file_path: gemfile_lock.path,
-                content: gemfile_lock.content
+                content: gemfile_lock.content,
+                encoding: "utf-8"
               },
               {
                 action: "create",
                 file_path: created_file.path,
-                content: created_file.content
+                content: created_file.content,
+                encoding: "utf-8"
               },
               {
                 action: "delete",
                 file_path: deleted_file.path,
-                content: ""
+                content: "",
+                encoding: "utf-8"
               }
             ],
             force: true,
@@ -255,7 +259,8 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
                 {
                   action: "update",
                   file_path: files[0].symlink_target,
-                  content: files[0].content
+                  content: files[0].content,
+                  encoding: "utf-8"
                 }
               ],
               force: true,


### PR DESCRIPTION
request_{creator,updater}/gitlab.rb doesn't pass the DependencyFile content_encoding to the GitLab API. This causes vendored files (in our case yarn pnp zip files) to be uploaded as text.