### PR TITLE
[Grouped Updates] Utilise a git-backed workspace for each group so we retain vendor file changes properly

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -26,6 +26,9 @@ module Dependabot
 
     def self.in_a_temporary_repo_directory(directory = "/", repo_contents_path = nil, &block)
       if repo_contents_path
+        # If a workspace has been defined to allow orcestration of the git repo
+        # by the runtime we should defer to it, otherwise we prepare the folder
+        # for direct use and yield.
         if Dependabot::Workspace.active_workspace
           Dependabot::Workspace.active_workspace.change(&block)
         else

--- a/common/lib/dependabot/workspace.rb
+++ b/common/lib/dependabot/workspace.rb
@@ -9,5 +9,31 @@ module Dependabot
     class << self
       attr_accessor :active_workspace
     end
+
+    def self.setup(repo_contents_path:, directory:)
+      Dependabot.logger.debug("Setting up workspace in #{repo_contents_path}")
+
+      @active_workspace = Dependabot::Workspace::Git.new(
+        repo_contents_path,
+        Pathname.new(directory || "/").cleanpath
+      )
+    end
+
+    def self.store_change(memo:)
+      return unless @active_workspace
+
+      Dependabot.logger.debug("Storing change to workspace: #{memo}")
+
+      @active_workspace.store_change(memo)
+    end
+
+    def self.cleanup!
+      return unless @active_workspace
+
+      Dependabot.logger.debug("Cleaning up current workspace")
+
+      @active_workspace.reset!
+      @active_workspace = nil
+    end
   end
 end

--- a/common/lib/dependabot/workspace.rb
+++ b/common/lib/dependabot/workspace.rb
@@ -13,10 +13,12 @@ module Dependabot
     def self.setup(repo_contents_path:, directory:)
       Dependabot.logger.debug("Setting up workspace in #{repo_contents_path}")
 
-      @active_workspace = Dependabot::Workspace::Git.new(
-        repo_contents_path,
-        Pathname.new(directory || "/").cleanpath
-      )
+      full_path = Pathname.new(File.join(repo_contents_path, directory)).expand_path
+      # Handle missing directories by creating an empty one and relying on the
+      # file fetcher to raise a DependencyFileNotFound error
+      FileUtils.mkdir_p(full_path)
+
+      @active_workspace = Dependabot::Workspace::Git.new(full_path)
     end
 
     def self.store_change(memo:)

--- a/common/lib/dependabot/workspace/base.rb
+++ b/common/lib/dependabot/workspace/base.rb
@@ -23,14 +23,11 @@ module Dependabot
       end
 
       def change(memo = nil)
-        change_attempt = nil
         Dir.chdir(path) { yield(path) }
       rescue StandardError => e
-        change_attempt = capture_failed_change_attempt(memo, e)
+        capture_failed_change_attempt(memo, e)
         clean # clean up any failed changes
         raise e
-      ensure
-        change_attempts << change_attempt unless change_attempt.nil?
       end
 
       def store_change(memo = nil); end

--- a/common/lib/dependabot/workspace/base.rb
+++ b/common/lib/dependabot/workspace/base.rb
@@ -25,14 +25,15 @@ module Dependabot
       def change(memo = nil)
         change_attempt = nil
         Dir.chdir(path) { yield(path) }
-        change_attempt = capture_change(memo)
       rescue StandardError => e
         change_attempt = capture_failed_change_attempt(memo, e)
+        clean # clean up any failed changes
         raise e
       ensure
         change_attempts << change_attempt unless change_attempt.nil?
-        clean
       end
+
+      def store_change(memo = nil); end
 
       def to_patch
         ""
@@ -41,8 +42,6 @@ module Dependabot
       def reset!; end
 
       protected
-
-      def capture_change(memo = nil); end
 
       def capture_failed_change_attempt(memo = nil, error = nil); end
     end

--- a/common/lib/dependabot/workspace/git.rb
+++ b/common/lib/dependabot/workspace/git.rb
@@ -9,7 +9,11 @@ module Dependabot
       attr_reader :initial_head_sha
 
       def initialize(repo_contents_path, directory = "/")
-        super(Pathname.new(File.join(repo_contents_path, directory)).expand_path)
+        full_path = Pathname.new(File.join(repo_contents_path, directory)).expand_path
+        # Handle missing directories by creating an empty one and relying on the
+        # file fetcher to raise a DependencyFileNotFound error
+        FileUtils.mkdir_p(full_path)
+        super(full_path)
         @initial_head_sha = head_sha
       end
 

--- a/common/lib/dependabot/workspace/git.rb
+++ b/common/lib/dependabot/workspace/git.rb
@@ -37,11 +37,12 @@ module Dependabot
       def store_change(memo = nil)
         return nil if changed_files.empty?
 
-        debug("HEAD: #{current_commit}")
+        debug("store_change - before: #{current_commit}")
         sha, diff = commit(memo)
-        debug("Comitted: #{current_commit}")
 
         change_attempts << ChangeAttempt.new(self, id: sha, memo: memo, diff: diff)
+      ensure
+        debug("store_change - after: #{current_commit}")
       end
 
       protected

--- a/common/lib/dependabot/workspace/git.rb
+++ b/common/lib/dependabot/workspace/git.rb
@@ -26,15 +26,15 @@ module Dependabot
         nil
       end
 
-      protected
-
-      def capture_change(memo = nil)
+      def store_change(memo = nil)
         changed_files = run_shell_command("git status --short .").strip
         return nil if changed_files.empty?
 
         sha, diff = commit(memo)
         ChangeAttempt.new(self, id: sha, memo: memo, diff: diff)
       end
+
+      protected
 
       def capture_failed_change_attempt(memo = nil, error = nil)
         changed_files =

--- a/common/lib/dependabot/workspace/git.rb
+++ b/common/lib/dependabot/workspace/git.rb
@@ -6,6 +6,9 @@ require "dependabot/workspace/change_attempt"
 module Dependabot
   module Workspace
     class Git < Base
+      USER = "dependabot[bot]"
+      EMAIL = "#{USER}@users.noreply.github.com"
+
       attr_reader :initial_head_sha
 
       def initialize(repo_contents_path, directory = "/")
@@ -15,6 +18,9 @@ module Dependabot
         FileUtils.mkdir_p(full_path)
         super(full_path)
         @initial_head_sha = head_sha
+
+        run_shell_command(%(git config user.name "#{USER}"), allow_unsafe_shell_command: true)
+        run_shell_command(%(git config user.email "#{EMAIL}"), allow_unsafe_shell_command: true)
       end
 
       def to_patch

--- a/common/lib/dependabot/workspace/git.rb
+++ b/common/lib/dependabot/workspace/git.rb
@@ -11,16 +11,10 @@ module Dependabot
 
       attr_reader :initial_head_sha
 
-      def initialize(repo_contents_path, directory = "/")
-        full_path = Pathname.new(File.join(repo_contents_path, directory)).expand_path
-        # Handle missing directories by creating an empty one and relying on the
-        # file fetcher to raise a DependencyFileNotFound error
-        FileUtils.mkdir_p(full_path)
-        super(full_path)
+      def initialize(path)
+        super(path)
         @initial_head_sha = head_sha
-
-        run_shell_command(%(git config user.name "#{USER}"), allow_unsafe_shell_command: true)
-        run_shell_command(%(git config user.email "#{EMAIL}"), allow_unsafe_shell_command: true)
+        configure_git
       end
 
       def to_patch
@@ -56,6 +50,11 @@ module Dependabot
       end
 
       private
+
+      def configure_git
+        run_shell_command(%(git config user.name "#{USER}"), allow_unsafe_shell_command: true)
+        run_shell_command(%(git config user.email "#{EMAIL}"), allow_unsafe_shell_command: true)
+      end
 
       def head_sha
         run_shell_command("git rev-parse HEAD").strip

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -106,7 +106,8 @@ RSpec.describe Dependabot::SharedHelpers do
     context "when there is an active workspace" do
       let(:project_name) { "simple" }
       let(:repo_contents_path) { build_tmp_repo(project_name, tmp_dir_path: Dir.tmpdir) }
-      let(:workspace) { Dependabot::Workspace::Git.new(repo_contents_path, directory) }
+      let(:workspace_path) { Pathname.new(File.join(repo_contents_path, directory)).expand_path }
+      let(:workspace) { Dependabot::Workspace::Git.new(workspace_path) }
 
       before do
         allow(Dependabot::Workspace).to receive(:active_workspace).and_return(workspace)

--- a/common/spec/dependabot/workspace/git_spec.rb
+++ b/common/spec/dependabot/workspace/git_spec.rb
@@ -37,28 +37,21 @@ RSpec.describe Dependabot::Workspace::Git do
     context "when there are changes" do
       before do
         workspace.change("rspec") { `echo 'gem "rspec", "~> 3.12.0", group: :test' >> Gemfile` }
+        workspace.store_change("rspec")
         workspace.change("timecop") { `echo 'gem "timecop", "~> 0.9.6", group: :test' >> Gemfile` }
+        workspace.store_change("rspec")
       end
 
-      # rubocop:disable Layout/TrailingWhitespace
       it "returns the diff of all changes" do
         expect(workspace.changes.size).to eq(2)
-        expect(workspace.to_patch).to eq(
+        expect(workspace.to_patch).to end_with(
           <<~DIFF
-            diff --git a/Gemfile b/Gemfile
-            index 0e6bb68..7a464a8 100644
-            --- a/Gemfile
-            +++ b/Gemfile
-            @@ -1,3 +1,5 @@
-             source "https://rubygems.org"
-             
              gem "activesupport", ">= 6.0.0"
             +gem "rspec", "~> 3.12.0", group: :test
             +gem "timecop", "~> 0.9.6", group: :test
           DIFF
         )
       end
-      # rubocop:enable Layout/TrailingWhitespace
 
       context "when there are failed change attempts" do
         before do
@@ -70,65 +63,34 @@ RSpec.describe Dependabot::Workspace::Git do
           # nop
         end
 
-        # rubocop:disable Layout/TrailingWhitespace
         it "returns the diff of all changes excluding failed change attempts" do
           expect(workspace.changes.size).to eq(2)
           expect(workspace.failed_change_attempts.size).to eq(1)
-          expect(workspace.to_patch).to eq(
+          expect(workspace.to_patch).to end_with(
             <<~DIFF
-              diff --git a/Gemfile b/Gemfile
-              index 0e6bb68..7a464a8 100644
-              --- a/Gemfile
-              +++ b/Gemfile
-              @@ -1,3 +1,5 @@
-               source "https://rubygems.org"
-               
                gem "activesupport", ">= 6.0.0"
               +gem "rspec", "~> 3.12.0", group: :test
               +gem "timecop", "~> 0.9.6", group: :test
             DIFF
           )
         end
-        # rubocop:enable Layout/TrailingWhitespace
       end
     end
   end
 
   describe "#change" do
     context "on success" do
-      # rubocop:disable Layout/TrailingWhitespace
       it "captures the change" do
         workspace.change("timecop") do
           `echo 'gem "timecop", "~> 0.9.6", group: :test' >> Gemfile`
         end
         expect(workspace.failed_change_attempts).to be_empty
-        expect(workspace.changes.size).to eq(1)
+        expect(workspace.changes.size).to eq(0)
         expect(workspace).to be_changed
-        expect(workspace.change_attempts.size).to eq(1)
-        expect(workspace.change_attempts.first.id).to eq(`git rev-parse HEAD`.strip)
-        expect(workspace.change_attempts.first.diff).to eq(
-          <<~DIFF
-            diff --git a/Gemfile b/Gemfile
-            index 0e6bb68..77d166d 100644
-            --- a/Gemfile
-            +++ b/Gemfile
-            @@ -1,3 +1,4 @@
-             source "https://rubygems.org"
-             
-             gem "activesupport", ">= 6.0.0"
-            +gem "timecop", "~> 0.9.6", group: :test
-          DIFF
-        )
-        expect(workspace.change_attempts.first.memo).to eq("timecop")
-        expect(workspace.change_attempts.first.error).to be_nil
-        expect(workspace.change_attempts.first.error?).to be_falsy
-        expect(workspace.change_attempts.first.success?).to be_truthy
       end
-      # rubocop:enable Layout/TrailingWhitespace
     end
 
     context "on error" do
-      # rubocop:disable Layout/TrailingWhitespace
       it "captures the failed change attempt" do
         expect do
           workspace.change("timecop") do
@@ -142,15 +104,8 @@ RSpec.describe Dependabot::Workspace::Git do
         expect(workspace.failed_change_attempts.size).to eq(1)
         expect(workspace.change_attempts.size).to eq(1)
         expect(workspace.change_attempts.first.id).to eq(`git rev-parse refs/stash`.strip)
-        expect(workspace.change_attempts.first.diff).to eq(
+        expect(workspace.change_attempts.first.diff).to end_with(
           <<~DIFF
-            diff --git a/Gemfile b/Gemfile
-            index 0e6bb68..77d166d 100644
-            --- a/Gemfile
-            +++ b/Gemfile
-            @@ -1,3 +1,4 @@
-             source "https://rubygems.org"
-             
              gem "activesupport", ">= 6.0.0"
             +gem "timecop", "~> 0.9.6", group: :test
           DIFF
@@ -161,9 +116,7 @@ RSpec.describe Dependabot::Workspace::Git do
         expect(workspace.change_attempts.first.error?).to be_truthy
         expect(workspace.change_attempts.first.success?).to be_falsy
       end
-      # rubocop:enable Layout/TrailingWhitespace
 
-      # rubocop:disable Layout/TrailingWhitespace
       context "when there are untracked/ignored files" do
         # See: common/spec/fixtures/projects/simple/.gitignore
 
@@ -180,43 +133,27 @@ RSpec.describe Dependabot::Workspace::Git do
 
         it "captures the untracked/ignored files" do
           expect(workspace.failed_change_attempts.size).to eq(1)
-          expect(workspace.failed_change_attempts.first.diff).to eq(
+          expect(workspace.failed_change_attempts.first.diff).to include(
             <<~DIFF
-              diff --git a/Gemfile b/Gemfile
-              index 0e6bb68..958f479 100644
-              --- a/Gemfile
-              +++ b/Gemfile
-              @@ -1,3 +1,4 @@
-               source "https://rubygems.org"
-               
                gem "activesupport", ">= 6.0.0"
               +gem "fail"
-              diff --git a/ignored-file.txt b/ignored-file.txt
-              new file mode 100644
-              index 0000000..85d9237
-              --- /dev/null
-              +++ b/ignored-file.txt
-              @@ -0,0 +1 @@
-              +ignored output
-              diff --git a/untracked-file.txt b/untracked-file.txt
-              new file mode 100644
-              index 0000000..b65afb0
-              --- /dev/null
-              +++ b/untracked-file.txt
-              @@ -0,0 +1 @@
-              +untracked output
             DIFF
+          )
+          expect(workspace.failed_change_attempts.first.diff).to include(
+            "diff --git a/ignored-file.txt b/ignored-file.txt",
+            "diff --git a/untracked-file.txt b/untracked-file.txt"
           )
         end
       end
-      # rubocop:enable Layout/TrailingWhitespace
     end
   end
 
   describe "#reset!" do
     it "clears change attempts, drops stashes, and resets HEAD to initial_head_sha" do
       workspace.change("rspec") { `echo 'gem "rspec", "~> 3.12.0", group: :test' >> Gemfile` }
+      workspace.store_change("rspec")
       workspace.change("timecop") { `echo 'gem "timecop", "~> 0.9.6", group: :test' >> Gemfile` }
+      workspace.store_change("timecop")
 
       begin
         workspace.change do
@@ -259,6 +196,41 @@ RSpec.describe Dependabot::Workspace::Git do
       expect(`git rev-parse HEAD`.strip).to eq(initial_head_sha)
       expect(`git log --format='%H' #{initial_head_sha}..HEAD | wc -l`.strip).to eq("0")
       expect(`git stash list | wc -l`.strip).to eq("0")
+    end
+  end
+
+  describe "#store_change" do
+    context "when there are no changes to store" do
+      it "returns nil and doesn't add any changes to the workspace" do
+        workspace.store_change("noop")
+
+        expect(workspace).not_to be_changed
+        expect(workspace.changes).to be_empty
+      end
+    end
+
+    context "when there are changes to store" do
+      it "captures the stores the changes correctly" do
+        workspace.change("timecop") do
+          `echo 'gem "timecop", "~> 0.9.6", group: :test' >> Gemfile`
+        end
+        workspace.store_change("Update timecop")
+        expect(workspace.failed_change_attempts).to be_empty
+        expect(workspace.changes.size).to eq(1)
+        expect(workspace).to be_changed
+        expect(workspace.change_attempts.size).to eq(1)
+        expect(workspace.change_attempts.first.id).to eq(`git rev-parse HEAD`.strip)
+        expect(workspace.change_attempts.first.diff).to end_with(
+          <<~DIFF
+             gem "activesupport", ">= 6.0.0"
+            +gem "timecop", "~> 0.9.6", group: :test
+          DIFF
+        )
+        expect(workspace.change_attempts.first.memo).to eq("Update timecop")
+        expect(workspace.change_attempts.first.error).to be_nil
+        expect(workspace.change_attempts.first.error?).to be_falsy
+        expect(workspace.change_attempts.first.success?).to be_truthy
+      end
     end
   end
 end

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -242,11 +242,6 @@ module Dependabot
       def prepare_workspace
         return unless job.clone? && job.repo_contents_path
 
-        # TODO: Remove the directory parameter
-        #
-        # We should defer calculation of the `path` to the call site in the shared_helper
-        # so it is impossible to calculate different values for workspace and non-workspace
-        # calls to the helper.
         Dependabot::Workspace.setup(
           repo_contents_path: job.repo_contents_path,
           directory: Pathname.new(job.source.directory || "/").cleanpath

--- a/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
       Dependabot::Job.new_update_job(
         job_id: "1558782000",
         job_definition: job_definition_with_fetched_files,
-        repo_contents_path: create_temporary_content_directory(fixture: "bundler_vendored")
+        repo_contents_path: create_temporary_content_directory(fixture: "bundler_vendored", directory: "bundler/")
       )
     end
 
@@ -305,7 +305,7 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
 
     let(:dependency_files) do
       # Let's use the already up-to-date files
-      original_bundler_files(fixture: "bundler_vendored")
+      original_bundler_files(fixture: "bundler_vendored", directory: "bundler/")
     end
 
     before do
@@ -324,32 +324,37 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
         expect(dependency_change.updated_dependency_files_hash.length).to eql(8)
 
         # We've updated the gemfiles properly
-        gemfile = dependency_change.updated_dependency_files.find { |file| file.path == "/Gemfile" }
+        gemfile = dependency_change.updated_dependency_files.find do |file|
+          file.path == "/bundler/Gemfile"
+        end
         expect(gemfile.content).to eql(fixture("bundler_vendored/updated/Gemfile"))
-        gemfile_lock = dependency_change.updated_dependency_files.find { |file| file.path == "/Gemfile.lock" }
+
+        gemfile_lock = dependency_change.updated_dependency_files.find do |file|
+          file.path == "/bundler/Gemfile.lock"
+        end
         expect(gemfile_lock.content).to eql(fixture("bundler_vendored/updated/Gemfile.lock"))
 
         # We've deleted the old version of dummy-pkg-b
         old_dummy_pkg_b = dependency_change.updated_dependency_files.find do |file|
-          file.path == "/vendor/cache/dummy-pkg-b-1.1.0.gem"
+          file.path == "/bundler/vendor/cache/dummy-pkg-b-1.1.0.gem"
         end
         expect(old_dummy_pkg_b.operation).to eql("delete")
 
         # We've created the new version of dummy-pkg-b
         new_dummy_pkg_b = dependency_change.updated_dependency_files.find do |file|
-          file.path == "/vendor/cache/dummy-pkg-b-1.2.0.gem"
+          file.path == "/bundler/vendor/cache/dummy-pkg-b-1.2.0.gem"
         end
         expect(new_dummy_pkg_b.operation).to eql("create")
 
         # We've deleted the old version of the vendored git dependency
         old_git_dependency_files = dependency_change.updated_dependency_files.select do |file|
-          file.path.start_with?("/vendor/cache/ruby-dummy-git-dependency-20151f9b67c8")
+          file.path.start_with?("/bundler/vendor/cache/ruby-dummy-git-dependency-20151f9b67c8")
         end
         expect(old_git_dependency_files.map(&:operation)).to eql(%w(delete delete))
 
         # We've created the new version of the vendored git dependency
         new_git_dependency_files = dependency_change.updated_dependency_files.select do |file|
-          file.path.start_with?("/vendor/cache/ruby-dummy-git-dependency-c0e25c2eb332")
+          file.path.start_with?("/bundler/vendor/cache/ruby-dummy-git-dependency-c0e25c2eb332")
         end
         expect(new_git_dependency_files.map(&:operation)).to eql(%w(create create))
       end

--- a/updater/spec/support/dummy_pkg_helpers.rb
+++ b/updater/spec/support/dummy_pkg_helpers.rb
@@ -20,39 +20,39 @@ module DummyPkgHelpers
       to_return(status: 200, body: fixture("rubygems-versions-b.json"))
   end
 
-  def original_bundler_files(fixture: "bundler")
+  def original_bundler_files(fixture: "bundler", directory: "/")
     [
       Dependabot::DependencyFile.new(
         name: "Gemfile",
         content: fixture("#{fixture}/original/Gemfile"),
-        directory: "/"
+        directory: directory
       ),
       Dependabot::DependencyFile.new(
         name: "Gemfile.lock",
         content: fixture("#{fixture}/original/Gemfile.lock"),
-        directory: "/"
+        directory: directory
       )
     ]
   end
 
-  def updated_bundler_files(fixture: "bundler")
+  def updated_bundler_files(fixture: "bundler", directory: "/")
     [
       Dependabot::DependencyFile.new(
         name: "Gemfile",
         content: fixture("#{fixture}/updated/Gemfile"),
-        directory: "/"
+        directory: directory
       ),
       Dependabot::DependencyFile.new(
         name: "Gemfile.lock",
         content: fixture("#{fixture}/updated/Gemfile.lock"),
-        directory: "/"
+        directory: directory
       )
     ]
   end
 
-  def create_temporary_content_directory(fixture:, state: "original")
+  def create_temporary_content_directory(fixture:, directory: "/", state: "original")
     tmp_dir = Dir.mktmpdir
-    FileUtils.cp_r(File.join("spec", "fixtures", fixture, state, "/."), tmp_dir)
+    FileUtils.cp_r(File.join("spec", "fixtures", fixture, state, "/."), File.join(tmp_dir, directory))
 
     # The content directory needs to a repo
     Dir.chdir(tmp_dir) do


### PR DESCRIPTION
Merges into https://github.com/dependabot/dependabot-core/pull/7404

We've updated the group update strategy to avoid polluting the manifest files passed into each instance of Dependabot Core objects with changed vendored files, but the problem with this is that we also revert the project-on-disk to the state it was in before the previous update **and only copy the manifest back in**.

This means it is up to the native package manager to re-download the vendor files that changed in the previous step as well as the current step, which over time results in us replacing the same files over and over. Whether this is cached or we end up fully re-downloading binaries can end up being an implementation detail of the tools we shell out to, so we can't really rely on this long-term.

This branch solves the problem by using a workspace library to allow the Updater to orchestrate commits to the files on disk so each subsequent step has the previous step's changes persisted. We will still copy in the manifests as we need to modify their content before running native tooling to make the subsequent update, but this avoids risk of double-work.