### PR TITLE
[Updater] When a Dependency Group is refreshed as part of a scheduled GroupUpdateAllVersions, it defers rebasing

### DIFF
--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -110,6 +110,8 @@ module Dependabot
           end
         end
 
+        # If a PR exists for a group, we defer to this logic to determine if the existing changes
+        # still apply or if we need to replace the existing PR.
         def run_refresh_for(group, pull_request)
           Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest.new(
             service: service,
@@ -122,6 +124,9 @@ module Dependabot
             operation.previous_dependency_names = pull_request["dependencies"].map do |dependency|
               dependency["dependency-name"]
             end
+            # Unlike a standalone refresh job, we shouldn't rebase the PR - we only care about
+            # replacing it if the target dependencies or versions have changed.
+            operation.defer_rebasing_existing_prs = true
           end.perform
         end
 


### PR DESCRIPTION
Fix for https://github.com/dependabot/dependabot-core/pull/7310

When testing #7310 yesterday we realised that any attempt to 'rebase', i.e. call the `update_pull_request` endpoint, from within a scheduled `GroupUpdateAllVersions` job fails as the endpoint expects the job to specify a _single_ target PullRequest to update.

After discussing this, we realised that having rebases happen within the scheduled job is something we can and should defer - rebases should honour the user configuration and only be triggered when the branch goes into conflict, it's not intentional nor well understood that we rebase during a schedule for some PRs right now.

This change course-corrects our approach so that the delegation to the `RefreshGroupUpdatePullRequest` will defer rebases but will replace or supersede PRs if the dependencies or versions involved have changed respectively.