### PR TITLE
Add `DEPENDABOT` environment variable for users

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -46,6 +46,9 @@ USER dependabot
 ENV DEPENDABOT_HOME="/home/dependabot"
 WORKDIR $DEPENDABOT_HOME
 
+# For users to determine if dependabot is running
+ENV DEPENDABOT=true
+
 # Disable automatic pulling of files stored with Git LFS
 # This avoids downloading large files not necessary for the dependabot scripts
 ENV GIT_LFS_SKIP_SMUDGE=1

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ may be useful for advanced users looking for examples of how to hack on Dependab
 
 ## Dependabot on CI
 
-In an environment such as GitHub where Dependabot is running in a container, if you want to change your build or installation process depending on whether Dependabot is checking, you can determine it by the existence of `DEPENDABOT_HOME` environment variable.
+In an environment such as GitHub where Dependabot is running in a container, if you want to change your build or installation process depending on whether Dependabot is checking, you can determine it by the existence of `DEPENDABOT` environment variable.
 
 # Contributing to Dependabot
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ The [Dependabot CLI](https://github.com/dependabot/cli) is a newer tool that may
 While it creates dependency diffs, it's currently missing the logic to turn those diffs into actual PR's. Nevertheless, it
 may be useful for advanced users looking for examples of how to hack on Dependabot.
 
+## Dependabot on CI
+
+In an environment such as GitHub where Dependabot is running in a container, if you want to change your build or installation process depending on whether Dependabot is checking, you can determine it by the existence of `DEPENDABOT_HOME` environment variable.
+
 # Contributing to Dependabot
 
 ## Reporting issues and Feature Requests


### PR DESCRIPTION
Describe usage of `DEPENDABOT_HOME` environment variable to determine whether Dependabot is running or not.

in favor of https://github.com/dependabot/dependabot-core/issues/7048