### PR TITLE
[Grouped Updates] Don't instantiate any groups without the feature flag

### DIFF
--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -56,6 +56,7 @@ module Dependabot
     # Returns just the group that is specifically requested to be updated by
     # the job definition
     def job_group
+      return nil unless Dependabot::Experiments.enabled?(:grouped_updates_prototype)
       return nil unless job.dependency_group_to_refresh
       return @job_group if defined?(@job_group)
 
@@ -63,6 +64,8 @@ module Dependabot
     end
 
     def groups
+      return [] unless Dependabot::Experiments.enabled?(:grouped_updates_prototype)
+
       @dependency_group_engine.dependency_groups
     end
 
@@ -81,6 +84,9 @@ module Dependabot
       @dependency_files = dependency_files
 
       @dependencies = parse_files!
+
+      return unless Dependabot::Experiments.enabled?(:grouped_updates_prototype)
+
       @dependency_group_engine = DependencyGroupEngine.from_job_config(job: job)
       @dependency_group_engine.assign_to_groups!(dependencies: allowed_dependencies)
     end

--- a/updater/spec/dependabot/dependency_snapshot_spec.rb
+++ b/updater/spec/dependabot/dependency_snapshot_spec.rb
@@ -105,6 +105,8 @@ RSpec.describe Dependabot::DependencySnapshot do
       end
 
       it "correctly instantiates any configured dependency groups" do
+        Dependabot::Experiments.register("grouped_updates_prototype", true)
+
         snapshot = create_dependency_snapshot
 
         expect(snapshot.groups.length).to eql(1)
@@ -117,6 +119,14 @@ RSpec.describe Dependabot::DependencySnapshot do
 
         expect(snapshot.ungrouped_dependencies.length).to eql(1)
         expect(snapshot.ungrouped_dependencies.first.name).to eql("dummy-pkg-b")
+
+        Dependabot::Experiments.reset!
+      end
+
+      it "ignores any configured dependency groups when the experiment is disabled" do
+        snapshot = create_dependency_snapshot
+
+        expect(snapshot.groups.length).to eql(0)
       end
     end
 


### PR DESCRIPTION
With the changes made in https://github.com/dependabot/dependabot-core/pull/7548 we have a clear touch-point as to when groups are hydrated from the configuration at job startup.

This follows up on that to correct and oversight where the feature flag / experiment for grouped updates didn't stop us attempting to interpret your group config if the feature was disabled.

At this point we're in public beta so this experiment is generally true in production but this reduces the splash radius for anyone using the CLI and ensures that the feature flag is a proper circuit breaker if we need to turn things off temporarily.