### PR TITLE
Add smoke tests for go, npm and bundler+vendoring

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -20,6 +20,7 @@ jobs:
         suite:
           - { path: bundler, name: bundler, ecosystem: bundler }
           - { path: bundler, name: bundler-group-rules, ecosystem: bundler }
+          - { path: bundler, name: bundler-group-vendoring, ecosystem: bundler }
           - { path: cargo, name: cargo, ecosystem: cargo }
           - { path: composer, name: composer, ecosystem: composer }
           - { path: docker, name: docker, ecosystem: docker }
@@ -28,6 +29,7 @@ jobs:
           - { path: github_actions, name: actions, ecosystem: github-actions }
           - { path: go_modules, name: go, ecosystem: gomod }
           - { path: go_modules, name: go-close-pr, ecosystem: gomod }
+          - { path: go_modules, name: go-group-rules, ecosystem: gomod }
           - { path: go_modules, name: go-security, ecosystem: gomod }
           - { path: go_modules, name: go-update-pr, ecosystem: gomod }
           - { path: gradle, name: gradle, ecosystem: gradle }
@@ -35,6 +37,7 @@ jobs:
           - { path: hex, name: hex, ecosystem: mix }
           - { path: maven, name: maven, ecosystem: maven }
           - { path: npm_and_yarn, name: npm, ecosystem: npm}
+          - { path: npm_and_yarn, name: npm-group-rules, ecosystem: npm}
           - { path: npm_and_yarn, name: npm-remove-transitive, ecosystem: npm}
           - { path: npm_and_yarn, name: pnpm, ecosystem: npm}
           - { path: npm_and_yarn, name: yarn, ecosystem: npm}


### PR DESCRIPTION
We've been running these tests nightly, but let's start adding them to CI builds to avoid regressions.

The bundler+vendoring spec might be worth dropping eventually, but since the code involved is still subject to change we'd prefer not to see regressions in the next few months.