### PR TITLE
python: Handle explicit PyPI source in pyproject.toml

### DIFF
--- a/python/lib/dependabot/python/update_checker/index_finder.rb
+++ b/python/lib/dependabot/python/update_checker/index_finder.rb
@@ -118,6 +118,9 @@ module Dependabot
             []
 
           sources.each do |source|
+            # If source is PyPI, skip it, and let it pick the default URI
+            next if source["name"].casecmp?("PyPI")
+
             if source["default"]
               urls[:main] = source["url"]
             else

--- a/python/spec/dependabot/python/update_checker/index_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/index_finder_spec.rb
@@ -124,6 +124,20 @@ RSpec.describe Dependabot::Python::UpdateChecker::IndexFinder do
         end
       end
 
+      context "set pypi explicitly in a pyproject.toml" do
+        let(:pyproject_fixture_name) { "pypi_explicit.toml" }
+        let(:dependency_files) { [pyproject] }
+
+        it { is_expected.to eq(["https://pypi.org/simple/"]) }
+      end
+
+      context "set pypi explicitly in a pyproject.toml, in lowercase" do
+        let(:pyproject_fixture_name) { "pypi_explicit_lowercase.toml" }
+        let(:dependency_files) { [pyproject] }
+
+        it { is_expected.to eq(["https://pypi.org/simple/"]) }
+      end
+
       context "set in credentials" do
         let(:credentials) do
           [{

--- a/python/spec/fixtures/pyproject_files/pypi_explicit.toml
+++ b/python/spec/fixtures/pyproject_files/pypi_explicit.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "PythonProjects"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+description = "Various small python projects."
+
+[tool.poetry.dependencies]
+python = "^3.7"
+requests = "2.18.0"
+
+[[tool.poetry.source]]
+name = "PyPI"
+priority = "primary"

--- a/python/spec/fixtures/pyproject_files/pypi_explicit_lowercase.toml
+++ b/python/spec/fixtures/pyproject_files/pypi_explicit_lowercase.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "PythonProjects"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+description = "Various small python projects."
+
+[tool.poetry.dependencies]
+python = "^3.7"
+requests = "2.18.0"
+
+[[tool.poetry.source]]
+name = "pypi"
+priority = "primary"


### PR DESCRIPTION
Fixes #7431.
Fixes #7724.

When a github user has poetry >= 1.5.0, they will be nagged by a warning to run `poetry source add pypi`, which will add the following section to the users pyproject.toml:

    [[tool.poetry.source]]
    name = "PyPI"
    priority = "primary"

This causes the problem outlined in #7431, that the index_finder will fail due to this section missing a `url`.

This commit works around this issue by explicitly adding a url for the case where the source "name" is equal to "PyPI".