### PR TITLE
Instantiate less dependencies

### DIFF
--- a/common/lib/dependabot/file_parsers/base/dependency_set.rb
+++ b/common/lib/dependabot/file_parsers/base/dependency_set.rb
@@ -91,13 +91,7 @@ module Dependabot
             @combined = if @combined
                           combined_dependency(@combined, dep)
                         else
-                          Dependency.new(
-                            name: dep.name,
-                            version: dep.version,
-                            requirements: dep.requirements,
-                            package_manager: dep.package_manager,
-                            subdependency_metadata: dep.subdependency_metadata
-                          )
+                          dep
                         end
 
             index_of_same_version =


### PR DESCRIPTION
While working on #7344 I was experimenting with adding some metadata to dependencies during file parsing that I would then use in subsequent steps. But I noticed that metadata is not being passed around.

I _think_ this is a bug introduced by 3a0f9950396b46421eb5009836f87809d6f88388, but I'm opening this PR and running CI to make sure I'm not missing anything. 