### PR TITLE
Configure git with ENV

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -17,8 +17,6 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 USER dependabot
 
-RUN git config --global user.name dependabot-ci \
-  && git config --global user.email no-reply@github.com
 RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/main/vimrc-vanilla.vim && \
   echo 'export PS1="[dependabot-core-dev] \w \[$(tput setaf 4)\]$ \[$(tput sgr 0)\]"' >> ~/.bashrc
 

--- a/common/spec/spec_helper.rb
+++ b/common/spec/spec_helper.rb
@@ -34,8 +34,10 @@ if ENV["COVERAGE"]
   end
 end
 
-Dependabot::SharedHelpers.run_shell_command("git config --global user.email no-reply@github.com")
-Dependabot::SharedHelpers.run_shell_command("git config --global user.name dependabot-ci")
+ENV["GIT_AUTHOR_NAME"] = "dependabot-ci"
+ENV["GIT_AUTHOR_EMAIL"] = "no-reply@github.com"
+ENV["GIT_COMMITTER_NAME"] = "dependabot-ci"
+ENV["GIT_COMMITTER_EMAIL"] = "no-reply@github.com"
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
This makes tests have less side effects.

For example, if you run tests locally (outside of the development image), you'll end up with your git user set as `dependabot-ci`. That actually leaked into a PR we merged recently:

<img width="1225" alt="Captura de pantalla 2023-06-22 a las 16 05 33" src="https://github.com/dependabot/dependabot-core/assets/2887858/ea41de43-e7f7-411d-9a23-495a197025c0">


