### PR TITLE
Remove pnpm experiment flag

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -74,7 +74,7 @@ module Dependabot
         fetched_files << package_json
         fetched_files += npm_files
         fetched_files += yarn_files
-        fetched_files += pnpm_files if Experiments.enabled?(:pnpm_updates)
+        fetched_files += pnpm_files
         fetched_files += lerna_files
         fetched_files += workspace_package_jsons
         fetched_files += path_dependencies(fetched_files)


### PR DESCRIPTION
Pnpm is now available to everyone so we can remove the experiment flag.