### PR TITLE
Only record ecosystem versions when flag set

### DIFF
--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -21,8 +21,14 @@ module Dependabot
         @base_commit_sha = file_fetcher.commit
         raise "base commit SHA not found" unless @base_commit_sha
 
-        version = file_fetcher.package_manager_version
-        api_client.record_package_manager_version(version[:package_managers]) unless version.nil?
+        # We don't set this flag in GHES because there's no point in recording versions since we can't access that data.
+        # TODO: The flag is named `record_ecosystem_versions` because `package_manager_version` is getting renamed to
+        # to that shortly... but splitting into separate PR's for lower risk/easiery testability. Once the follow-on PR
+        # with the rename lands, the name confusion will disappear.
+        if Experiments.enabled?(:record_ecosystem_versions)
+          version = file_fetcher.package_manager_version
+          api_client.record_package_manager_version(version[:package_managers]) unless version.nil?
+        end
 
         dependency_files
       rescue StandardError => e


### PR DESCRIPTION
There's no point in recording the versions on GHES / non-cloud instances because we can't access that data for telemetry purposes. So put it behind a feature flag.

This will also make it so later on when we do the rename of `record_package_manager_version` to `record_ecosystem_versions`, there is less to worry about for backwards incompatible changes on GHES.

Before merging this, first need to merge the internal change that sets this feature flag, so that we don't lose visibility on cloud after we merge it.

Related:
* https://github.com/dependabot/dependabot-core/pull/7492
* https://github.com/dependabot/dependabot-core/pull/7517