### PR TITLE
Fix actions updates when inconsistent casing is used

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -96,7 +96,7 @@ module Dependabot
             groups: [],
             source: {
               type: "git",
-              url: "https://#{hostname}/#{name}",
+              url: "https://#{hostname}/#{name}".downcase,
               ref: ref,
               branch: nil
             },

--- a/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
@@ -296,6 +296,53 @@ RSpec.describe Dependabot::GithubActions::FileParser do
       end
     end
 
+    context "with actions using inconsistent case" do
+      let(:workflow_file_fixture_name) { "inconsistent_case.yml" }
+
+      its(:length) { is_expected.to eq(1) }
+
+      describe "the first dependency" do
+        subject(:dependency) { dependencies.first }
+        let(:expected_requirements) do
+          [{
+            requirement: nil,
+            groups: [],
+            file: ".github/workflows/workflow.yml",
+            source: {
+              type: "git",
+              url: "https://github.com/actions/checkout",
+              ref: "v1",
+              branch: nil
+            },
+            metadata: {
+              declaration_string: "actions/checkout@v1"
+            }
+          },
+           {
+             requirement: nil,
+             groups: [],
+             file: ".github/workflows/workflow.yml",
+             source: {
+               type: "git",
+               url: "https://github.com/actions/checkout",
+               ref: "v2",
+               branch: nil
+             },
+             metadata: {
+               declaration_string: "Actions/checkout@v2"
+             }
+           }]
+        end
+
+        it "has the right details" do
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.name).to eq("actions/checkout")
+          expect(dependency.version).to eq("1")
+          expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+    end
+
     context "with a semver tag pinned to a reusable workflow commit" do
       let(:workflow_file_fixture_name) { "workflow_semver_reusable.yml" }
 

--- a/github_actions/spec/fixtures/workflow_files/inconsistent_case.yml
+++ b/github_actions/spec/fixtures/workflow_files/inconsistent_case.yml
@@ -1,0 +1,8 @@
+on:
+  pull_request:
+
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v1
+      - uses: Actions/checkout@v2


### PR DESCRIPTION
Fixes a small GitHub Actions edge case where we'll get a `Multiple sources!` error instead of proper updates.