### PR TITLE
Update the `hex.pm/orgs/dependabot` token

### DIFF
--- a/hex/spec/dependabot/hex/update_checker_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
           }, {
             "type" => "hex_organization",
             "organization" => "dependabot",
-            "token" => "855f6cbeffc6e14c6a884f0111caff3e"
+            "token" => "b6294cd1e1cf158e9f65ea6b02a9a1ec"
           }]
         end
 


### PR DESCRIPTION
The previous token was tied to a user account of someone who is no longer on the Dependabot team. When I removed that user from the Hex org, this [test started breaking](https://github.com/dependabot/dependabot-core/actions/runs/5487053978/jobs/9997970150?pr=7525).

So this updates the token to an organization-based token, which is not tied to any user.

This is a read-only token, which has access to _all_ private packages in the https://hex.pm/orgs/dependabot org.

This is a security risk if we don't realize this and accidentally upload a private test package to this organization that we don't want to make public, but there's currently no way to prevent that other than using two separate organizations.

I filed a feature request upstream:
* https://github.com/hexpm/hexpm/issues/1205