### PR TITLE
Revert "Pin CodeQL version (#7275)"

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,8 +49,6 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        # TODO: Unpin when https://github.com/github/codeql/issues/13103 fixed.
-        tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-20230418/codeql-bundle.tar.gz
         config: |
           paths-ignore:
             - 'bundler/spec/fixtures/projects/bundler1/invalid_ruby/Gemfile'


### PR DESCRIPTION
This reverts commit 8cc1dd7c337b9b451be5cefc7dd6dfc4fa10083d, since [the upstream issue ](https://github.com/github/codeql/issues/13103) is now fixed (I think).