### PR TITLE
Use ruby:3.1.4-bullseye

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -88,7 +88,7 @@ WORKDIR $DEPENDABOT_HOME/dependabot-updater
 
 # Install Ruby from official Docker image
 # When bumping Ruby minor, need to also add the previous version to `bundler/helpers/v{1,2}/monkey_patches/definition_ruby_version_patch.rb`
-COPY --from=ruby:3.1.4 --chown=dependabot:dependabot /usr/local /usr/local
+COPY --from=ruby:3.1.4-bullseye --chown=dependabot:dependabot /usr/local /usr/local
 
 # When bumping Bundler, need to also regenerate `updater/Gemfile.lock` via `bundle update --bundler`
 # Generally simplest to match the bundler version to the one that comes by default with whatever Ruby version we install.


### PR DESCRIPTION
Fixes https://github.com/dependabot/dependabot-core/issues/7438

The official Docker Ruby image tags used to default to Debian Bullseye, but now that there's [a new release of Debian](https://www.debian.org/releases/), the Docker image points to the new release.

This breaks things when we try to build or run Core:

```
 > [stage-0 32/33] RUN gem install bundler -v 2.4.13 --no-document &&  rm -rf /var/lib/gems/*/cache/* &&  bundle config set --global build.psych --with-libyaml-source-dir=/home/dependabot/src/libyaml/yaml-0.2.5 &&  bundle config set --local path 'vendor' &&  bundle config set --local frozen 'true' &&  bundle config set --local without 'development' &&  bundle install &&  rm -rf ~/.bundle/cache:
#0 0.188 /usr/local/bin/ruby: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/local/bin/ruby)
#0 0.188 /usr/local/bin/ruby: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found (required by /usr/local/lib/libruby.so.3.1)
#0 0.188 /usr/local/bin/ruby: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /usr/local/lib/libruby.so.3.1)
#0 0.188 /usr/local/bin/ruby: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /usr/local/lib/libruby.so.3.1)
#0 0.188 /usr/local/bin/ruby: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/local/lib/libruby.so.3.1)
```

This PR points our Ruby tag to the older Debian Bullseye image that we expect.