### PR TITLE
Detect interpolation in terragrunt sources and skip if present

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE=dependabot/dependabot-core
+ARG FROM_IMAGE=ghcr.io/dependabot/dependabot-core
 FROM $FROM_IMAGE
 
 # Temporarily switch to root user in order to install packages
@@ -15,6 +15,10 @@ RUN apt-get update \
     cmake \
     pkg-config \
   && rm -rf /var/lib/apt/lists/*
+
+RUN git config --system credential.'https://git-codecommit.us-east-1.amazonaws.com'.helper '!aws codecommit credential-helper $@' && \
+git config --system credential.'https://git-codecommit.us-east-1.amazonaws.com'.UseHttpPath true
+
 USER dependabot
 
 RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/main/vimrc-vanilla.vim && \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE=ghcr.io/dependabot/dependabot-core
+ARG FROM_IMAGE=dependabot/dependabot-core
 FROM $FROM_IMAGE
 
 # Temporarily switch to root user in order to install packages
@@ -15,10 +15,6 @@ RUN apt-get update \
     cmake \
     pkg-config \
   && rm -rf /var/lib/apt/lists/*
-
-RUN git config --system credential.'https://git-codecommit.us-east-1.amazonaws.com'.helper '!aws codecommit credential-helper $@' && \
-git config --system credential.'https://git-codecommit.us-east-1.amazonaws.com'.UseHttpPath true
-
 USER dependabot
 
 RUN curl -L -o ~/.vimrc https://github.com/hmarr/dotfiles/raw/main/vimrc-vanilla.vim && \

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -260,7 +260,7 @@ module Dependabot
 
       # rubocop:disable Metrics/PerceivedComplexity
       def source_type(source_string)
-        return :interpolation if source_string.match?(%r{\$\{[^{}/]+\}})
+        return :interpolation if source_string.include?("${")
         return :path if source_string.start_with?(".")
         return :github if source_string.start_with?("github.com/")
         return :bitbucket if source_string.start_with?("bitbucket.org/")

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -69,7 +69,7 @@ module Dependabot
             next unless details["source"]
 
             source = source_from(details)
-            # Cannot update local path modules, skip
+            # Cannot update nil (interpolation sources) or local path modules, skip
             next if source.nil? || source[:type] == "path"
 
             dependency_set << build_terragrunt_dependency(file, source)

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -260,7 +260,7 @@ module Dependabot
 
       # rubocop:disable Metrics/PerceivedComplexity
       def source_type(source_string)
-        return :interpolation if source_string.match?(/\$\{[^}]+\}/)
+        return :interpolation if source_string.match?(%r{\$\{[^{}/]+\}})
         return :path if source_string.start_with?(".")
         return :github if source_string.start_with?("github.com/")
         return :bitbucket if source_string.start_with?("bitbucket.org/")

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -911,7 +911,15 @@ RSpec.describe Dependabot::Terraform::FileParser do
     end
   end
 
-  let(:file_parser) { described_class.new }
+  let(:file_parser) do
+    described_class.new(
+      dependency_files: files,
+      source: source
+    )
+  end
+
+  let(:files) { [] }
+  let(:source) { Dependabot::Source.new(provider: "github", repo: "gocardless/bump", directory: "/") }
 
   describe "#source_type" do
     subject { file_parser.send(:source_type, source_string) }

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -910,4 +910,50 @@ RSpec.describe Dependabot::Terraform::FileParser do
       end
     end
   end
+
+  let(:file_parser) { described_class.new }
+
+  describe "#source_type" do
+    subject { file_parser.send(:source_type, source_string) }
+
+    context "when the source type is known" do
+      let(:source_string) { "github.com/org/repo" }
+
+      it "returns the correct source type" do
+        expect(subject).to eq(:github)
+      end
+    end
+
+    context "when the source type is a registry" do
+      let(:source_string) { "registry.terraform.io/hashicorp/aws" }
+
+      it "returns the correct source type" do
+        expect(subject).to eq(:registry)
+      end
+    end
+
+    context "when the source type is an HTTP archive" do
+      let(:source_string) { "https://example.com/archive.zip?ref=v1.0.0" }
+
+      it "returns the correct source type" do
+        expect(subject).to eq(:http_archive)
+      end
+    end
+
+    context "when the source type is an interpolation" do
+      let(:source_string) { "${var.source}" }
+
+      it "returns the correct source type" do
+        expect(subject).to eq(:interpolation)
+      end
+    end
+
+    context "when the source type is unknown" do
+      let(:source_string) { "unknown_source" }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(RuntimeError, "Unknown src: unknown_source")
+      end
+    end
+  end
 end

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -991,8 +991,8 @@ RSpec.describe Dependabot::Terraform::FileParser do
     context "when the source type is unknown" do
       let(:source_string) { "unknown_source" }
 
-      it "raises an error" do
-        expect { subject }.to raise_error(RuntimeError, "Unknown src: unknown_source")
+      it "returns the correct source type" do
+        expect(subject).to eq(:registry)
       end
     end
   end

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -948,6 +948,30 @@ RSpec.describe Dependabot::Terraform::FileParser do
       end
     end
 
+    context "when the source type is an interpolation at the end" do
+      let(:source_string) { "git::https://github.com/username/repo.git//path/to/${var.module_name}" }
+
+      it "returns the correct source type" do
+        expect(subject).to eq(:interpolation)
+      end
+    end
+
+    context "when the source type is an interpolation at the start" do
+      let(:source_string) { "${var.repo_url}/username/repo.git" }
+
+      it "returns the correct source type" do
+        expect(subject).to eq(:interpolation)
+      end
+    end
+
+    context "when the source type is an interpolation type with multiple" do
+      let(:source_string) { "git::https://github.com/${var.username}/${var.repo}//path/to/${var.module_name}" }
+
+      it "returns the correct source type" do
+        expect(subject).to eq(:interpolation)
+      end
+    end
+
     context "when the source type is unknown" do
       let(:source_string) { "unknown_source" }
 

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -918,7 +918,7 @@ RSpec.describe Dependabot::Terraform::FileParser do
     )
   end
 
-  let(:files) { [] }
+  let(:files) { project_dependency_files("registry") }
   let(:source) { Dependabot::Source.new(provider: "github", repo: "gocardless/bump", directory: "/") }
 
   describe "#source_type" do

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -972,6 +972,14 @@ RSpec.describe Dependabot::Terraform::FileParser do
       end
     end
 
+    context "when the source type is a compound interpolation" do
+      let(:source_string) { "test/${var.map[${var.key}']" }
+
+      it "returns the correct source type" do
+        expect(subject).to eq(:interpolation)
+      end
+    end
+
     context "when the source type is unknown" do
       let(:source_string) { "unknown_source" }
 


### PR DESCRIPTION
Fixes #5841 by using a regex to determine if interpolation syntax is used anywhere in a source.