### PR TITLE
exclude patterns for grouped updates

### DIFF
--- a/common/lib/dependabot/dependency_group.rb
+++ b/common/lib/dependabot/dependency_group.rb
@@ -14,7 +14,10 @@ module Dependabot
 
     def contains?(dependency)
       @dependencies.include?(dependency) if @dependencies.any?
-      rules.any? { |rule| WildcardMatcher.match?(rule, dependency.name) }
+      positive_match = rules["patterns"].any? { |rule| WildcardMatcher.match?(rule, dependency.name) }
+      negative_match =  rules["exclude-patterns"]&.any? { |rule| WildcardMatcher.match?(rule, dependency.name) } 
+
+      positive_match && !negative_match
     end
 
     def to_h

--- a/common/lib/dependabot/dependency_group.rb
+++ b/common/lib/dependabot/dependency_group.rb
@@ -15,7 +15,7 @@ module Dependabot
     def contains?(dependency)
       @dependencies.include?(dependency) if @dependencies.any?
       positive_match = rules["patterns"].any? { |rule| WildcardMatcher.match?(rule, dependency.name) }
-      negative_match =  rules["exclude-patterns"]&.any? { |rule| WildcardMatcher.match?(rule, dependency.name) } 
+      negative_match =  rules["exclude-patterns"]&.any? { |rule| WildcardMatcher.match?(rule, dependency.name) }
 
       positive_match && !negative_match
     end

--- a/common/spec/dependabot/dependency_group_spec.rb
+++ b/common/spec/dependabot/dependency_group_spec.rb
@@ -8,7 +8,7 @@ require "dependabot/dependency"
 RSpec.describe Dependabot::DependencyGroup do
   let(:dependency_group) { described_class.new(name: name, rules: rules) }
   let(:name) { "test_group" }
-  let(:rules) { ["test-*"] }
+  let(:rules) { { "patterns" => ["test-*"] } }
 
   let(:test_dependency1) do
     Dependabot::Dependency.new(

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -257,7 +257,7 @@ module Dependabot
       return if dependency_groups.nil?
 
       dependency_groups.each do |group|
-        Dependabot::DependencyGroupEngine.register(group["name"], group["rules"]["patterns"])
+        Dependabot::DependencyGroupEngine.register(group["name"], group["rules"])
       end
     end
 

--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe Dependabot::DependencyGroupEngine do
       expect(dependency_group_engine.instance_variable_get(:@registered_groups)).to eq([])
 
       # We have to call the original here for the DependencyGroupEngine to actually register the groups
-      expect(dependency_group_engine).to receive(:register).with("group-a", ["dummy-pkg-*"]).and_call_original
-      expect(dependency_group_engine).to receive(:register).with("group-b", ["dummy-pkg-b"]).and_call_original
+      expect(dependency_group_engine).to receive(:register).with("group-a", {"patterns" => ["dummy-pkg-*"]}).and_call_original
+      expect(dependency_group_engine).to receive(:register).with("group-b", {"patterns" => ["dummy-pkg-b"]}).and_call_original
 
       # Groups are registered by the job when a DependencySnapshot is created
       create_dependency_snapshot

--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
       expect(dependency_group_engine.instance_variable_get(:@registered_groups)).to eq([])
 
       # We have to call the original here for the DependencyGroupEngine to actually register the groups
-      expect(dependency_group_engine).to receive(:register).with("group-a", {"patterns" => ["dummy-pkg-*"]}).and_call_original
+      expect(dependency_group_engine).to receive(:register).with("group-a", {"exclude-patterns" => ["dummy-pkg-b"], "patterns" => ["dummy-pkg-*"]}).and_call_original
       expect(dependency_group_engine).to receive(:register).with("group-b", {"patterns" => ["dummy-pkg-b"]}).and_call_original
 
       # Groups are registered by the job when a DependencySnapshot is created
@@ -98,7 +98,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
       snapshot = create_dependency_snapshot
 
       expect(dependency_group_engine.send(:groups_for, snapshot.dependencies[0]).count).to eq(1)
-      expect(dependency_group_engine.send(:groups_for, snapshot.dependencies[1]).count).to eq(2)
+      expect(dependency_group_engine.send(:groups_for, snapshot.dependencies[1]).count).to eq(1)
       expect(dependency_group_engine.send(:groups_for, snapshot.dependencies[2]).count).to eq(0)
     end
   end

--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -78,8 +78,11 @@ RSpec.describe Dependabot::DependencyGroupEngine do
       expect(dependency_group_engine.instance_variable_get(:@registered_groups)).to eq([])
 
       # We have to call the original here for the DependencyGroupEngine to actually register the groups
-      expect(dependency_group_engine).to receive(:register).with("group-a", {"exclude-patterns" => ["dummy-pkg-b"], "patterns" => ["dummy-pkg-*"]}).and_call_original
-      expect(dependency_group_engine).to receive(:register).with("group-b", {"patterns" => ["dummy-pkg-b"]}).and_call_original
+      expect(dependency_group_engine).to receive(:register).with("group-a",
+                                                                 { "exclude-patterns" => ["dummy-pkg-b"],
+                                                                   "patterns" => ["dummy-pkg-*"] }).and_call_original
+      expect(dependency_group_engine).to receive(:register).with("group-b",
+                                                                 { "patterns" => ["dummy-pkg-b"] }).and_call_original
 
       # Groups are registered by the job when a DependencySnapshot is created
       create_dependency_snapshot

--- a/updater/spec/fixtures/jobs/job_with_dependency_groups.json
+++ b/updater/spec/fixtures/jobs/job_with_dependency_groups.json
@@ -37,7 +37,8 @@
       {
         "name": "group-a",
         "rules": { 
-          "patterns": ["dummy-pkg-*"]
+          "patterns": ["dummy-pkg-*"],
+          "exclude-patterns": ["dummy-pkg-b"]
         }
       },
       {


### PR DESCRIPTION
This uses an `exclude-patterns` key from the Dependabot update config that behaves the same way as the regular `patterns` key, but will exclude any matching dependencies from a grouped update.

The tests for this are somewhat minimal, so if you think this would require more testing before we deploy please don't hesitate to let me know.