### PR TITLE
Switch to using the new `record_ecosystem_versions` endpoint.

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -799,8 +799,8 @@ StackProf.stop if $options[:profile]
 StackProf.results("tmp/stackprof-#{Time.now.strftime('%Y-%m-%d-%H:%M')}.dump") if $options[:profile]
 
 puts "🌍 Total requests made: '#{$network_trace_count}'"
-package_manager = fetcher.package_manager_version
-puts "🎈 Package manager version log: #{package_manager}" unless package_manager.nil?
+ecosystem_versions = fetcher.ecosystem_versions
+puts "🎈 Ecosystem Versions log: #{ecosystem_versions}" unless ecosystem_versions.nil?
 
 # rubocop:enable Metrics/BlockLength
 

--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -23,7 +23,7 @@ module Dependabot
         "Repo must contain either a Gemfile, a gemspec, or a gems.rb."
       end
 
-      def package_manager_version
+      def ecosystem_versions
         {
           package_managers: {
             "bundler" => Helpers.detected_bundler_version(lockfile)

--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -20,7 +20,7 @@ module Dependabot
         "Repo must contain a Cargo.toml."
       end
 
-      def package_manager_version
+      def ecosystem_versions
         channel = if rust_toolchain
                     TomlRB.parse(rust_toolchain.content).fetch("toolchain", nil)&.fetch("channel", nil)
                   else

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
     end
 
     it "provides the Rust channel" do
-      expect(file_fetcher_instance.package_manager_version).to eq({
+      expect(file_fetcher_instance.ecosystem_versions).to eq({
         package_managers: { "cargo" => "default" }
       })
     end
@@ -115,7 +115,7 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
     end
 
     it "raises a DependencyFileNotParseable error" do
-      expect { file_fetcher_instance.package_manager_version }.to raise_error(Dependabot::DependencyFileNotParseable)
+      expect { file_fetcher_instance.ecosystem_versions }.to raise_error(Dependabot::DependencyFileNotParseable)
     end
   end
 
@@ -144,7 +144,7 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
     end
 
     it "provides the Rust channel" do
-      expect(file_fetcher_instance.package_manager_version).to eq({
+      expect(file_fetcher_instance.ecosystem_versions).to eq({
         package_managers: { "cargo" => "1.2.3" }
       })
     end

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -102,7 +102,7 @@ module Dependabot
         raise Dependabot::RepoNotFound, source
       end
 
-      def package_manager_version
+      def ecosystem_versions
         nil
       end
 

--- a/go_modules/lib/dependabot/go_modules/file_fetcher.rb
+++ b/go_modules/lib/dependabot/go_modules/file_fetcher.rb
@@ -14,7 +14,7 @@ module Dependabot
         "Repo must contain a go.mod."
       end
 
-      def package_manager_version
+      def ecosystem_versions
         return nil unless go_mod
 
         {

--- a/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_fetcher_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
   end
 
   it "provides the Go modules version" do
-    expect(file_fetcher_instance.package_manager_version).to eq({
+    expect(file_fetcher_instance.ecosystem_versions).to eq({
       package_managers: { "gomod" => "unknown" }
     })
   end
@@ -77,7 +77,7 @@ RSpec.describe Dependabot::GoModules::FileFetcher do
     end
 
     it "provides the Go modules version" do
-      expect(file_fetcher_instance.package_manager_version).to eq({
+      expect(file_fetcher_instance.ecosystem_versions).to eq({
         package_managers: { "gomod" => "1.19" }
       })
     end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -52,7 +52,7 @@ module Dependabot
         end
       end
 
-      def package_manager_version
+      def ecosystem_versions
         package_managers = {}
 
         package_managers["npm"] = Helpers.npm_version_numeric(package_lock.content) if package_lock

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
 
     it "parses the yarn lockfile" do
-      expect(file_fetcher_instance.package_manager_version).to eq(
+      expect(file_fetcher_instance.ecosystem_versions).to eq(
         { package_managers: { "yarn" => 1 } }
       )
     end
@@ -340,7 +340,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
 
     it "parses the shrinkwrap file" do
-      expect(file_fetcher_instance.package_manager_version).to eq(
+      expect(file_fetcher_instance.ecosystem_versions).to eq(
         { package_managers: { "shrinkwrap" => 1 } }
       )
     end
@@ -373,7 +373,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
 
     it "parses the npm lockfile" do
-      expect(file_fetcher_instance.package_manager_version).to eq(
+      expect(file_fetcher_instance.ecosystem_versions).to eq(
         { package_managers: { "npm" => 6 } }
       )
     end
@@ -410,7 +410,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
 
     it "parses the package manager version" do
-      expect(file_fetcher_instance.package_manager_version).to eq(
+      expect(file_fetcher_instance.ecosystem_versions).to eq(
         { package_managers: { "npm" => 6, "yarn" => 1 } }
       )
     end

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -119,13 +119,10 @@ module Dependabot
       sleep(rand(3.0..10.0)) && retry
     end
 
-    def record_package_manager_version(package_managers)
-      api_url = "#{base_url}/update_jobs/#{job_id}/record_package_manager_version"
+    def record_ecosystem_versions(ecosystem_versions)
+      api_url = "#{base_url}/update_jobs/#{job_id}/record_ecosystem_versions"
       body = {
-        data: {
-          ecosystem: "deprecated",
-          "package-managers": package_managers
-        }
+        data: { ecosystem_versions: ecosystem_versions }
       }
       response = http_client.post(api_url, json: body)
       raise ApiError, response.body if response.code >= 400

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -22,12 +22,9 @@ module Dependabot
         raise "base commit SHA not found" unless @base_commit_sha
 
         # We don't set this flag in GHES because there's no point in recording versions since we can't access that data.
-        # TODO: The flag is named `record_ecosystem_versions` because `package_manager_version` is getting renamed to
-        # to that shortly... but splitting into separate PR's for lower risk/easiery testability. Once the follow-on PR
-        # with the rename lands, the name confusion will disappear.
         if Experiments.enabled?(:record_ecosystem_versions)
-          version = file_fetcher.package_manager_version
-          api_client.record_package_manager_version(version[:package_managers]) unless version.nil?
+          ecosystem_versions = file_fetcher.ecosystem_versions
+          api_client.record_ecosystem_versions(ecosystem_versions) unless ecosystem_versions.nil?
         end
 
         dependency_files

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -24,7 +24,7 @@ module Dependabot
     def_delegators :client,
                    :mark_job_as_processed,
                    :update_dependency_list,
-                   :record_package_manager_version,
+                   :record_ecosystem_versions,
                    :increment_metric
 
     def create_pull_request(dependency_change, base_commit_sha)

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -384,12 +384,12 @@ RSpec.describe Dependabot::ApiClient do
     end
   end
 
-  describe "record_package_manager_version" do
-    let(:url) { "http://example.com/update_jobs/1/record_package_manager_version" }
+  describe "ecosystem_versions" do
+    let(:url) { "http://example.com/update_jobs/1/record_ecosystem_versions" }
     before { stub_request(:post, url).to_return(status: 204) }
 
     it "hits the correct endpoint" do
-      client.record_package_manager_version({ "bundler" => "2" })
+      client.record_ecosystem_versions({ "ruby" => { "min" => 3, "max" => 3.2 } })
 
       expect(WebMock).
         to have_requested(:post, url).

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
 
     allow(api_client).to receive(:mark_job_as_processed)
     allow(api_client).to receive(:record_update_job_error)
-    allow(api_client).to receive(:record_package_manager_version)
+    allow(api_client).to receive(:record_ecosystem_versions)
 
     allow(Dependabot::Environment).to receive(:output_path).and_return(File.join(Dir.mktmpdir, "output.json"))
     allow(Dependabot::Environment).to receive(:job_id).and_return(job_id)
@@ -109,9 +109,6 @@ RSpec.describe Dependabot::FileFetcherCommand do
         allow_any_instance_of(Dependabot::Bundler::FileFetcher).
           to receive(:files).
           and_raise(exception)
-        allow_any_instance_of(Dependabot::Bundler::FileFetcher).
-          to receive(:package_manager_version).
-          and_return(nil)
       end
 
       it "retries the job when the rate-limit is reset and reports api error" do

--- a/updater/spec/dependabot/integration_spec.rb
+++ b/updater/spec/dependabot/integration_spec.rb
@@ -51,14 +51,13 @@ RSpec.describe "Dependabot Updates" do
                     mark_job_as_processed: nil,
                     update_dependency_list: nil,
                     record_update_job_error: nil,
-                    record_package_manager_version: nil,
+                    record_ecosystem_versions: nil,
                     increment_metric: nil)
   end
   let(:file_fetcher) do
     instance_double(Dependabot::FileFetchers::Base,
                     files: dependency_files,
-                    commit: "sha",
-                    package_manager_version: nil)
+                    commit: "sha")
   end
   let(:message_builder) do
     instance_double(Dependabot::PullRequestCreator::MessageBuilder, message: nil)
@@ -79,8 +78,6 @@ RSpec.describe "Dependabot Updates" do
 
     # Stub Dependabot object with instance doubles
     allow(Dependabot::ApiClient).to receive(:new).and_return(api_client)
-    # Recording the package manager happens via an observer so the instantiated `api_client` does not receive this call
-    allow_any_instance_of(Dependabot::ApiClient).to receive(:record_package_manager_version)
     allow(Dependabot::FileFetchers).to receive_message_chain(:for_package_manager, :new).and_return(file_fetcher)
     allow(Dependabot::PullRequestCreator::MessageBuilder).to receive(:new).and_return(message_builder)
 

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Dependabot::Service do
   describe "Instance methods delegated to @client" do
     {
       mark_job_as_processed: %w(mock_sha),
-      record_package_manager_version: %w(mock_package_managers)
+      record_ecosystem_versions: %w(mock_ecosystem_versions)
     }.each do |method, arguments|
       before { allow(mock_client).to receive(method) }
 


### PR DESCRIPTION
This flips the `updater` to calling the new `record_ecosystem_versions`
endpoint.

Additionally, this flips the per-ecosystem implementations of
`package_manager_version` to this new `ecosystem_versions` hash.

Note that we expect the shape of the data to be slightly different in
the long term for these metrics... ie, we plan to record a
`min`/`max`/`raw` or something along those lines for the range of
versions supported by the manifest.

However, changing that will be done in separate PR's for easier
review/discussion/audit of those individual ecosystems.

Related:
* https://github.com/dependabot/dependabot-core/pull/7492
* https://github.com/dependabot/dependabot-core/pull/7516