### PR TITLE
Update Bundler to 2.4.14

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -96,7 +96,7 @@ COPY --from=ruby:3.1.4-bullseye --chown=dependabot:dependabot /usr/local /usr/lo
 # When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
 # Generally simplest to match the bundler version to the one that comes by default with whatever Ruby version we install.
 # This way other projects that import this library don't have to futz around with installing new / unexpected bundler versions.
-ARG BUNDLER_V2_VERSION=2.4.13
+ARG BUNDLER_V2_VERSION=2.4.14
 
 # We had to explicitly bump this as the bundled version `0.2.2` in ubuntu 20.04 has a bug.
 # Once Ubuntu base image pulls in a new enough yaml version, we may not need to

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -322,4 +322,4 @@ DEPENDENCIES
   webmock (~> 3.18)
 
 BUNDLED WITH
-   2.4.13
+   2.4.14


### PR DESCRIPTION
Closes #7273 through https://github.com/rubygems/rubygems/pull/6694.