### PR TITLE
[Grouped Updates] Cleaner management of the update dependency list

### DIFF
--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
 # This class is responsible for aggregating individual DependencyChange objects
-# by merging the sequential changes to files and the updated dependency list
-# into a data structure that can then be used to create a single
-# DependencyChange object which represents the aggregated outcome.
+# by tracking changes to individual files and the overall dependency list.
 module Dependabot
   class Updater
     class DependencyGroupChangeBatch
       attr_reader :updated_dependencies
 
-      def initialize(initial_dependency_files)
+      def initialize(initial_dependency_files:)
         @updated_dependencies = []
 
         @dependency_file_batch = initial_dependency_files.each_with_object({}) do |file, hash|
@@ -21,14 +19,14 @@ module Dependabot
       end
 
       # Returns an array of DependencyFile objects for the current state
-      def dependency_files
+      def current_dependency_files
         @dependency_file_batch.map do |_path, data|
           data[:file]
         end
       end
 
       # Returns an array of DependencyFile objects that have changed at least once
-      def updated_files
+      def updated_dependency_files
         @dependency_file_batch.filter_map do |_path, data|
           data[:file] if data[:changed]
         end

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -10,8 +10,8 @@ module Dependabot
       def initialize(initial_dependency_files:)
         @updated_dependencies = []
 
-        @dependency_file_batch = initial_dependency_files.each_with_object({}) do |file, hash|
-          hash[file.path] = { file: file, changed: false, changes: 0 }
+        @dependency_file_batch = initial_dependency_files.each_with_object({}) do |file, hsh|
+          hsh[file.path] = { file: file, changed: false, changes: 0 }
         end
 
         Dependabot.logger.debug("Starting with '#{@dependency_file_batch.count}' dependency files:")

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -15,7 +15,7 @@ module Dependabot
         end
 
         Dependabot.logger.debug("Starting with '#{@dependency_file_batch.count}' dependency files:")
-        debug_current_state
+        debug_current_file_state
       end
 
       # Returns an array of DependencyFile objects for the current state
@@ -58,11 +58,25 @@ module Dependabot
           @dependency_file_batch[updated_file.path] = { file: updated_file, changed: true, changes: change_count + 1 }
         end
 
+        Dependabot.logger.debug("Dependencies updated:")
+        debug_updated_dependencies
+
         Dependabot.logger.debug("Dependency files updated:")
-        debug_current_state
+        debug_current_file_state
       end
 
-      def debug_current_state
+      private
+
+      def debug_updated_dependencies
+        return unless Dependabot.logger.debug?
+
+        @updated_dependencies.each do |dependency|
+          version_change = "#{dependency.humanized_previous_version} to #{dependency.humanized_version}"
+          Dependabot.logger.debug(" - #{dependency.name} ( #{version_change} )")
+        end
+      end
+
+      def debug_current_file_state
         return unless Dependabot.logger.debug?
 
         @dependency_file_batch.each do |path, data|

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "dependabot/dependency_change_builder"
-require "dependabot/updater/group_dependency_file_batch"
+require "dependabot/updater/dependency_group_change_batch"
 
 # This module contains the methods required to build a DependencyChange for
 # a single DependencyGroup.
@@ -19,15 +19,10 @@ module Dependabot
       # outcome of attempting to update every dependency iteratively which
       # can be used for PR creation.
       def compile_all_dependency_changes_for(group)
-        all_updated_dependencies = []
-        # TODO: Iterate to a GroupDependencyBatch?
-        #
-        # It might make sense for this class to take on responsibility for `all_updated_dependencies` as well,
-        # but I'm deferring on that for compatability with other work in progress.
-        dependency_file_batch = Dependabot::Updater::GroupDependencyFileBatch.new(dependency_snapshot.dependency_files)
+        group_changes = Dependabot::Updater::DependencyGroupChangeBatch.new(dependency_snapshot.dependency_files)
 
         group.dependencies.each do |dependency|
-          dependency_files = dependency_file_batch.dependency_files
+          dependency_files = group_changes.dependency_files
           reparsed_dependencies = dependency_file_parser(dependency_files).parse
           dependency = reparsed_dependencies.find { |d| d.name == dependency.name }
 
@@ -49,28 +44,16 @@ module Dependabot
           # could not create a change for any reason
           next unless dependency_change
 
-          # FIXME: all_updated_dependencies may need to be de-duped
-          #
-          # To start out with, using a variant on the 'existing_pull_request'
-          # logic might make sense -or- we could employ a one-and-done rule
-          # where the first update to a dependency blocks subsequent changes.
-          #
-          # In a follow-up iteration, a 'shared workspace' could provide the
-          # filtering for us assuming we iteratively make file changes for
-          # each Array of dependencies in the batch and the FileUpdater tells
-          # us which cannot be applied.
-          all_updated_dependencies.concat(dependency_change.updated_dependencies)
-
           # Store the updated files for the next loop
-          dependency_file_batch.merge(dependency_change.updated_dependency_files)
+          group_changes.merge(dependency_change)
         end
 
         # Create a single Dependabot::DependencyChange that aggregates everything we've updated
         # into a single object we can pass to PR creation.
         Dependabot::DependencyChange.new(
           job: job,
-          updated_dependencies: all_updated_dependencies,
-          updated_dependency_files: dependency_file_batch.updated_files,
+          updated_dependencies: group_changes.updated_dependencies,
+          updated_dependency_files: group_changes.updated_files,
           dependency_group: group
         )
       end


### PR DESCRIPTION
This PR moves the management of the overall Dependency list into the `GroupDependencyFileBatch` class and repositions it as a `DependencyGroupChangeBatch`.

This affords us an interface where we just pass in each `DependencyChange` and the right thing happens internally to the `DependencyGroupChangeBatch` for both the files and dependency list without the actual group updater worrying about the details.

### De-duplication

I've had a walk through the implications of us updating a Dependency twice in a single group, this has the potential to happen more for transitive dependencies if we do something like:
- `dep_a` and `dep_b` both depend on `dep_x`
- We update `dep_a` which unlocks updating `dep_x` to the highest version currently permitted by `dep_b`
- We update `dep_b` which now unlocks updating `dep_x` to a newer version

This means we would have two `Dependency` objects for `dep_x` with would have the following attributes:
1. name: `dep_x`, version: 1.4, previous_version: 1.3
2. name: `dep_x`, version: 1.5, previous_version: 1.4

If we were to de-duplicate this, we would need to replace these two `Dependency` objects with a new one which has the following values:
- name: `dep_x`, version: 1.5, previous_version: 1.3

This is pretty non-trivial as the `Dependency` class [mutates some of it's input arguments](https://github.com/dependabot/dependabot-core/blob/502ea799b4a39a723124871a789f22aaa6c680a7/common/lib/dependabot/dependency.rb#L42-L60) so we cannot instantiate replacement from the two objects and be confident it is correct, nor can we just merge the `previous_version` of (1) into (2) as we might not correctly capture the metadata for the entire leap from v1.3 to v1.4.

Ultimately, I've decided to leave this alone but give us some debug affordance so we can investigate the dependency list and learn more about these cases if and when they happen in future.

### Potential Improvements

Rather than mutating data and risking creating unforeseen corner cases, this is mostly a presentation concern when it comes to us creating the Pull Request body.

Overall, this is likely to be an edge case and if in the worst case we show two bumps for a library in the PR body with a changelog from 1.3 to 1.4, and then from 1.4 to 1.5 the information presented is still complete end-to-end and represents what happened within the update accurately.

If we do decide to deduplicate as a presentation concern, we will not need to mutate the dependency data but we can use it to render a single aggregate entry as a follow-up which feels less risky.

I haven't explored this as part of this PR as:
- It means we need to modify the PullRequest builder to handle dependencies-grouped-by-name instead of individual dependencies in several places which is non-trivial
- We have some other work in the pipe to change the PR content for groups I don't want to collide with on such a significant change
- I'm not convinced this will happen frequently enough that the default behaviour of showing two bumps to the dependency isn't sufficient