### PR TITLE
Fix flaky spec

### DIFF
--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -526,6 +526,8 @@ RSpec.describe Dependabot::SharedHelpers do
         allow(File).to receive(:open).
           with(described_class::GIT_CONFIG_GLOBAL_PATH, anything).
           and_raise(Errno::ENOSPC)
+        allow(FileUtils).to receive(:rm).
+          with(described_class::GIT_CONFIG_GLOBAL_PATH)
       end
 
       specify { expect { configured_git_config }.to raise_error(Dependabot::OutOfDisk) }


### PR DESCRIPTION
In an ensure block, this tries to delete the temporary file it creates, but since we mocked creation, it fails. So mock deletion too.

I don't know why this does not fail normally, but it does fail when running the spec in isolation:

```
$ rspec spec/dependabot/shared_helpers_spec.rb:531
Run options: include {:locations=>{"./spec/dependabot/shared_helpers_spec.rb"=>[531]}}

Randomized with seed 16877
F

Failures:

  1) Dependabot::SharedHelpers.with_git_configured when the host has run out of disk space is expected to raise Dependabot::OutOfDisk
     Failure/Error: specify { expect { configured_git_config }.to raise_error(Dependabot::OutOfDisk) }

       expected Dependabot::OutOfDisk, got #<Errno::ENOENT: No such file or directory @ apply2files - /home/dependabot/.gitconfig> with backtrace:
         # ./lib/dependabot/shared_helpers.rb:309:in `reset_global_git_config'
         # ./lib/dependabot/shared_helpers.rb:190:in `ensure in with_git_configured'
         # ./lib/dependabot/shared_helpers.rb:190:in `with_git_configured'
         # ./spec/dependabot/shared_helpers_spec.rb:386:in `with_git_configured'
         # ./spec/dependabot/shared_helpers_spec.rb:389:in `block (3 levels) in <top (required)>'
         # ./spec/dependabot/shared_helpers_spec.rb:531:in `block (5 levels) in <top (required)>'
         # ./spec/dependabot/shared_helpers_spec.rb:531:in `block (4 levels) in <top (required)>'
         # ./spec/spec_helper.rb:66:in `block (2 levels) in <top (required)>'
         # /home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
     # ./spec/dependabot/shared_helpers_spec.rb:531:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:66:in `block (2 levels) in <top (required)>'
     # /home/dependabot/dependabot-core/omnibus/.bundle/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

Finished in 0.01278 seconds (files took 2.24 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/dependabot/shared_helpers_spec.rb:531 # Dependabot::SharedHelpers.with_git_configured when the host has run out of disk space is expected to raise Dependabot::OutOfDisk

Randomized with seed 16877
```