### PR TITLE
Fix fetching files in symlinked folders

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -277,7 +277,7 @@ def show_diff(original_file, updated_file)
   removed_lines = diff.count { |line| line.start_with?("-") }
 
   puts
-  puts "    ± #{original_file.name}"
+  puts "    ± #{original_file.realpath}"
   puts "    ~~~"
   puts diff.map { |line| "    " + line }.join
   puts "    ~~~"

--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -44,7 +44,7 @@ module Dependabot
       @type = type
 
       begin
-        @mode = File.stat((symlink_target || path).sub(%r{^/}, "")).mode.to_s(8)
+        @mode = File.stat(realpath).mode.to_s(8)
       rescue StandardError
         @mode = mode
       end
@@ -74,6 +74,10 @@ module Dependabot
 
     def path
       Pathname.new(File.join(directory, name)).cleanpath.to_path
+    end
+
+    def realpath
+      (symlink_target || path).sub(%r{^/}, "")
     end
 
     def ==(other)

--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -193,8 +193,7 @@ module Dependabot
                       end
 
             {
-              path: (file.symlink_target ||
-                     file.path).sub(%r{^/}, ""),
+              path: file.realpath,
               mode: (file.mode || "100644"),
               type: "blob"
             }.merge(content)

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -144,8 +144,7 @@ module Dependabot
                       end
 
             {
-              path: (file.symlink_target ||
-                     file.path).sub(%r{^/}, ""),
+              path: file.realpath,
               mode: "100644",
               type: "blob"
             }.merge(content)


### PR DESCRIPTION
We have logic to fetch symlinked files through the Github API, but the logic does not work for files inside symlinked folders.

This PR tries to fix that.

This, if it works, would be an alternative to #7352, which would not need to reintroduce the bug fixed by the original PR.

Fixes #7071.