### PR TITLE
Allow parsing symbols, time and date values in workflow yaml

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -38,7 +38,7 @@ module Dependabot
       def workfile_file_dependencies(file)
         dependency_set = DependencySet.new
 
-        json = YAML.safe_load(file.content, aliases: true)
+        json = YAML.safe_load(file.content, aliases: true, permitted_classes: [Date, Time, Symbol])
         return dependency_set if json.nil?
 
         uses_strings = deep_fetch_uses(json.fetch("jobs", json.fetch("runs", nil))).uniq

--- a/github_actions/spec/fixtures/workflow_files/workflow.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow.yml
@@ -112,3 +112,16 @@ jobs:
     steps:
       - name: Set up node without quotes
         uses: actions/setup-node@master
+
+  set-up-node-with-colon:
+    name: :set-up-node-with-colon
+
+  set-up-node-with-date:
+    name: "Set up node with date"
+    env:
+      START_DATE: 2016-01-01
+
+  set-up-node-with-time:
+    name: "Set up node with time"
+    env:
+      NYC_BALL_DROP: 2022-01-01T05:00:00Z


### PR DESCRIPTION
In github_actions, it's valid to use symbol, date and time objects in your workflow yaml files. Up until now, Dependabot was failing parsing on these, as the classes are by default not allowed by `YAML.safe_load`, this changes that to match the behavior in GitHub.