### PR TITLE
Roll pub. Use dart 3 for running helpers.

### DIFF
--- a/pub/Dockerfile
+++ b/pub/Dockerfile
@@ -6,7 +6,7 @@ ENV PUB_CACHE=/opt/dart/pub-cache \
   PATH="${PATH}:/opt/dart/dart-sdk/bin"
 
 # https://dart.dev/get-dart/archive
-ARG DART_VERSION=2.19.0
+ARG DART_VERSION=3.0.2
 
 RUN DART_ARCH=${TARGETARCH} \
   && if [ "$TARGETARCH" = "amd64" ]; then DART_ARCH=x64; fi \

--- a/pub/helpers/pubspec.lock
+++ b/pub/helpers/pubspec.lock
@@ -5,26 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "8880b4cfe7b5b17d57c052a5a3a8cc1d4f546261c7cc8fbd717bd53f48db0568"
+      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
       url: "https://pub.dev"
     source: hosted
-    version: "59.0.0"
+    version: "61.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: a89627f49b0e70e068130a36571409726b04dab12da7e5625941d2c8ec278b96
+      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
       url: "https://pub.dev"
     source: hosted
-    version: "5.11.1"
+    version: "5.13.0"
   args:
     dependency: "direct main"
     description:
       name: args
-      sha256: c372bb384f273f0c2a8aaaa226dad84dc27c8519a691b888725dec59518ad53a
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   async:
     dependency: transitive
     description:
@@ -45,18 +45,18 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: "66f86e916d285c1a93d3b79587d94bd71984a66aac4ff74e524cfa7877f1395c"
+      sha256: b8db3080e59b2503ca9e7922c3df2072cf13992354d5e944074ffa836fba43b7
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5"
+    version: "0.4.0"
   collection:
     dependency: "direct main"
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -93,18 +93,18 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   http:
     dependency: "direct main"
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "4c3f04bfb64d3efd508d06b41b825542f08122d30bda4933fb95c069d22a4fa3"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.0.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: logging
-      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   meta:
     dependency: transitive
     description:
@@ -181,8 +181,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "554b3c32f71ff96ca03fb8b40c367b1fa564c239"
-      resolved-ref: "554b3c32f71ff96ca03fb8b40c367b1fa564c239"
+      ref: a16763a93b5050c6a9d917fca5a132cfcb00f1a9
+      resolved-ref: a16763a93b5050c6a9d917fca5a132cfcb00f1a9
       url: "https://github.com/dart-lang/pub"
     source: git
     version: "0.0.0"
@@ -206,10 +206,10 @@ packages:
     dependency: transitive
     description:
       name: retry
-      sha256: a8a1e475a100a0bdc73f529ca8ea1e9c9c76bec8ad86a1f47780139a34ce7aea
+      sha256: "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   shelf:
     dependency: transitive
     description:
@@ -270,10 +270,10 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   usage:
     dependency: transitive
     description:
@@ -286,18 +286,18 @@ packages:
     dependency: transitive
     description:
       name: vendor
-      sha256: "6a6ea8bc1a65d7187ecc506dfdc2e5f801b7d6a02c9d9661a0348965b60ba72e"
+      sha256: fbc575a1ba97fa7a18ed09935b72522ba2f1f678d6645eb6212345ce7f82d1b9
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3"
+    version: "0.9.5"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   yaml:
     dependency: "direct main"
     description:
@@ -315,4 +315,4 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=2.19.0 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/pub/helpers/pubspec.yaml
+++ b/pub/helpers/pubspec.yaml
@@ -8,8 +8,8 @@ dependencies:
   args: ^2.4.0
   collection: ^1.17.1
   pub_semver: ^2.1.3
-  http: ^0.13.5
+  http: ^1.0.0
   pub:
     git:
      url: https://github.com/dart-lang/pub
-     ref: 554b3c32f71ff96ca03fb8b40c367b1fa564c239
+     ref: a16763a93b5050c6a9d917fca5a132cfcb00f1a9

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
           {
             "name" => "protobuf",
             "version" => "2.0.0",
-            "requirements" => [{ requirement: "^2.0.0", groups: ["direct"], source: nil, file: "pubspec.yaml" }],
+            "requirements" => [{ requirement: "2.0.0", groups: ["direct"], source: nil, file: "pubspec.yaml" }],
             "previous_version" => "1.1.4",
             "previous_requirements" => [{
               requirement: "1.1.4", groups: ["direct"], source: nil, file: "pubspec.yaml"
@@ -417,7 +417,7 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
           {
             "name" => "fixnum",
             "version" => "1.0.0",
-            "requirements" => [{ requirement: "^1.0.0", groups: ["direct"], source: nil, file: "pubspec.yaml" }],
+            "requirements" => [{ requirement: "1.0.0", groups: ["direct"], source: nil, file: "pubspec.yaml" }],
             "previous_version" => "0.10.11",
             "previous_requirements" => [{
               requirement: "0.10.11", groups: ["direct"], source: nil, file: "pubspec.yaml"


### PR DESCRIPTION
Also upgrades other dependencies of pub/helper

New in this pub-commit:
```
 git log --format="%C(auto) %h %s" 554b3c32f71ff96ca03fb8b40c367b1fa564c239...a167
63a93b5050c6a9d917fca5a132cfcb00f1a9 
 a16763a9 Validate that dependency names are valid package names (#3940)
 4a109f30 Expand constraint for `http` (#3930)
 8aee9515 Retry package:http ClientException (#3939)
 d7fa780d Add test for publish --skip-validation (#3935)
 5a3f21b4 Add strict-cast analysis option (#3919)
 fbb6f750 Merge pull request #3934 from sigurdm/cherry_pick_cache_warning
 0dc18c02 Merge remote-tracking branch 'origin/master' into cherry_pick_cache_warning
 fe6acca8 Warn about presence of legacy cache (#3921)
 0c2b0bb8 Handle pubspec_overrides.yaml in `add` and `upgrade --major-versions` (#3920)
 078c7fea Handle version not parsing gracefully (#3929)
 f7494d3f Warn about presence of legacy cache (#3921)
 9e466406 Bump cli_util from 0.3.5 to 0.4.0 (#3928)
 a391bcec blast_repo fixes (#3925)
 e32e88c3 blast_repo fixes (no-response) (#3927)
 8ff8febc Hint when pinned by flutter (#3914)
 9a8da3c0 Flag `pub publish --skip-validation` to publish without resolution and validation (#3904)
 d2798f91 Remove dead code (#3910)
 2917fa95 Handle cached version listing not being a map (#3909)
 d145bbe4 Bump actions/checkout from 3.5.0 to 3.5.2 (#3903)
 2c2eb2cd fix repository spec typos and grammar (#3898)
 3a7dc04e Reinterpret dart sdk constraints when read from a lockfile (#3897)
 a3f8b2fd Reinterpret dart sdk constraints when read from a lockfile (#3897)
 7ac56a97 Document cache layout (#3890)
 daf16c78 Suggest resolution updates (#3569)
 23fd8ad4 Use the lockfile when computing upgradable, resolvable in outdated (#3887)
 642b1f58 Distinguish between package:flutter_gen and the synthetic flutter_gen (#3889)
 d1ae5469 Merge pull request #3888 from sigurdm/cherry_pick_to_3
 ef45ef4a Merge remote-tracking branch 'origin/master' into cherry_pick_to_3
 762a16d4 Improve message when sdk constraint is not null-safety enabled (#3875)
 21eb39e1 Don't pass --fatal-infos to `dart analyze` in validation (#3877)
 95044c22 Improve message when sdk constraint is not null-safety enabled (#3875)
 b666c920 Fix tests to work in context of 3.1 (#3876)
 c890afa1 Refactor `cache add` check for existing package. (#3872)
 460283b7 Bump actions/checkout from 3.3.0 to 3.5.0 (#3858)
 b5df2113 Bump dart-lang/setup-dart from 1.4.0 to 1.5.0 (#3857)
 3e2c92a8 Don't extend something which should be an interface. (#3862)
 196e89e5 Make --example be the default (#3856)
 b615e9e1 Throw catchable exception from ensurePubspecResolved (#3852)
 8434b40d Be more quiet when doing implicit pub get (#3847)
 29a7c099 Dependency services: preserve pub.dartlang.org in lockfile (#3846)
 41963ddd Api entrypoint for ensuring resolution is up-to-date (#3844)
 92f6bf79 If pinned to an exact version, keep the pin when bumping (#3736)
 c68939ba Add missing closing quote in dependency override example (#3843)
 0cdeb85f Hint if version is not an incremental update (#3840)
 c795dcd8 Upgrade language version to 3.0 (#3822)
 4bd757ce Handle http errors gracefully when downloading archive (#3811)
 c939e81f Fix issue with _ in package names in dart add (#3838)
 9df0fddf Lazy construction of cache path. (#3837)
```
The main interesting commits for dependabot is: https://github.com/dart-lang/pub/commit/92f6bf79a0c7f87b86d057c7c05b21a510f0859d that fixes: https://github.com/dependabot/dependabot-core/issues/6446
and
https://github.com/dart-lang/pub/commit/29a7c099 preserve pub.dartlang.org in lockfiles.