### PR TITLE
Track unknown errors

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -64,7 +64,7 @@ module Dependabot
 
       def initialize(message:, error_context:, error_class: nil, trace: nil)
         super(message)
-        @error_class = error_class || ""
+        @error_class = error_class || "HelperSubprocessFailed"
         @error_context = error_context
         @fingerprint = error_context[:fingerprint] || error_context[:command]
         @trace = trace

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -130,14 +130,14 @@ module Dependabot
       return response["result"] if process.success?
 
       raise HelperSubprocessFailed.new(
-        message: response["error"],
+        message: "Command \"#{error_context['command']}\" failed with #{response['error']}",
         error_class: response["error_class"],
         error_context: error_context,
         trace: response["trace"]
       )
     rescue JSON::ParserError
       raise HelperSubprocessFailed.new(
-        message: stdout || "No output from command",
+        message: stdout.empty? ? "No output from command \"#{error_context['command']}\"" : stdout,
         error_class: "JSON::ParserError",
         error_context: error_context
       )

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -131,14 +131,14 @@ module Dependabot
       return response["result"] if process.success?
 
       raise HelperSubprocessFailed.new(
-        message: "Command \"#{error_context['command']}\" failed with #{response['error']}",
+        message: "#{response['error']} failed with command (#{error_context[:command]})",
         error_class: response["error_class"],
         error_context: error_context,
         trace: response["trace"]
       )
     rescue JSON::ParserError
       raise HelperSubprocessFailed.new(
-        message: stdout.empty? ? "No output from command \"#{error_context['command']}\"" : stdout,
+        message: stdout.empty? ? "No output from command (#{error_context[:command]})" : stdout,
         error_class: "JSON::ParserError",
         error_context: error_context
       )

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -82,6 +82,7 @@ module Dependabot
     end
 
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def self.run_helper_subprocess(command:, function:, args:, env: nil,
                                    stderr_to_stdout: false,
                                    allow_unsafe_shell_command: false)
@@ -143,6 +144,7 @@ module Dependabot
       )
     end
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     def self.check_out_of_memory_error(stderr, error_context)
       return unless stderr&.include?("JavaScript heap out of memory")

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Dependabot::SharedHelpers do
       it "raises a HelperSubprocessFailed error" do
         expect { run_subprocess }
           .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed) do |error|
-            expect(error.message).to eq("Something went wrong: https://www.example.com")
+            expect(error.message).to include("Something went wrong: https://www.example.com")
           end
       end
     end

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       it "raises a Dependabot::PrivateSourceTimedOut error" do
         expect { resolver.latest_resolvable_version }
           .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
-            expect(error.message).to start_with(
+            expect(error.message).to include(
               'The "https://github.com/dependabot/composer-not-found/packages.json"' \
               " file could not be downloaded"
             )

--- a/python/spec/dependabot/python/file_parser/setup_file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser/setup_file_parser_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Dependabot::Python::FileParser::SetupFileParser do
               expect(error.class)
                 .to eq(Dependabot::DependencyFileNotEvaluatable)
               expect(error.message)
-                .to eq("InstallationError(\"Invalid requirement: 'psycopg2==2.6.1raven == 5.32.0'\")")
+                .to include("InstallationError(\"Invalid requirement: 'psycopg2==2.6.1raven == 5.32.0'\")")
             end
         end
       end

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -89,11 +89,12 @@ module Dependabot
       sleep(rand(3.0..10.0)) && retry
     end
 
-    def record_unknown_error(error_details:)
+    def record_unknown_error(error_type: "unknown", error_details:)
       api_url = "#{base_url}/update_jobs/#{job_id}/record_unknown_error"
       body = {
         data: {
-          "error-details": error_details
+          "error-type": error_type,
+          "error-details": error_details,
         }
       }
       response = http_client.post(api_url, json: body)

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -89,6 +89,23 @@ module Dependabot
       sleep(rand(3.0..10.0)) && retry
     end
 
+    def record_unknown_error(error_details:)
+      api_url = "#{base_url}/update_jobs/#{job_id}/record_unknown_error"
+      body = {
+        data: {
+          "error-details": error_details
+        }
+      }
+      response = http_client.post(api_url, json: body)
+      raise ApiError, response.body if response.code >= 400
+    rescue HTTP::ConnectionError, OpenSSL::SSL::SSLError
+      retry_count ||= 0
+      retry_count += 1
+      raise if retry_count > 3
+
+      sleep(rand(3.0..10.0)) && retry
+    end
+
     def mark_job_as_processed(base_commit_sha)
       api_url = "#{base_url}/update_jobs/#{job_id}/mark_as_processed"
       body = { data: { "base-commit-sha": base_commit_sha } }

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -89,7 +89,7 @@ module Dependabot
       sleep(rand(3.0..10.0)) && retry
     end
 
-    def record_update_job_unknown_error(error_type: "unknown", error_details:)
+    def record_update_job_unknown_error(error_type: "unknown_error", error_details:)
       api_url = "#{base_url}/update_jobs/#{job_id}/record_update_job_unknown_error"
       body = {
         data: {

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -89,12 +89,12 @@ module Dependabot
       sleep(rand(3.0..10.0)) && retry
     end
 
-    def record_unknown_error(error_type: "unknown", error_details:)
-      api_url = "#{base_url}/update_jobs/#{job_id}/record_unknown_error"
+    def record_update_job_unknown_error(error_type: "unknown", error_details:)
+      api_url = "#{base_url}/update_jobs/#{job_id}/record_update_job_unknown_error"
       body = {
         data: {
           "error-type": error_type,
-          "error-details": error_details,
+          "error-details": error_details
         }
       }
       response = http_client.post(api_url, json: body)

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -66,7 +66,7 @@ module Dependabot
       err.backtrace.each { |line| Dependabot.logger.error(line) }
 
       service.capture_exception(error: err, job: job)
-      service.record_update_job_error(error_type: "unknown_error", error_details: { message: err.message })
+      service.record_unknown_error(error_details: error_details)
       service.increment_metric("updater.unknown_error", tags: {
         package_manager: job.package_manager,
         class_name: err.class.name,

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -67,6 +67,10 @@ module Dependabot
 
       service.capture_exception(error: err, job: job)
       service.record_update_job_error(error_type: "unknown_error", error_details: { message: err.message })
+      service.increment_metric("updater.unknown_error", tags: {
+        package_manager: job.package_manager,
+        class_name: err.class.name,
+      })
     end
 
     def job_id

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -69,7 +69,7 @@ module Dependabot
       service.record_unknown_error(error_details: error_details)
       service.increment_metric("updater.unknown_error", tags: {
         package_manager: job.package_manager,
-        class_name: err.class.name,
+        class_name: err.class.name
       })
     end
 

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -64,10 +64,16 @@ module Dependabot
     def handle_exception(err)
       Dependabot.logger.error(err.message)
       err.backtrace.each { |line| Dependabot.logger.error(line) }
+      error_details = {
+        "error-class" => err.class.to_s,
+        "error-message" => err.message,
+        "error-backtrace" => err.backtrace,
+        "package-manager" => job.package_manager
+      }
 
       service.capture_exception(error: err, job: job)
-      service.record_unknown_error(error_type: "updater_error", error_details: error_details)
-      service.increment_metric("updater.unknown_error", tags: {
+      service.record_update_job_unknown_error(error_type: "updater_error", error_details: error_details)
+      service.increment_metric("updater.update_job_unknown_error", tags: {
         package_manager: job.package_manager,
         class_name: err.class.name
       })

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -66,7 +66,7 @@ module Dependabot
       err.backtrace.each { |line| Dependabot.logger.error(line) }
 
       service.capture_exception(error: err, job: job)
-      service.record_unknown_error(error_details: error_details)
+      service.record_unknown_error(error_type: "updater_error", error_details: error_details)
       service.increment_metric("updater.unknown_error", tags: {
         package_manager: job.package_manager,
         class_name: err.class.name

--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -67,9 +67,12 @@ module Dependabot
       error_details = {
         "error-class" => err.class.to_s,
         "error-message" => err.message,
-        "error-backtrace" => err.backtrace,
-        "package-manager" => job.package_manager
-      }
+        "error-backtrace" => err.backtrace.join("\n"),
+        "package-manager" => job.package_manager,
+        "job-id" => job.id,
+        "job-dependencies" => job.dependencies,
+        "job-dependency_group" => job.dependency_groups
+      }.compact
 
       service.capture_exception(error: err, job: job)
       service.record_update_job_unknown_error(error_type: "updater_error", error_details: error_details)

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -205,8 +205,8 @@ module Dependabot
     def record_error(error_details)
       if error_details[:"error-type"] == "file_fetcher_error"
         service.record_update_job_unknown_error(
-          error_type: "file_fetcher_error",
-          error_details: error_details
+          error_type: error_details.fetch(:"error-type"),
+          error_details: error_details[:"error-detail"]
         )
       else
         service.record_update_job_error(

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -177,10 +177,11 @@ module Dependabot
           error_details = {
             "error-class" => error.class.to_s,
             "error-message" => error.message,
-            "error-backtrace" => error.backtrace,
+            "error-backtrace" => error.backtrace.join("\n"),
             "package-manager" => job.package_manager,
-            "dependency" => job.dependency,
-            "dependency_group" => job.dependency_group
+            "job-id" => job.id,
+            "job-dependencies" => job.dependencies,
+            "job-dependency_group" => job.dependency_groups
           }.compact
 
           service.record_update_job_unknown_error(error_type: "file_fetcher_error", error_details: error_details)

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -175,7 +175,7 @@ module Dependabot
           Dependabot.logger.error(error.message)
           error.backtrace.each { |line| Dependabot.logger.error line }
 
-          service.record_unknown_error(error_details: { error: error })
+          service.record_unknown_error(error_type: "file_fetcher_error", error_details: { error: error })
           service.capture_exception(error: error, job: job)
           { "error-type": "unknown_error" }
         end

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -175,6 +175,7 @@ module Dependabot
           Dependabot.logger.error(error.message)
           error.backtrace.each { |line| Dependabot.logger.error line }
 
+          service.record_unknown_error(error_details: { "error": error })
           service.capture_exception(error: error, job: job)
           { "error-type": "unknown_error" }
         end

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -174,8 +174,16 @@ module Dependabot
         else
           Dependabot.logger.error(error.message)
           error.backtrace.each { |line| Dependabot.logger.error line }
+          error_details = {
+            "error-class" => error.class.to_s,
+            "error-message" => error.message,
+            "error-backtrace" => error.backtrace,
+            "package-manager" => job.package_manager,
+            "dependency" => job.dependency,
+            "dependency_group" => job.dependency_group
+          }.compact
 
-          service.record_unknown_error(error_type: "file_fetcher_error", error_details: { error: error })
+          service.record_update_job_unknown_error(error_type: "file_fetcher_error", error_details: error_details)
           service.capture_exception(error: error, job: job)
           { "error-type": "unknown_error" }
         end

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -175,7 +175,7 @@ module Dependabot
           Dependabot.logger.error(error.message)
           error.backtrace.each { |line| Dependabot.logger.error line }
 
-          service.record_unknown_error(error_details: { "error": error })
+          service.record_unknown_error(error_details: { error: error })
           service.capture_exception(error: error, job: job)
           { "error-type": "unknown_error" }
         end

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -161,7 +161,7 @@ module Dependabot
           # If we get a 500 from GitHub there's very little we can do about it,
           # and responsibility for fixing it is on them, not us. As a result we
           # quietly log these as errors
-          { "error-type": "unknown_error" }
+          { "error-type": "server_error" }
         when *Octokit::RATE_LIMITED_ERRORS
           # If we get a rate-limited error we let dependabot-api handle the
           # retry by re-enqueing the update job after the reset

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -49,9 +49,9 @@ module Dependabot
       client.record_update_job_error(error_type: error_type, error_details: error_details)
     end
 
-    def record_unknown_error(error_details:, dependency: nil)
-      @errors << ["unknown_error", dependency]
-      client.record_unknown_error(error_details: error_details)
+    def record_unknown_error(error_type:, error_details:, dependency: nil)
+      @errors << [error_type.to_s, dependency]
+      client.record_unknown_error(error_type: error_type, error_details: error_details)
     end
 
     def update_dependency_list(dependency_snapshot:)

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -49,9 +49,9 @@ module Dependabot
       client.record_update_job_error(error_type: error_type, error_details: error_details)
     end
 
-    def record_unknown_error(error_type:, error_details:, dependency: nil)
+    def record_update_job_unknown_error(error_type:, error_details:, dependency: nil)
       @errors << [error_type.to_s, dependency]
-      client.record_unknown_error(error_type: error_type, error_details: error_details)
+      client.record_update_job_unknown_error(error_type: error_type, error_details: error_details)
     end
 
     def update_dependency_list(dependency_snapshot:)

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -49,6 +49,11 @@ module Dependabot
       client.record_update_job_error(error_type: error_type, error_details: error_details)
     end
 
+    def record_unknown_error(error_details:, dependency: nil)
+      @errors << ["unknown_error", dependency]
+      client.record_unknown_error(error_details: error_details)
+    end
+
     def update_dependency_list(dependency_snapshot:)
       dependency_payload = dependency_snapshot.dependencies.map do |dep|
         {

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -121,7 +121,7 @@ module Dependabot
           # If we get a 500 from GitHub there's very little we can do about it,
           # and responsibility for fixing it is on them, not us. As a result we
           # quietly log these as errors
-          { "error-type": "unknown_error" }
+          { "error-type": "server_error" }
         else
           # Check if the error is a known "run halting" state we should handle
           if (error_type = Updater::ErrorHandler::RUN_HALTING_ERRORS[error.class])

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -132,17 +132,16 @@ module Dependabot
             # tracker know about it
             Dependabot.logger.error error.message
             error.backtrace.each { |line| Dependabot.logger.error line }
+            error_details = {
+              "error-class" => error.class.to_s,
+              "error-message" => error.message,
+              "error-backtrace" => error.backtrace,
+              "package-manager" => job.package_manager,
+              "dependency" => job.dependency,
+              "dependency_group" => job.dependency_group
+            }.compact
 
-            service.record_unknown_error(
-              error_type: "update_files_error",
-              error_details: {
-                error: error,
-                "error-class": error.class.to_s,
-                "error-backtrace": error.backtrace,
-                "package-manager": job.package_manager,
-                message: error.message
-              }
-            )
+            service.record_update_job_unknown_error(error_type: "update_files_error", error_details: error_details)
             service.capture_exception(error: error, job: job)
 
             # Set an unknown error type to be added to the job

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -133,13 +133,16 @@ module Dependabot
             Dependabot.logger.error error.message
             error.backtrace.each { |line| Dependabot.logger.error line }
 
-            service.record_unknown_error(error_details: {
-              error: error,
-              "error-class": error.class.to_s,
-              "error-backtrace": error.backtrace,
-              "package-manager": job.package_manager,
-              message: error.message
-            })
+            service.record_unknown_error(
+              error_type: "update_files_error",
+              error_details: {
+                error: error,
+                "error-class": error.class.to_s,
+                "error-backtrace": error.backtrace,
+                "package-manager": job.package_manager,
+                message: error.message
+              }
+            )
             service.capture_exception(error: error, job: job)
 
             # Set an unknown error type to be added to the job

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -135,10 +135,8 @@ module Dependabot
             error_details = {
               "error-class" => error.class.to_s,
               "error-message" => error.message,
-              "error-backtrace" => error.backtrace,
-              "package-manager" => job.package_manager,
-              "dependency" => job.dependency,
-              "dependency_group" => job.dependency_group
+              "error-backtrace" => error.backtrace.join("\n"),
+              "package-manager" => job.package_manager
             }.compact
 
             service.record_update_job_unknown_error(error_type: "update_files_error", error_details: error_details)

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -136,7 +136,10 @@ module Dependabot
               "error-class" => error.class.to_s,
               "error-message" => error.message,
               "error-backtrace" => error.backtrace.join("\n"),
-              "package-manager" => job.package_manager
+              "package-manager" => job.package_manager,
+              "job-id" => job.id,
+              "job-dependencies" => job.dependencies,
+              "job-dependency_group" => job.dependency_groups
             }.compact
 
             service.record_update_job_unknown_error(error_type: "update_files_error", error_details: error_details)

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -132,6 +132,13 @@ module Dependabot
             Dependabot.logger.error error.message
             error.backtrace.each { |line| Dependabot.logger.error line }
 
+            service.record_unknown_error(error_details: {
+              "error": error,
+              "error-class": error.class.to_s,
+              "error-backtrace": error.backtrace,
+              "package-manager": job.package_manager,
+              "message": error.message,
+            })
             service.capture_exception(error: error, job: job)
 
             # Set an unknown error type to be added to the job

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -59,6 +59,7 @@ module Dependabot
     end
 
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def handle_parser_error(error)
       # This happens if the repo gets removed after a job gets kicked off.
       # The service will handle the removal without any prompt from the updater,
@@ -133,11 +134,11 @@ module Dependabot
             error.backtrace.each { |line| Dependabot.logger.error line }
 
             service.record_unknown_error(error_details: {
-              "error": error,
+              error: error,
               "error-class": error.class.to_s,
               "error-backtrace": error.backtrace,
               "package-manager": job.package_manager,
-              "message": error.message,
+              message: error.message
             })
             service.capture_exception(error: error, job: job)
 
@@ -152,5 +153,6 @@ module Dependabot
       )
     end
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -86,7 +86,7 @@ module Dependabot
         else
           service.record_update_job_error(
             error_type: error_details.fetch(:"error-type"),
-            error_details: error_details[:"error-detail"],
+            error_details: error_details[:"error-detail"]
           )
         end
 
@@ -209,7 +209,7 @@ module Dependabot
         end
       end
 
-      def log_unknown_error_with_backtrace(error, dependency = nil, dependency_group = nil)
+      def log_unknown_error_with_backtrace(error, dependency = nil, _dependency_group = nil)
         Dependabot.logger.error error.message
         error.backtrace.each { |line| Dependabot.logger.error line }
 

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -207,19 +207,19 @@ module Dependabot
         error.backtrace.each { |line| Dependabot.logger.error line }
 
         details = {
-          "error": error,
+          error: error,
           "error-detail": error_detail,
           "error-class": error.class.name,
           "error-backtrace": error.backtrace,
           "package-manager": job.package_manager,
-          "message": error.message,
-          "dependency": dependency if dependency
-        }
+          message: error.message,
+          dependency: dependency
+        }.compact
 
         service.record_unknown_error(error_details: details, dependency: dependency)
         service.increment_metric("updater.unknown_error", tags: {
           package_manager: job.package_manager,
-          class_name: error.class.name,
+          class_name: error.class.name
         })
       end
     end

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -205,6 +205,10 @@ module Dependabot
       def log_unknown_error_with_backtrace(error)
         Dependabot.logger.error error.message
         error.backtrace.each { |line| Dependabot.logger.error line }
+        service.increment_metric("updater.unknown_error", tags: {
+          package_manager: job.package_manager,
+          class_name: error.class.name,
+        })
       end
     end
   end

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -91,7 +91,7 @@ module Dependabot
 
       # Provides logging for errors that occur outside of a dependency context
       def log_job_error(error:, error_type:, error_detail: nil)
-        if error_type == "unknown_error" && !Dependabot.enterprise?
+        if error_type == "unknown_error"
           Dependabot.logger.error "Error processing job (#{error.class.name})"
           log_unknown_error_with_backtrace(error, error_detail)
         else

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -60,7 +60,7 @@ module Dependabot
 
       # Provides logging for errors that occur when processing a dependency
       def log_dependency_error(dependency:, error:, error_type:, error_detail: nil)
-        if error_type == "unknown_error"
+        if error_type == "unknown_error" && !Dependabot.enterprise?
           Dependabot.logger.error "Error processing #{dependency.name} (#{error.class.name})"
           log_unknown_error_with_backtrace(error, error_detail, dependency)
         else
@@ -91,7 +91,7 @@ module Dependabot
 
       # Provides logging for errors that occur outside of a dependency context
       def log_job_error(error:, error_type:, error_detail: nil)
-        if error_type == "unknown_error"
+        if error_type == "unknown_error" && !Dependabot.enterprise?
           Dependabot.logger.error "Error processing job (#{error.class.name})"
           log_unknown_error_with_backtrace(error, error_detail)
         else
@@ -216,7 +216,7 @@ module Dependabot
           dependency: dependency
         }.compact
 
-        service.record_unknown_error(error_details: details, dependency: dependency)
+        service.record_unknown_error(error_type: "unknown_error", error_details: details, dependency: dependency)
         service.increment_metric("updater.unknown_error", tags: {
           package_manager: job.package_manager,
           class_name: error.class.name

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -361,9 +361,9 @@ RSpec.describe Dependabot::ApiClient do
         error_details: error_detail
       )
 
-      expect(WebMock).
-        to have_requested(:post, url).
-        with(headers: { "Authorization" => "token" })
+      expect(WebMock)
+        .to have_requested(:post, url)
+        .with(headers: { "Authorization" => "token" })
     end
   end
 

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -349,6 +349,24 @@ RSpec.describe Dependabot::ApiClient do
     end
   end
 
+  describe "record_update_job_unknown_error" do
+    let(:url) { "http://example.com/update_jobs/1/record_update_job_unknown_error" }
+    let(:error_type) { "server_error" }
+    let(:error_detail) { { "message" => "My message" } }
+    before { stub_request(:post, url).to_return(status: 204) }
+
+    it "hits the correct endpoint" do
+      client.record_update_job_unknown_error(
+        error_type: error_type,
+        error_details: error_detail
+      )
+
+      expect(WebMock).
+        to have_requested(:post, url).
+        with(headers: { "Authorization" => "token" })
+    end
+  end
+
   describe "mark_job_as_processed" do
     let(:url) { "http://example.com/update_jobs/1/mark_as_processed" }
     let(:base_commit) { "sha" }

--- a/updater/spec/dependabot/integration_spec.rb
+++ b/updater/spec/dependabot/integration_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe "Dependabot Updates" do
                     mark_job_as_processed: nil,
                     update_dependency_list: nil,
                     record_update_job_error: nil,
+                    record_update_job_unknown_error: nil,
                     record_ecosystem_versions: nil,
                     increment_metric: nil)
   end

--- a/updater/spec/dependabot/integration_spec.rb
+++ b/updater/spec/dependabot/integration_spec.rb
@@ -208,8 +208,18 @@ RSpec.describe "Dependabot Updates" do
       end
 
       it "notifies Dependabot API of the problem" do
-        expect(api_client).to receive(:record_update_job_error)
-          .with({ error_type: "unknown_error", error_details: nil })
+        expect(api_client).to receive(:record_update_job_unknown_error)
+          .with(
+            { error_type: "unknown_error",
+              error_details: {
+                "error-backtrace" => an_instance_of(String),
+                "error-message" => "oh no!",
+                "error-class" => "StandardError",
+                "package-manager" => "bundler",
+                "job-id" => 1,
+                "job-dependency_group" => []
+              } }
+          )
 
         expect { run_job }.to output(/oh no!/).to_stdout_from_any_process
       end

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Dependabot::Service do
       create_pull_request: nil,
       update_pull_request: nil,
       close_pull_request: nil,
-      record_update_job_error: nil
+      record_update_job_error: nil,
+      record_update_job_unknown_error: nil
     })
   end
   subject(:service) { described_class.new(client: mock_client) }

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -126,7 +126,9 @@ RSpec.describe Dependabot::UpdateFilesCommand do
             "error-backtrace" => an_instance_of(String),
             "error-message" => "hell",
             "error-class" => "StandardError",
-            "package-manager" => "bundler"
+            "package-manager" => "bundler",
+            "job-id" => "123123",
+            "job-dependency_group" => []
           }
         )
 

--- a/updater/spec/dependabot/updater/error_handler_spec.rb
+++ b/updater/spec/dependabot/updater/error_handler_spec.rb
@@ -18,11 +18,13 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
   end
 
   let(:mock_service) do
-    instance_double(Dependabot::Service)
+    instance_double(Dependabot::Service).tap do |service|
+      allow(service).to receive(:increment_metric)
+    end
   end
 
   let(:mock_job) do
-    instance_double(Dependabot::Job)
+    instance_double(Dependabot::Job, package_manager: "bundler", id: "123123", dependencies: [], dependency_groups: [])
   end
 
   describe "#handle_dependency_error" do
@@ -62,9 +64,17 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
       end
 
       it "records the error with the service, logs the backtrace and captures the exception" do
-        expect(mock_service).to receive(:record_update_job_error).with(
+        expect(mock_service).to receive(:record_update_job_unknown_error).with(
           error_type: "unknown_error",
-          error_details: nil,
+          error_details: {
+            "error-backtrace" => "bees.rb:5:in `buzz`",
+            "error-message" => "There are bees everywhere",
+            "error-class" => "StandardError",
+            "package-manager" => "bundler",
+            "job-id" => "123123",
+            "job-dependencies" => [],
+            "job-dependency_group" => []
+          },
           dependency: dependency
         )
 
@@ -112,9 +122,17 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
       end
 
       it "records the error with the service and logs the backtrace" do
-        expect(mock_service).to receive(:record_update_job_error).with(
+        expect(mock_service).to receive(:record_update_job_unknown_error).with(
           error_type: "unknown_error",
-          error_details: nil,
+          error_details: {
+            "error-backtrace" => "****** ERROR 8335 -- 101",
+            "error-message" => "the kernal is full of bees",
+            "error-class" => "Dependabot::SharedHelpers::HelperSubprocessFailed",
+            "package-manager" => "bundler",
+            "job-id" => "123123",
+            "job-dependencies" => [],
+            "job-dependency_group" => []
+          },
           dependency: dependency
         )
 
@@ -135,7 +153,7 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
 
       it "sanitizes the error and captures it" do
         allow(Dependabot.logger).to receive(:error)
-        allow(mock_service).to receive(:record_update_job_error)
+        allow(mock_service).to receive(:record_update_job_unknown_error)
         expect(mock_service).to receive(:capture_exception).with(
           error: an_instance_of(Dependabot::Updater::SubprocessFailed), job: mock_job
         ) do |args|
@@ -185,9 +203,18 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
       end
 
       it "records the error with the service, logs the backtrace and captures the exception" do
-        expect(mock_service).to receive(:record_update_job_error).with(
+        expect(mock_service).to receive(:record_update_job_unknown_error).with(
           error_type: "unknown_error",
-          error_details: nil
+          error_details: {
+            "error-backtrace" => "bees.rb:5:in `buzz`",
+            "error-message" => "There are bees everywhere",
+            "error-class" => "StandardError",
+            "package-manager" => "bundler",
+            "job-id" => "123123",
+            "job-dependencies" => [],
+            "job-dependency_group" => []
+          },
+          dependency: nil
         )
 
         expect(mock_service).to receive(:capture_exception).with(

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1604,11 +1604,18 @@ RSpec.describe Dependabot::Updater do
         service = build_service
         updater = build_updater(service: service, job: job)
 
-        expect(service)
-          .to receive(:record_update_job_error)
-          .with(
+        expect(service).
+          to receive(:record_update_job_unknown_error).
+          with(
             error_type: "unknown_error",
-            error_details: nil,
+            error_details: {
+              "error-backtrace" => an_instance_of(String),
+              "error-message" => "hell",
+              "error-class" => "StandardError",
+              "package-manager" => "bundler",
+              "job-id" => 1,
+              "job-dependency_group" => []
+            },
             dependency: an_instance_of(Dependabot::Dependency)
           )
 
@@ -1915,11 +1922,18 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service)
-            .to receive(:record_update_job_error)
-            .with(
+          expect(service).
+            to receive(:record_update_job_unknown_error).
+            with(
               error_type: "unknown_error",
-              error_details: nil,
+              error_details: {
+                "error-backtrace" => an_instance_of(String),
+                "error-message" => "Potentially sensitive log content goes here",
+                "error-class" => "Dependabot::SharedHelpers::HelperSubprocessFailed",
+                "package-manager" => "bundler",
+                "job-id" => 1,
+                "job-dependency_group" => []
+              },
               dependency: an_instance_of(Dependabot::Dependency)
             )
           updater.run

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -2346,6 +2346,7 @@ RSpec.describe Dependabot::Updater do
       close_pull_request: nil,
       mark_job_as_processed: nil,
       record_update_job_error: nil,
+      record_update_job_unknown_error: nil,
       increment_metric: nil
     )
 
@@ -2353,6 +2354,7 @@ RSpec.describe Dependabot::Updater do
       client: api_client
     )
     allow(service).to receive(:record_update_job_error)
+    allow(service).to receive(:record_update_job_unknown_error)
 
     service
   end

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -1604,9 +1604,9 @@ RSpec.describe Dependabot::Updater do
         service = build_service
         updater = build_updater(service: service, job: job)
 
-        expect(service).
-          to receive(:record_update_job_unknown_error).
-          with(
+        expect(service)
+          .to receive(:record_update_job_unknown_error)
+          .with(
             error_type: "unknown_error",
             error_details: {
               "error-backtrace" => an_instance_of(String),
@@ -1922,9 +1922,9 @@ RSpec.describe Dependabot::Updater do
           service = build_service
           updater = build_updater(service: service, job: job)
 
-          expect(service).
-            to receive(:record_update_job_unknown_error).
-            with(
+          expect(service)
+            .to receive(:record_update_job_unknown_error)
+            .with(
               error_type: "unknown_error",
               error_details: {
                 "error-backtrace" => an_instance_of(String),


### PR DESCRIPTION
Dependabot currently treats `unknown_errors` the same as any other error type.

However, `unknown_errors` are a bit of a special case because they are mostly caused by a HelperSubprocessFailure when Dependabot shells out to native package managers. The helper subprocess failures are harder to debug because they can be specific to a dependency set or some combination of a package manager version and project file features.

In order to better investigate unknown errors, we should send the error details to the backend service so we can look for trends.

This PR makes a few changes to the way unknown errors are logged:

1. unknown errors can only be generated from a few sources:
    a. helper subprocess failures
    b. file fetcher command errors
    c. update files command errors 
2. helper subprocess failure commands are now logged to the Dependabot job log so users can investigate issues themselves (https://github.com/dependabot/dependabot-core/pull/6521)
3. octokit 500 errors are treated as a new error type, `server_error`, since they are well-known
4. unknown errors also increment an `updater.unknown_error` metric with tags for the package manager

~Still needs a feature flag for GHES support and tests for the new endpoint.~

EDIT: Check has been added in Dependabot-api to to return immediately if in GHES or Proxima environment 