### PR TITLE
Fix edge case when updating Actions with mixed versions

### DIFF
--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -182,15 +182,13 @@ module Dependabot
 
         # Return the git tag if updating a pinned version
         if git_commit_checker.pinned_ref_looks_like_version? &&
-           (new_tag = latest_version_tag) &&
-           new_tag.fetch(:commit_sha) != current_commit
+           (new_tag = latest_version_tag)
           return new_tag.fetch(:tag)
         end
 
         # Return the pinned git commit if one is available
         if git_commit_checker.pinned_ref_looks_like_commit_sha? &&
-           (new_commit_sha = latest_commit_sha) &&
-           new_commit_sha != current_commit
+           (new_commit_sha = latest_commit_sha)
           return new_commit_sha
         end
 

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -915,6 +915,72 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       end
     end
 
+    context "with multiple requirement sources pinned to different versions" do
+      let(:dependency_name) { "actions/checkout" }
+      let(:upload_pack_fixture) { "checkout" }
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "actions/checkout",
+          version: "2",
+          package_manager: "github_actions",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".github/workflows/bump-datadog-ci.yml",
+            metadata: { declaration_string: "actions/checkout@v3" },
+            source: {
+              type: "git",
+              url: "https://github.com/actions/checkout",
+              ref: "v3",
+              branch: nil
+            }
+          }, {
+            requirement: nil,
+            groups: [],
+            file: ".github/workflows/check-license.yml",
+            metadata: { declaration_string: "actions/checkout@v2" },
+            source: {
+              type: "git",
+              url: "https://github.com/actions/checkout",
+              ref: "v2",
+              branch: nil
+            }
+          }]
+        )
+      end
+
+      let(:expected_requirements) do
+        [{
+          requirement: nil,
+          groups: [],
+          file: ".github/workflows/bump-datadog-ci.yml",
+          metadata: { declaration_string: "actions/checkout@v3" },
+          source: {
+            type: "git",
+            url: "https://github.com/actions/checkout",
+            ref: "v3",
+            branch: nil
+          }
+        }, {
+          requirement: nil,
+          groups: [],
+          file: ".github/workflows/check-license.yml",
+          metadata: { declaration_string: "actions/checkout@v2" },
+          source: {
+            type: "git",
+            url: "https://github.com/actions/checkout",
+            ref: "v3",
+            branch: nil
+          }
+        }]
+      end
+
+      it "updates all source refs to the target ref" do
+        expect(subject).to eq(expected_requirements)
+      end
+    end
+
     context "with multiple requirement sources pinned to different SHAs" do
       let(:dependency_name) { "actions/checkout" }
       let(:upload_pack_fixture) { "checkout" }


### PR DESCRIPTION
Previously we would avoid updating requirements if the commit for the dependency does not match the commit for the updated reference.

The commit for the dependency is guessed by the `GitCommitChecker` using the _first_ source as the dependency source. However, this can be inaccurate when updating dependencies with sources with mixed versions, since they may point to different commits.

I think this is an issue in the `GitCommitChecker` but I also noticed that these checks should not be necessary, we can unconditionally update the source, even if the commits don't match.

Fixes https://github.com/dependabot/dependabot-core/issues/7384.