### PR TITLE
Add a newline after the group intro

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -321,6 +321,7 @@ module Dependabot
                else
                  ": #{dependency_links.first}."
                end
+        msg += "\n"
 
         msg
       end


### PR DESCRIPTION
Adds a newline for grouped update intros.

![image](https://github.com/dependabot/dependabot-core/assets/12107187/7f883017-3018-4e53-a475-241705ed9a8f)
